### PR TITLE
dyninst/irgen: include type information for interface implementors

### DIFF
--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -203,12 +203,10 @@ func (d *Decoder) encodeValue(
 	if err := writeTokens(enc, jsontext.BeginObject); err != nil {
 		return err
 	}
-	if !decoderType.hasDynamicType() {
-		if err := writeTokens(
-			enc, jsontext.String("type"), jsontext.String(valueType),
-		); err != nil {
-			return err
-		}
+	if err := writeTokens(
+		enc, jsontext.String("type"), jsontext.String(valueType),
+	); err != nil {
+		return err
 	}
 	if err := decoderType.encodeValueFields(d, enc, data); err != nil {
 		return err

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -1135,6 +1135,15 @@ func encodeInterface(
 	}
 
 	runtimeType := binary.NativeEndian.Uint64(data[goRuntimeTypeOffset : goRuntimeTypeOffset+8])
+	if runtimeType == 0 {
+		return writeTokens(enc,
+			jsontext.String("isNull"),
+			jsontext.Bool(true),
+			jsontext.EndObject,
+			jsontext.EndObject,
+		)
+	}
+
 	typeID, ok := d.typesByGoRuntimeType[uint32(runtimeType)]
 	if !ok {
 		name, err := d.typeNameResolver.ResolveTypeName(gotype.TypeID(runtimeType))

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -30,7 +30,6 @@ import (
 // value types.
 type decoderType interface {
 	irType() ir.Type
-	hasDynamicType() bool
 	encodeValueFields(
 		d *Decoder,
 		enc *jsontext.Encoder,
@@ -469,7 +468,6 @@ func (b *baseType) encodeValueFields(
 		return fmt.Errorf("%s is not a base type", kind)
 	}
 }
-func (*baseType) hasDynamicType() bool { return false }
 
 func (e *eventRootType) irType() ir.Type { return (*ir.EventRootType)(e) }
 func (e *eventRootType) encodeValueFields(
@@ -482,7 +480,6 @@ func (e *eventRootType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
-func (*eventRootType) hasDynamicType() bool { return false }
 
 func (m *goMapType) irType() ir.Type { return (*ir.GoMapType)(m) }
 func (m *goMapType) encodeValueFields(
@@ -493,7 +490,6 @@ func (m *goMapType) encodeValueFields(
 	const encodeAddress = false
 	return encodePointer(data, encodeAddress, m.HeaderType.GetID(), enc, d)
 }
-func (*goMapType) hasDynamicType() bool { return false }
 
 func (h *goHMapHeaderType) irType() ir.Type { return h.GoHMapHeaderType }
 func (h *goHMapHeaderType) encodeValueFields(
@@ -563,7 +559,6 @@ func (h *goHMapHeaderType) encodeValueFields(
 	}
 	return nil
 }
-func (*goHMapHeaderType) hasDynamicType() bool { return false }
 
 func encodeHMapBucket(
 	d *Decoder,
@@ -640,7 +635,6 @@ func (*goHMapBucketType) encodeValueFields(
 ) error {
 	return fmt.Errorf("hmap bucket type is never directly encoded")
 }
-func (*goHMapBucketType) hasDynamicType() bool { return false }
 
 func (s *goSwissMapHeaderType) irType() ir.Type { return s.GoSwissMapHeaderType }
 func (s *goSwissMapHeaderType) encodeValueFields(
@@ -727,7 +721,6 @@ func (s *goSwissMapHeaderType) encodeValueFields(
 	}
 	return writeTokens(enc, jsontext.EndArray)
 }
-func (*goSwissMapHeaderType) hasDynamicType() bool { return false }
 
 func (s *goSwissMapGroupsType) irType() ir.Type { return (*ir.GoSwissMapGroupsType)(s) }
 func (s *goSwissMapGroupsType) encodeValueFields(
@@ -740,7 +733,6 @@ func (s *goSwissMapGroupsType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
-func (*goSwissMapGroupsType) hasDynamicType() bool { return false }
 
 func (v *voidPointerType) irType() ir.Type { return (*ir.VoidPointerType)(v) }
 func (v *voidPointerType) encodeValueFields(
@@ -756,7 +748,6 @@ func (v *voidPointerType) encodeValueFields(
 		jsontext.String("0x"+strconv.FormatUint(binary.NativeEndian.Uint64(data), 16)),
 	)
 }
-func (*voidPointerType) hasDynamicType() bool { return false }
 
 func (p *pointerType) irType() ir.Type { return (*ir.PointerType)(p) }
 func (p *pointerType) encodeValueFields(
@@ -774,7 +765,6 @@ func (p *pointerType) encodeValueFields(
 	writeAddress := ok && goKind != reflect.Pointer
 	return encodePointer(data, writeAddress, p.Pointee.GetID(), enc, d)
 }
-func (*pointerType) hasDynamicType() bool { return false }
 
 func encodePointer(
 	data []byte,
@@ -858,14 +848,13 @@ func (s *structureType) encodeValueFields(
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
-	var err error
-	if err = writeTokens(enc,
+	if err := writeTokens(enc,
 		jsontext.String("fields"),
 		jsontext.BeginObject); err != nil {
 		return err
 	}
 	for field := range s.irType().(*ir.StructureType).Fields() {
-		if err = writeTokens(enc, jsontext.String(field.Name)); err != nil {
+		if err := writeTokens(enc, jsontext.String(field.Name)); err != nil {
 			return err
 		}
 		fieldEnd := field.Offset + field.Type.GetByteSize()
@@ -873,7 +862,7 @@ func (s *structureType) encodeValueFields(
 			return fmt.Errorf("field %s extends beyond data bounds: need %d bytes, have %d", field.Name, fieldEnd, len(data))
 		}
 
-		if err = d.encodeValue(enc,
+		if err := d.encodeValue(enc,
 			field.Type.GetID(),
 			data[field.Offset:field.Offset+field.Type.GetByteSize()],
 			field.Type.GetName(),
@@ -883,7 +872,6 @@ func (s *structureType) encodeValueFields(
 	}
 	return writeTokens(enc, jsontext.EndObject)
 }
-func (*structureType) hasDynamicType() bool { return false }
 
 func (a *arrayType) irType() ir.Type { return (*ir.ArrayType)(a) }
 func (a *arrayType) encodeValueFields(
@@ -930,7 +918,6 @@ func (a *arrayType) encodeValueFields(
 	}
 	return nil
 }
-func (*arrayType) hasDynamicType() bool { return false }
 
 func (s *goSliceHeaderType) irType() ir.Type { return (*ir.GoSliceHeaderType)(s) }
 func (s *goSliceHeaderType) encodeValueFields(
@@ -1018,7 +1005,6 @@ func (s *goSliceHeaderType) encodeValueFields(
 	}
 	return nil
 }
-func (*goSliceHeaderType) hasDynamicType() bool { return false }
 
 func (s *goSliceDataType) irType() ir.Type { return (*ir.GoSliceDataType)(s) }
 func (s *goSliceDataType) encodeValueFields(
@@ -1031,7 +1017,6 @@ func (s *goSliceDataType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
-func (*goSliceDataType) hasDynamicType() bool { return false }
 
 func (s *goStringHeaderType) irType() ir.Type { return s.GoStringHeaderType }
 func (s *goStringHeaderType) encodeValueFields(
@@ -1085,7 +1070,6 @@ func (s *goStringHeaderType) encodeValueFields(
 	str := unsafe.String(unsafe.SliceData(stringData), int(length))
 	return writeTokens(enc, jsontext.String(str))
 }
-func (*goStringHeaderType) hasDynamicType() bool { return false }
 
 func (s *goStringDataType) irType() ir.Type { return (*ir.GoStringDataType)(s) }
 func (s *goStringDataType) encodeValueFields(
@@ -1098,7 +1082,6 @@ func (s *goStringDataType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
-func (*goStringDataType) hasDynamicType() bool { return false }
 
 func (c *goChannelType) irType() ir.Type { return (*ir.GoChannelType)(c) }
 func (c *goChannelType) encodeValueFields(
@@ -1111,7 +1094,6 @@ func (c *goChannelType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
-func (*goChannelType) hasDynamicType() bool { return false }
 
 const goRuntimeTypeOffset = 0x00
 const goInterfaceDataOffset = 0x08
@@ -1124,7 +1106,6 @@ func (e *goEmptyInterfaceType) encodeValueFields(
 ) error {
 	return encodeInterface(d, enc, data)
 }
-func (*goEmptyInterfaceType) hasDynamicType() bool { return true }
 
 func (i *goInterfaceType) irType() ir.Type { return (*ir.GoInterfaceType)(i) }
 func (i *goInterfaceType) encodeValueFields(
@@ -1134,7 +1115,6 @@ func (i *goInterfaceType) encodeValueFields(
 ) error {
 	return encodeInterface(d, enc, data)
 }
-func (*goInterfaceType) hasDynamicType() bool { return true }
 
 func encodeInterface(
 	d *Decoder,
@@ -1144,6 +1124,16 @@ func encodeInterface(
 	if len(data) != 16 {
 		return fmt.Errorf("go interface data must be 16 bytes, got %d", len(data))
 	}
+
+	if err := writeTokens(enc,
+		jsontext.String("fields"),
+		jsontext.BeginObject,
+		jsontext.String("data"),
+		jsontext.BeginObject,
+	); err != nil {
+		return err
+	}
+
 	runtimeType := binary.NativeEndian.Uint64(data[goRuntimeTypeOffset : goRuntimeTypeOffset+8])
 	typeID, ok := d.typesByGoRuntimeType[uint32(runtimeType)]
 	if !ok {
@@ -1156,6 +1146,8 @@ func encodeInterface(
 			jsontext.String(name),
 			tokenNotCapturedReason,
 			tokenNotCapturedReasonMissingTypeInfo,
+			jsontext.EndObject,
+			jsontext.EndObject,
 		); err != nil {
 			return err
 		}
@@ -1166,23 +1158,27 @@ func encodeInterface(
 	if !ok {
 		return fmt.Errorf("no type found for type ID: %d", typeID)
 	}
-	if err := writeTokens(enc,
-		jsontext.String("type"),
-		jsontext.String(t.GetName()),
+	if err := writeTokens(
+		enc, jsontext.String("type"), jsontext.String(t.GetName()),
 	); err != nil {
 		return err
 	}
 	ptrData := data[goInterfaceDataOffset : goInterfaceDataOffset+8]
-	switch t := t.(type) {
-	case *ir.PointerType:
-		// Delegate to the pointer type for its handling of the decision
-		// when to write out the address.
-		return (*pointerType)(t).encodeValueFields(d, enc, ptrData)
-	case *ir.GoMapType /* *ir.GoChannelType, *ir.GoSubroutineType */ :
-		typeID = t.HeaderType.GetID()
-	default:
+	var err error
+	if pt, ok := t.(*ir.PointerType); ok {
+		err = (*pointerType)(pt).encodeValueFields(d, enc, ptrData)
+	} else {
+		switch t := t.(type) {
+		// Reference types need to be indirected appropriately
+		case *ir.GoMapType /* *ir.GoChannelType, *ir.GoSubroutineType */ :
+			typeID = t.HeaderType.GetID()
+		}
+		err = encodePointer(ptrData, false, typeID, enc, d)
 	}
-	return encodePointer(ptrData, false, typeID, enc, d)
+	if err != nil {
+		return err
+	}
+	return writeTokens(enc, jsontext.EndObject, jsontext.EndObject)
 }
 
 func (s *goSubroutineType) irType() ir.Type { return (*ir.GoSubroutineType)(s) }
@@ -1196,10 +1192,8 @@ func (s *goSubroutineType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
-func (*goSubroutineType) hasDynamicType() bool { return false }
 
-func (u *unresolvedPointeeType) irType() ir.Type    { return (*ir.UnresolvedPointeeType)(u) }
-func (*unresolvedPointeeType) hasDynamicType() bool { return false }
+func (u *unresolvedPointeeType) irType() ir.Type { return (*ir.UnresolvedPointeeType)(u) }
 func (u *unresolvedPointeeType) encodeValueFields(
 	_ *Decoder,
 	enc *jsontext.Encoder,

--- a/pkg/dyninst/ebpf/stack_machine.h
+++ b/pkg/dyninst/ebpf/stack_machine.h
@@ -339,7 +339,7 @@ sm_record_go_interface_impl(global_ctx_t* global_ctx, uint64_t go_runtime_type,
     LOG(4, "chase: interface type not found %llx", go_runtime_type);
     return true;
   }
-  const bool decrease_ttl = false;
+  const bool decrease_ttl = true;
   return sm_record_pointer(global_ctx, t, addr, decrease_ttl, ENQUEUE_LEN_SENTINEL);
 }
 

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -85,11 +85,11 @@ func dockerIsEnabled(t *testing.T) bool {
 	return true
 }
 
-const expectationsPath = "testdata/e2e/rc_tester.json"
+const expectationsDir = "testdata/e2e"
 
 const e2eTmpDirEnv = "E2E_TMP_DIR"
 
-//go:embed testdata/e2e/rc_tester.json
+//go:embed testdata/e2e/rc_tester.json testdata/e2e/rc_tester_v1.json
 var expectations embed.FS
 
 func TestEndToEnd(t *testing.T) {
@@ -218,7 +218,7 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 	sendTestRequests(t, serverPort, numRequests)
 	waitForLogMessages(
 		t, ts.backend, numRequests*len(expectedProbeIDs),
-		expectationsPath, cfg.rewrite,
+		path.Join(expectationsDir, cfg.binary+".json"), cfg.rewrite,
 	)
 	waitForProbeStatus(
 		t, ts.backend.diagPayloadCh,

--- a/pkg/dyninst/gotype/table.go
+++ b/pkg/dyninst/gotype/table.go
@@ -92,6 +92,11 @@ func NewTable(obj object.File) (*Table, error) {
 	}, nil
 }
 
+// DataByteSize returns the size of the data in bytes.
+func (tb *Table) DataByteSize() uint64 {
+	return uint64(len(tb.data))
+}
+
 // Close closes the table.
 func (tb *Table) Close() error {
 	return tb.closer.Close()

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000c9540"
+- offset: "0x000c9600"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000e7200"
+- offset: "0x000e72c0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000c9540"
+  ptrToThis: "0x000c9600"
   struct:
     fields: []
-- offset: "0x000c91e0"
+- offset: "0x000c92a0"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000c9240"
+- offset: "0x000c9300"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000c92a0"
+- offset: "0x000c9360"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000d65c0"
+- offset: "0x000d6680"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000d6620"
+- offset: "0x000d66e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,347 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000ef140"
+- offset: "0x000ef200"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x00056c00"
+  ptrToThis: "0x00056c40"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x0010c760"
+- offset: "0x0010c920"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x00056f40"
+  ptrToThis: "0x00057000"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x0010c6e0"
+- offset: "0x0010c8a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x00056f00"
+  ptrToThis: "0x00056fc0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x0010c660"
+- offset: "0x0010c820"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x00056ec0"
+  ptrToThis: "0x00056f80"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x0010c5e0"
+- offset: "0x0010c7a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x00056e80"
+  ptrToThis: "0x00056f40"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x0010c560"
+- offset: "0x0010c720"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x00056e40"
+  ptrToThis: "0x00056f00"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x0010c4e0"
+- offset: "0x0010c6a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x00056e00"
+  ptrToThis: "0x00056ec0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x0010c460"
+- offset: "0x0010c620"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x00056dc0"
+  ptrToThis: "0x00056e80"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x0010c3e0"
+- offset: "0x0010c5a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x00056d80"
+  ptrToThis: "0x00056e40"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x0010c360"
+- offset: "0x0010c520"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x00056d40"
+  ptrToThis: "0x00056e00"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x0010cbe0"
+- offset: "0x0010cda0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x00057180"
+  ptrToThis: "0x00057240"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x0010cb60"
+- offset: "0x0010cd20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x00057140"
+  ptrToThis: "0x00057200"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x0010cae0"
+- offset: "0x0010cca0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x00057100"
+  ptrToThis: "0x000571c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x0010ca60"
+- offset: "0x0010cc20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x000570c0"
+  ptrToThis: "0x00057180"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x0010c9e0"
+- offset: "0x0010cba0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x00057080"
+  ptrToThis: "0x00057140"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x0010c960"
+- offset: "0x0010cb20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x00057040"
+  ptrToThis: "0x00057100"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x0010c8e0"
+- offset: "0x0010caa0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x00057000"
+  ptrToThis: "0x000570c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x0010c860"
+- offset: "0x0010ca20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x00056fc0"
+  ptrToThis: "0x00057080"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x0010c7e0"
+- offset: "0x0010c9a0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x00056f80"
+  ptrToThis: "0x00057040"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x0010d060"
+- offset: "0x0010d220"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x000573c0"
+  ptrToThis: "0x00057480"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x0010cfe0"
+- offset: "0x0010d1a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x00057380"
+  ptrToThis: "0x00057440"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x0010cf60"
+- offset: "0x0010d120"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x00057340"
+  ptrToThis: "0x00057400"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x0010cee0"
+- offset: "0x0010d0a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x00057300"
+  ptrToThis: "0x000573c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x0010ce60"
+- offset: "0x0010d020"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x000572c0"
+  ptrToThis: "0x00057380"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x0010cde0"
+- offset: "0x0010cfa0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x00057280"
+  ptrToThis: "0x00057340"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x0010cd60"
+- offset: "0x0010cf20"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x00057240"
+  ptrToThis: "0x00057300"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x0010cce0"
+- offset: "0x0010cea0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x00057200"
+  ptrToThis: "0x000572c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x0010cc60"
+- offset: "0x0010ce20"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x000571c0"
+  ptrToThis: "0x00057280"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x0019fec0"
+- offset: "0x001a0080"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x00057400"
+  ptrToThis: "0x000574c0"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001becc0"
+- offset: "0x001bee80"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x00056c80"
+  ptrToThis: "0x00056cc0"
   struct:
     fields:
     - name: _
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x0012c8c0"
+- offset: "0x0012ca80"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000c91e0"
+  ptrToThis: "0x000c92a0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00138600"
+- offset: "0x001387c0"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x00057480"
+  ptrToThis: "0x00057540"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00138560"
+- offset: "0x00138720"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x00057440"
+  ptrToThis: "0x00057500"
   struct:
     fields:
     - name: val
@@ -506,13 +506,37 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x0012c960"
+- offset: "0x0010c320"
+  size: 16
+  kind: struct
+  nameEntry: main.otherFirstBehavior
+  name: main.otherFirstBehavior
+  pkg: main
+  ptrToThis: "0x00056d00"
+  struct:
+    fields:
+    - name: s
+      type: string
+      offset: 0
+- offset: "0x0010c3a0"
+  size: 8
+  kind: struct
+  nameEntry: main.otherSecondBehavior
+  name: main.otherSecondBehavior
+  pkg: main
+  ptrToThis: "0x00056d40"
+  struct:
+    fields:
+    - name: i
+      type: int
+      offset: 0
+- offset: "0x0012cb20"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000c9240"
+  ptrToThis: "0x000c9300"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,56 +545,56 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000ef1c0"
+- offset: "0x000ef280"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x00056c40"
+  ptrToThis: "0x00056c80"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000e7080"
+- offset: "0x000e7140"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000c92a0"
+  ptrToThis: "0x000c9360"
   struct:
     fields: []
-- offset: "0x0010c260"
+- offset: "0x0010c420"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x00056cc0"
+  ptrToThis: "0x00056d80"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x0010c2e0"
+- offset: "0x0010c4a0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x00056d00"
+  ptrToThis: "0x00056dc0"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00135880"
+- offset: "0x00135a40"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000d65c0"
+  ptrToThis: "0x000d6680"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -579,13 +603,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00135920"
+- offset: "0x00135ae0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000d6620"
+  ptrToThis: "0x000d66e0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000c9500"
+- offset: "0x000c9540"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000e71c0"
+- offset: "0x000e7200"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000c9500"
+  ptrToThis: "0x000c9540"
   struct:
     fields: []
-- offset: "0x000c91a0"
+- offset: "0x000c91e0"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000c9200"
+- offset: "0x000c9240"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000c9260"
+- offset: "0x000c92a0"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000d6580"
+- offset: "0x000d65c0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000d65e0"
+- offset: "0x000d6620"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,7 +73,7 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000ef100"
+- offset: "0x000ef140"
   size: 16
   kind: interface
   nameEntry: main.behavior
@@ -83,337 +83,337 @@
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x0010c6a0"
+- offset: "0x0010c760"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x00056f00"
+  ptrToThis: "0x00056f40"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x0010c620"
+- offset: "0x0010c6e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x00056ec0"
+  ptrToThis: "0x00056f00"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x0010c5a0"
+- offset: "0x0010c660"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x00056e80"
+  ptrToThis: "0x00056ec0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x0010c520"
+- offset: "0x0010c5e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x00056e40"
+  ptrToThis: "0x00056e80"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x0010c4a0"
+- offset: "0x0010c560"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x00056e00"
+  ptrToThis: "0x00056e40"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x0010c420"
+- offset: "0x0010c4e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x00056dc0"
+  ptrToThis: "0x00056e00"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x0010c3a0"
+- offset: "0x0010c460"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x00056d80"
+  ptrToThis: "0x00056dc0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x0010c320"
+- offset: "0x0010c3e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x00056d40"
+  ptrToThis: "0x00056d80"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x0010c2a0"
+- offset: "0x0010c360"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x00056d00"
+  ptrToThis: "0x00056d40"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x0010cb20"
+- offset: "0x0010cbe0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x00057140"
+  ptrToThis: "0x00057180"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x0010caa0"
+- offset: "0x0010cb60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x00057100"
+  ptrToThis: "0x00057140"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x0010ca20"
+- offset: "0x0010cae0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x000570c0"
+  ptrToThis: "0x00057100"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x0010c9a0"
+- offset: "0x0010ca60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x00057080"
+  ptrToThis: "0x000570c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x0010c920"
+- offset: "0x0010c9e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x00057040"
+  ptrToThis: "0x00057080"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x0010c8a0"
+- offset: "0x0010c960"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x00057000"
+  ptrToThis: "0x00057040"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x0010c820"
+- offset: "0x0010c8e0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x00056fc0"
+  ptrToThis: "0x00057000"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x0010c7a0"
+- offset: "0x0010c860"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x00056f80"
+  ptrToThis: "0x00056fc0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x0010c720"
+- offset: "0x0010c7e0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x00056f40"
+  ptrToThis: "0x00056f80"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x0010cfa0"
+- offset: "0x0010d060"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x00057380"
+  ptrToThis: "0x000573c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x0010cf20"
+- offset: "0x0010cfe0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x00057340"
+  ptrToThis: "0x00057380"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x0010cea0"
+- offset: "0x0010cf60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x00057300"
+  ptrToThis: "0x00057340"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x0010ce20"
+- offset: "0x0010cee0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x000572c0"
+  ptrToThis: "0x00057300"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x0010cda0"
+- offset: "0x0010ce60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x00057280"
+  ptrToThis: "0x000572c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x0010cd20"
+- offset: "0x0010cde0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x00057240"
+  ptrToThis: "0x00057280"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x0010cca0"
+- offset: "0x0010cd60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x00057200"
+  ptrToThis: "0x00057240"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x0010cc20"
+- offset: "0x0010cce0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x000571c0"
+  ptrToThis: "0x00057200"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x0010cba0"
+- offset: "0x0010cc60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x00057180"
+  ptrToThis: "0x000571c0"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x0019fe00"
+- offset: "0x0019fec0"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x000573c0"
+  ptrToThis: "0x00057400"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,7 +431,7 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001bec00"
+- offset: "0x001becc0"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x0012c800"
+- offset: "0x0012c8c0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000c91a0"
+  ptrToThis: "0x000c91e0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00138540"
+- offset: "0x00138600"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x00057440"
+  ptrToThis: "0x00057480"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x001384a0"
+- offset: "0x00138560"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x00057400"
+  ptrToThis: "0x00057440"
   struct:
     fields:
     - name: val
@@ -506,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x0012c8a0"
+- offset: "0x0012c960"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000c9200"
+  ptrToThis: "0x000c9240"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,7 +521,7 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000ef180"
+- offset: "0x000ef1c0"
   size: 16
   kind: interface
   nameEntry: main.something
@@ -531,34 +531,46 @@
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000e7040"
+- offset: "0x000e7080"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000c9260"
+  ptrToThis: "0x000c92a0"
   struct:
     fields: []
-- offset: "0x0010c220"
+- offset: "0x0010c260"
+  size: 16
+  kind: struct
+  nameEntry: main.structWithAny
+  name: main.structWithAny
+  pkg: main
+  ptrToThis: "0x00056cc0"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x0010c2e0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x00056cc0"
+  ptrToThis: "0x00056d00"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x001357c0"
+- offset: "0x00135880"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000d6580"
+  ptrToThis: "0x000d65c0"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -567,13 +579,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00135860"
+- offset: "0x00135920"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000d65e0"
+  ptrToThis: "0x000d6620"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000d9ea0"
+- offset: "0x000d9ee0"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f03c0"
+- offset: "0x000f0400"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000d9ea0"
+  ptrToThis: "0x000d9ee0"
   struct:
     fields: []
-- offset: "0x000d9b40"
+- offset: "0x000d9b80"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d9ba0"
+- offset: "0x000d9be0"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000d9c00"
+- offset: "0x000d9c40"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e7340"
+- offset: "0x000e7380"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e73a0"
+- offset: "0x000e73e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,7 +73,7 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f88c0"
+- offset: "0x000f8900"
   size: 16
   kind: interface
   nameEntry: main.behavior
@@ -83,337 +83,337 @@
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x00120860"
+- offset: "0x00120920"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005d840"
+  ptrToThis: "0x0005d880"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x001207e0"
+- offset: "0x001208a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005d800"
+  ptrToThis: "0x0005d840"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x00120760"
+- offset: "0x00120820"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005d7c0"
+  ptrToThis: "0x0005d800"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x001206e0"
+- offset: "0x001207a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005d780"
+  ptrToThis: "0x0005d7c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x00120660"
+- offset: "0x00120720"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005d740"
+  ptrToThis: "0x0005d780"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x001205e0"
+- offset: "0x001206a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005d700"
+  ptrToThis: "0x0005d740"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x00120560"
+- offset: "0x00120620"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005d6c0"
+  ptrToThis: "0x0005d700"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x001204e0"
+- offset: "0x001205a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005d680"
+  ptrToThis: "0x0005d6c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x00120460"
+- offset: "0x00120520"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005d640"
+  ptrToThis: "0x0005d680"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x00120ce0"
+- offset: "0x00120da0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005da80"
+  ptrToThis: "0x0005dac0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x00120c60"
+- offset: "0x00120d20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005da40"
+  ptrToThis: "0x0005da80"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x00120be0"
+- offset: "0x00120ca0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005da00"
+  ptrToThis: "0x0005da40"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x00120b60"
+- offset: "0x00120c20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005d9c0"
+  ptrToThis: "0x0005da00"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x00120ae0"
+- offset: "0x00120ba0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005d980"
+  ptrToThis: "0x0005d9c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x00120a60"
+- offset: "0x00120b20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005d940"
+  ptrToThis: "0x0005d980"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x001209e0"
+- offset: "0x00120aa0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005d900"
+  ptrToThis: "0x0005d940"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x00120960"
+- offset: "0x00120a20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005d8c0"
+  ptrToThis: "0x0005d900"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x001208e0"
+- offset: "0x001209a0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005d880"
+  ptrToThis: "0x0005d8c0"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00121160"
+- offset: "0x00121220"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005dcc0"
+  ptrToThis: "0x0005dd00"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x001210e0"
+- offset: "0x001211a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005dc80"
+  ptrToThis: "0x0005dcc0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x00121060"
+- offset: "0x00121120"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005dc40"
+  ptrToThis: "0x0005dc80"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x00120fe0"
+- offset: "0x001210a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005dc00"
+  ptrToThis: "0x0005dc40"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x00120f60"
+- offset: "0x00121020"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005dbc0"
+  ptrToThis: "0x0005dc00"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x00120ee0"
+- offset: "0x00120fa0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005db80"
+  ptrToThis: "0x0005dbc0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x00120e60"
+- offset: "0x00120f20"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005db40"
+  ptrToThis: "0x0005db80"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x00120de0"
+- offset: "0x00120ea0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005db00"
+  ptrToThis: "0x0005db40"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x00120d60"
+- offset: "0x00120e20"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005dac0"
+  ptrToThis: "0x0005db00"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001bd740"
+- offset: "0x001bd800"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005dd00"
+  ptrToThis: "0x0005dd40"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,7 +431,7 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001de200"
+- offset: "0x001de2c0"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x00157ac0"
+- offset: "0x00157b80"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000d9b40"
+  ptrToThis: "0x000d9b80"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00163b40"
+- offset: "0x00163c00"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005dd80"
+  ptrToThis: "0x0005ddc0"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00163aa0"
+- offset: "0x00163b60"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005dd40"
+  ptrToThis: "0x0005dd80"
   struct:
     fields:
     - name: val
@@ -506,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00157b60"
+- offset: "0x00157c20"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000d9ba0"
+  ptrToThis: "0x000d9be0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,7 +521,7 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f8940"
+- offset: "0x000f8980"
   size: 16
   kind: interface
   nameEntry: main.something
@@ -531,34 +531,46 @@
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000f0240"
+- offset: "0x000f0280"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000d9c00"
+  ptrToThis: "0x000d9c40"
   struct:
     fields: []
-- offset: "0x001203e0"
+- offset: "0x00120420"
+  size: 16
+  kind: struct
+  nameEntry: main.structWithAny
+  name: main.structWithAny
+  pkg: main
+  ptrToThis: "0x0005d600"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x001204a0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005d600"
+  ptrToThis: "0x0005d640"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00160e40"
+- offset: "0x00160f00"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e7340"
+  ptrToThis: "0x000e7380"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -567,13 +579,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00160ee0"
+- offset: "0x00160fa0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e73a0"
+  ptrToThis: "0x000e73e0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000d9ee0"
+- offset: "0x000d9fa0"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f0400"
+- offset: "0x000f04c0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000d9ee0"
+  ptrToThis: "0x000d9fa0"
   struct:
     fields: []
-- offset: "0x000d9b80"
+- offset: "0x000d9c40"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d9be0"
+- offset: "0x000d9ca0"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000d9c40"
+- offset: "0x000d9d00"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e7380"
+- offset: "0x000e7440"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e73e0"
+- offset: "0x000e74a0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,347 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f8900"
+- offset: "0x000f89c0"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005d540"
+  ptrToThis: "0x0005d580"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x00120920"
+- offset: "0x00120ae0"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005d880"
+  ptrToThis: "0x0005d940"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x001208a0"
+- offset: "0x00120a60"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005d840"
+  ptrToThis: "0x0005d900"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x00120820"
+- offset: "0x001209e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005d800"
+  ptrToThis: "0x0005d8c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x001207a0"
+- offset: "0x00120960"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005d7c0"
+  ptrToThis: "0x0005d880"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x00120720"
+- offset: "0x001208e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005d780"
+  ptrToThis: "0x0005d840"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x001206a0"
+- offset: "0x00120860"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005d740"
+  ptrToThis: "0x0005d800"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x00120620"
+- offset: "0x001207e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005d700"
+  ptrToThis: "0x0005d7c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x001205a0"
+- offset: "0x00120760"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005d6c0"
+  ptrToThis: "0x0005d780"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x00120520"
+- offset: "0x001206e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005d680"
+  ptrToThis: "0x0005d740"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x00120da0"
+- offset: "0x00120f60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005dac0"
+  ptrToThis: "0x0005db80"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x00120d20"
+- offset: "0x00120ee0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005da80"
+  ptrToThis: "0x0005db40"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x00120ca0"
+- offset: "0x00120e60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005da40"
+  ptrToThis: "0x0005db00"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x00120c20"
+- offset: "0x00120de0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005da00"
+  ptrToThis: "0x0005dac0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x00120ba0"
+- offset: "0x00120d60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005d9c0"
+  ptrToThis: "0x0005da80"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x00120b20"
+- offset: "0x00120ce0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005d980"
+  ptrToThis: "0x0005da40"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x00120aa0"
+- offset: "0x00120c60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005d940"
+  ptrToThis: "0x0005da00"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x00120a20"
+- offset: "0x00120be0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005d900"
+  ptrToThis: "0x0005d9c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x001209a0"
+- offset: "0x00120b60"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005d8c0"
+  ptrToThis: "0x0005d980"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00121220"
+- offset: "0x001213e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005dd00"
+  ptrToThis: "0x0005ddc0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x001211a0"
+- offset: "0x00121360"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005dcc0"
+  ptrToThis: "0x0005dd80"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x00121120"
+- offset: "0x001212e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005dc80"
+  ptrToThis: "0x0005dd40"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x001210a0"
+- offset: "0x00121260"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005dc40"
+  ptrToThis: "0x0005dd00"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x00121020"
+- offset: "0x001211e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005dc00"
+  ptrToThis: "0x0005dcc0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x00120fa0"
+- offset: "0x00121160"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005dbc0"
+  ptrToThis: "0x0005dc80"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x00120f20"
+- offset: "0x001210e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005db80"
+  ptrToThis: "0x0005dc40"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x00120ea0"
+- offset: "0x00121060"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005db40"
+  ptrToThis: "0x0005dc00"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x00120e20"
+- offset: "0x00120fe0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005db00"
+  ptrToThis: "0x0005dbc0"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001bd800"
+- offset: "0x001bd9c0"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005dd40"
+  ptrToThis: "0x0005de00"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001de2c0"
+- offset: "0x001de480"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005d5c0"
+  ptrToThis: "0x0005d600"
   struct:
     fields:
     - name: _
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x00157b80"
+- offset: "0x00157d40"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000d9b80"
+  ptrToThis: "0x000d9c40"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00163c00"
+- offset: "0x00163dc0"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005ddc0"
+  ptrToThis: "0x0005de80"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00163b60"
+- offset: "0x00163d20"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005dd80"
+  ptrToThis: "0x0005de40"
   struct:
     fields:
     - name: val
@@ -506,13 +506,37 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00157c20"
+- offset: "0x001204e0"
+  size: 16
+  kind: struct
+  nameEntry: main.otherFirstBehavior
+  name: main.otherFirstBehavior
+  pkg: main
+  ptrToThis: "0x0005d640"
+  struct:
+    fields:
+    - name: s
+      type: string
+      offset: 0
+- offset: "0x00120560"
+  size: 8
+  kind: struct
+  nameEntry: main.otherSecondBehavior
+  name: main.otherSecondBehavior
+  pkg: main
+  ptrToThis: "0x0005d680"
+  struct:
+    fields:
+    - name: i
+      type: int
+      offset: 0
+- offset: "0x00157de0"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000d9be0"
+  ptrToThis: "0x000d9ca0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,56 +545,56 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f8980"
+- offset: "0x000f8a40"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005d580"
+  ptrToThis: "0x0005d5c0"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000f0280"
+- offset: "0x000f0340"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000d9c40"
+  ptrToThis: "0x000d9d00"
   struct:
     fields: []
-- offset: "0x00120420"
+- offset: "0x001205e0"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x0005d600"
+  ptrToThis: "0x0005d6c0"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x001204a0"
+- offset: "0x00120660"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005d640"
+  ptrToThis: "0x0005d700"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00160f00"
+- offset: "0x001610c0"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e7380"
+  ptrToThis: "0x000e7440"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -579,13 +603,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00160fa0"
+- offset: "0x00161160"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e73e0"
+  ptrToThis: "0x000e74a0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000db000"
+- offset: "0x000db0c0"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f1540"
+- offset: "0x000f1600"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000db000"
+  ptrToThis: "0x000db0c0"
   struct:
     fields: []
-- offset: "0x000daca0"
+- offset: "0x000dad60"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000dad00"
+- offset: "0x000dadc0"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000dad60"
+- offset: "0x000dae20"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e8620"
+- offset: "0x000e86e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e8680"
+- offset: "0x000e8740"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,347 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f99c0"
+- offset: "0x000f9a80"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005e040"
+  ptrToThis: "0x0005e080"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x001218c0"
+- offset: "0x00121a80"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005e380"
+  ptrToThis: "0x0005e440"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x00121840"
+- offset: "0x00121a00"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005e340"
+  ptrToThis: "0x0005e400"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x001217c0"
+- offset: "0x00121980"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005e300"
+  ptrToThis: "0x0005e3c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x00121740"
+- offset: "0x00121900"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005e2c0"
+  ptrToThis: "0x0005e380"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x001216c0"
+- offset: "0x00121880"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005e280"
+  ptrToThis: "0x0005e340"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x00121640"
+- offset: "0x00121800"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005e240"
+  ptrToThis: "0x0005e300"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x001215c0"
+- offset: "0x00121780"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005e200"
+  ptrToThis: "0x0005e2c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x00121540"
+- offset: "0x00121700"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005e1c0"
+  ptrToThis: "0x0005e280"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x001214c0"
+- offset: "0x00121680"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005e180"
+  ptrToThis: "0x0005e240"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x00121d40"
+- offset: "0x00121f00"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005e5c0"
+  ptrToThis: "0x0005e680"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x00121cc0"
+- offset: "0x00121e80"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005e580"
+  ptrToThis: "0x0005e640"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x00121c40"
+- offset: "0x00121e00"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005e540"
+  ptrToThis: "0x0005e600"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x00121bc0"
+- offset: "0x00121d80"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005e500"
+  ptrToThis: "0x0005e5c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x00121b40"
+- offset: "0x00121d00"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005e4c0"
+  ptrToThis: "0x0005e580"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x00121ac0"
+- offset: "0x00121c80"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005e480"
+  ptrToThis: "0x0005e540"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x00121a40"
+- offset: "0x00121c00"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005e440"
+  ptrToThis: "0x0005e500"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x001219c0"
+- offset: "0x00121b80"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005e400"
+  ptrToThis: "0x0005e4c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x00121940"
+- offset: "0x00121b00"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005e3c0"
+  ptrToThis: "0x0005e480"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x001221c0"
+- offset: "0x00122380"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005e800"
+  ptrToThis: "0x0005e8c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x00122140"
+- offset: "0x00122300"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005e7c0"
+  ptrToThis: "0x0005e880"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x001220c0"
+- offset: "0x00122280"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005e780"
+  ptrToThis: "0x0005e840"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x00122040"
+- offset: "0x00122200"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005e740"
+  ptrToThis: "0x0005e800"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x00121fc0"
+- offset: "0x00122180"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005e700"
+  ptrToThis: "0x0005e7c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x00121f40"
+- offset: "0x00122100"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005e6c0"
+  ptrToThis: "0x0005e780"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x00121ec0"
+- offset: "0x00122080"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005e680"
+  ptrToThis: "0x0005e740"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x00121e40"
+- offset: "0x00122000"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005e640"
+  ptrToThis: "0x0005e700"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x00121dc0"
+- offset: "0x00121f80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005e600"
+  ptrToThis: "0x0005e6c0"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001bfc40"
+- offset: "0x001bfe00"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005e840"
+  ptrToThis: "0x0005e900"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001e0500"
+- offset: "0x001e06c0"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005e0c0"
+  ptrToThis: "0x0005e100"
   struct:
     fields:
     - name: _
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x00158aa0"
+- offset: "0x00158c60"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000daca0"
+  ptrToThis: "0x000dad60"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00164de0"
+- offset: "0x00164fa0"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005e8c0"
+  ptrToThis: "0x0005e980"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00164d40"
+- offset: "0x00164f00"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005e880"
+  ptrToThis: "0x0005e940"
   struct:
     fields:
     - name: val
@@ -506,13 +506,37 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00158b40"
+- offset: "0x00121480"
+  size: 16
+  kind: struct
+  nameEntry: main.otherFirstBehavior
+  name: main.otherFirstBehavior
+  pkg: main
+  ptrToThis: "0x0005e140"
+  struct:
+    fields:
+    - name: s
+      type: string
+      offset: 0
+- offset: "0x00121500"
+  size: 8
+  kind: struct
+  nameEntry: main.otherSecondBehavior
+  name: main.otherSecondBehavior
+  pkg: main
+  ptrToThis: "0x0005e180"
+  struct:
+    fields:
+    - name: i
+      type: int
+      offset: 0
+- offset: "0x00158d00"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000dad00"
+  ptrToThis: "0x000dadc0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,56 +545,56 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f9a40"
+- offset: "0x000f9b00"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005e080"
+  ptrToThis: "0x0005e0c0"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000f13c0"
+- offset: "0x000f1480"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000dad60"
+  ptrToThis: "0x000dae20"
   struct:
     fields: []
-- offset: "0x001213c0"
+- offset: "0x00121580"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x0005e100"
+  ptrToThis: "0x0005e1c0"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00121440"
+- offset: "0x00121600"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005e140"
+  ptrToThis: "0x0005e200"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00162000"
+- offset: "0x001621c0"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e8620"
+  ptrToThis: "0x000e86e0"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -579,13 +603,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x001620a0"
+- offset: "0x00162260"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e8680"
+  ptrToThis: "0x000e8740"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000dafc0"
+- offset: "0x000db000"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f1500"
+- offset: "0x000f1540"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000dafc0"
+  ptrToThis: "0x000db000"
   struct:
     fields: []
-- offset: "0x000dac60"
+- offset: "0x000daca0"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000dacc0"
+- offset: "0x000dad00"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000dad20"
+- offset: "0x000dad60"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e85e0"
+- offset: "0x000e8620"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e8640"
+- offset: "0x000e8680"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,7 +73,7 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f9980"
+- offset: "0x000f99c0"
   size: 16
   kind: interface
   nameEntry: main.behavior
@@ -83,337 +83,337 @@
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x00121800"
+- offset: "0x001218c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005e340"
+  ptrToThis: "0x0005e380"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x00121780"
+- offset: "0x00121840"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005e300"
+  ptrToThis: "0x0005e340"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x00121700"
+- offset: "0x001217c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005e2c0"
+  ptrToThis: "0x0005e300"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x00121680"
+- offset: "0x00121740"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005e280"
+  ptrToThis: "0x0005e2c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x00121600"
+- offset: "0x001216c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005e240"
+  ptrToThis: "0x0005e280"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x00121580"
+- offset: "0x00121640"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005e200"
+  ptrToThis: "0x0005e240"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x00121500"
+- offset: "0x001215c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005e1c0"
+  ptrToThis: "0x0005e200"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x00121480"
+- offset: "0x00121540"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005e180"
+  ptrToThis: "0x0005e1c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x00121400"
+- offset: "0x001214c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005e140"
+  ptrToThis: "0x0005e180"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x00121c80"
+- offset: "0x00121d40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005e580"
+  ptrToThis: "0x0005e5c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x00121c00"
+- offset: "0x00121cc0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005e540"
+  ptrToThis: "0x0005e580"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x00121b80"
+- offset: "0x00121c40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005e500"
+  ptrToThis: "0x0005e540"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x00121b00"
+- offset: "0x00121bc0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005e4c0"
+  ptrToThis: "0x0005e500"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x00121a80"
+- offset: "0x00121b40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005e480"
+  ptrToThis: "0x0005e4c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x00121a00"
+- offset: "0x00121ac0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005e440"
+  ptrToThis: "0x0005e480"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x00121980"
+- offset: "0x00121a40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005e400"
+  ptrToThis: "0x0005e440"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x00121900"
+- offset: "0x001219c0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005e3c0"
+  ptrToThis: "0x0005e400"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x00121880"
+- offset: "0x00121940"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005e380"
+  ptrToThis: "0x0005e3c0"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00122100"
+- offset: "0x001221c0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005e7c0"
+  ptrToThis: "0x0005e800"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x00122080"
+- offset: "0x00122140"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005e780"
+  ptrToThis: "0x0005e7c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x00122000"
+- offset: "0x001220c0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005e740"
+  ptrToThis: "0x0005e780"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x00121f80"
+- offset: "0x00122040"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005e700"
+  ptrToThis: "0x0005e740"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x00121f00"
+- offset: "0x00121fc0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005e6c0"
+  ptrToThis: "0x0005e700"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x00121e80"
+- offset: "0x00121f40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005e680"
+  ptrToThis: "0x0005e6c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x00121e00"
+- offset: "0x00121ec0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005e640"
+  ptrToThis: "0x0005e680"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x00121d80"
+- offset: "0x00121e40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005e600"
+  ptrToThis: "0x0005e640"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x00121d00"
+- offset: "0x00121dc0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005e5c0"
+  ptrToThis: "0x0005e600"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001bfb80"
+- offset: "0x001bfc40"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005e800"
+  ptrToThis: "0x0005e840"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,7 +431,7 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001e0440"
+- offset: "0x001e0500"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x001589e0"
+- offset: "0x00158aa0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000dac60"
+  ptrToThis: "0x000daca0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00164d20"
+- offset: "0x00164de0"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005e880"
+  ptrToThis: "0x0005e8c0"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00164c80"
+- offset: "0x00164d40"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005e840"
+  ptrToThis: "0x0005e880"
   struct:
     fields:
     - name: val
@@ -506,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00158a80"
+- offset: "0x00158b40"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000dacc0"
+  ptrToThis: "0x000dad00"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,7 +521,7 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f9a00"
+- offset: "0x000f9a40"
   size: 16
   kind: interface
   nameEntry: main.something
@@ -531,34 +531,46 @@
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000f1380"
+- offset: "0x000f13c0"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000dad20"
+  ptrToThis: "0x000dad60"
   struct:
     fields: []
-- offset: "0x00121380"
+- offset: "0x001213c0"
+  size: 16
+  kind: struct
+  nameEntry: main.structWithAny
+  name: main.structWithAny
+  pkg: main
+  ptrToThis: "0x0005e100"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x00121440"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005e100"
+  ptrToThis: "0x0005e140"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00161f40"
+- offset: "0x00162000"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e85e0"
+  ptrToThis: "0x000e8620"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -567,13 +579,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00161fe0"
+- offset: "0x001620a0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e8640"
+  ptrToThis: "0x000e8680"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000c95c0"
+- offset: "0x000c9660"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000e72e0"
+- offset: "0x000e7380"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000c95c0"
+  ptrToThis: "0x000c9660"
   struct:
     fields: []
-- offset: "0x000c9260"
+- offset: "0x000c9300"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000c92c0"
+- offset: "0x000c9360"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000c9320"
+- offset: "0x000c93c0"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000d6640"
+- offset: "0x000d66e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000d66a0"
+- offset: "0x000d6740"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,347 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000ef220"
+- offset: "0x000ef2c0"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x00056c60"
+  ptrToThis: "0x00056c80"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x0010c840"
+- offset: "0x0010c9e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x00056fa0"
+  ptrToThis: "0x00057040"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x0010c7c0"
+- offset: "0x0010c960"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x00056f60"
+  ptrToThis: "0x00057000"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x0010c740"
+- offset: "0x0010c8e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x00056f20"
+  ptrToThis: "0x00056fc0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x0010c6c0"
+- offset: "0x0010c860"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x00056ee0"
+  ptrToThis: "0x00056f80"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x0010c640"
+- offset: "0x0010c7e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x00056ea0"
+  ptrToThis: "0x00056f40"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x0010c5c0"
+- offset: "0x0010c760"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x00056e60"
+  ptrToThis: "0x00056f00"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x0010c540"
+- offset: "0x0010c6e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x00056e20"
+  ptrToThis: "0x00056ec0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x0010c4c0"
+- offset: "0x0010c660"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x00056de0"
+  ptrToThis: "0x00056e80"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x0010c440"
+- offset: "0x0010c5e0"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x00056da0"
+  ptrToThis: "0x00056e40"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x0010ccc0"
+- offset: "0x0010ce60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x000571e0"
+  ptrToThis: "0x00057280"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x0010cc40"
+- offset: "0x0010cde0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x000571a0"
+  ptrToThis: "0x00057240"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x0010cbc0"
+- offset: "0x0010cd60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x00057160"
+  ptrToThis: "0x00057200"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x0010cb40"
+- offset: "0x0010cce0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x00057120"
+  ptrToThis: "0x000571c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x0010cac0"
+- offset: "0x0010cc60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x000570e0"
+  ptrToThis: "0x00057180"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x0010ca40"
+- offset: "0x0010cbe0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x000570a0"
+  ptrToThis: "0x00057140"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x0010c9c0"
+- offset: "0x0010cb60"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x00057060"
+  ptrToThis: "0x00057100"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x0010c940"
+- offset: "0x0010cae0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x00057020"
+  ptrToThis: "0x000570c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x0010c8c0"
+- offset: "0x0010ca60"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x00056fe0"
+  ptrToThis: "0x00057080"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x0010d140"
+- offset: "0x0010d2e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x00057420"
+  ptrToThis: "0x000574c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x0010d0c0"
+- offset: "0x0010d260"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x000573e0"
+  ptrToThis: "0x00057480"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x0010d040"
+- offset: "0x0010d1e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x000573a0"
+  ptrToThis: "0x00057440"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x0010cfc0"
+- offset: "0x0010d160"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x00057360"
+  ptrToThis: "0x00057400"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x0010cf40"
+- offset: "0x0010d0e0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x00057320"
+  ptrToThis: "0x000573c0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x0010cec0"
+- offset: "0x0010d060"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x000572e0"
+  ptrToThis: "0x00057380"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x0010ce40"
+- offset: "0x0010cfe0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x000572a0"
+  ptrToThis: "0x00057340"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x0010cdc0"
+- offset: "0x0010cf60"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x00057260"
+  ptrToThis: "0x00057300"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x0010cd40"
+- offset: "0x0010cee0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x00057220"
+  ptrToThis: "0x000572c0"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001a0100"
+- offset: "0x001a02a0"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x00057460"
+  ptrToThis: "0x00057500"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001bef00"
+- offset: "0x001bf0a0"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x00056ce0"
+  ptrToThis: "0x00056d00"
   struct:
     fields:
     - name: _
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x0012c9a0"
+- offset: "0x0012cb40"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000c9260"
+  ptrToThis: "0x000c9300"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x001386e0"
+- offset: "0x00138880"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x000574e0"
+  ptrToThis: "0x00057580"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00138640"
+- offset: "0x001387e0"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x000574a0"
+  ptrToThis: "0x00057540"
   struct:
     fields:
     - name: val
@@ -506,13 +506,37 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x0012ca40"
+- offset: "0x0010c3e0"
+  size: 16
+  kind: struct
+  nameEntry: main.otherFirstBehavior
+  name: main.otherFirstBehavior
+  pkg: main
+  ptrToThis: "0x00056d40"
+  struct:
+    fields:
+    - name: s
+      type: string
+      offset: 0
+- offset: "0x0010c460"
+  size: 8
+  kind: struct
+  nameEntry: main.otherSecondBehavior
+  name: main.otherSecondBehavior
+  pkg: main
+  ptrToThis: "0x00056d80"
+  struct:
+    fields:
+    - name: i
+      type: int
+      offset: 0
+- offset: "0x0012cbe0"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000c92c0"
+  ptrToThis: "0x000c9360"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,56 +545,56 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000ef2a0"
+- offset: "0x000ef340"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x00056ca0"
+  ptrToThis: "0x00056cc0"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000e7160"
+- offset: "0x000e7200"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000c9320"
+  ptrToThis: "0x000c93c0"
   struct:
     fields: []
-- offset: "0x0010c340"
+- offset: "0x0010c4e0"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x00056d20"
+  ptrToThis: "0x00056dc0"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x0010c3c0"
+- offset: "0x0010c560"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x00056d60"
+  ptrToThis: "0x00056e00"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00135960"
+- offset: "0x00135b00"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000d6640"
+  ptrToThis: "0x000d66e0"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -579,13 +603,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00135a00"
+- offset: "0x00135ba0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000d66a0"
+  ptrToThis: "0x000d6740"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000c9560"
+- offset: "0x000c95c0"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000e7280"
+- offset: "0x000e72e0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000c9560"
+  ptrToThis: "0x000c95c0"
   struct:
     fields: []
-- offset: "0x000c9200"
+- offset: "0x000c9260"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000c9260"
+- offset: "0x000c92c0"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000c92c0"
+- offset: "0x000c9320"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000d65e0"
+- offset: "0x000d6640"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000d6640"
+- offset: "0x000d66a0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,347 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000ef1c0"
+- offset: "0x000ef220"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x00056c40"
+  ptrToThis: "0x00056c60"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x0010c760"
+- offset: "0x0010c840"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x00056f40"
+  ptrToThis: "0x00056fa0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x0010c6e0"
+- offset: "0x0010c7c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x00056f00"
+  ptrToThis: "0x00056f60"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x0010c660"
+- offset: "0x0010c740"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x00056ec0"
+  ptrToThis: "0x00056f20"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x0010c5e0"
+- offset: "0x0010c6c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x00056e80"
+  ptrToThis: "0x00056ee0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x0010c560"
+- offset: "0x0010c640"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x00056e40"
+  ptrToThis: "0x00056ea0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x0010c4e0"
+- offset: "0x0010c5c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x00056e00"
+  ptrToThis: "0x00056e60"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x0010c460"
+- offset: "0x0010c540"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x00056dc0"
+  ptrToThis: "0x00056e20"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x0010c3e0"
+- offset: "0x0010c4c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x00056d80"
+  ptrToThis: "0x00056de0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x0010c360"
+- offset: "0x0010c440"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x00056d40"
+  ptrToThis: "0x00056da0"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x0010cbe0"
+- offset: "0x0010ccc0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x00057180"
+  ptrToThis: "0x000571e0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x0010cb60"
+- offset: "0x0010cc40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x00057140"
+  ptrToThis: "0x000571a0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x0010cae0"
+- offset: "0x0010cbc0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x00057100"
+  ptrToThis: "0x00057160"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x0010ca60"
+- offset: "0x0010cb40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x000570c0"
+  ptrToThis: "0x00057120"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x0010c9e0"
+- offset: "0x0010cac0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x00057080"
+  ptrToThis: "0x000570e0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x0010c960"
+- offset: "0x0010ca40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x00057040"
+  ptrToThis: "0x000570a0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x0010c8e0"
+- offset: "0x0010c9c0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x00057000"
+  ptrToThis: "0x00057060"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x0010c860"
+- offset: "0x0010c940"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x00056fc0"
+  ptrToThis: "0x00057020"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x0010c7e0"
+- offset: "0x0010c8c0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x00056f80"
+  ptrToThis: "0x00056fe0"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x0010d060"
+- offset: "0x0010d140"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x000573c0"
+  ptrToThis: "0x00057420"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x0010cfe0"
+- offset: "0x0010d0c0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x00057380"
+  ptrToThis: "0x000573e0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x0010cf60"
+- offset: "0x0010d040"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x00057340"
+  ptrToThis: "0x000573a0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x0010cee0"
+- offset: "0x0010cfc0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x00057300"
+  ptrToThis: "0x00057360"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x0010ce60"
+- offset: "0x0010cf40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x000572c0"
+  ptrToThis: "0x00057320"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x0010cde0"
+- offset: "0x0010cec0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x00057280"
+  ptrToThis: "0x000572e0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x0010cd60"
+- offset: "0x0010ce40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x00057240"
+  ptrToThis: "0x000572a0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x0010cce0"
+- offset: "0x0010cdc0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x00057200"
+  ptrToThis: "0x00057260"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x0010cc60"
+- offset: "0x0010cd40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x000571c0"
+  ptrToThis: "0x00057220"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001a0020"
+- offset: "0x001a0100"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x00057400"
+  ptrToThis: "0x00057460"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001bee20"
+- offset: "0x001bef00"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x00056cc0"
+  ptrToThis: "0x00056ce0"
   struct:
     fields:
     - name: _
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x0012c8c0"
+- offset: "0x0012c9a0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000c9200"
+  ptrToThis: "0x000c9260"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00138600"
+- offset: "0x001386e0"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x00057480"
+  ptrToThis: "0x000574e0"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00138560"
+- offset: "0x00138640"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x00057440"
+  ptrToThis: "0x000574a0"
   struct:
     fields:
     - name: val
@@ -506,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x0012c960"
+- offset: "0x0012ca40"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000c9260"
+  ptrToThis: "0x000c92c0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,44 +521,56 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000ef240"
+- offset: "0x000ef2a0"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x00056c80"
+  ptrToThis: "0x00056ca0"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000e7100"
+- offset: "0x000e7160"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000c92c0"
+  ptrToThis: "0x000c9320"
   struct:
     fields: []
-- offset: "0x0010c2e0"
+- offset: "0x0010c340"
+  size: 16
+  kind: struct
+  nameEntry: main.structWithAny
+  name: main.structWithAny
+  pkg: main
+  ptrToThis: "0x00056d20"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x0010c3c0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x00056d00"
+  ptrToThis: "0x00056d60"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00135880"
+- offset: "0x00135960"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000d65e0"
+  ptrToThis: "0x000d6640"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -567,13 +579,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00135920"
+- offset: "0x00135a00"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000d6640"
+  ptrToThis: "0x000d66a0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000d9ca0"
+- offset: "0x000d9d40"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f0160"
+- offset: "0x000f0200"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000d9ca0"
+  ptrToThis: "0x000d9d40"
   struct:
     fields: []
-- offset: "0x000d9940"
+- offset: "0x000d99e0"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d99a0"
+- offset: "0x000d9a40"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000d9a00"
+- offset: "0x000d9aa0"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e70e0"
+- offset: "0x000e7180"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e7140"
+- offset: "0x000e71e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,347 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f8660"
+- offset: "0x000f8700"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005d500"
+  ptrToThis: "0x0005d520"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x00120680"
+- offset: "0x00120820"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005d840"
+  ptrToThis: "0x0005d8e0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x00120600"
+- offset: "0x001207a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005d800"
+  ptrToThis: "0x0005d8a0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x00120580"
+- offset: "0x00120720"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005d7c0"
+  ptrToThis: "0x0005d860"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x00120500"
+- offset: "0x001206a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005d780"
+  ptrToThis: "0x0005d820"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x00120480"
+- offset: "0x00120620"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005d740"
+  ptrToThis: "0x0005d7e0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x00120400"
+- offset: "0x001205a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005d700"
+  ptrToThis: "0x0005d7a0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x00120380"
+- offset: "0x00120520"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005d6c0"
+  ptrToThis: "0x0005d760"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x00120300"
+- offset: "0x001204a0"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005d680"
+  ptrToThis: "0x0005d720"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x00120280"
+- offset: "0x00120420"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005d640"
+  ptrToThis: "0x0005d6e0"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x00120b00"
+- offset: "0x00120ca0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005da80"
+  ptrToThis: "0x0005db20"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x00120a80"
+- offset: "0x00120c20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005da40"
+  ptrToThis: "0x0005dae0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x00120a00"
+- offset: "0x00120ba0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005da00"
+  ptrToThis: "0x0005daa0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x00120980"
+- offset: "0x00120b20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005d9c0"
+  ptrToThis: "0x0005da60"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x00120900"
+- offset: "0x00120aa0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005d980"
+  ptrToThis: "0x0005da20"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x00120880"
+- offset: "0x00120a20"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005d940"
+  ptrToThis: "0x0005d9e0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x00120800"
+- offset: "0x001209a0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005d900"
+  ptrToThis: "0x0005d9a0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x00120780"
+- offset: "0x00120920"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005d8c0"
+  ptrToThis: "0x0005d960"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x00120700"
+- offset: "0x001208a0"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005d880"
+  ptrToThis: "0x0005d920"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00120f80"
+- offset: "0x00121120"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005dcc0"
+  ptrToThis: "0x0005dd60"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x00120f00"
+- offset: "0x001210a0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005dc80"
+  ptrToThis: "0x0005dd20"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x00120e80"
+- offset: "0x00121020"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005dc40"
+  ptrToThis: "0x0005dce0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x00120e00"
+- offset: "0x00120fa0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005dc00"
+  ptrToThis: "0x0005dca0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x00120d80"
+- offset: "0x00120f20"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005dbc0"
+  ptrToThis: "0x0005dc60"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x00120d00"
+- offset: "0x00120ea0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005db80"
+  ptrToThis: "0x0005dc20"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x00120c80"
+- offset: "0x00120e20"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005db40"
+  ptrToThis: "0x0005dbe0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x00120c00"
+- offset: "0x00120da0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005db00"
+  ptrToThis: "0x0005dba0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x00120b80"
+- offset: "0x00120d20"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005dac0"
+  ptrToThis: "0x0005db60"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001bd600"
+- offset: "0x001bd7a0"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005dd00"
+  ptrToThis: "0x0005dda0"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001ddfe0"
+- offset: "0x001de180"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005d580"
+  ptrToThis: "0x0005d5a0"
   struct:
     fields:
     - name: _
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x001578e0"
+- offset: "0x00157a80"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000d9940"
+  ptrToThis: "0x000d99e0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00163960"
+- offset: "0x00163b00"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005dd80"
+  ptrToThis: "0x0005de20"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x001638c0"
+- offset: "0x00163a60"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005dd40"
+  ptrToThis: "0x0005dde0"
   struct:
     fields:
     - name: val
@@ -506,13 +506,37 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00157980"
+- offset: "0x00120220"
+  size: 16
+  kind: struct
+  nameEntry: main.otherFirstBehavior
+  name: main.otherFirstBehavior
+  pkg: main
+  ptrToThis: "0x0005d5e0"
+  struct:
+    fields:
+    - name: s
+      type: string
+      offset: 0
+- offset: "0x001202a0"
+  size: 8
+  kind: struct
+  nameEntry: main.otherSecondBehavior
+  name: main.otherSecondBehavior
+  pkg: main
+  ptrToThis: "0x0005d620"
+  struct:
+    fields:
+    - name: i
+      type: int
+      offset: 0
+- offset: "0x00157b20"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000d99a0"
+  ptrToThis: "0x000d9a40"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,56 +545,56 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f86e0"
+- offset: "0x000f8780"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005d540"
+  ptrToThis: "0x0005d560"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000effe0"
+- offset: "0x000f0080"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000d9a00"
+  ptrToThis: "0x000d9aa0"
   struct:
     fields: []
-- offset: "0x00120180"
+- offset: "0x00120320"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x0005d5c0"
+  ptrToThis: "0x0005d660"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00120200"
+- offset: "0x001203a0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005d600"
+  ptrToThis: "0x0005d6a0"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00160c60"
+- offset: "0x00160e00"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e70e0"
+  ptrToThis: "0x000e7180"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -579,13 +603,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00160d00"
+- offset: "0x00160ea0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e7140"
+  ptrToThis: "0x000e71e0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000d9c40"
+- offset: "0x000d9ca0"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f0100"
+- offset: "0x000f0160"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000d9c40"
+  ptrToThis: "0x000d9ca0"
   struct:
     fields: []
-- offset: "0x000d98e0"
+- offset: "0x000d9940"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d9940"
+- offset: "0x000d99a0"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000d99a0"
+- offset: "0x000d9a00"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e7080"
+- offset: "0x000e70e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e70e0"
+- offset: "0x000e7140"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,347 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f8600"
+- offset: "0x000f8660"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005d4e0"
+  ptrToThis: "0x0005d500"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x001205a0"
+- offset: "0x00120680"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005d7e0"
+  ptrToThis: "0x0005d840"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x00120520"
+- offset: "0x00120600"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005d7a0"
+  ptrToThis: "0x0005d800"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x001204a0"
+- offset: "0x00120580"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005d760"
+  ptrToThis: "0x0005d7c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x00120420"
+- offset: "0x00120500"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005d720"
+  ptrToThis: "0x0005d780"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x001203a0"
+- offset: "0x00120480"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005d6e0"
+  ptrToThis: "0x0005d740"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x00120320"
+- offset: "0x00120400"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005d6a0"
+  ptrToThis: "0x0005d700"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x001202a0"
+- offset: "0x00120380"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005d660"
+  ptrToThis: "0x0005d6c0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x00120220"
+- offset: "0x00120300"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005d620"
+  ptrToThis: "0x0005d680"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x001201a0"
+- offset: "0x00120280"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005d5e0"
+  ptrToThis: "0x0005d640"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x00120a20"
+- offset: "0x00120b00"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005da20"
+  ptrToThis: "0x0005da80"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x001209a0"
+- offset: "0x00120a80"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005d9e0"
+  ptrToThis: "0x0005da40"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x00120920"
+- offset: "0x00120a00"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005d9a0"
+  ptrToThis: "0x0005da00"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x001208a0"
+- offset: "0x00120980"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005d960"
+  ptrToThis: "0x0005d9c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x00120820"
+- offset: "0x00120900"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005d920"
+  ptrToThis: "0x0005d980"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x001207a0"
+- offset: "0x00120880"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005d8e0"
+  ptrToThis: "0x0005d940"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x00120720"
+- offset: "0x00120800"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005d8a0"
+  ptrToThis: "0x0005d900"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x001206a0"
+- offset: "0x00120780"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005d860"
+  ptrToThis: "0x0005d8c0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x00120620"
+- offset: "0x00120700"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005d820"
+  ptrToThis: "0x0005d880"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00120ea0"
+- offset: "0x00120f80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005dc60"
+  ptrToThis: "0x0005dcc0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x00120e20"
+- offset: "0x00120f00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005dc20"
+  ptrToThis: "0x0005dc80"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x00120da0"
+- offset: "0x00120e80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005dbe0"
+  ptrToThis: "0x0005dc40"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x00120d20"
+- offset: "0x00120e00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005dba0"
+  ptrToThis: "0x0005dc00"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x00120ca0"
+- offset: "0x00120d80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005db60"
+  ptrToThis: "0x0005dbc0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x00120c20"
+- offset: "0x00120d00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005db20"
+  ptrToThis: "0x0005db80"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x00120ba0"
+- offset: "0x00120c80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005dae0"
+  ptrToThis: "0x0005db40"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x00120b20"
+- offset: "0x00120c00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005daa0"
+  ptrToThis: "0x0005db00"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x00120aa0"
+- offset: "0x00120b80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005da60"
+  ptrToThis: "0x0005dac0"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001bd520"
+- offset: "0x001bd600"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005dca0"
+  ptrToThis: "0x0005dd00"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001ddf00"
+- offset: "0x001ddfe0"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005d560"
+  ptrToThis: "0x0005d580"
   struct:
     fields:
     - name: _
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x00157800"
+- offset: "0x001578e0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000d98e0"
+  ptrToThis: "0x000d9940"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00163880"
+- offset: "0x00163960"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005dd20"
+  ptrToThis: "0x0005dd80"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x001637e0"
+- offset: "0x001638c0"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005dce0"
+  ptrToThis: "0x0005dd40"
   struct:
     fields:
     - name: val
@@ -506,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x001578a0"
+- offset: "0x00157980"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000d9940"
+  ptrToThis: "0x000d99a0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,44 +521,56 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f8680"
+- offset: "0x000f86e0"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005d520"
+  ptrToThis: "0x0005d540"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000eff80"
+- offset: "0x000effe0"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000d99a0"
+  ptrToThis: "0x000d9a00"
   struct:
     fields: []
-- offset: "0x00120120"
+- offset: "0x00120180"
+  size: 16
+  kind: struct
+  nameEntry: main.structWithAny
+  name: main.structWithAny
+  pkg: main
+  ptrToThis: "0x0005d5c0"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x00120200"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005d5a0"
+  ptrToThis: "0x0005d600"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00160b80"
+- offset: "0x00160c60"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e7080"
+  ptrToThis: "0x000e70e0"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -567,13 +579,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00160c20"
+- offset: "0x00160d00"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e70e0"
+  ptrToThis: "0x000e7140"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000dada0"
+- offset: "0x000dae60"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f1280"
+- offset: "0x000f1340"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000dada0"
+  ptrToThis: "0x000dae60"
   struct:
     fields: []
-- offset: "0x000daa40"
+- offset: "0x000dab00"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000daaa0"
+- offset: "0x000dab60"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000dab00"
+- offset: "0x000dabc0"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e8360"
+- offset: "0x000e8420"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e83c0"
+- offset: "0x000e8480"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,347 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f9700"
+- offset: "0x000f97c0"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005dfe0"
+  ptrToThis: "0x0005e020"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x00121600"
+- offset: "0x001217c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005e320"
+  ptrToThis: "0x0005e3e0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x00121580"
+- offset: "0x00121740"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005e2e0"
+  ptrToThis: "0x0005e3a0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x00121500"
+- offset: "0x001216c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005e2a0"
+  ptrToThis: "0x0005e360"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x00121480"
+- offset: "0x00121640"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005e260"
+  ptrToThis: "0x0005e320"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x00121400"
+- offset: "0x001215c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005e220"
+  ptrToThis: "0x0005e2e0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x00121380"
+- offset: "0x00121540"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005e1e0"
+  ptrToThis: "0x0005e2a0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x00121300"
+- offset: "0x001214c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005e1a0"
+  ptrToThis: "0x0005e260"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x00121280"
+- offset: "0x00121440"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005e160"
+  ptrToThis: "0x0005e220"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x00121200"
+- offset: "0x001213c0"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005e120"
+  ptrToThis: "0x0005e1e0"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x00121a80"
+- offset: "0x00121c40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005e560"
+  ptrToThis: "0x0005e620"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x00121a00"
+- offset: "0x00121bc0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005e520"
+  ptrToThis: "0x0005e5e0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x00121980"
+- offset: "0x00121b40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005e4e0"
+  ptrToThis: "0x0005e5a0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x00121900"
+- offset: "0x00121ac0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005e4a0"
+  ptrToThis: "0x0005e560"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x00121880"
+- offset: "0x00121a40"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005e460"
+  ptrToThis: "0x0005e520"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x00121800"
+- offset: "0x001219c0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005e420"
+  ptrToThis: "0x0005e4e0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x00121780"
+- offset: "0x00121940"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005e3e0"
+  ptrToThis: "0x0005e4a0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x00121700"
+- offset: "0x001218c0"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005e3a0"
+  ptrToThis: "0x0005e460"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x00121680"
+- offset: "0x00121840"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005e360"
+  ptrToThis: "0x0005e420"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00121f00"
+- offset: "0x001220c0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005e7a0"
+  ptrToThis: "0x0005e860"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x00121e80"
+- offset: "0x00122040"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005e760"
+  ptrToThis: "0x0005e820"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x00121e00"
+- offset: "0x00121fc0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005e720"
+  ptrToThis: "0x0005e7e0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x00121d80"
+- offset: "0x00121f40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005e6e0"
+  ptrToThis: "0x0005e7a0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x00121d00"
+- offset: "0x00121ec0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005e6a0"
+  ptrToThis: "0x0005e760"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x00121c80"
+- offset: "0x00121e40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005e660"
+  ptrToThis: "0x0005e720"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x00121c00"
+- offset: "0x00121dc0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005e620"
+  ptrToThis: "0x0005e6e0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x00121b80"
+- offset: "0x00121d40"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005e5e0"
+  ptrToThis: "0x0005e6a0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x00121b00"
+- offset: "0x00121cc0"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005e5a0"
+  ptrToThis: "0x0005e660"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001bfa20"
+- offset: "0x001bfbe0"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005e7e0"
+  ptrToThis: "0x0005e8a0"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001e0200"
+- offset: "0x001e03c0"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005e060"
+  ptrToThis: "0x0005e0a0"
   struct:
     fields:
     - name: _
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x001587e0"
+- offset: "0x001589a0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000daa40"
+  ptrToThis: "0x000dab00"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00164b20"
+- offset: "0x00164ce0"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005e860"
+  ptrToThis: "0x0005e920"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00164a80"
+- offset: "0x00164c40"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005e820"
+  ptrToThis: "0x0005e8e0"
   struct:
     fields:
     - name: val
@@ -506,13 +506,37 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00158880"
+- offset: "0x001211c0"
+  size: 16
+  kind: struct
+  nameEntry: main.otherFirstBehavior
+  name: main.otherFirstBehavior
+  pkg: main
+  ptrToThis: "0x0005e0e0"
+  struct:
+    fields:
+    - name: s
+      type: string
+      offset: 0
+- offset: "0x00121240"
+  size: 8
+  kind: struct
+  nameEntry: main.otherSecondBehavior
+  name: main.otherSecondBehavior
+  pkg: main
+  ptrToThis: "0x0005e120"
+  struct:
+    fields:
+    - name: i
+      type: int
+      offset: 0
+- offset: "0x00158a40"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000daaa0"
+  ptrToThis: "0x000dab60"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,56 +545,56 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f9780"
+- offset: "0x000f9840"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005e020"
+  ptrToThis: "0x0005e060"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000f1100"
+- offset: "0x000f11c0"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000dab00"
+  ptrToThis: "0x000dabc0"
   struct:
     fields: []
-- offset: "0x00121100"
+- offset: "0x001212c0"
   size: 16
   kind: struct
   nameEntry: main.structWithAny
   name: main.structWithAny
   pkg: main
-  ptrToThis: "0x0005e0a0"
+  ptrToThis: "0x0005e160"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00121180"
+- offset: "0x00121340"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005e0e0"
+  ptrToThis: "0x0005e1a0"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00161d40"
+- offset: "0x00161f00"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e8360"
+  ptrToThis: "0x000e8420"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -579,13 +603,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00161de0"
+- offset: "0x00161fa0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e83c0"
+  ptrToThis: "0x000e8480"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000dad60"
+- offset: "0x000dada0"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000f1240"
+- offset: "0x000f1280"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000dad60"
+  ptrToThis: "0x000dada0"
   struct:
     fields: []
-- offset: "0x000daa00"
+- offset: "0x000daa40"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000daa60"
+- offset: "0x000daaa0"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000daac0"
+- offset: "0x000dab00"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e8320"
+- offset: "0x000e8360"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e8380"
+- offset: "0x000e83c0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,7 +73,7 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f96c0"
+- offset: "0x000f9700"
   size: 16
   kind: interface
   nameEntry: main.behavior
@@ -83,337 +83,337 @@
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x00121540"
+- offset: "0x00121600"
   size: 8
   kind: struct
   nameEntry: main.deepMap1
   name: main.deepMap1
   pkg: main
-  ptrToThis: "0x0005e2e0"
+  ptrToThis: "0x0005e320"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap2
       offset: 0
-- offset: "0x001214c0"
+- offset: "0x00121580"
   size: 8
   kind: struct
   nameEntry: main.deepMap2
   name: main.deepMap2
   pkg: main
-  ptrToThis: "0x0005e2a0"
+  ptrToThis: "0x0005e2e0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap3
       offset: 0
-- offset: "0x00121440"
+- offset: "0x00121500"
   size: 8
   kind: struct
   nameEntry: main.deepMap3
   name: main.deepMap3
   pkg: main
-  ptrToThis: "0x0005e260"
+  ptrToThis: "0x0005e2a0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap4
       offset: 0
-- offset: "0x001213c0"
+- offset: "0x00121480"
   size: 8
   kind: struct
   nameEntry: main.deepMap4
   name: main.deepMap4
   pkg: main
-  ptrToThis: "0x0005e220"
+  ptrToThis: "0x0005e260"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap5
       offset: 0
-- offset: "0x00121340"
+- offset: "0x00121400"
   size: 8
   kind: struct
   nameEntry: main.deepMap5
   name: main.deepMap5
   pkg: main
-  ptrToThis: "0x0005e1e0"
+  ptrToThis: "0x0005e220"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap6
       offset: 0
-- offset: "0x001212c0"
+- offset: "0x00121380"
   size: 8
   kind: struct
   nameEntry: main.deepMap6
   name: main.deepMap6
   pkg: main
-  ptrToThis: "0x0005e1a0"
+  ptrToThis: "0x0005e1e0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap7
       offset: 0
-- offset: "0x00121240"
+- offset: "0x00121300"
   size: 8
   kind: struct
   nameEntry: main.deepMap7
   name: main.deepMap7
   pkg: main
-  ptrToThis: "0x0005e160"
+  ptrToThis: "0x0005e1a0"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap8
       offset: 0
-- offset: "0x001211c0"
+- offset: "0x00121280"
   size: 8
   kind: struct
   nameEntry: main.deepMap8
   name: main.deepMap8
   pkg: main
-  ptrToThis: "0x0005e120"
+  ptrToThis: "0x0005e160"
   struct:
     fields:
     - name: a
       type: map[int]*main.deepMap9
       offset: 0
-- offset: "0x00121140"
+- offset: "0x00121200"
   size: 8
   kind: struct
   nameEntry: main.deepMap9
   name: main.deepMap9
   pkg: main
-  ptrToThis: "0x0005e0e0"
+  ptrToThis: "0x0005e120"
   struct:
     fields:
     - name: a
       type: map[int]interface {}
       offset: 0
-- offset: "0x001219c0"
+- offset: "0x00121a80"
   size: 8
   kind: struct
   nameEntry: main.deepPtr1
   name: main.deepPtr1
   pkg: main
-  ptrToThis: "0x0005e520"
+  ptrToThis: "0x0005e560"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr2"
       offset: 0
-- offset: "0x00121940"
+- offset: "0x00121a00"
   size: 8
   kind: struct
   nameEntry: main.deepPtr2
   name: main.deepPtr2
   pkg: main
-  ptrToThis: "0x0005e4e0"
+  ptrToThis: "0x0005e520"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr3"
       offset: 0
-- offset: "0x001218c0"
+- offset: "0x00121980"
   size: 8
   kind: struct
   nameEntry: main.deepPtr3
   name: main.deepPtr3
   pkg: main
-  ptrToThis: "0x0005e4a0"
+  ptrToThis: "0x0005e4e0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr4"
       offset: 0
-- offset: "0x00121840"
+- offset: "0x00121900"
   size: 8
   kind: struct
   nameEntry: main.deepPtr4
   name: main.deepPtr4
   pkg: main
-  ptrToThis: "0x0005e460"
+  ptrToThis: "0x0005e4a0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr5"
       offset: 0
-- offset: "0x001217c0"
+- offset: "0x00121880"
   size: 8
   kind: struct
   nameEntry: main.deepPtr5
   name: main.deepPtr5
   pkg: main
-  ptrToThis: "0x0005e420"
+  ptrToThis: "0x0005e460"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr6"
       offset: 0
-- offset: "0x00121740"
+- offset: "0x00121800"
   size: 8
   kind: struct
   nameEntry: main.deepPtr6
   name: main.deepPtr6
   pkg: main
-  ptrToThis: "0x0005e3e0"
+  ptrToThis: "0x0005e420"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr7"
       offset: 0
-- offset: "0x001216c0"
+- offset: "0x00121780"
   size: 8
   kind: struct
   nameEntry: main.deepPtr7
   name: main.deepPtr7
   pkg: main
-  ptrToThis: "0x0005e3a0"
+  ptrToThis: "0x0005e3e0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr8"
       offset: 0
-- offset: "0x00121640"
+- offset: "0x00121700"
   size: 8
   kind: struct
   nameEntry: main.deepPtr8
   name: main.deepPtr8
   pkg: main
-  ptrToThis: "0x0005e360"
+  ptrToThis: "0x0005e3a0"
   struct:
     fields:
     - name: a
       type: "*main.deepPtr9"
       offset: 0
-- offset: "0x001215c0"
+- offset: "0x00121680"
   size: 16
   kind: struct
   nameEntry: main.deepPtr9
   name: main.deepPtr9
   pkg: main
-  ptrToThis: "0x0005e320"
+  ptrToThis: "0x0005e360"
   struct:
     fields:
     - name: a
       type: interface {}
       offset: 0
-- offset: "0x00121e40"
+- offset: "0x00121f00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice1
   name: main.deepSlice1
   pkg: main
-  ptrToThis: "0x0005e760"
+  ptrToThis: "0x0005e7a0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice2"
       offset: 0
-- offset: "0x00121dc0"
+- offset: "0x00121e80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice2
   name: main.deepSlice2
   pkg: main
-  ptrToThis: "0x0005e720"
+  ptrToThis: "0x0005e760"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice3"
       offset: 0
-- offset: "0x00121d40"
+- offset: "0x00121e00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice3
   name: main.deepSlice3
   pkg: main
-  ptrToThis: "0x0005e6e0"
+  ptrToThis: "0x0005e720"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice4"
       offset: 0
-- offset: "0x00121cc0"
+- offset: "0x00121d80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice4
   name: main.deepSlice4
   pkg: main
-  ptrToThis: "0x0005e6a0"
+  ptrToThis: "0x0005e6e0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice5"
       offset: 0
-- offset: "0x00121c40"
+- offset: "0x00121d00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice5
   name: main.deepSlice5
   pkg: main
-  ptrToThis: "0x0005e660"
+  ptrToThis: "0x0005e6a0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice6"
       offset: 0
-- offset: "0x00121bc0"
+- offset: "0x00121c80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice6
   name: main.deepSlice6
   pkg: main
-  ptrToThis: "0x0005e620"
+  ptrToThis: "0x0005e660"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice7"
       offset: 0
-- offset: "0x00121b40"
+- offset: "0x00121c00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice7
   name: main.deepSlice7
   pkg: main
-  ptrToThis: "0x0005e5e0"
+  ptrToThis: "0x0005e620"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice8"
       offset: 0
-- offset: "0x00121ac0"
+- offset: "0x00121b80"
   size: 24
   kind: struct
   nameEntry: main.deepSlice8
   name: main.deepSlice8
   pkg: main
-  ptrToThis: "0x0005e5a0"
+  ptrToThis: "0x0005e5e0"
   struct:
     fields:
     - name: a
       type: "[]*main.deepSlice9"
       offset: 0
-- offset: "0x00121a40"
+- offset: "0x00121b00"
   size: 24
   kind: struct
   nameEntry: main.deepSlice9
   name: main.deepSlice9
   pkg: main
-  ptrToThis: "0x0005e560"
+  ptrToThis: "0x0005e5a0"
   struct:
     fields:
     - name: a
       type: "[]interface {}"
       offset: 0
-- offset: "0x001bf960"
+- offset: "0x001bfa20"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005e7a0"
+  ptrToThis: "0x0005e7e0"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -431,7 +431,7 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001e0140"
+- offset: "0x001e0200"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
@@ -461,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x00158720"
+- offset: "0x001587e0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000daa00"
+  ptrToThis: "0x000daa40"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -476,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00164a60"
+- offset: "0x00164b20"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005e820"
+  ptrToThis: "0x0005e860"
   struct:
     fields:
     - name: anotherInt
@@ -491,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x001649c0"
+- offset: "0x00164a80"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005e7e0"
+  ptrToThis: "0x0005e820"
   struct:
     fields:
     - name: val
@@ -506,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x001587c0"
+- offset: "0x00158880"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000daa60"
+  ptrToThis: "0x000daaa0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -521,7 +521,7 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f9740"
+- offset: "0x000f9780"
   size: 16
   kind: interface
   nameEntry: main.something
@@ -531,34 +531,46 @@
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000f10c0"
+- offset: "0x000f1100"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000daac0"
+  ptrToThis: "0x000dab00"
   struct:
     fields: []
-- offset: "0x001210c0"
+- offset: "0x00121100"
+  size: 16
+  kind: struct
+  nameEntry: main.structWithAny
+  name: main.structWithAny
+  pkg: main
+  ptrToThis: "0x0005e0a0"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x00121180"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005e0a0"
+  ptrToThis: "0x0005e0e0"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00161c80"
+- offset: "0x00161d40"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e8320"
+  ptrToThis: "0x000e8360"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -567,13 +579,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00161d20"
+- offset: "0x00161de0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e8380"
+  ptrToThis: "0x000e83c0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/irgen/config.go
+++ b/pkg/dyninst/irgen/config.go
@@ -20,7 +20,7 @@ var defaultConfig = config{
 	maxDynamicTypeSize: defaultMaxDynamicTypeSize,
 	maxHashBucketsSize: defaultMaxHashBucketsSize,
 	objectLoader:       object.NewInMemoryLoader(),
-	typeIndexFactory:   &inMemoryTypeIndexFactory{},
+	typeIndexFactory:   &inMemoryGoTypeIndexFactory{},
 }
 
 // This is an arbitrary limit for how much data will be captured for
@@ -56,6 +56,13 @@ func WithMaxDynamicDataSize(size int) Option {
 // WithObjectLoader sets the object loader to use for loading object files.
 func WithObjectLoader(loader object.Loader) Option {
 	return optionFunc(func(c *config) { c.objectLoader = loader })
+}
+
+// WithOnDiskGoTypeIndexFactory make irgen store the go type indexes on disk.
+func WithOnDiskGoTypeIndexFactory(diskCache *object.DiskCache) Option {
+	return optionFunc(func(c *config) {
+		c.typeIndexFactory = &onDiskGoTypeIndexFactory{diskCache: diskCache}
+	})
 }
 
 type optionFunc func(c *config)

--- a/pkg/dyninst/irgen/config.go
+++ b/pkg/dyninst/irgen/config.go
@@ -13,12 +13,14 @@ type config struct {
 	maxDynamicTypeSize uint32
 	maxHashBucketsSize uint32
 	objectLoader       object.Loader
+	typeIndexFactory   goTypeIndexFactory
 }
 
 var defaultConfig = config{
 	maxDynamicTypeSize: defaultMaxDynamicTypeSize,
 	maxHashBucketsSize: defaultMaxHashBucketsSize,
 	objectLoader:       object.NewInMemoryLoader(),
+	typeIndexFactory:   &inMemoryTypeIndexFactory{},
 }
 
 // This is an arbitrary limit for how much data will be captured for

--- a/pkg/dyninst/irgen/implementors.go
+++ b/pkg/dyninst/irgen/implementors.go
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package irgen
+
+import (
+	"container/heap"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
+)
+
+// implementorIterator is an iterator that can enumerate the implementations of
+// an interface.
+type implementorIterator struct {
+	idx     methodToGoTypeIndex
+	current gotype.TypeID
+	done    bool
+	heap    methodHeap
+}
+
+// makeImplementorIterator creates a new implementor iterator using the given
+// method index.
+func makeImplementorIterator(idx methodToGoTypeIndex) implementorIterator {
+	return implementorIterator{
+		idx: idx,
+	}
+}
+
+type imethodsToGoTypeIterator = iterator[[]gotype.IMethod, gotype.TypeID]
+
+var _ imethodsToGoTypeIterator = (*implementorIterator)(nil)
+
+// init initializes the implementor iterator with the given method set, and
+// returns the first implementation.
+func (ii *implementorIterator) seek(imethods []gotype.IMethod) {
+	h := &ii.heap
+	// Reuse the existing iterators if possible.
+	h.iters = h.iters[:min(cap(h.iters), len(imethods))]
+	for i := range imethods {
+		if i < len(h.iters) {
+			if h.iters[i] == nil {
+				h.iters[i] = ii.idx.Iterator()
+			}
+		} else {
+			h.iters = append(h.iters, ii.idx.Iterator())
+		}
+	}
+	ii.done = true
+	for i, im := range imethods {
+		m := gotype.Method{
+			Name: im.Name,
+			Mtyp: im.Typ,
+		}
+		if h.iters[i].seek(m); !h.iters[i].valid() {
+			return
+		}
+	}
+	h.len = len(imethods)
+	h.init()
+	ii.done = false
+	ii.next()
+}
+
+func (ii *implementorIterator) valid() bool { return !ii.done }
+func (ii *implementorIterator) cur() gotype.TypeID {
+	if ii.valid() {
+		return ii.current
+	}
+	return 0
+}
+
+// next returns the next implementation of the interface.
+func (ii *implementorIterator) next() {
+	if !ii.valid() {
+		return
+	}
+	h := &ii.heap
+outer:
+	for {
+		// Add all the popped iterators back to the heap.
+		for _, iter := range h.iters[h.len:] {
+			if iter.next(); !iter.valid() {
+				ii.done = true
+				return
+			}
+			h.push(iter)
+		}
+		// Pop the next implementation from the heap and check if all the
+		// iterators have the same implementation.
+		ii.current = h.pop().cur()
+		for h.len > 0 {
+			if h.iters[0].cur() != ii.current {
+				continue outer
+			}
+			h.pop()
+		}
+		return // matched
+	}
+}
+
+type methodHeap struct {
+	iters []methodToGoTypeIterator
+	len   int
+}
+
+func (h *methodHeap) push(iter methodToGoTypeIterator) {
+	h.iters[h.len] = iter
+	h.len++
+	heap.Push((*methodHeapI)(h), nil)
+}
+func (h *methodHeap) pop() methodToGoTypeIterator {
+	heap.Pop((*methodHeapI)(h))
+	h.len--
+	return h.iters[h.len]
+}
+func (h *methodHeap) init() { heap.Init((*methodHeapI)(h)) }
+
+type methodHeapI methodHeap
+
+func (h *methodHeapI) Len() int           { return h.len }
+func (h *methodHeapI) Less(i, j int) bool { return h.iters[i].cur() < h.iters[j].cur() }
+func (h *methodHeapI) Swap(i, j int)      { h.iters[i], h.iters[j] = h.iters[j], h.iters[i] }
+func (h *methodHeapI) Push(any)           {}
+func (h *methodHeapI) Pop() any           { return nil }

--- a/pkg/dyninst/irgen/implementors_test.go
+++ b/pkg/dyninst/irgen/implementors_test.go
@@ -86,6 +86,8 @@ func newFunction(t *testing.T, cfg testprogs.Config, factory goTypeIndexFactory)
 	typeTab, interestingInterfaces, methodIndex := buildMethodIndex(
 		t, cfg, "sample", factory, interestingInterfaceNames,
 	)
+	defer func() { require.NoError(t, typeTab.Close()) }()
+	defer func() { require.NoError(t, methodIndex.Close()) }()
 
 	interfaceNames := slices.Sorted(maps.Keys(expectedImplementors))
 	require.Equal(t, interfaceNames, slices.Sorted(maps.Keys(interestingInterfaces)))
@@ -137,6 +139,7 @@ func buildMethodIndex(
 	}
 	typeIndex, err := typeIndexBuilder.build()
 	require.NoError(t, err)
+	defer func() { require.NoError(t, typeIndex.Close()) }()
 
 	interestingInterfaces := make(map[string]gotype.Type)
 

--- a/pkg/dyninst/irgen/implementors_test.go
+++ b/pkg/dyninst/irgen/implementors_test.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package irgen
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+)
+
+var expectedImplementors = map[string][]string{
+	"context.Context": {
+		"*context.backgroundCtx",
+		"*context.cancelCtx",
+		"*context.emptyCtx",
+		"*context.stopCtx",
+		"*context.timerCtx",
+		"*context.todoCtx",
+		"*context.valueCtx",
+		"*context.withoutCancelCtx",
+		"*net.onlyValuesCtx",
+		"*orchestrion.glsContext",
+		"context.backgroundCtx",
+		"context.emptyCtx",
+		"context.stopCtx",
+		"context.todoCtx",
+		"context.withoutCancelCtx",
+	},
+	"net.Conn": {
+		"*net.IPConn",
+		"*net.TCPConn",
+		"*net.UDPConn",
+		"*net.UnixConn",
+		"*net.conn",
+		"*net.dialResult",
+		"*net.tcpConnWithoutReadFrom",
+		"*net.tcpConnWithoutWriteTo",
+		"*tls.Conn",
+		"*transport.bufConn",
+		"net.dialResult",
+		"net.tcpConnWithoutReadFrom",
+		"net.tcpConnWithoutWriteTo",
+	},
+}
+var interestingInterfaceNames = makeSet(expectedImplementors)
+
+func makeSet[K comparable, V any](m map[K]V) map[K]struct{} {
+	s := make(map[K]struct{}, len(m))
+	for k := range m {
+		s[k] = struct{}{}
+	}
+	return s
+}
+
+func TestImplementorIterator(t *testing.T) {
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	factory := &inMemoryTypeIndexFactory{}
+	typeTab, interestingInterfaces, methodIndex := buildMethodIndex(
+		t, cfgs[0], "sample", factory, interestingInterfaceNames,
+	)
+
+	interfaceNames := slices.Sorted(maps.Keys(expectedImplementors))
+	require.Equal(t, interfaceNames, slices.Sorted(maps.Keys(interestingInterfaces)))
+	ii := makeImplementorIterator(methodIndex)
+	var methodsBuf []gotype.IMethod
+	for _, name := range interfaceNames {
+		goType, ok := interestingInterfaces[name]
+		require.True(t, ok)
+		iface, ok := goType.Interface()
+		require.True(t, ok)
+		var err error
+		methodsBuf, err = iface.Methods(methodsBuf[:0])
+		require.NoError(t, err)
+		var impls []string
+		for ii.seek(methodsBuf); ii.valid(); ii.next() {
+			tt, err := typeTab.ParseGoType(ii.cur())
+			require.NoError(t, err)
+			impls = append(impls, tt.Name().Name())
+		}
+		slices.Sort(impls)
+		require.Equal(t, expectedImplementors[name], impls)
+	}
+}
+
+// Build a method index from the sample binary and find the interesting interfaces.
+func buildMethodIndex(
+	t testing.TB, cfg testprogs.Config, progName string,
+	factory goTypeIndexFactory,
+	interfaceNames map[string]struct{},
+) (*gotype.Table, map[string]gotype.Type, methodToGoTypeIndex) {
+	prog := testprogs.MustGetBinary(t, progName, cfg)
+	obj, err := object.OpenElfFileWithDwarf(prog)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, obj.Close()) }()
+	// Prepare the main DWARF visitor that will gather all the information we
+	// need from the binary.
+	arch := obj.Architecture()
+	d := obj.DwarfData()
+	typeIndexBuilder, err := factory.newGoTypeToOffsetIndexBuilder()
+	require.NoError(t, err)
+	interests, _ := makeInterests(nil)
+	{
+		_, err := processDwarf(interests, d, arch, typeIndexBuilder)
+		require.NoError(t, err)
+	}
+	typeIndex, err := typeIndexBuilder.build()
+	require.NoError(t, err)
+	typeTab, err := gotype.NewTable(obj)
+	require.NoError(t, err)
+
+	interestingInterfaces := make(map[string]gotype.Type)
+
+	methodIndexBuilder, err := factory.newMethodToGoTypeIndexBuilder()
+	require.NoError(t, err)
+	var methodBuf []gotype.Method
+	for tid := range typeIndex.allGoTypes() {
+		goType, err := typeTab.ParseGoType(tid)
+		require.NoError(t, err, "failed to parse go type %q", tid)
+		methodBuf, err := goType.Methods(methodBuf[:0])
+		require.NoError(t, err, "failed to get methods for go type %q", tid)
+		for _, m := range methodBuf {
+			methodIndexBuilder.addMethod(m, tid)
+		}
+		name := goType.Name().Name()
+		if _, ok := interfaceNames[name]; ok {
+			interestingInterfaces[name] = goType
+		}
+	}
+	methodIndex, err := methodIndexBuilder.build()
+	require.NoError(t, err)
+	return typeTab, interestingInterfaces, methodIndex
+}
+
+func BenchmarkImplementorIterator(b *testing.B) {
+	cfgs := testprogs.MustGetCommonConfigs(b)
+	factory := &inMemoryTypeIndexFactory{}
+	_, interestingInterfaces, methodIndex := buildMethodIndex(
+		b, cfgs[0], "sample", factory, interestingInterfaceNames,
+	)
+	names := slices.Sorted(maps.Keys(interestingInterfaces))
+	for _, name := range names {
+		b.Run(name, func(b *testing.B) {
+			goType, ok := interestingInterfaces[name]
+			require.True(b, ok)
+			iface, ok := goType.Interface()
+			require.True(b, ok)
+			imethods, err := iface.Methods(nil)
+			require.NoError(b, err)
+			ii := makeImplementorIterator(methodIndex)
+			b.ResetTimer()
+			for b.Loop() {
+				for ii.seek(imethods); ii.valid(); ii.next() {
+					_ = ii.cur()
+				}
+			}
+		})
+	}
+}

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -27,6 +27,7 @@ import (
 	"debug/dwarf"
 	"errors"
 	"fmt"
+	"io"
 	"iter"
 	"maps"
 	"math"
@@ -42,6 +43,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/dwarfutil"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/loclist"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -135,12 +137,32 @@ func generateIR(
 	// Build the initial set of interests from the provided probe definitions.
 	interests, issues := makeInterests(probeDefs)
 
+	cleanupCloser := func(c io.Closer, name string) func() {
+		return func() {
+			err := c.Close()
+			if err == nil {
+				return
+			}
+			err = fmt.Errorf("failed to close %s: %w", name, err)
+			if retErr != nil {
+				retErr = errors.Join(retErr, err)
+			} else {
+				retErr = err
+			}
+		}
+	}
+
 	// Prepare the main DWARF visitor that will gather all the information we
 	// need from the binary.
 	arch := objFile.Architecture()
 	ptrSize := uint8(arch.PointerSize())
 	d := objFile.DwarfData()
-	processed, err := processDwarf(interests, d, arch)
+	typeIndexBuilder, err := cfg.typeIndexFactory.newGoTypeToOffsetIndexBuilder()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create type index builder: %w", err)
+	}
+	defer cleanupCloser(typeIndexBuilder, "type index builder")()
+	processed, err := processDwarf(interests, d, arch, typeIndexBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -185,6 +207,46 @@ func generateIR(
 		return nil, err
 	}
 
+	typeIndex, err := typeIndexBuilder.build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build type index: %w", err)
+	}
+	defer cleanupCloser(typeIndex, "type index")()
+
+	typeTab, err := gotype.NewTable(objFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create type table: %w", err)
+	}
+	defer cleanupCloser(typeTab, "gotype.Table")()
+
+	ib, err := cfg.typeIndexFactory.newMethodToGoTypeIndexBuilder()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create method index builder: %w", err)
+	}
+	defer cleanupCloser(ib, "method index builder")()
+
+	var methodBuf []gotype.Method
+	for tid := range typeIndex.allGoTypes() {
+		goType, err := typeTab.ParseGoType(tid)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse go type: %w", err)
+		}
+		methodBuf, err = goType.Methods(methodBuf[:0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get methods: %w", err)
+		}
+		for _, m := range methodBuf {
+			if err := ib.addMethod(m, tid); err != nil {
+				return nil, fmt.Errorf("failed to add method implementation: %w", err)
+			}
+		}
+	}
+	methodIndex, err := ib.build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build method index: %w", err)
+	}
+	defer cleanupCloser(methodIndex, "method index")()
+
 	// Resolve placeholder types by a unified, budgeted expansion from
 	// subprogram parameter roots. Container internals are zero-cost.
 	{
@@ -193,7 +255,9 @@ func generateIR(
 		if err := completeGoTypes(typeCatalog, 1, typeCatalog.idAlloc.alloc); err != nil {
 			return nil, err
 		}
-		if err := expandTypesWithBudgets(typeCatalog, materializedSubprograms, budgets); err != nil {
+		if err := expandTypesWithBudgets(
+			typeCatalog, typeTab, methodIndex, typeIndex, materializedSubprograms, budgets,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -315,6 +379,9 @@ func newTypeQueue() *typeQueue {
 // ensure correct container specialization.
 func expandTypesWithBudgets(
 	tc *typeCatalog,
+	goTypes *gotype.Table,
+	methodIndex methodToGoTypeIndex,
+	gotypeTypeIndex goTypeToOffsetIndex,
 	subprograms []*ir.Subprogram,
 	budgets map[ir.SubprogramID]uint32,
 ) error {
@@ -356,6 +423,8 @@ func expandTypesWithBudgets(
 		return completeGoTypes(tc, id, id)
 	}
 
+	var methodBuf []gotype.IMethod
+	ii := makeImplementorIterator(methodIndex)
 	for q.Len() > 0 {
 		wi := q.pop()
 		if r, ok := processedBest[wi.id]; ok && wi.remaining <= r {
@@ -368,9 +437,6 @@ func expandTypesWithBudgets(
 		}
 
 		t := tc.typesByID[wi.id]
-		if t == nil {
-			continue
-		}
 
 		switch tt := t.(type) {
 
@@ -379,11 +445,74 @@ func expandTypesWithBudgets(
 			*ir.EventRootType,
 			*ir.GoChannelType,
 			*ir.GoEmptyInterfaceType,
-			*ir.GoInterfaceType,
 			*ir.GoStringDataType,
 			*ir.GoSubroutineType,
 			*ir.UnresolvedPointeeType,
 			*ir.VoidPointerType:
+
+		case *ir.GoInterfaceType:
+			if wi.remaining <= 0 {
+				break
+			}
+			// Now we need to iterate through the implementations of the
+			// interface.
+			grtID, ok := tt.GetGoRuntimeType()
+			if !ok {
+				break
+			}
+			grt, err := goTypes.ParseGoType(gotype.TypeID(grtID))
+			if err != nil {
+				return fmt.Errorf("failed to parse go type for interface %q: %w", tt.GetName(), err)
+			}
+			iface, ok := grt.Interface()
+			if !ok {
+				return fmt.Errorf("go type for interface %q is not an interface: %v", tt.GetName(), grt.Kind())
+			}
+			methods, err := iface.Methods(methodBuf[:0])
+			if err != nil {
+				return fmt.Errorf("failed to get methods for interface %q: %w", tt.GetName(), err)
+			}
+			var i, added int
+			for ii.seek(methods); ii.valid(); ii.next() {
+				impl := ii.cur()
+				i++
+				var t ir.Type
+				if tid, ok := tc.typesByGoRuntimeType[impl]; ok {
+					t = tc.typesByID[tid]
+				} else {
+					implOffset, ok := gotypeTypeIndex.resolveDwarfOffset(impl)
+					if !ok {
+						// This is suspicious, but not obviously worth failing out
+						// over.
+						continue
+					}
+					if tid, ok := tc.typesByDwarfType[implOffset]; ok {
+						t = tc.typesByID[tid]
+					} else {
+						added++
+						var err error
+						t, err = tc.addType(implOffset)
+						if err != nil {
+							return fmt.Errorf("failed to add type for implementation of %q: %w", tt.GetName(), err)
+						}
+						if err := ensureCompleted(t.GetID()); err != nil {
+							return fmt.Errorf("failed to complete type for implementation of %q: %w", tt.GetName(), err)
+						}
+					}
+				}
+				if ppt, ok := t.(*pointeePlaceholderType); ok {
+					var err error
+					t, err = tc.addType(ppt.offset)
+					if err != nil {
+						return fmt.Errorf("failed to add type for implementation of %q: %w", tt.GetName(), err)
+					}
+					if err := ensureCompleted(t.GetID()); err != nil {
+						return fmt.Errorf("failed to complete type for implementation of %q: %w", tt.GetName(), err)
+					}
+				}
+				push(t, wi.remaining-1)
+			}
+			log.Tracef("added %d (%d new) types for interface %q (depth %d)", i, added, tt.GetName(), wi.remaining)
 
 		// Zero-cost neighbors (do not dereference pointers here).
 		case *ir.StructureType:
@@ -415,7 +544,7 @@ func expandTypesWithBudgets(
 
 		// Depth-cost step: pointer dereference.
 		case *ir.PointerType:
-			if wi.remaining == 0 {
+			if wi.remaining <= 0 {
 				break
 			}
 			if placeholder, ok := tt.Pointee.(*pointeePlaceholderType); ok {
@@ -704,6 +833,7 @@ func processDwarf(
 	interests interests,
 	d *dwarf.Data,
 	arch object.Architecture,
+	typeIndexBuilder goTypeToOffsetIndexBuilder,
 ) (processedDwarf, error) {
 	v := &rootVisitor{
 		interests:           interests,
@@ -712,6 +842,7 @@ func processDwarf(
 		abstractSubprograms: make(map[dwarf.Offset]*abstractSubprogram),
 		inlinedSubprograms:  make(map[*dwarf.Entry][]*inlinedSubprogram),
 		pointerSize:         uint8(arch.PointerSize()),
+		typeIndexBuilder:    typeIndexBuilder,
 	}
 
 	// Visit the entire DWARF tree.
@@ -885,7 +1016,9 @@ func completeGoMapType(tc *typeCatalog, t *ir.GoMapType) error {
 			t.Name, headerType, headerStructureType,
 		)
 	}
-
+	// Convert the header type from a structure type to the appropriate
+	// Go-specific type.
+	//
 	// Use the type name to determine whether this is an hmap or a swiss map.
 	// We could alternatively use the go version or the structure field layout.
 	// This works for now.
@@ -1219,6 +1352,7 @@ type rootVisitor struct {
 	// InlinedSubprograms grouped by the compilation unit entry.
 	inlinedSubprograms map[*dwarf.Entry][]*inlinedSubprogram
 	interestingTypes   []dwarf.Offset
+	typeIndexBuilder   goTypeToOffsetIndexBuilder
 
 	goRuntimeInformation ir.GoModuledataInfo
 
@@ -1371,6 +1505,19 @@ func (v *unitChildVisitor) push(
 		if err != nil || !ok {
 			return nil, err
 		}
+
+		goAttrs, err := getGoTypeAttributes(entry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get go type attributes: %w", err)
+		}
+		if gt, ok := goAttrs.GetGoRuntimeType(); ok {
+			if err := v.root.typeIndexBuilder.addType(
+				gotype.TypeID(gt), entry.Offset,
+			); err != nil {
+				return nil, fmt.Errorf("failed to add type %q: %w", name, err)
+			}
+		}
+
 		nameWithoutStar := name
 		if entry.Tag == dwarf.TagPointerType {
 			nameWithoutStar = name[1:]

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -477,10 +477,8 @@ func expandTypesWithBudgets(
 			if err != nil {
 				return fmt.Errorf("failed to get methods for interface %q: %w", tt.GetName(), err)
 			}
-			var i, added int
 			for ii.seek(methods); ii.valid(); ii.next() {
 				impl := ii.cur()
-				i++
 				var t ir.Type
 				if tid, ok := tc.typesByGoRuntimeType[impl]; ok {
 					t = tc.typesByID[tid]
@@ -494,7 +492,6 @@ func expandTypesWithBudgets(
 					if tid, ok := tc.typesByDwarfType[implOffset]; ok {
 						t = tc.typesByID[tid]
 					} else {
-						added++
 						var err error
 						t, err = tc.addType(implOffset)
 						if err != nil {
@@ -517,7 +514,6 @@ func expandTypesWithBudgets(
 				}
 				push(t, wi.remaining-1)
 			}
-			log.Tracef("added %d (%d new) types for interface %q (depth %d)", i, added, tt.GetName(), wi.remaining)
 
 		// Zero-cost neighbors (do not dereference pointers here).
 		case *ir.StructureType:

--- a/pkg/dyninst/irgen/snapshot_test.go
+++ b/pkg/dyninst/irgen/snapshot_test.go
@@ -102,13 +102,6 @@ func runTest(t *testing.T, cfg testprogs.Config, prog string) {
 		if i == 1 {
 			irWithLimit1 = irWithLimit
 		}
-		if len(irWithLimit.Types) < len(irWithDefaultLimits.Types) {
-			t.Logf(
-				"IR with limit %d has %d types < %d types",
-				i, len(irWithLimit.Types), len(irWithDefaultLimits.Types),
-			)
-			continue
-		}
 		typeNames := func(p *ir.Program) []string {
 			var names []string
 			for _, t := range p.Types {
@@ -117,8 +110,15 @@ func runTest(t *testing.T, cfg testprogs.Config, prog string) {
 			slices.Sort(names)
 			return names
 		}
-		require.Equal(t, typeNames(irWithDefaultLimits), typeNames(irWithLimit))
-		break
+		if slices.Equal(typeNames(irWithDefaultLimits), typeNames(irWithLimit)) {
+			t.Logf("types converged with limit %d", i)
+			break
+		}
+		require.Less(t, i, 100, "types did not converge in 100 iterations")
+		t.Logf(
+			"limit %d has %d types < %d types",
+			i, len(irWithLimit.Types), len(irWithDefaultLimits.Types),
+		)
 	}
 
 	// Use the default probe definitions so it's less noisy.

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 83 EventRootType Probe[main.HandleHTTP]
+          Type: 124 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 84 EventRootType Probe[main.LookAtTheRequest]
+          Type: 125 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -113,10 +113,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 80
+      ID: 121
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 79 GoSliceDataType []string.array
+      Pointee: 120 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -125,15 +125,15 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 52
+      ID: 93
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 53 GoHMapBucketType bucket<string,[]string>
+      Pointee: 94 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 73
+      ID: 114
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 74 GoHMapBucketType bucket<string,string>
+      Pointee: 115 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 41
       Name: '*bytes.Buffer'
@@ -142,12 +142,12 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 62
+      ID: 103
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 63 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 104 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -177,15 +177,22 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 50
+      ID: 47
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.396768e+06
+      GoKind: 22
+      Pointee: 48 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+    - __kind: PointerType
+      ID: 91
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 51 GoHMapHeaderType hash<string,[]string>
+      Pointee: 92 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 71
+      ID: 112
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 72 GoHMapHeaderType hash<string,string>
+      Pointee: 113 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -222,12 +229,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 60
+      ID: 101
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 61 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 102 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -236,33 +243,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 65
+      ID: 106
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 66 UnresolvedPointeeType net/http.Response
+      Pointee: 107 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 68
+      ID: 84
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.876224e+06
+      GoKind: 22
+      Pointee: 85 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 109
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 69 UnresolvedPointeeType net/http.pattern
+      Pointee: 110 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 47
+      ID: 86
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.117184e+06
+      GoKind: 22
+      Pointee: 87 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 88
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 48 UnresolvedPointeeType net/url.URL
+      Pointee: 89 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 54
+      ID: 95
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 379904
       GoKind: 22
-      Pointee: 55 UnresolvedPointeeType runtime.mapextra
+      Pointee: 96 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -275,6 +296,111 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 45 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 53
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.532416e+06
+      GoKind: 22
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 67
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.656736e+06
+      GoKind: 22
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 49
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.532032e+06
+      GoKind: 22
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 59
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.655968e+06
+      GoKind: 22
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 73
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.726624e+06
+      GoKind: 22
+      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 61
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.65616e+06
+      GoKind: 22
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 57
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.655776e+06
+      GoKind: 22
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 69
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.726176e+06
+      GoKind: 22
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 77
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.794496e+06
+      GoKind: 22
+      Pointee: 78 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 71
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.7264e+06
+      GoKind: 22
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 55
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.532608e+06
+      GoKind: 22
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 51
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.532224e+06
+      GoKind: 22
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 63
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.656352e+06
+      GoKind: 22
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 75
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.726848e+06
+      GoKind: 22
+      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 65
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.656544e+06
+      GoKind: 22
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -318,12 +444,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 64
+      ID: 105
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: EventRootType
-      ID: 83
+      ID: 124
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -347,7 +473,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 84
+      ID: 125
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -362,7 +488,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 75
+      ID: 116
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -371,24 +497,24 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 53 GoHMapBucketType bucket<string,[]string>
+      Element: 94 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 82
+      ID: 123
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 74 GoHMapBucketType bucket<string,string>
+      Element: 115 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 76
+      ID: 117
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 58
+      ID: 99
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -403,21 +529,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 79 GoSliceDataType []string.array
+      Data: 120 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 79
+      ID: 120
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 77
+      ID: 118
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 58 GoSliceHeaderType []string
+      Element: 99 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 81
+      ID: 122
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -430,41 +556,41 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 53
+      ID: 94
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 75 ArrayType [8]uint8
+          Type: 116 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 76 ArrayType []key<string>
+          Type: 117 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 77 ArrayType []val<[]string>
+          Type: 118 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 52 PointerType *bucket<string,[]string>
+          Type: 93 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 58 GoSliceHeaderType []string
+      ValueType: 99 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 74
+      ID: 115
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 75 ArrayType [8]uint8
+          Type: 116 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 76 ArrayType []key<string>
+          Type: 117 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 81 ArrayType []val<string>
+          Type: 122 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 73 PointerType *bucket<string,string>
+          Type: 114 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
@@ -484,7 +610,7 @@ Types:
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 67
+      ID: 108
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215552e+06
@@ -512,7 +638,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 63
+      ID: 104
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -541,7 +667,7 @@ Types:
       GoRuntimeType: 543264
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 57
+      ID: 98
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
@@ -550,8 +676,25 @@ Types:
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.265696e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 48
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 51
+      ID: 92
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -572,20 +715,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 52 PointerType *bucket<string,[]string>
+          Type: 93 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 52 PointerType *bucket<string,[]string>
+          Type: 93 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 54 PointerType *runtime.mapextra
-      BucketType: 53 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 78 GoSliceDataType []bucket<string,[]string>.array
+          Type: 95 PointerType *runtime.mapextra
+      BucketType: 94 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 119 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 72
+      ID: 113
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -606,18 +749,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 73 PointerType *bucket<string,string>
+          Type: 114 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 73 PointerType *bucket<string,string>
+          Type: 114 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 54 PointerType *runtime.mapextra
-      BucketType: 74 GoHMapBucketType bucket<string,string>
-      BucketsType: 82 GoSliceDataType []bucket<string,string>.array
+          Type: 95 PointerType *runtime.mapextra
+      BucketType: 115 GoHMapBucketType bucket<string,string>
+      BucketsType: 123 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -649,7 +792,7 @@ Types:
       GoRuntimeType: 542368
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 56
+      ID: 97
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.092864e+06
@@ -662,23 +805,75 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 70
+      ID: 111
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 72 GoHMapHeaderType hash<string,string>
+      HeaderType: 113 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 61
+      ID: 102
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 82
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.006528e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.00512e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 49
+      ID: 90
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.963712e+06
       GoKind: 21
-      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 92 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 83
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.005248e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.005504e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -691,7 +886,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 47 PointerType *net/url.URL
+          Type: 88 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -703,19 +898,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 49 GoMapType net/http.Header
+          Type: 90 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 56 GoInterfaceType io.ReadCloser
+          Type: 97 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 57 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 98 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 58 GoSliceHeaderType []string
+          Type: 99 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -724,16 +919,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 59 GoMapType net/url.Values
+          Type: 100 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 59 GoMapType net/url.Values
+          Type: 100 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 60 PointerType *mime/multipart.Form
+          Type: 101 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 49 GoMapType net/http.Header
+          Type: 90 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -742,30 +937,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 62 PointerType *crypto/tls.ConnectionState
+          Type: 103 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 64 GoChannelType <-chan struct {}
+          Type: 105 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 65 PointerType *net/http.Response
+          Type: 106 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 67 GoInterfaceType context.Context
+          Type: 108 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 68 PointerType *net/http.pattern
+          Type: 109 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 58 GoSliceHeaderType []string
+          Type: 99 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 70 GoMapType map[string]string
+          Type: 111 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 66
+      ID: 107
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -782,22 +977,30 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 69
+      ID: 85
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 110
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 48
+      ID: 87
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 89
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 59
+      ID: 100
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.71184e+06
       GoKind: 21
-      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 92 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 55
+      ID: 96
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -818,6 +1021,252 @@ Types:
       ID: 45
       Name: string.str
       ByteSize: 2048
+    - __kind: StructureType
+      ID: 54
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.855808e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 68
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.931104e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 50
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.855296e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 60
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 1.929952e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 74
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.999552e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 62
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.93024e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 58
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 1.929664e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 70
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 1.998912e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 78
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.058656e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 72
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.999232e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 56
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.856064e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 52
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.855552e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 64
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 1.930528e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 76
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.999872e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 66
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.930816e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -860,6 +1309,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543392
       GoKind: 26
-MaxTypeID: 84
+MaxTypeID: 125
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 196 EventRootType Probe[main.HandleHTTP]
+          Type: 83 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 197 EventRootType Probe[main.LookAtTheRequest]
+          Type: 84 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -105,126 +113,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 102
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      Pointee: 103 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 91
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 92 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 145
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 146 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 143
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 47 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 105
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 101 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 112
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 111 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 96
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 95 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 176
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 175 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 114
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 113 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 116
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 115 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 172
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 171 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 181
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 156
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 155 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 168
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 167 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 170
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 169 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 174
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 173 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 82
+      ID: 80
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 81 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 164
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 163 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 166
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 165 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 107
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 456768
-      GoKind: 22
-      Pointee: 98 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 100
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 99 GoSliceDataType []uint8.array
+      Pointee: 79 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -232,11 +124,6 @@ Types:
       GoRuntimeType: 377024
       GoKind: 22
       Pointee: 4 BaseType bool
-    - __kind: PointerType
-      ID: 87
-      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 52
       Name: '*bucket<string,[]string>'
@@ -260,54 +147,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 63 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 1.952864e+06
-      GoKind: 22
-      Pointee: 110 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 137
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 400640
-      GoKind: 22
-      Pointee: 138 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 148
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.761792e+06
-      GoKind: 22
-      Pointee: 149 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 124
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 417344
-      GoKind: 22
-      Pointee: 125 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 131
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 417536
-      GoKind: 22
-      Pointee: 132 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 134
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.037248e+06
-      GoKind: 22
-      Pointee: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 183
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 63 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -336,11 +176,6 @@ Types:
       GoRuntimeType: 2.187104e+06
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 85
-      Name: '*hash<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 50
       Name: '*hash<string,[]string>'
@@ -387,62 +222,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 120
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.296864e+06
-      GoKind: 22
-      Pointee: 121 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 151
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 403456
-      GoKind: 22
-      Pointee: 152 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 154
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 153 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 92
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 853632
-      GoKind: 22
-      Pointee: 94 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 60
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 61 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 140
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.028544e+06
-      GoKind: 22
-      Pointee: 141 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 185
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 188
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 187 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 146
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.122688e+06
-      GoKind: 22
-      Pointee: 177 StructureType net.IPNet
+      Pointee: 61 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -456,35 +241,21 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 66 StructureType net/http.Response
+      Pointee: 66 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 68
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 69 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 190
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 367808
-      GoKind: 22
-      Pointee: 191 StructureType net/http.segment
+      Pointee: 69 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 47
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 48 StructureType net/url.URL
-    - __kind: PointerType
-      ID: 75
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.141376e+06
-      GoKind: 22
-      Pointee: 76 StructureType net/url.Userinfo
+      Pointee: 48 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 54
       Name: '*runtime.mapextra'
@@ -504,27 +275,6 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 45 GoStringDataType string.str
-    - __kind: PointerType
-      ID: 127
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.458112e+06
-      GoKind: 22
-      Pointee: 128 StructureType time.Location
-    - __kind: PointerType
-      ID: 158
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 370880
-      GoKind: 22
-      Pointee: 159 StructureType time.zone
-    - __kind: PointerType
-      ID: 161
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 370944
-      GoKind: 22
-      Pointee: 162 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -573,7 +323,7 @@ Types:
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: EventRootType
-      ID: 196
+      ID: 83
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -597,7 +347,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 197
+      ID: 84
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -612,7 +362,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 77
+      ID: 75
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -620,314 +370,23 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 101
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 473760
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 102 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 111 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 111
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 103 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 461504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 95 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 95
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 92 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 144
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 486816
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 145 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 178 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 146 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 142
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 486752
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 143 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 175 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 47 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 104
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 473888
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 105 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 113 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 113
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 101 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 457024
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 107 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 115 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 115
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 98 GoSliceHeaderType []uint8
-    - __kind: GoSliceDataType
-      ID: 93
-      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 2048
-      Element: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 53 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 82
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 74 GoHMapBucketType bucket<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 136
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 475040
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 137 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 171 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 171
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 138 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 147
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 486880
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 148 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 180 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 149 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 123
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 487136
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 124 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 155 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 155
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 125 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 130
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 486624
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 131 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 167 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 167
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 132 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 133
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 486688
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 134 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 169 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 169
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 78
+      ID: 76
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 139
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 458240
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 140 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 173 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 173
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 141 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 189
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 459008
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 190 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 192 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 191 StructureType net/http.segment
     - __kind: GoSliceHeaderType
       ID: 58
       Name: '[]string'
@@ -944,94 +403,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 81 GoSliceDataType []string.array
+      Data: 79 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 81
+      ID: 79
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 157
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 463104
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 158 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 163 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 163
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 159 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 160
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 463168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 161 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 165 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 162 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 98
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 467840
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 99 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 99
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 89
-      Name: '[]val<[]*mime/multipart.FileHeader>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 90 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: ArrayType
-      ID: 79
+      ID: 77
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 58 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 194
+      ID: 81
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1044,38 +430,19 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 88
-      Name: bucket<string,[]*mime/multipart.FileHeader>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 77 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 78 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 89 ArrayType []val<[]*mime/multipart.FileHeader>
-        - Name: overflow
-          Offset: 328
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 90 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: GoHMapBucketType
       ID: 53
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 77 ArrayType [8]uint8
+          Type: 75 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 78 ArrayType []key<string>
+          Type: 76 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 79 ArrayType []val<[]string>
+          Type: 77 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 52 PointerType *bucket<string,[]string>
@@ -1088,13 +455,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 77 ArrayType [8]uint8
+          Type: 75 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 78 ArrayType []key<string>
+          Type: 76 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 194 ArrayType []val<string>
+          Type: 81 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 73 PointerType *bucket<string,string>
@@ -1144,334 +511,10 @@ Types:
       GoRuntimeType: 1.43472e+06
       GoKind: 25
       RawFields: []
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 63
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.160384e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 7 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 7 BaseType uint16
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 11 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 101 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 104 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 106 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 108 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyCurveID
-          Offset: 186
-          Type: 109 BaseType crypto/tls.CurveID
-    - __kind: BaseType
-      ID: 109
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 778464
-      GoKind: 9
-    - __kind: StructureType
-      ID: 110
-      Name: crypto/x509.Certificate
-      ByteSize: 1352
-      GoRuntimeType: 2.300416e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 117 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 118 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 119 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 9 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 120 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 122 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 122 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 126 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 126 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 129 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 136 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 9 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 58 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 58 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 58 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 58 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 139 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 142 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 58 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 58 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 144 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 144 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 58 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 58 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 58 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 58 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 58 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 147 GoSliceHeaderType []crypto/x509.OID
-    - __kind: BaseType
-      ID: 138
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 546400
-      GoKind: 2
-    - __kind: BaseType
-      ID: 129
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 546336
-      GoKind: 2
-    - __kind: StructureType
-      ID: 149
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.762016e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 98 GoSliceHeaderType []uint8
-    - __kind: BaseType
-      ID: 118
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 780768
-      GoKind: 2
-    - __kind: BaseType
-      ID: 117
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.097216e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 125
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.349024e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 119 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 132
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.494592e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 98 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 122
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.10512e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 58 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 58 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 58 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 58 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 58 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 58 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 58 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 11 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 11 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 123 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 123 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 135
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.037376e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 27 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 182 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 9 BaseType int
     - __kind: GoInterfaceType
       ID: 18
       Name: error
@@ -1503,50 +546,10 @@ Types:
       ByteSize: 8
       GoRuntimeType: 645280
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 108
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 982976
-      GoKind: 19
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
-    - __kind: GoHMapHeaderType
-      ID: 86
-      Name: hash<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 54 PointerType *runtime.mapextra
-      BucketType: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 93 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
       ID: 51
       Name: hash<string,[]string>
@@ -1580,7 +583,7 @@ Types:
           Offset: 40
           Type: 54 PointerType *runtime.mapextra
       BucketType: 53 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 80 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 78 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 72
       Name: hash<string,string>
@@ -1614,7 +617,7 @@ Types:
           Offset: 40
           Type: 54 PointerType *runtime.mapextra
       BucketType: 74 GoHMapBucketType bucket<string,string>
-      BucketsType: 195 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 82 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1645,19 +648,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 542368
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 119
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 797888
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 56
       Name: io.ReadCloser
@@ -1672,165 +662,16 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 84
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 904032
-      GoKind: 21
-      HeaderType: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 899232
-      GoKind: 21
-      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoMapType
       ID: 70
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
       HeaderType: 72 GoHMapHeaderType hash<string,string>
-    - __kind: StructureType
-      ID: 121
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.340544e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 150 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 152
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 546656
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 150
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.279968e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 151 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 153 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 153
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 152 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 94
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.88112e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 97 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 13 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 13 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 61
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.325824e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 83 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 141
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.000864e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 184 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 186
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 999232
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 187 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 187
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 177
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.306944e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 141 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 186 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 49
       Name: net/http.Header
@@ -1923,55 +764,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 70 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 66
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.123456e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 9 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 11 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 9 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 9 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 49 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 56 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 58 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 49 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 62 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -1985,107 +781,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 69
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.744992e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 189 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 191
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.452928e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 97
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.637344e+06
-      GoKind: 21
-      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 48
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.040992e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 75 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 11 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 11 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 11 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 76
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.469248e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 59
       Name: net/url.Values
@@ -2115,85 +818,6 @@ Types:
       ID: 45
       Name: string.str
       ByteSize: 2048
-    - __kind: StructureType
-      ID: 128
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.877376e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 157 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 160 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 11 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 158 PointerType *time.zone
-    - __kind: StructureType
-      ID: 126
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.280896e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 10 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 13 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 127 PointerType *time.Location
-    - __kind: StructureType
-      ID: 159
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.45792e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 9 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 162
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.663616e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 13 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -2236,6 +860,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543392
       GoKind: 26
-MaxTypeID: 197
+MaxTypeID: 84
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 91 EventRootType Probe[main.HandleHTTP]
+          Type: 132 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 92 EventRootType Probe[main.LookAtTheRequest]
+          Type: 133 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -113,20 +113,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 52
+      ID: 93
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 53 PointerType *table<string,[]string>
+      Pointee: 94 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 71
+      ID: 112
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 72 PointerType *table<string,string>
+      Pointee: 113 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 82
+      ID: 123
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 81 GoSliceDataType []string.array
+      Pointee: 122 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -142,12 +142,12 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 60
+      ID: 101
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 61 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 102 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -176,6 +176,13 @@ Types:
       GoRuntimeType: 2.32752e+06
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 47
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.577632e+06
+      GoKind: 22
+      Pointee: 48 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -212,22 +219,22 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 50
+      ID: 91
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 51 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 92 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 69
+      ID: 110
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 70 GoSwissMapHeaderType map<string,string>
+      Pointee: 111 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 58
+      ID: 99
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 59 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 100 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -236,36 +243,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 63
+      ID: 104
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 64 UnresolvedPointeeType net/http.Response
+      Pointee: 105 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 66
+      ID: 84
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.045344e+06
+      GoKind: 22
+      Pointee: 85 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 107
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 67 UnresolvedPointeeType net/http.pattern
+      Pointee: 108 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 47
+      ID: 86
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.254144e+06
+      GoKind: 22
+      Pointee: 87 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 88
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 48 UnresolvedPointeeType net/url.URL
+      Pointee: 89 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 75
+      ID: 116
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 76 StructureType noalg.map.group[string][]string
+      Pointee: 117 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 85
+      ID: 126
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 86 StructureType noalg.map.group[string]string
+      Pointee: 127 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -280,14 +301,119 @@ Types:
       Pointee: 45 GoStringDataType string.str
     - __kind: PointerType
       ID: 53
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.716704e+06
+      GoKind: 22
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 67
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.774624e+06
+      GoKind: 22
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 49
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.71632e+06
+      GoKind: 22
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 59
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.773856e+06
+      GoKind: 22
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 73
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.845888e+06
+      GoKind: 22
+      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 61
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.774048e+06
+      GoKind: 22
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 57
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.773664e+06
+      GoKind: 22
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 69
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.84544e+06
+      GoKind: 22
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 77
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.918112e+06
+      GoKind: 22
+      Pointee: 78 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 71
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.845664e+06
+      GoKind: 22
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 55
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.716896e+06
+      GoKind: 22
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 51
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.716512e+06
+      GoKind: 22
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 63
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.77424e+06
+      GoKind: 22
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 75
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.846112e+06
+      GoKind: 22
+      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 65
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.774432e+06
+      GoKind: 22
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 94
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 73 StructureType table<string,[]string>
+      Pointee: 114 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 72
+      ID: 113
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 83 StructureType table<string,string>
+      Pointee: 124 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -331,12 +457,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 62
+      ID: 103
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: EventRootType
-      ID: 91
+      ID: 132
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -360,7 +486,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 92
+      ID: 133
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -375,27 +501,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 79
+      ID: 120
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 53 PointerType *table<string,[]string>
+      Element: 94 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 89
+      ID: 130
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 72 PointerType *table<string,string>
+      Element: 113 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 80
+      ID: 121
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 76 StructureType noalg.map.group[string][]string
+      Element: 117 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 90
+      ID: 131
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 86 StructureType noalg.map.group[string]string
+      Element: 127 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 56
+      ID: 97
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -410,9 +536,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 81 GoSliceDataType []string.array
+      Data: 122 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 81
+      ID: 122
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -439,7 +565,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 65
+      ID: 106
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298688e+06
@@ -467,7 +593,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 61
+      ID: 102
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -496,7 +622,7 @@ Types:
       GoRuntimeType: 591328
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 55
+      ID: 96
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
@@ -505,34 +631,51 @@ Types:
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.440512e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 48
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 74
+      ID: 115
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 75 PointerType *noalg.map.group[string][]string
+          Type: 116 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 76 StructureType noalg.map.group[string][]string
-      GroupSliceType: 80 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 117 StructureType noalg.map.group[string][]string
+      GroupSliceType: 121 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 84
+      ID: 125
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 85 PointerType *noalg.map.group[string]string
+          Type: 126 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 86 StructureType noalg.map.group[string]string
-      GroupSliceType: 90 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 127 StructureType noalg.map.group[string]string
+      GroupSliceType: 131 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -564,7 +707,7 @@ Types:
       GoRuntimeType: 590432
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 54
+      ID: 95
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.130304e+06
@@ -577,7 +720,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 51
+      ID: 92
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -590,7 +733,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 52 PointerType **table<string,[]string>
+          Type: 93 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -606,10 +749,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 79 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 76 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 120 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 117 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 70
+      ID: 111
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -622,7 +765,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 71 PointerType **table<string,string>
+          Type: 112 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -638,26 +781,78 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 89 GoSliceDataType []*table<string,string>.array
-      GroupType: 86 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 130 GoSliceDataType []*table<string,string>.array
+      GroupType: 127 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 68
+      ID: 109
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.149376e+06
       GoKind: 21
-      HeaderType: 70 GoSwissMapHeaderType map<string,string>
+      HeaderType: 111 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 59
+      ID: 100
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 82
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.04576e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.044352e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 49
+      ID: 90
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.148192e+06
       GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 92 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 83
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.04448e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.044736e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -670,7 +865,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 47 PointerType *net/url.URL
+          Type: 88 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -682,19 +877,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 49 GoMapType net/http.Header
+          Type: 90 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 54 GoInterfaceType io.ReadCloser
+          Type: 95 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 55 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 96 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 56 GoSliceHeaderType []string
+          Type: 97 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -703,16 +898,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 98 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 98 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 99 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 49 GoMapType net/http.Header
+          Type: 90 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -721,30 +916,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 60 PointerType *crypto/tls.ConnectionState
+          Type: 101 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 62 GoChannelType <-chan struct {}
+          Type: 103 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 63 PointerType *net/http.Response
+          Type: 104 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 65 GoInterfaceType context.Context
+          Type: 106 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 66 PointerType *net/http.pattern
+          Type: 107 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 56 GoSliceHeaderType []string
+          Type: 97 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 68 GoMapType map[string]string
+          Type: 109 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 64
+      ID: 105
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -761,40 +956,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 67
+      ID: 85
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 108
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 48
+      ID: 87
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 89
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 57
+      ID: 98
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.9208e+06
       GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 92 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 77
+      ID: 118
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 78 StructureType noalg.struct { key string; elem []string }
+      Element: 119 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 87
+      ID: 128
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 88 StructureType noalg.struct { key string; elem string }
+      Element: 129 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 76
+      ID: 117
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -805,9 +1008,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 77 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 118 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 86
+      ID: 127
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -818,9 +1021,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 87 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 128 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 78
+      ID: 119
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -831,9 +1034,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 56 GoSliceHeaderType []string
+          Type: 97 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 88
+      ID: 129
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -864,7 +1067,253 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 73
+      ID: 54
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.982976e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 68
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.06032e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 50
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.982464e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 60
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.059168e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 74
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.129376e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 62
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.059456e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 58
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 2.05888e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 70
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 2.128736e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 78
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.191008e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 72
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.129056e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 56
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.983232e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 52
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.98272e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 64
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.059744e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 76
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.129696e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 66
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.060032e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 114
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -886,9 +1335,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 74 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 115 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 83
+      ID: 124
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -910,7 +1359,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 84 GoSwissMapGroupsType groupReference<string,string>
+          Type: 125 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -953,6 +1402,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591456
       GoKind: 26
-MaxTypeID: 92
+MaxTypeID: 133
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 215 EventRootType Probe[main.HandleHTTP]
+          Type: 91 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 216 EventRootType Probe[main.LookAtTheRequest]
+          Type: 92 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -105,35 +113,6 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 110
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 111 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 98
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 153
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 154 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 151
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 47 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 89
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 90 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 52
       Name: '**table<string,[]string>'
       ByteSize: 8
@@ -144,108 +123,10 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 113
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 109 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 120
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 119 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 104
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 103 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 190
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 189 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 187
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 124
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 123 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 194
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 193 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 167
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 166 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 181
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 206
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 205 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 84
+      ID: 82
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 83 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 177
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 176 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 115
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 483552
-      GoKind: 22
-      Pointee: 106 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 108
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 107 GoSliceDataType []uint8.array
+      Pointee: 81 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -266,61 +147,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 61 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 111
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.082688e+06
-      GoKind: 22
-      Pointee: 118 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 145
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 426912
-      GoKind: 22
-      Pointee: 146 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 156
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.989632e+06
-      GoKind: 22
-      Pointee: 157 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 159
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 426976
-      GoKind: 22
-      Pointee: 160 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 132
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 443680
-      GoKind: 22
-      Pointee: 133 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 139
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 443872
-      GoKind: 22
-      Pointee: 140 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 142
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.0752e+06
-      GoKind: 22
-      Pointee: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 196
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 195 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 61 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -385,11 +212,6 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 87
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 88 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 50
       Name: '*map<string,[]string>'
       ByteSize: 8
@@ -400,62 +222,12 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 128
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.440832e+06
-      GoKind: 22
-      Pointee: 129 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 162
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 429856
-      GoKind: 22
-      Pointee: 163 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 165
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 99
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 920864
-      GoKind: 22
-      Pointee: 102 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 148
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.198272e+06
-      GoKind: 22
-      Pointee: 149 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 198
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 197 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 201
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 200 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 154
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.204416e+06
-      GoKind: 22
-      Pointee: 188 StructureType net.IPNet
+      Pointee: 59 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -469,50 +241,31 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 64 StructureType net/http.Response
+      Pointee: 64 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 66
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 67 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 203
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 393504
-      GoKind: 22
-      Pointee: 204 StructureType net/http.segment
+      Pointee: 67 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 47
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 48 StructureType net/url.URL
+      Pointee: 48 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 73
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.222208e+06
-      GoKind: 22
-      Pointee: 74 StructureType net/url.Userinfo
-    - __kind: PointerType
-      ID: 93
-      Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
-      ByteSize: 8
-      Pointee: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 77
+      ID: 75
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 78 StructureType noalg.map.group[string][]string
+      Pointee: 76 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 209
+      ID: 85
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 210 StructureType noalg.map.group[string]string
+      Pointee: 86 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -526,41 +279,15 @@ Types:
       ByteSize: 8
       Pointee: 45 GoStringDataType string.str
     - __kind: PointerType
-      ID: 90
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 91 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 53
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 75 StructureType table<string,[]string>
+      Pointee: 73 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 72
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 207 StructureType table<string,string>
-    - __kind: PointerType
-      ID: 135
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.642784e+06
-      GoKind: 22
-      Pointee: 136 StructureType time.Location
-    - __kind: PointerType
-      ID: 169
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 396640
-      GoKind: 22
-      Pointee: 170 StructureType time.zone
-    - __kind: PointerType
-      ID: 172
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 396704
-      GoKind: 22
-      Pointee: 173 StructureType time.zoneTrans
+      Pointee: 83 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -609,7 +336,7 @@ Types:
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: EventRootType
-      ID: 215
+      ID: 91
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -633,7 +360,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 216
+      ID: 92
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -647,344 +374,26 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-    - __kind: GoSliceHeaderType
-      ID: 109
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 503808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 110 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 119
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 111 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 489088
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 103 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 103
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 99 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 152
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 518592
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 153 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 189 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 189
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 154 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 150
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 518528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 151 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 186 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 186
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 47 PointerType *net/url.URL
-    - __kind: GoSliceDataType
-      ID: 100
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 90 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 81
+      ID: 79
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 53 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 89
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 112
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 503936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 113 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 121
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 109 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 114
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 483936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 115 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 123 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 123
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 106 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 144
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 505280
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 145 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 146 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 155
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 518656
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 156 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 157 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 158
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 518720
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 159 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 193 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 193
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 160 StructureType crypto/x509.PolicyMapping
-    - __kind: GoSliceHeaderType
-      ID: 131
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 519168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 132 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 166 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 133 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 138
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 518400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 139 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 140 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 141
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 518464
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 142 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 147
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 484896
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 148 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 184 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 149 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 202
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 486528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 203 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 205 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 205
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 204 StructureType net/http.segment
-    - __kind: GoSliceDataType
-      ID: 101
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 82
+      ID: 80
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 78 StructureType noalg.map.group[string][]string
+      Element: 76 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 90
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 210 StructureType noalg.map.group[string]string
+      Element: 86 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 56
       Name: '[]string'
@@ -1001,78 +410,12 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 83 GoSliceDataType []string.array
+      Data: 81 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 83
+      ID: 81
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 168
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 491072
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 169 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 174 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 170 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 171
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 491136
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 172 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 176 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 176
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 173 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 497024
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 107 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 107
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1123,368 +466,10 @@ Types:
       GoRuntimeType: 1.618752e+06
       GoKind: 25
       RawFields: []
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 61
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.302368e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 109 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 112 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 114 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 116 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyCurveID
-          Offset: 186
-          Type: 117 BaseType crypto/tls.CurveID
-    - __kind: BaseType
-      ID: 117
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 843936
-      GoKind: 9
-    - __kind: StructureType
-      ID: 118
-      Name: crypto/x509.Certificate
-      ByteSize: 1424
-      GoRuntimeType: 2.453248e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 125 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 126 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 127 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 7 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 128 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 130 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 130 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 134 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 134 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 137 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 138 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 138 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 144 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 7 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 56 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 56 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 56 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 56 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 147 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 150 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 56 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 56 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 152 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 152 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 56 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 56 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 56 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 56 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 56 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 155 GoSliceHeaderType []crypto/x509.OID
-        - Name: InhibitAnyPolicy
-          Offset: 1352
-          Type: 7 BaseType int
-        - Name: InhibitAnyPolicyZero
-          Offset: 1360
-          Type: 4 BaseType bool
-        - Name: InhibitPolicyMapping
-          Offset: 1368
-          Type: 7 BaseType int
-        - Name: InhibitPolicyMappingZero
-          Offset: 1376
-          Type: 4 BaseType bool
-        - Name: RequireExplicitPolicy
-          Offset: 1384
-          Type: 7 BaseType int
-        - Name: RequireExplicitPolicyZero
-          Offset: 1392
-          Type: 4 BaseType bool
-        - Name: PolicyMappings
-          Offset: 1400
-          Type: 158 GoSliceHeaderType []crypto/x509.PolicyMapping
-    - __kind: BaseType
-      ID: 146
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 594464
-      GoKind: 2
-    - __kind: BaseType
-      ID: 137
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 594400
-      GoKind: 2
-    - __kind: StructureType
-      ID: 157
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.989888e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 106 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 160
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.515072e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 157 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 157 StructureType crypto/x509.OID
-    - __kind: BaseType
-      ID: 126
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 846240
-      GoKind: 2
-    - __kind: BaseType
-      ID: 125
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.134784e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 133
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.527392e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 127 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 140
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.678688e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 106 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 130
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.241664e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 56 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 56 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 56 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 56 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 56 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 56 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 56 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 9 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 9 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 131 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 131 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 143
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.075328e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 27 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 195 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 7 BaseType int
     - __kind: GoInterfaceType
       ID: 13
       Name: error
@@ -1516,58 +501,38 @@ Types:
       ByteSize: 8
       GoRuntimeType: 701280
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 116
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.020736e+06
-      GoKind: 19
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 92
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 93 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 101 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
-    - __kind: GoSwissMapGroupsType
-      ID: 76
+      ID: 74
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 77 PointerType *noalg.map.group[string][]string
+          Type: 75 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 78 StructureType noalg.map.group[string][]string
-      GroupSliceType: 82 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 76 StructureType noalg.map.group[string][]string
+      GroupSliceType: 80 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 208
+      ID: 84
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 209 PointerType *noalg.map.group[string]string
+          Type: 85 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 210 StructureType noalg.map.group[string]string
-      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 86 StructureType noalg.map.group[string]string
+      GroupSliceType: 90 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1598,19 +563,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 590432
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 127
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 863648
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 54
       Name: io.ReadCloser
@@ -1624,38 +576,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: GoSwissMapHeaderType
-      ID: 88
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 89 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 100 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 51
       Name: map<string,[]string>
@@ -1686,8 +606,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 81 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 78 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 79 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 76 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<string,string>
@@ -1718,22 +638,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 210 StructureType noalg.map.group[string]string
-    - __kind: GoMapType
-      ID: 86
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.15296e+06
-      GoKind: 21
-      HeaderType: 88 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 85
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.148352e+06
-      GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
+      TablePtrSliceType: 89 GoSliceDataType []*table<string,string>.array
+      GroupType: 86 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 68
       Name: map[string]string
@@ -1741,145 +647,10 @@ Types:
       GoRuntimeType: 1.149376e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<string,string>
-    - __kind: StructureType
-      ID: 129
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.518112e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 161 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 163
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 594656
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 161
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.4216e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 162 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 164 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 163 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 102
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 2.010048e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 105 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 12 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 12 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 59
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.501472e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 85 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 86 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.17104e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 197 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 197
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 199
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.03808e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 200 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 188
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.482432e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 149 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 199 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 49
       Name: net/http.Header
@@ -1972,55 +743,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 68 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 64
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.260416e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 7 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 7 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 49 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 54 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 12 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 56 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 49 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 60 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2034,107 +760,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 67
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.866368e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 202 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 204
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.6376e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 105
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.85488e+06
-      GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 48
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.173728e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 73 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 9 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 9 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 74
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.653536e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 57
       Name: net/url.Values
@@ -2143,47 +776,25 @@ Types:
       GoKind: 21
       HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 95
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 707328
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 96 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 79
+      ID: 77
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 80 StructureType noalg.struct { key string; elem []string }
+      Element: 78 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 211
+      ID: 87
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 212 StructureType noalg.struct { key string; elem string }
+      Element: 88 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 94
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.3216e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 95 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 78
+      ID: 76
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -2194,9 +805,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 79 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 77 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 210
+      ID: 86
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -2207,22 +818,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 211 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 87 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 96
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.321472e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 97 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 80
+      ID: 78
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -2235,7 +833,7 @@ Types:
           Offset: 16
           Type: 56 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 212
+      ID: 88
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -2266,31 +864,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 91
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 92 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 75
+      ID: 73
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2312,9 +886,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 76 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 74 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 207
+      ID: 83
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2336,86 +910,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 208 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: StructureType
-      ID: 136
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 2.006016e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 168 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 171 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 9 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 12 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 12 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 169 PointerType *time.zone
-    - __kind: StructureType
-      ID: 134
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.424416e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 12 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 135 PointerType *time.Location
-    - __kind: StructureType
-      ID: 170
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.642592e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 173
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.781504e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 12 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
+          Type: 84 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -2458,6 +953,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591456
       GoKind: 26
-MaxTypeID: 216
+MaxTypeID: 92
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 214 EventRootType Probe[main.HandleHTTP]
+          Type: 89 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 215 EventRootType Probe[main.LookAtTheRequest]
+          Type: 90 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
 Subprograms:
@@ -98,35 +106,6 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 109
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 110 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 96
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 97 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 152
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 153 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 150
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 45 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 87
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 88 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 50
       Name: '**table<string,[]string>'
       ByteSize: 8
@@ -137,108 +116,10 @@ Types:
       ByteSize: 8
       Pointee: 70 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 112
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 119
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 118 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 102
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 101 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 186
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 185 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 121
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 123
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 122 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 182
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 191
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 190 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 166
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 178
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 180
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 184
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 82
+      ID: 80
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 81 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 174
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 173 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 176
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 175 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 114
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 486560
-      GoKind: 22
-      Pointee: 104 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 106
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 105 GoSliceDataType []uint8.array
+      Pointee: 79 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -259,61 +140,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 59 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 110
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.089664e+06
-      GoKind: 22
-      Pointee: 117 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 144
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 429920
-      GoKind: 22
-      Pointee: 145 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 155
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.998112e+06
-      GoKind: 22
-      Pointee: 156 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 158
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 429984
-      GoKind: 22
-      Pointee: 159 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 131
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 446624
-      GoKind: 22
-      Pointee: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 138
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 446816
-      GoKind: 22
-      Pointee: 139 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 141
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.079776e+06
-      GoKind: 22
-      Pointee: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 195
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 59 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -378,11 +205,6 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 85
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 86 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 48
       Name: '*map<string,[]string>'
       ByteSize: 8
@@ -393,62 +215,12 @@ Types:
       ByteSize: 8
       Pointee: 68 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 127
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.447424e+06
-      GoKind: 22
-      Pointee: 128 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 161
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 432800
-      GoKind: 22
-      Pointee: 162 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 164
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 163 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 97
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 925568
-      GoKind: 22
-      Pointee: 100 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 56
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 57 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 147
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.206912e+06
-      GoKind: 22
-      Pointee: 148 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 197
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 200
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 199 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 153
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.208416e+06
-      GoKind: 22
-      Pointee: 187 StructureType net.IPNet
+      Pointee: 57 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -462,50 +234,31 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.7584e+06
       GoKind: 22
-      Pointee: 62 StructureType net/http.Response
+      Pointee: 62 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 64
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642688e+06
       GoKind: 22
-      Pointee: 65 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 202
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 396384
-      GoKind: 22
-      Pointee: 203 StructureType net/http.segment
+      Pointee: 65 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 45
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 46 StructureType net/url.URL
+      Pointee: 46 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 71
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.22608e+06
-      GoKind: 22
-      Pointee: 72 StructureType net/url.Userinfo
-    - __kind: PointerType
-      ID: 91
-      Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
-      ByteSize: 8
-      Pointee: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 75
+      ID: 73
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 76 StructureType noalg.map.group[string][]string
+      Pointee: 74 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 208
+      ID: 83
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[string]string
+      Pointee: 84 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -519,41 +272,15 @@ Types:
       ByteSize: 8
       Pointee: 43 GoStringDataType string.str
     - __kind: PointerType
-      ID: 88
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 89 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 51
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 73 StructureType table<string,[]string>
+      Pointee: 71 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 70
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 206 StructureType table<string,string>
-    - __kind: PointerType
-      ID: 134
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.64768e+06
-      GoKind: 22
-      Pointee: 135 StructureType time.Location
-    - __kind: PointerType
-      ID: 168
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 399456
-      GoKind: 22
-      Pointee: 169 StructureType time.zone
-    - __kind: PointerType
-      ID: 171
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 399520
-      GoKind: 22
-      Pointee: 172 StructureType time.zoneTrans
+      Pointee: 81 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -602,7 +329,7 @@ Types:
       GoRuntimeType: 607264
       GoKind: 18
     - __kind: EventRootType
-      ID: 214
+      ID: 89
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -626,7 +353,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 215
+      ID: 90
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -640,344 +367,26 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-    - __kind: GoSliceHeaderType
-      ID: 108
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 507488
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 109 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 118
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 110 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 492224
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 101 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 101
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 97 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 151
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 509088
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 152 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 188 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 188
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 153 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 509024
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 150 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 185 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 185
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 45 PointerType *net/url.URL
-    - __kind: GoSliceDataType
-      ID: 98
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 88 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 79
+      ID: 77
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 51 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 87
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 111
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 507552
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 112 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 120
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 113
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 486880
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 114 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 122 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 122
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 104 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 143
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 508960
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 144 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 181
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 145 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 154
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 509152
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 155 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 190 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 190
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 156 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 157
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 509216
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 158 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 159 StructureType crypto/x509.PolicyMapping
-    - __kind: GoSliceHeaderType
-      ID: 130
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 523680
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 131 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 137
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 508832
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 138 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 139 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 140
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 508896
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 141 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 179
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 146
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 487904
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 147 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 183 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 183
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 148 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 201
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 489600
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 202 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 204 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 204
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 203 StructureType net/http.segment
-    - __kind: GoSliceDataType
-      ID: 99
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 76 StructureType noalg.map.group[string][]string
+      Element: 74 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 88
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[string]string
+      Element: 84 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 54
       Name: '[]string'
@@ -994,78 +403,12 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 81 GoSliceDataType []string.array
+      Data: 79 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 81
+      ID: 79
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 167
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 494336
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 168 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 173 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 173
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 169 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 170
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 494400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 171 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 175 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 172 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 104
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 500288
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 105 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 105
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1101,377 +444,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 59
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.323424e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: CurveID
-          Offset: 6
-          Type: 107 BaseType crypto/tls.CurveID
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 108 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 111 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 113 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 115 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyPeerSignatureAlgorithm
-          Offset: 186
-          Type: 116 BaseType crypto/tls.SignatureScheme
-    - __kind: BaseType
-      ID: 107
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 847200
-      GoKind: 9
-    - __kind: BaseType
-      ID: 116
-      Name: crypto/tls.SignatureScheme
-      ByteSize: 2
-      GoRuntimeType: 847296
-      GoKind: 9
-    - __kind: StructureType
-      ID: 117
-      Name: crypto/x509.Certificate
-      ByteSize: 1424
-      GoRuntimeType: 2.458688e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 124 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 125 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 126 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 7 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 127 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 129 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 129 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 133 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 133 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 136 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 143 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 7 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 54 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 54 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 54 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 54 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 146 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 149 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 54 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 54 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 151 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 151 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 54 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 54 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 54 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 54 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 54 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 154 GoSliceHeaderType []crypto/x509.OID
-        - Name: InhibitAnyPolicy
-          Offset: 1352
-          Type: 7 BaseType int
-        - Name: InhibitAnyPolicyZero
-          Offset: 1360
-          Type: 4 BaseType bool
-        - Name: InhibitPolicyMapping
-          Offset: 1368
-          Type: 7 BaseType int
-        - Name: InhibitPolicyMappingZero
-          Offset: 1376
-          Type: 4 BaseType bool
-        - Name: RequireExplicitPolicy
-          Offset: 1384
-          Type: 7 BaseType int
-        - Name: RequireExplicitPolicyZero
-          Offset: 1392
-          Type: 4 BaseType bool
-        - Name: PolicyMappings
-          Offset: 1400
-          Type: 157 GoSliceHeaderType []crypto/x509.PolicyMapping
-    - __kind: BaseType
-      ID: 145
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 598304
-      GoKind: 2
-    - __kind: BaseType
-      ID: 136
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 598240
-      GoKind: 2
-    - __kind: StructureType
-      ID: 156
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.998368e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 104 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 159
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.520416e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 156 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 156 StructureType crypto/x509.OID
-    - __kind: BaseType
-      ID: 125
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 849696
-      GoKind: 2
-    - __kind: BaseType
-      ID: 124
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.139648e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 132
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.532736e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 126 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 139
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.683776e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 104 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 129
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.250272e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 54 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 54 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 54 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 54 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 54 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 54 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 54 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 9 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 9 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 142
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.079904e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 26 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 7 BaseType int
     - __kind: GoInterfaceType
       ID: 13
       Name: error
@@ -1503,58 +479,38 @@ Types:
       ByteSize: 8
       GoRuntimeType: 705088
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 115
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.025152e+06
-      GoKind: 19
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 90
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 91 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 99 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
-    - __kind: GoSwissMapGroupsType
-      ID: 74
+      ID: 72
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 75 PointerType *noalg.map.group[string][]string
+          Type: 73 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 76 StructureType noalg.map.group[string][]string
-      GroupSliceType: 80 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 74 StructureType noalg.map.group[string][]string
+      GroupSliceType: 78 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 82
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[string]string
+          Type: 83 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 84 StructureType noalg.map.group[string]string
+      GroupSliceType: 88 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1585,19 +541,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 594272
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 126
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 867104
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 52
       Name: io.ReadCloser
@@ -1611,41 +554,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: GoSwissMapHeaderType
-      ID: 86
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 87 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 98 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 49
       Name: map<string,[]string>
@@ -1679,8 +587,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 79 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 76 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 77 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 74 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<string,string>
@@ -1714,22 +622,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 209 StructureType noalg.map.group[string]string
-    - __kind: GoMapType
-      ID: 84
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.157568e+06
-      GoKind: 21
-      HeaderType: 86 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.153216e+06
-      GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      TablePtrSliceType: 87 GoSliceDataType []*table<string,string>.array
+      GroupType: 84 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 66
       Name: map[string]string
@@ -1737,145 +631,10 @@ Types:
       GoRuntimeType: 1.15424e+06
       GoKind: 21
       HeaderType: 68 GoSwissMapHeaderType map<string,string>
-    - __kind: StructureType
-      ID: 128
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.523456e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 160 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 162
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 598496
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 160
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.426912e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 161 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 163 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 163
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 162 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 100
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 2.018784e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 103 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 12 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 12 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 57
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.506656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 83 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 148
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.178944e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 196 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 198
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.042272e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 199 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 199
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 187
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.486976e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 148 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 198 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 47
       Name: net/http.Header
@@ -1968,55 +727,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 66 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 62
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.268608e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 7 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 7 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 47 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 52 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 12 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 54 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 47 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 58 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2030,107 +744,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 65
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.875616e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 201 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 203
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.642496e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 103
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.86368e+06
-      GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 46
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.181632e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 71 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 9 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 9 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 72
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.658624e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 55
       Name: net/url.Values
@@ -2139,47 +760,25 @@ Types:
       GoKind: 21
       HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 93
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 710944
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 94 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 77
+      ID: 75
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 78 StructureType noalg.struct { key string; elem []string }
+      Element: 76 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 210
+      ID: 85
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key string; elem string }
+      Element: 86 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 92
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.325728e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 93 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 76
+      ID: 74
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -2190,9 +789,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 77 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 75 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 209
+      ID: 84
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -2203,22 +802,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 85 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 94
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.3256e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 95 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 78
+      ID: 76
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -2231,7 +817,7 @@ Types:
           Offset: 16
           Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 211
+      ID: 86
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -2262,31 +848,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 89
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 90 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 73
+      ID: 71
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2308,9 +870,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 74 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 72 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 206
+      ID: 81
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2332,86 +894,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: StructureType
-      ID: 135
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 2.014752e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 167 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 170 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 9 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 12 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 12 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 168 PointerType *time.zone
-    - __kind: StructureType
-      ID: 133
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.42976e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 12 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 134 PointerType *time.Location
-    - __kind: StructureType
-      ID: 169
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.647488e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 172
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.789472e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 12 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
+          Type: 82 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -2454,6 +937,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595296
       GoKind: 26
-MaxTypeID: 215
+MaxTypeID: 90
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18bb880", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 89 EventRootType Probe[main.HandleHTTP]
+          Type: 130 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 90 EventRootType Probe[main.LookAtTheRequest]
+          Type: 131 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
 Subprograms:
@@ -106,20 +106,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 50
+      ID: 91
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 51 PointerType *table<string,[]string>
+      Pointee: 92 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 69
+      ID: 110
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 70 PointerType *table<string,string>
+      Pointee: 111 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 80
+      ID: 121
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 79 GoSliceDataType []string.array
+      Pointee: 120 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -135,12 +135,12 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 58
+      ID: 99
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 59 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 100 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -169,6 +169,13 @@ Types:
       GoRuntimeType: 2.33264e+06
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 45
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.582816e+06
+      GoKind: 22
+      Pointee: 46 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -205,22 +212,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 48
+      ID: 89
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 49 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 90 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 67
+      ID: 108
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 68 GoSwissMapHeaderType map<string,string>
+      Pointee: 109 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 56
+      ID: 97
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 57 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 98 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -229,36 +236,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 61
+      ID: 102
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.7584e+06
       GoKind: 22
-      Pointee: 62 UnresolvedPointeeType net/http.Response
+      Pointee: 103 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 64
+      ID: 82
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.053472e+06
+      GoKind: 22
+      Pointee: 83 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 105
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642688e+06
       GoKind: 22
-      Pointee: 65 UnresolvedPointeeType net/http.pattern
+      Pointee: 106 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 45
+      ID: 84
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.27712e+06
+      GoKind: 22
+      Pointee: 85 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 86
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 46 UnresolvedPointeeType net/url.URL
+      Pointee: 87 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 73
+      ID: 114
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 74 StructureType noalg.map.group[string][]string
+      Pointee: 115 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 83
+      ID: 124
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 84 StructureType noalg.map.group[string]string
+      Pointee: 125 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -273,14 +294,119 @@ Types:
       Pointee: 43 GoStringDataType string.str
     - __kind: PointerType
       ID: 51
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.722368e+06
+      GoKind: 22
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 65
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.781632e+06
+      GoKind: 22
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 47
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.721984e+06
+      GoKind: 22
+      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 57
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.780864e+06
+      GoKind: 22
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 71
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.853888e+06
+      GoKind: 22
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 59
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.781056e+06
+      GoKind: 22
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 55
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.780672e+06
+      GoKind: 22
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 67
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.85344e+06
+      GoKind: 22
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 75
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.925792e+06
+      GoKind: 22
+      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 69
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.853664e+06
+      GoKind: 22
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 53
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.72256e+06
+      GoKind: 22
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 49
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.722176e+06
+      GoKind: 22
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 61
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.781248e+06
+      GoKind: 22
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 73
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.854112e+06
+      GoKind: 22
+      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 63
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.78144e+06
+      GoKind: 22
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 92
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 71 StructureType table<string,[]string>
+      Pointee: 112 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 70
+      ID: 111
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 81 StructureType table<string,string>
+      Pointee: 122 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -324,12 +450,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 60
+      ID: 101
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
     - __kind: EventRootType
-      ID: 89
+      ID: 130
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -353,7 +479,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 90
+      ID: 131
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -368,27 +494,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 77
+      ID: 118
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 51 PointerType *table<string,[]string>
+      Element: 92 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 87
+      ID: 128
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 70 PointerType *table<string,string>
+      Element: 111 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 74 StructureType noalg.map.group[string][]string
+      Element: 115 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 88
+      ID: 129
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 84 StructureType noalg.map.group[string]string
+      Element: 125 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 95
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -403,9 +529,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 79 GoSliceDataType []string.array
+      Data: 120 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 79
+      ID: 120
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -432,7 +558,7 @@ Types:
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 63
+      ID: 104
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.3032e+06
@@ -445,7 +571,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 59
+      ID: 100
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -474,7 +600,7 @@ Types:
       GoRuntimeType: 595168
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 53
+      ID: 94
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 705088
@@ -483,34 +609,51 @@ Types:
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 77
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.445024e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 46
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 72
+      ID: 113
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 73 PointerType *noalg.map.group[string][]string
+          Type: 114 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 74 StructureType noalg.map.group[string][]string
-      GroupSliceType: 78 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 115 StructureType noalg.map.group[string][]string
+      GroupSliceType: 119 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 82
+      ID: 123
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 83 PointerType *noalg.map.group[string]string
+          Type: 124 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 84 StructureType noalg.map.group[string]string
-      GroupSliceType: 88 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 125 StructureType noalg.map.group[string]string
+      GroupSliceType: 129 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -542,7 +685,7 @@ Types:
       GoRuntimeType: 594272
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 52
+      ID: 93
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.135168e+06
@@ -555,7 +698,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 49
+      ID: 90
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -568,7 +711,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 50 PointerType **table<string,[]string>
+          Type: 91 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -587,10 +730,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 77 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 74 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 118 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 115 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 68
+      ID: 109
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -603,7 +746,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 69 PointerType **table<string,string>
+          Type: 110 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -622,26 +765,78 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 87 GoSliceDataType []*table<string,string>.array
-      GroupType: 84 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 128 GoSliceDataType []*table<string,string>.array
+      GroupType: 125 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 66
+      ID: 107
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.15424e+06
       GoKind: 21
-      HeaderType: 68 GoSwissMapHeaderType map<string,string>
+      HeaderType: 109 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 57
+      ID: 98
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.05008e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 78
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.048544e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 47
+      ID: 88
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.15504e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 90 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.048672e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.048928e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -654,7 +849,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 45 PointerType *net/url.URL
+          Type: 86 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -666,19 +861,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 88 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 52 GoInterfaceType io.ReadCloser
+          Type: 93 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 53 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 94 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 95 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -687,16 +882,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 55 GoMapType net/url.Values
+          Type: 96 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 55 GoMapType net/url.Values
+          Type: 96 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 56 PointerType *mime/multipart.Form
+          Type: 97 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 47 GoMapType net/http.Header
+          Type: 88 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -705,30 +900,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 58 PointerType *crypto/tls.ConnectionState
+          Type: 99 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 60 GoChannelType <-chan struct {}
+          Type: 101 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 61 PointerType *net/http.Response
+          Type: 102 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 63 GoInterfaceType context.Context
+          Type: 104 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 64 PointerType *net/http.pattern
+          Type: 105 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 95 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 66 GoMapType map[string]string
+          Type: 107 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 62
+      ID: 103
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -745,40 +940,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 65
+      ID: 83
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 106
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 46
+      ID: 85
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 87
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 55
+      ID: 96
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.92848e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 90 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 75
+      ID: 116
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 76 StructureType noalg.struct { key string; elem []string }
+      Element: 117 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 85
+      ID: 126
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 86 StructureType noalg.struct { key string; elem string }
+      Element: 127 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 74
+      ID: 115
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -789,9 +992,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 75 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 116 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 84
+      ID: 125
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -802,9 +1005,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 85 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 126 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 76
+      ID: 117
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -815,9 +1018,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 95 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 86
+      ID: 127
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -848,7 +1051,253 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 71
+      ID: 52
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.991456e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 66
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.067584e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 48
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.990944e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 58
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.066432e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 72
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.137312e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 60
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.06672e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 56
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 2.066144e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 68
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 2.136672e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 76
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.199296e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 70
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.136992e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 54
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.991712e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 50
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.9912e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 62
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.067008e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 74
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.137632e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 64
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.067296e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 112
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -870,9 +1319,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 72 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 113 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 81
+      ID: 122
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -894,7 +1343,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 82 GoSwissMapGroupsType groupReference<string,string>
+          Type: 123 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -937,6 +1386,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595296
       GoKind: 26
-MaxTypeID: 90
+MaxTypeID: 131
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18bb880", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 196 EventRootType Probe[main.HandleHTTP]
+          Type: 83 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff40", Frameless: true}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 197 EventRootType Probe[main.LookAtTheRequest]
+          Type: 84 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e025c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -105,125 +113,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 102
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      Pointee: 103 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 91
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 92 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 145
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 146 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 143
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 47 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 105
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 101 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 112
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 111 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 96
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 95 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 176
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 175 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 114
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 113 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 116
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 115 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 172
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 171 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 181
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 156
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 155 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 168
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 167 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 170
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 169 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 174
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 173 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 82
+      ID: 80
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 81 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 164
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 163 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 166
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 165 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 107
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 456928
-      GoKind: 22
-      Pointee: 98 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 100
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 99 GoSliceDataType []uint8.array
+      Pointee: 79 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -231,11 +124,6 @@ Types:
       GoRuntimeType: 377120
       GoKind: 22
       Pointee: 4 BaseType bool
-    - __kind: PointerType
-      ID: 87
-      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 52
       Name: '*bucket<string,[]string>'
@@ -259,54 +147,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 63 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 1.95344e+06
-      GoKind: 22
-      Pointee: 110 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 137
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 400736
-      GoKind: 22
-      Pointee: 138 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 148
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.762368e+06
-      GoKind: 22
-      Pointee: 149 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 124
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 417504
-      GoKind: 22
-      Pointee: 125 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 131
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 417696
-      GoKind: 22
-      Pointee: 132 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 134
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.037472e+06
-      GoKind: 22
-      Pointee: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 183
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 63 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -335,11 +176,6 @@ Types:
       GoRuntimeType: 2.18768e+06
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 85
-      Name: '*hash<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 50
       Name: '*hash<string,[]string>'
@@ -386,62 +222,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 120
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.29744e+06
-      GoKind: 22
-      Pointee: 121 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 151
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 403552
-      GoKind: 22
-      Pointee: 152 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 154
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 153 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 92
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 853760
-      GoKind: 22
-      Pointee: 94 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 60
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 61 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 140
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.02912e+06
-      GoKind: 22
-      Pointee: 141 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 185
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 188
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 187 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 146
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.122912e+06
-      GoKind: 22
-      Pointee: 177 StructureType net.IPNet
+      Pointee: 61 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -455,35 +241,21 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 66 StructureType net/http.Response
+      Pointee: 66 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 68
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 69 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 190
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 367904
-      GoKind: 22
-      Pointee: 191 StructureType net/http.segment
+      Pointee: 69 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 47
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 48 StructureType net/url.URL
-    - __kind: PointerType
-      ID: 75
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.1416e+06
-      GoKind: 22
-      Pointee: 76 StructureType net/url.Userinfo
+      Pointee: 48 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 54
       Name: '*runtime.mapextra'
@@ -503,27 +275,6 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 45 GoStringDataType string.str
-    - __kind: PointerType
-      ID: 127
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.458496e+06
-      GoKind: 22
-      Pointee: 128 StructureType time.Location
-    - __kind: PointerType
-      ID: 158
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 370976
-      GoKind: 22
-      Pointee: 159 StructureType time.zone
-    - __kind: PointerType
-      ID: 161
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 371040
-      GoKind: 22
-      Pointee: 162 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -572,7 +323,7 @@ Types:
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: EventRootType
-      ID: 196
+      ID: 83
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -596,7 +347,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 197
+      ID: 84
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -611,7 +362,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 77
+      ID: 75
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -619,314 +370,23 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 101
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 473920
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 102 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 111 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 111
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 103 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 461664
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 95 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 95
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 92 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 144
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 486976
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 145 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 178 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 146 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 142
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 486912
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 143 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 175 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 47 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 104
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 474048
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 105 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 113 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 113
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 101 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 457184
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 107 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 115 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 115
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 98 GoSliceHeaderType []uint8
-    - __kind: GoSliceDataType
-      ID: 93
-      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 2048
-      Element: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 53 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 82
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 74 GoHMapBucketType bucket<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 136
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 475200
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 137 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 171 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 171
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 138 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 147
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 487040
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 148 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 180 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 149 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 123
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 487296
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 124 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 155 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 155
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 125 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 130
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 486784
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 131 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 167 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 167
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 132 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 133
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 486848
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 134 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 169 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 169
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 78
+      ID: 76
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 139
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 458400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 140 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 173 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 173
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 141 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 189
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 459168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 190 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 192 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 191 StructureType net/http.segment
     - __kind: GoSliceHeaderType
       ID: 58
       Name: '[]string'
@@ -943,94 +403,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 81 GoSliceDataType []string.array
+      Data: 79 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 81
+      ID: 79
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 157
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 463264
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 158 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 163 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 163
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 159 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 160
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 463328
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 161 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 165 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 162 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 98
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 468000
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 99 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 99
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 89
-      Name: '[]val<[]*mime/multipart.FileHeader>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 90 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: ArrayType
-      ID: 79
+      ID: 77
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 58 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 194
+      ID: 81
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1043,38 +430,19 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 88
-      Name: bucket<string,[]*mime/multipart.FileHeader>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 77 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 78 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 89 ArrayType []val<[]*mime/multipart.FileHeader>
-        - Name: overflow
-          Offset: 328
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 90 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: GoHMapBucketType
       ID: 53
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 77 ArrayType [8]uint8
+          Type: 75 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 78 ArrayType []key<string>
+          Type: 76 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 79 ArrayType []val<[]string>
+          Type: 77 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 52 PointerType *bucket<string,[]string>
@@ -1087,13 +455,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 77 ArrayType [8]uint8
+          Type: 75 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 78 ArrayType []key<string>
+          Type: 76 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 194 ArrayType []val<string>
+          Type: 81 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 73 PointerType *bucket<string,string>
@@ -1143,334 +511,10 @@ Types:
       GoRuntimeType: 1.435104e+06
       GoKind: 25
       RawFields: []
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 63
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.16096e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 7 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 7 BaseType uint16
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 11 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 101 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 104 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 106 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 108 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyCurveID
-          Offset: 186
-          Type: 109 BaseType crypto/tls.CurveID
-    - __kind: BaseType
-      ID: 109
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 778592
-      GoKind: 9
-    - __kind: StructureType
-      ID: 110
-      Name: crypto/x509.Certificate
-      ByteSize: 1352
-      GoRuntimeType: 2.300992e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 117 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 118 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 119 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 9 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 120 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 122 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 122 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 126 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 126 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 129 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 136 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 9 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 58 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 58 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 58 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 58 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 139 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 142 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 58 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 58 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 144 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 144 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 58 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 58 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 58 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 58 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 58 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 147 GoSliceHeaderType []crypto/x509.OID
-    - __kind: BaseType
-      ID: 138
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 546624
-      GoKind: 2
-    - __kind: BaseType
-      ID: 129
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 546560
-      GoKind: 2
-    - __kind: StructureType
-      ID: 149
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.762592e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 98 GoSliceHeaderType []uint8
-    - __kind: BaseType
-      ID: 118
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 780896
-      GoKind: 2
-    - __kind: BaseType
-      ID: 117
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.09744e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 125
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.349408e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 119 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 132
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.494976e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 98 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 122
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.105696e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 58 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 58 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 58 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 58 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 58 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 58 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 58 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 11 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 11 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 123 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 123 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 135
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.0376e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 28 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 182 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 9 BaseType int
     - __kind: GoInterfaceType
       ID: 18
       Name: error
@@ -1502,50 +546,10 @@ Types:
       ByteSize: 8
       GoRuntimeType: 645600
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 108
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 983200
-      GoKind: 19
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
-    - __kind: GoHMapHeaderType
-      ID: 86
-      Name: hash<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 54 PointerType *runtime.mapextra
-      BucketType: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 93 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
       ID: 51
       Name: hash<string,[]string>
@@ -1579,7 +583,7 @@ Types:
           Offset: 40
           Type: 54 PointerType *runtime.mapextra
       BucketType: 53 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 80 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 78 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 72
       Name: hash<string,string>
@@ -1613,7 +617,7 @@ Types:
           Offset: 40
           Type: 54 PointerType *runtime.mapextra
       BucketType: 74 GoHMapBucketType bucket<string,string>
-      BucketsType: 195 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 82 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1644,19 +648,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 542592
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 119
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 798016
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 56
       Name: io.ReadCloser
@@ -1671,165 +662,16 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 84
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 904160
-      GoKind: 21
-      HeaderType: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 899360
-      GoKind: 21
-      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoMapType
       ID: 70
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
       HeaderType: 72 GoHMapHeaderType hash<string,string>
-    - __kind: StructureType
-      ID: 121
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.340768e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 150 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 152
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 546880
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 150
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.280544e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 151 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 153 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 153
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 152 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 94
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.881696e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 97 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 14 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 98 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 14 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 61
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.326048e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 83 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 141
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.00144e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 184 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 186
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 999456
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 187 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 187
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 177
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.307168e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 141 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 186 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 49
       Name: net/http.Header
@@ -1922,55 +764,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 70 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 66
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.124032e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 9 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 11 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 9 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 9 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 49 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 56 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 14 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 58 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 49 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 62 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -1984,107 +781,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 69
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.745568e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 189 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 191
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.453312e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 97
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.63792e+06
-      GoKind: 21
-      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 48
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.041568e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 75 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 11 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 11 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 11 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 76
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.469632e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 59
       Name: net/url.Values
@@ -2114,85 +818,6 @@ Types:
       ID: 45
       Name: string.str
       ByteSize: 2048
-    - __kind: StructureType
-      ID: 128
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.877952e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 157 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 160 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 11 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 14 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 14 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 158 PointerType *time.zone
-    - __kind: StructureType
-      ID: 126
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.281472e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 10 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 14 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 127 PointerType *time.Location
-    - __kind: StructureType
-      ID: 159
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.458304e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 9 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 162
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.664192e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 14 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -2235,6 +860,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543616
       GoKind: 26
-MaxTypeID: 197
+MaxTypeID: 84
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 83 EventRootType Probe[main.HandleHTTP]
+          Type: 124 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff40", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 84 EventRootType Probe[main.LookAtTheRequest]
+          Type: 125 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e025c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -113,10 +113,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 80
+      ID: 121
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 79 GoSliceDataType []string.array
+      Pointee: 120 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -125,15 +125,15 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 52
+      ID: 93
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 53 GoHMapBucketType bucket<string,[]string>
+      Pointee: 94 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 73
+      ID: 114
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 74 GoHMapBucketType bucket<string,string>
+      Pointee: 115 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 41
       Name: '*bytes.Buffer'
@@ -142,12 +142,12 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 62
+      ID: 103
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 63 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 104 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -177,15 +177,22 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 50
+      ID: 47
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.397152e+06
+      GoKind: 22
+      Pointee: 48 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+    - __kind: PointerType
+      ID: 91
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 51 GoHMapHeaderType hash<string,[]string>
+      Pointee: 92 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 71
+      ID: 112
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 72 GoHMapHeaderType hash<string,string>
+      Pointee: 113 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -222,12 +229,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 60
+      ID: 101
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 61 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 102 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -236,33 +243,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 65
+      ID: 106
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 66 UnresolvedPointeeType net/http.Response
+      Pointee: 107 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 68
+      ID: 84
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.8768e+06
+      GoKind: 22
+      Pointee: 85 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 109
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 69 UnresolvedPointeeType net/http.pattern
+      Pointee: 110 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 47
+      ID: 86
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.11776e+06
+      GoKind: 22
+      Pointee: 87 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 88
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 48 UnresolvedPointeeType net/url.URL
+      Pointee: 89 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 54
+      ID: 95
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 380000
       GoKind: 22
-      Pointee: 55 UnresolvedPointeeType runtime.mapextra
+      Pointee: 96 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -275,6 +296,111 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 45 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 53
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.5328e+06
+      GoKind: 22
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 67
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.657312e+06
+      GoKind: 22
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 49
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.532416e+06
+      GoKind: 22
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 59
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.656544e+06
+      GoKind: 22
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 73
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.7272e+06
+      GoKind: 22
+      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 61
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.656736e+06
+      GoKind: 22
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 57
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.656352e+06
+      GoKind: 22
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 69
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.726752e+06
+      GoKind: 22
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 77
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.795072e+06
+      GoKind: 22
+      Pointee: 78 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 71
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.726976e+06
+      GoKind: 22
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 55
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.532992e+06
+      GoKind: 22
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 51
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.532608e+06
+      GoKind: 22
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 63
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.656928e+06
+      GoKind: 22
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 75
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.727424e+06
+      GoKind: 22
+      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 65
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.65712e+06
+      GoKind: 22
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -318,12 +444,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 64
+      ID: 105
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: EventRootType
-      ID: 83
+      ID: 124
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -347,7 +473,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 84
+      ID: 125
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -362,7 +488,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 75
+      ID: 116
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -371,24 +497,24 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 53 GoHMapBucketType bucket<string,[]string>
+      Element: 94 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 82
+      ID: 123
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 74 GoHMapBucketType bucket<string,string>
+      Element: 115 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 76
+      ID: 117
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 58
+      ID: 99
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -403,21 +529,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 79 GoSliceDataType []string.array
+      Data: 120 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 79
+      ID: 120
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 77
+      ID: 118
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 58 GoSliceHeaderType []string
+      Element: 99 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 81
+      ID: 122
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -430,41 +556,41 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 53
+      ID: 94
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 75 ArrayType [8]uint8
+          Type: 116 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 76 ArrayType []key<string>
+          Type: 117 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 77 ArrayType []val<[]string>
+          Type: 118 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 52 PointerType *bucket<string,[]string>
+          Type: 93 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 58 GoSliceHeaderType []string
+      ValueType: 99 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 74
+      ID: 115
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 75 ArrayType [8]uint8
+          Type: 116 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 76 ArrayType []key<string>
+          Type: 117 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 81 ArrayType []val<string>
+          Type: 122 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 73 PointerType *bucket<string,string>
+          Type: 114 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
@@ -484,7 +610,7 @@ Types:
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 67
+      ID: 108
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215776e+06
@@ -512,7 +638,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 63
+      ID: 104
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -541,7 +667,7 @@ Types:
       GoRuntimeType: 543488
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 57
+      ID: 98
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
@@ -550,8 +676,25 @@ Types:
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.26592e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 48
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 51
+      ID: 92
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -572,20 +715,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 52 PointerType *bucket<string,[]string>
+          Type: 93 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 52 PointerType *bucket<string,[]string>
+          Type: 93 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 54 PointerType *runtime.mapextra
-      BucketType: 53 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 78 GoSliceDataType []bucket<string,[]string>.array
+          Type: 95 PointerType *runtime.mapextra
+      BucketType: 94 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 119 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 72
+      ID: 113
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -606,18 +749,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 73 PointerType *bucket<string,string>
+          Type: 114 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 73 PointerType *bucket<string,string>
+          Type: 114 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 54 PointerType *runtime.mapextra
-      BucketType: 74 GoHMapBucketType bucket<string,string>
-      BucketsType: 82 GoSliceDataType []bucket<string,string>.array
+          Type: 95 PointerType *runtime.mapextra
+      BucketType: 115 GoHMapBucketType bucket<string,string>
+      BucketsType: 123 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -649,7 +792,7 @@ Types:
       GoRuntimeType: 542592
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 56
+      ID: 97
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.093088e+06
@@ -662,23 +805,75 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 70
+      ID: 111
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 72 GoHMapHeaderType hash<string,string>
+      HeaderType: 113 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 61
+      ID: 102
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 82
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.006752e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.005344e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 49
+      ID: 90
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.964288e+06
       GoKind: 21
-      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 92 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 83
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.005472e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.005728e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -691,7 +886,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 47 PointerType *net/url.URL
+          Type: 88 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -703,19 +898,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 49 GoMapType net/http.Header
+          Type: 90 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 56 GoInterfaceType io.ReadCloser
+          Type: 97 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 57 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 98 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 58 GoSliceHeaderType []string
+          Type: 99 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -724,16 +919,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 59 GoMapType net/url.Values
+          Type: 100 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 59 GoMapType net/url.Values
+          Type: 100 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 60 PointerType *mime/multipart.Form
+          Type: 101 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 49 GoMapType net/http.Header
+          Type: 90 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -742,30 +937,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 62 PointerType *crypto/tls.ConnectionState
+          Type: 103 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 64 GoChannelType <-chan struct {}
+          Type: 105 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 65 PointerType *net/http.Response
+          Type: 106 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 67 GoInterfaceType context.Context
+          Type: 108 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 68 PointerType *net/http.pattern
+          Type: 109 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 58 GoSliceHeaderType []string
+          Type: 99 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 70 GoMapType map[string]string
+          Type: 111 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 66
+      ID: 107
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -782,22 +977,30 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 69
+      ID: 85
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 110
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 48
+      ID: 87
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 89
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 59
+      ID: 100
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.712416e+06
       GoKind: 21
-      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 92 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 55
+      ID: 96
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -818,6 +1021,252 @@ Types:
       ID: 45
       Name: string.str
       ByteSize: 2048
+    - __kind: StructureType
+      ID: 54
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.856384e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 68
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.93168e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 50
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.855872e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 60
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 1.930528e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 74
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.000128e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 62
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.930816e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 58
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 1.93024e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 70
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 1.999488e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 78
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.059232e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 72
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.999808e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 56
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.85664e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 52
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.856128e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 64
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 1.931104e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 76
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.000448e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 66
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.931392e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -860,6 +1309,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543616
       GoKind: 26
-MaxTypeID: 84
+MaxTypeID: 125
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 215 EventRootType Probe[main.HandleHTTP]
+          Type: 91 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0ca0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 216 EventRootType Probe[main.LookAtTheRequest]
+          Type: 92 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0f9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -105,34 +113,6 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 110
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 111 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 98
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 153
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 154 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 151
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 47 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 89
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 90 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 52
       Name: '**table<string,[]string>'
       ByteSize: 8
@@ -143,108 +123,10 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 113
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 109 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 120
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 119 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 104
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 103 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 190
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 189 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 187
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 124
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 123 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 194
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 193 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 167
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 166 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 181
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 206
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 205 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 84
+      ID: 82
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 83 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 177
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 176 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 115
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 483424
-      GoKind: 22
-      Pointee: 106 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 108
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 107 GoSliceDataType []uint8.array
+      Pointee: 81 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -265,61 +147,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 61 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 111
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.081952e+06
-      GoKind: 22
-      Pointee: 118 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 145
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 426848
-      GoKind: 22
-      Pointee: 146 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 156
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.988896e+06
-      GoKind: 22
-      Pointee: 157 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 159
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 426912
-      GoKind: 22
-      Pointee: 160 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 132
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 443616
-      GoKind: 22
-      Pointee: 133 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 139
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 443808
-      GoKind: 22
-      Pointee: 140 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 142
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.074528e+06
-      GoKind: 22
-      Pointee: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 196
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 195 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 61 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -384,11 +212,6 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 87
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 88 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 50
       Name: '*map<string,[]string>'
       ByteSize: 8
@@ -399,62 +222,12 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 128
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.440096e+06
-      GoKind: 22
-      Pointee: 129 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 162
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 429728
-      GoKind: 22
-      Pointee: 163 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 165
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 99
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 920288
-      GoKind: 22
-      Pointee: 102 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 148
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.197536e+06
-      GoKind: 22
-      Pointee: 149 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 198
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 197 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 201
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 200 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 154
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.203744e+06
-      GoKind: 22
-      Pointee: 188 StructureType net.IPNet
+      Pointee: 59 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -468,50 +241,31 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 64 StructureType net/http.Response
+      Pointee: 64 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 66
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 67 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 203
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 393440
-      GoKind: 22
-      Pointee: 204 StructureType net/http.segment
+      Pointee: 67 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 47
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 48 StructureType net/url.URL
+      Pointee: 48 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 73
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.221536e+06
-      GoKind: 22
-      Pointee: 74 StructureType net/url.Userinfo
-    - __kind: PointerType
-      ID: 93
-      Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
-      ByteSize: 8
-      Pointee: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 77
+      ID: 75
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 78 StructureType noalg.map.group[string][]string
+      Pointee: 76 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 209
+      ID: 85
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 210 StructureType noalg.map.group[string]string
+      Pointee: 86 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -525,41 +279,15 @@ Types:
       ByteSize: 8
       Pointee: 45 GoStringDataType string.str
     - __kind: PointerType
-      ID: 90
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 91 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 53
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 75 StructureType table<string,[]string>
+      Pointee: 73 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 72
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 207 StructureType table<string,string>
-    - __kind: PointerType
-      ID: 135
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.642272e+06
-      GoKind: 22
-      Pointee: 136 StructureType time.Location
-    - __kind: PointerType
-      ID: 169
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 396576
-      GoKind: 22
-      Pointee: 170 StructureType time.zone
-    - __kind: PointerType
-      ID: 172
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 396640
-      GoKind: 22
-      Pointee: 173 StructureType time.zoneTrans
+      Pointee: 83 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -608,7 +336,7 @@ Types:
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: EventRootType
-      ID: 215
+      ID: 91
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -632,7 +360,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 216
+      ID: 92
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -646,344 +374,26 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-    - __kind: GoSliceHeaderType
-      ID: 109
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 503680
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 110 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 119
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 111 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 488960
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 103 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 103
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 99 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 152
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 518464
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 153 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 189 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 189
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 154 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 150
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 518400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 151 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 186 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 186
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 47 PointerType *net/url.URL
-    - __kind: GoSliceDataType
-      ID: 100
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 90 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 81
+      ID: 79
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 53 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 89
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 112
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 503808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 113 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 121
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 109 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 114
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 483808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 115 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 123 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 123
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 106 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 144
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 505152
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 145 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 146 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 155
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 518528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 156 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 157 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 158
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 518592
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 159 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 193 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 193
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 160 StructureType crypto/x509.PolicyMapping
-    - __kind: GoSliceHeaderType
-      ID: 131
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 519040
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 132 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 166 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 133 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 138
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 518272
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 139 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 140 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 141
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 518336
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 142 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 147
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 484768
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 148 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 184 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 149 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 202
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 486400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 203 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 205 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 205
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 204 StructureType net/http.segment
-    - __kind: GoSliceDataType
-      ID: 101
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 82
+      ID: 80
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 78 StructureType noalg.map.group[string][]string
+      Element: 76 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 90
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 210 StructureType noalg.map.group[string]string
+      Element: 86 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 56
       Name: '[]string'
@@ -1000,78 +410,12 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 83 GoSliceDataType []string.array
+      Data: 81 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 83
+      ID: 81
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 168
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 490944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 169 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 174 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 170 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 171
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 491008
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 172 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 176 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 176
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 173 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 496896
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 107 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 107
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1122,368 +466,10 @@ Types:
       GoRuntimeType: 1.61824e+06
       GoKind: 25
       RawFields: []
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 61
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.301632e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 109 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 112 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 114 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 116 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyCurveID
-          Offset: 186
-          Type: 117 BaseType crypto/tls.CurveID
-    - __kind: BaseType
-      ID: 117
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 843360
-      GoKind: 9
-    - __kind: StructureType
-      ID: 118
-      Name: crypto/x509.Certificate
-      ByteSize: 1424
-      GoRuntimeType: 2.452512e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 125 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 126 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 127 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 7 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 128 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 130 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 130 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 134 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 134 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 137 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 138 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 138 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 144 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 7 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 56 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 56 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 56 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 56 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 147 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 150 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 56 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 56 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 152 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 152 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 56 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 56 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 56 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 56 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 56 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 155 GoSliceHeaderType []crypto/x509.OID
-        - Name: InhibitAnyPolicy
-          Offset: 1352
-          Type: 7 BaseType int
-        - Name: InhibitAnyPolicyZero
-          Offset: 1360
-          Type: 4 BaseType bool
-        - Name: InhibitPolicyMapping
-          Offset: 1368
-          Type: 7 BaseType int
-        - Name: InhibitPolicyMappingZero
-          Offset: 1376
-          Type: 4 BaseType bool
-        - Name: RequireExplicitPolicy
-          Offset: 1384
-          Type: 7 BaseType int
-        - Name: RequireExplicitPolicyZero
-          Offset: 1392
-          Type: 4 BaseType bool
-        - Name: PolicyMappings
-          Offset: 1400
-          Type: 158 GoSliceHeaderType []crypto/x509.PolicyMapping
-    - __kind: BaseType
-      ID: 146
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 594272
-      GoKind: 2
-    - __kind: BaseType
-      ID: 137
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 594208
-      GoKind: 2
-    - __kind: StructureType
-      ID: 157
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.989152e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 106 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 160
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.5144e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 157 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 157 StructureType crypto/x509.OID
-    - __kind: BaseType
-      ID: 126
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 845664
-      GoKind: 2
-    - __kind: BaseType
-      ID: 125
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.134112e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 133
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.52688e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 127 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 140
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.678176e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 106 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 130
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.240928e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 56 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 56 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 56 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 56 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 56 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 56 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 56 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 9 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 9 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 131 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 131 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 143
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.074656e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 28 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 195 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 7 BaseType int
     - __kind: GoInterfaceType
       ID: 14
       Name: error
@@ -1515,58 +501,38 @@ Types:
       ByteSize: 8
       GoRuntimeType: 701088
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 116
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.020064e+06
-      GoKind: 19
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 92
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 93 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 101 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
-    - __kind: GoSwissMapGroupsType
-      ID: 76
+      ID: 74
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 77 PointerType *noalg.map.group[string][]string
+          Type: 75 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 78 StructureType noalg.map.group[string][]string
-      GroupSliceType: 82 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 76 StructureType noalg.map.group[string][]string
+      GroupSliceType: 80 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 208
+      ID: 84
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 209 PointerType *noalg.map.group[string]string
+          Type: 85 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 210 StructureType noalg.map.group[string]string
-      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 86 StructureType noalg.map.group[string]string
+      GroupSliceType: 90 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1597,19 +563,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 590240
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 127
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 863072
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 54
       Name: io.ReadCloser
@@ -1623,38 +576,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: GoSwissMapHeaderType
-      ID: 88
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 89 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 100 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 51
       Name: map<string,[]string>
@@ -1685,8 +606,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 81 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 78 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 79 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 76 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<string,string>
@@ -1717,22 +638,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 210 StructureType noalg.map.group[string]string
-    - __kind: GoMapType
-      ID: 86
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.152288e+06
-      GoKind: 21
-      HeaderType: 88 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 85
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.14768e+06
-      GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
+      TablePtrSliceType: 89 GoSliceDataType []*table<string,string>.array
+      GroupType: 86 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 68
       Name: map[string]string
@@ -1740,145 +647,10 @@ Types:
       GoRuntimeType: 1.148704e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<string,string>
-    - __kind: StructureType
-      ID: 129
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.51744e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 161 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 163
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 594464
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 161
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.420864e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 162 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 164 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 163 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 102
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 2.009312e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 105 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 13 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 106 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 13 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 59
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.5008e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 85 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 86 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.170304e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 197 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 197
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 199
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.037408e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 200 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 188
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.48176e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 149 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 199 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 49
       Name: net/http.Header
@@ -1971,55 +743,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 68 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 64
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.25968e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 7 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 7 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 49 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 54 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 56 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 49 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 60 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2033,107 +760,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 67
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.865856e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 202 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 204
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.637088e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 105
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.854368e+06
-      GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 48
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.172992e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 73 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 9 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 9 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 74
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.653024e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 57
       Name: net/url.Values
@@ -2142,47 +776,25 @@ Types:
       GoKind: 21
       HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 95
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 707136
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 96 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 79
+      ID: 77
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 80 StructureType noalg.struct { key string; elem []string }
+      Element: 78 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 211
+      ID: 87
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 212 StructureType noalg.struct { key string; elem string }
+      Element: 88 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 94
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.320928e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 95 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 78
+      ID: 76
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -2193,9 +805,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 79 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 77 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 210
+      ID: 86
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -2206,22 +818,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 211 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 87 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 96
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.3208e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 97 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 80
+      ID: 78
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -2234,7 +833,7 @@ Types:
           Offset: 16
           Type: 56 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 212
+      ID: 88
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -2265,31 +864,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 91
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 92 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 75
+      ID: 73
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2311,9 +886,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 76 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 74 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 207
+      ID: 83
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2335,86 +910,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 208 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: StructureType
-      ID: 136
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 2.00528e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 168 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 171 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 9 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 169 PointerType *time.zone
-    - __kind: StructureType
-      ID: 134
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.42368e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 13 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 135 PointerType *time.Location
-    - __kind: StructureType
-      ID: 170
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.64208e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 173
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.780992e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 13 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
+          Type: 84 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2457,6 +953,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591264
       GoKind: 26
-MaxTypeID: 216
+MaxTypeID: 92
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 91 EventRootType Probe[main.HandleHTTP]
+          Type: 132 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0ca0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 92 EventRootType Probe[main.LookAtTheRequest]
+          Type: 133 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0f9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -113,20 +113,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 52
+      ID: 93
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 53 PointerType *table<string,[]string>
+      Pointee: 94 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 71
+      ID: 112
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 72 PointerType *table<string,string>
+      Pointee: 113 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 82
+      ID: 123
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 81 GoSliceDataType []string.array
+      Pointee: 122 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -142,12 +142,12 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 60
+      ID: 101
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 61 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 102 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -176,6 +176,13 @@ Types:
       GoRuntimeType: 2.326784e+06
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 47
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.57712e+06
+      GoKind: 22
+      Pointee: 48 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -212,22 +219,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 50
+      ID: 91
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 51 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 92 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 69
+      ID: 110
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 70 GoSwissMapHeaderType map<string,string>
+      Pointee: 111 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 58
+      ID: 99
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 59 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 100 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -236,36 +243,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 63
+      ID: 104
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 64 UnresolvedPointeeType net/http.Response
+      Pointee: 105 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 66
+      ID: 84
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.044608e+06
+      GoKind: 22
+      Pointee: 85 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 107
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 67 UnresolvedPointeeType net/http.pattern
+      Pointee: 108 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 47
+      ID: 86
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.253408e+06
+      GoKind: 22
+      Pointee: 87 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 88
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 48 UnresolvedPointeeType net/url.URL
+      Pointee: 89 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 75
+      ID: 116
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 76 StructureType noalg.map.group[string][]string
+      Pointee: 117 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 85
+      ID: 126
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 86 StructureType noalg.map.group[string]string
+      Pointee: 127 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -280,14 +301,119 @@ Types:
       Pointee: 45 GoStringDataType string.str
     - __kind: PointerType
       ID: 53
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.716192e+06
+      GoKind: 22
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 67
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.774112e+06
+      GoKind: 22
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 49
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.715808e+06
+      GoKind: 22
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 59
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.773344e+06
+      GoKind: 22
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 73
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.845376e+06
+      GoKind: 22
+      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 61
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.773536e+06
+      GoKind: 22
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 57
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.773152e+06
+      GoKind: 22
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 69
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.844928e+06
+      GoKind: 22
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 77
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.917376e+06
+      GoKind: 22
+      Pointee: 78 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 71
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.845152e+06
+      GoKind: 22
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 55
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.716384e+06
+      GoKind: 22
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 51
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.716e+06
+      GoKind: 22
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 63
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.773728e+06
+      GoKind: 22
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 75
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.8456e+06
+      GoKind: 22
+      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 65
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.77392e+06
+      GoKind: 22
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 94
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 73 StructureType table<string,[]string>
+      Pointee: 114 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 72
+      ID: 113
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 83 StructureType table<string,string>
+      Pointee: 124 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -331,12 +457,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 62
+      ID: 103
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: EventRootType
-      ID: 91
+      ID: 132
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -360,7 +486,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 92
+      ID: 133
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -375,27 +501,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 79
+      ID: 120
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 53 PointerType *table<string,[]string>
+      Element: 94 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 89
+      ID: 130
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 72 PointerType *table<string,string>
+      Element: 113 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 80
+      ID: 121
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 76 StructureType noalg.map.group[string][]string
+      Element: 117 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 90
+      ID: 131
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 86 StructureType noalg.map.group[string]string
+      Element: 127 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 56
+      ID: 97
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -410,9 +536,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 81 GoSliceDataType []string.array
+      Data: 122 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 81
+      ID: 122
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -439,7 +565,7 @@ Types:
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 65
+      ID: 106
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298016e+06
@@ -467,7 +593,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 61
+      ID: 102
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -496,7 +622,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 55
+      ID: 96
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
@@ -505,34 +631,51 @@ Types:
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.43984e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 48
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 74
+      ID: 115
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 75 PointerType *noalg.map.group[string][]string
+          Type: 116 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 76 StructureType noalg.map.group[string][]string
-      GroupSliceType: 80 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 117 StructureType noalg.map.group[string][]string
+      GroupSliceType: 121 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 84
+      ID: 125
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 85 PointerType *noalg.map.group[string]string
+          Type: 126 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 86 StructureType noalg.map.group[string]string
-      GroupSliceType: 90 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 127 StructureType noalg.map.group[string]string
+      GroupSliceType: 131 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -564,7 +707,7 @@ Types:
       GoRuntimeType: 590240
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 54
+      ID: 95
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.129632e+06
@@ -577,7 +720,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 51
+      ID: 92
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -590,7 +733,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 52 PointerType **table<string,[]string>
+          Type: 93 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -606,10 +749,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 79 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 76 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 120 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 117 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 70
+      ID: 111
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -622,7 +765,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 71 PointerType **table<string,string>
+          Type: 112 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -638,26 +781,78 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 89 GoSliceDataType []*table<string,string>.array
-      GroupType: 86 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 130 GoSliceDataType []*table<string,string>.array
+      GroupType: 127 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 68
+      ID: 109
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.148704e+06
       GoKind: 21
-      HeaderType: 70 GoSwissMapHeaderType map<string,string>
+      HeaderType: 111 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 59
+      ID: 100
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 82
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.045088e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.04368e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 49
+      ID: 90
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.147456e+06
       GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 92 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 83
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.043808e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.044064e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -670,7 +865,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 47 PointerType *net/url.URL
+          Type: 88 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -682,19 +877,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 49 GoMapType net/http.Header
+          Type: 90 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 54 GoInterfaceType io.ReadCloser
+          Type: 95 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 55 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 96 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 56 GoSliceHeaderType []string
+          Type: 97 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -703,16 +898,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 98 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 98 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 99 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 49 GoMapType net/http.Header
+          Type: 90 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -721,30 +916,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 60 PointerType *crypto/tls.ConnectionState
+          Type: 101 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 62 GoChannelType <-chan struct {}
+          Type: 103 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 63 PointerType *net/http.Response
+          Type: 104 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 65 GoInterfaceType context.Context
+          Type: 106 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 66 PointerType *net/http.pattern
+          Type: 107 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 56 GoSliceHeaderType []string
+          Type: 97 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 68 GoMapType map[string]string
+          Type: 109 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 64
+      ID: 105
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -761,40 +956,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 67
+      ID: 85
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 108
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 48
+      ID: 87
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 89
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 57
+      ID: 98
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.920064e+06
       GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 92 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 77
+      ID: 118
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 78 StructureType noalg.struct { key string; elem []string }
+      Element: 119 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 87
+      ID: 128
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 88 StructureType noalg.struct { key string; elem string }
+      Element: 129 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 76
+      ID: 117
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -805,9 +1008,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 77 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 118 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 86
+      ID: 127
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -818,9 +1021,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 87 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 128 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 78
+      ID: 119
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -831,9 +1034,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 56 GoSliceHeaderType []string
+          Type: 97 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 88
+      ID: 129
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -864,7 +1067,253 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 73
+      ID: 54
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.98224e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 68
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.059584e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 50
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.981728e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 60
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.058432e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 74
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.12864e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 62
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.05872e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 58
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 2.058144e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 70
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 2.128e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 78
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.190272e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 72
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.12832e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 56
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.982496e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 52
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.981984e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 64
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.059008e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 76
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.12896e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 66
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.059296e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 83 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 114
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -886,9 +1335,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 74 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 115 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 83
+      ID: 124
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -910,7 +1359,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 84 GoSwissMapGroupsType groupReference<string,string>
+          Type: 125 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -953,6 +1402,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591264
       GoKind: 26
-MaxTypeID: 92
+MaxTypeID: 133
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 214 EventRootType Probe[main.HandleHTTP]
+          Type: 89 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859980", Frameless: true}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 215 EventRootType Probe[main.LookAtTheRequest]
+          Type: 90 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c5c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -98,34 +106,6 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 109
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 110 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 96
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 97 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 152
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 153 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 150
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 45 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 87
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 88 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 50
       Name: '**table<string,[]string>'
       ByteSize: 8
@@ -136,108 +116,10 @@ Types:
       ByteSize: 8
       Pointee: 70 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 112
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 119
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 118 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 102
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 101 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 186
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 185 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 121
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 123
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 122 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 182
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 191
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 190 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 166
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 178
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 180
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 184
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 82
+      ID: 80
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 81 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 174
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 173 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 176
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 175 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 114
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 486400
-      GoKind: 22
-      Pointee: 104 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 106
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 105 GoSliceDataType []uint8.array
+      Pointee: 79 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -258,61 +140,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 59 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 110
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.088896e+06
-      GoKind: 22
-      Pointee: 117 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 144
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 429824
-      GoKind: 22
-      Pointee: 145 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 155
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.997344e+06
-      GoKind: 22
-      Pointee: 156 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 158
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 429888
-      GoKind: 22
-      Pointee: 159 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 131
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 446528
-      GoKind: 22
-      Pointee: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 138
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 446720
-      GoKind: 22
-      Pointee: 139 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 141
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.079072e+06
-      GoKind: 22
-      Pointee: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 195
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 59 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -377,11 +205,6 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 85
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 86 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 48
       Name: '*map<string,[]string>'
       ByteSize: 8
@@ -392,62 +215,12 @@ Types:
       ByteSize: 8
       Pointee: 68 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 127
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.446656e+06
-      GoKind: 22
-      Pointee: 128 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 161
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 432640
-      GoKind: 22
-      Pointee: 162 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 164
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 163 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 97
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 924960
-      GoKind: 22
-      Pointee: 100 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 56
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 57 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 147
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.206144e+06
-      GoKind: 22
-      Pointee: 148 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 197
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 200
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 199 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 153
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.207712e+06
-      GoKind: 22
-      Pointee: 187 StructureType net.IPNet
+      Pointee: 57 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -461,50 +234,31 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.757856e+06
       GoKind: 22
-      Pointee: 62 StructureType net/http.Response
+      Pointee: 62 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 64
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642144e+06
       GoKind: 22
-      Pointee: 65 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 202
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 396288
-      GoKind: 22
-      Pointee: 203 StructureType net/http.segment
+      Pointee: 65 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 45
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 46 StructureType net/url.URL
+      Pointee: 46 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 71
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.225376e+06
-      GoKind: 22
-      Pointee: 72 StructureType net/url.Userinfo
-    - __kind: PointerType
-      ID: 91
-      Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
-      ByteSize: 8
-      Pointee: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 75
+      ID: 73
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 76 StructureType noalg.map.group[string][]string
+      Pointee: 74 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 208
+      ID: 83
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[string]string
+      Pointee: 84 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -518,41 +272,15 @@ Types:
       ByteSize: 8
       Pointee: 43 GoStringDataType string.str
     - __kind: PointerType
-      ID: 88
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 89 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 51
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 73 StructureType table<string,[]string>
+      Pointee: 71 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 70
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 206 StructureType table<string,string>
-    - __kind: PointerType
-      ID: 134
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.647136e+06
-      GoKind: 22
-      Pointee: 135 StructureType time.Location
-    - __kind: PointerType
-      ID: 168
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 399360
-      GoKind: 22
-      Pointee: 169 StructureType time.zone
-    - __kind: PointerType
-      ID: 171
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 399424
-      GoKind: 22
-      Pointee: 172 StructureType time.zoneTrans
+      Pointee: 81 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -601,7 +329,7 @@ Types:
       GoRuntimeType: 607040
       GoKind: 18
     - __kind: EventRootType
-      ID: 214
+      ID: 89
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -625,7 +353,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 215
+      ID: 90
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -639,344 +367,26 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-    - __kind: GoSliceHeaderType
-      ID: 108
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 507264
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 109 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 118
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 110 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 492064
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 101 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 101
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 97 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 151
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 508864
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 152 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 188 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 188
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 153 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 508800
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 150 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 185 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 185
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 45 PointerType *net/url.URL
-    - __kind: GoSliceDataType
-      ID: 98
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 88 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 79
+      ID: 77
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 51 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 87
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 111
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 507328
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 112 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 120
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 113
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 486720
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 114 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 122 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 122
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 104 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 143
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 508736
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 144 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 181
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 145 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 154
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 508928
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 155 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 190 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 190
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 156 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 157
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 508992
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 158 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 159 StructureType crypto/x509.PolicyMapping
-    - __kind: GoSliceHeaderType
-      ID: 130
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 523520
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 131 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 137
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 508608
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 138 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 139 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 140
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 508672
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 141 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 179
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 146
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 487744
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 147 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 183 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 183
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 148 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 201
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 489440
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 202 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 204 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 204
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 203 StructureType net/http.segment
-    - __kind: GoSliceDataType
-      ID: 99
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 76 StructureType noalg.map.group[string][]string
+      Element: 74 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 88
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[string]string
+      Element: 84 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 54
       Name: '[]string'
@@ -993,78 +403,12 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 81 GoSliceDataType []string.array
+      Data: 79 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 81
+      ID: 79
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 167
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 494176
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 168 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 173 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 173
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 169 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 170
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 494240
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 171 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 175 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 172 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 104
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 500128
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 105 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 105
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1100,377 +444,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 59
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.322656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: CurveID
-          Offset: 6
-          Type: 107 BaseType crypto/tls.CurveID
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 108 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 111 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 113 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 115 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyPeerSignatureAlgorithm
-          Offset: 186
-          Type: 116 BaseType crypto/tls.SignatureScheme
-    - __kind: BaseType
-      ID: 107
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 846592
-      GoKind: 9
-    - __kind: BaseType
-      ID: 116
-      Name: crypto/tls.SignatureScheme
-      ByteSize: 2
-      GoRuntimeType: 846688
-      GoKind: 9
-    - __kind: StructureType
-      ID: 117
-      Name: crypto/x509.Certificate
-      ByteSize: 1424
-      GoRuntimeType: 2.45792e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 124 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 125 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 126 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 7 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 127 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 129 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 129 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 133 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 133 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 136 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 143 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 7 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 54 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 54 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 54 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 54 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 146 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 149 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 54 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 54 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 151 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 151 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 54 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 54 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 54 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 54 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 54 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 154 GoSliceHeaderType []crypto/x509.OID
-        - Name: InhibitAnyPolicy
-          Offset: 1352
-          Type: 7 BaseType int
-        - Name: InhibitAnyPolicyZero
-          Offset: 1360
-          Type: 4 BaseType bool
-        - Name: InhibitPolicyMapping
-          Offset: 1368
-          Type: 7 BaseType int
-        - Name: InhibitPolicyMappingZero
-          Offset: 1376
-          Type: 4 BaseType bool
-        - Name: RequireExplicitPolicy
-          Offset: 1384
-          Type: 7 BaseType int
-        - Name: RequireExplicitPolicyZero
-          Offset: 1392
-          Type: 4 BaseType bool
-        - Name: PolicyMappings
-          Offset: 1400
-          Type: 157 GoSliceHeaderType []crypto/x509.PolicyMapping
-    - __kind: BaseType
-      ID: 145
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 598080
-      GoKind: 2
-    - __kind: BaseType
-      ID: 136
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 598016
-      GoKind: 2
-    - __kind: StructureType
-      ID: 156
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.9976e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 104 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 159
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.519712e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 156 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 156 StructureType crypto/x509.OID
-    - __kind: BaseType
-      ID: 125
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 849088
-      GoKind: 2
-    - __kind: BaseType
-      ID: 124
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.138944e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 132
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.532192e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 126 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 139
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.683232e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 104 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 129
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.249504e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 54 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 54 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 54 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 54 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 54 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 54 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 54 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 9 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 9 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 142
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.0792e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 27 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 7 BaseType int
     - __kind: GoInterfaceType
       ID: 14
       Name: error
@@ -1502,58 +479,38 @@ Types:
       ByteSize: 8
       GoRuntimeType: 704864
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 115
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.024448e+06
-      GoKind: 19
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 90
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 91 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 99 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
-    - __kind: GoSwissMapGroupsType
-      ID: 74
+      ID: 72
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 75 PointerType *noalg.map.group[string][]string
+          Type: 73 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 76 StructureType noalg.map.group[string][]string
-      GroupSliceType: 80 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 74 StructureType noalg.map.group[string][]string
+      GroupSliceType: 78 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 82
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[string]string
+          Type: 83 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 84 StructureType noalg.map.group[string]string
+      GroupSliceType: 88 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1584,19 +541,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 594048
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 126
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 866496
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 52
       Name: io.ReadCloser
@@ -1610,41 +554,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: GoSwissMapHeaderType
-      ID: 86
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 87 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 98 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 49
       Name: map<string,[]string>
@@ -1678,8 +587,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 79 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 76 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 77 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 74 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<string,string>
@@ -1713,22 +622,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 209 StructureType noalg.map.group[string]string
-    - __kind: GoMapType
-      ID: 84
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.156864e+06
-      GoKind: 21
-      HeaderType: 86 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.152512e+06
-      GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      TablePtrSliceType: 87 GoSliceDataType []*table<string,string>.array
+      GroupType: 84 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 66
       Name: map[string]string
@@ -1736,145 +631,10 @@ Types:
       GoRuntimeType: 1.153536e+06
       GoKind: 21
       HeaderType: 68 GoSwissMapHeaderType map<string,string>
-    - __kind: StructureType
-      ID: 128
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.522752e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 160 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 162
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 598272
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 160
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.426144e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 161 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 163 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 163
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 162 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 100
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 2.018016e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 103 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 13 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 104 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 13 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 57
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.505952e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 83 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 148
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.178176e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 196 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 198
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.041568e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 199 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 199
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 187
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.486272e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 148 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 198 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 47
       Name: net/http.Header
@@ -1967,55 +727,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 66 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 62
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.26784e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 7 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 7 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 47 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 52 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 54 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 47 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 58 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2029,107 +744,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 65
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.875072e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 201 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 203
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.641952e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 103
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.863136e+06
-      GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 46
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.180864e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 71 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 9 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 9 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 72
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.65808e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 55
       Name: net/url.Values
@@ -2138,47 +760,25 @@ Types:
       GoKind: 21
       HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 93
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 710720
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 94 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 77
+      ID: 75
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 78 StructureType noalg.struct { key string; elem []string }
+      Element: 76 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 210
+      ID: 85
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key string; elem string }
+      Element: 86 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 92
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.325024e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 93 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 76
+      ID: 74
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -2189,9 +789,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 77 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 75 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 209
+      ID: 84
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -2202,22 +802,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 85 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 94
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.324896e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 95 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 78
+      ID: 76
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -2230,7 +817,7 @@ Types:
           Offset: 16
           Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 211
+      ID: 86
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -2261,31 +848,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 89
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 90 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 73
+      ID: 71
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2307,9 +870,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 74 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 72 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 206
+      ID: 81
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2331,86 +894,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: StructureType
-      ID: 135
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 2.013984e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 167 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 170 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 9 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 168 PointerType *time.zone
-    - __kind: StructureType
-      ID: 133
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.428992e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 13 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 134 PointerType *time.Location
-    - __kind: StructureType
-      ID: 169
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.646944e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 172
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.788928e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 13 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
+          Type: 82 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2453,6 +937,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595072
       GoKind: 26
-MaxTypeID: 215
+MaxTypeID: 90
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x139d860", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 89 EventRootType Probe[main.HandleHTTP]
+          Type: 130 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859980", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 90 EventRootType Probe[main.LookAtTheRequest]
+          Type: 131 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c5c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -106,20 +106,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 50
+      ID: 91
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 51 PointerType *table<string,[]string>
+      Pointee: 92 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 69
+      ID: 110
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 70 PointerType *table<string,string>
+      Pointee: 111 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 80
+      ID: 121
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 79 GoSliceDataType []string.array
+      Pointee: 120 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -135,12 +135,12 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 58
+      ID: 99
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 59 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 100 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -169,6 +169,13 @@ Types:
       GoRuntimeType: 2.331872e+06
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 45
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.582272e+06
+      GoKind: 22
+      Pointee: 46 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -205,22 +212,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 48
+      ID: 89
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 49 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 90 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 67
+      ID: 108
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 68 GoSwissMapHeaderType map<string,string>
+      Pointee: 109 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 56
+      ID: 97
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 57 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 98 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -229,36 +236,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 61
+      ID: 102
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.757856e+06
       GoKind: 22
-      Pointee: 62 UnresolvedPointeeType net/http.Response
+      Pointee: 103 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 64
+      ID: 82
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.052704e+06
+      GoKind: 22
+      Pointee: 83 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 105
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642144e+06
       GoKind: 22
-      Pointee: 65 UnresolvedPointeeType net/http.pattern
+      Pointee: 106 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 45
+      ID: 84
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.276352e+06
+      GoKind: 22
+      Pointee: 85 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 86
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 46 UnresolvedPointeeType net/url.URL
+      Pointee: 87 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 73
+      ID: 114
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 74 StructureType noalg.map.group[string][]string
+      Pointee: 115 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 83
+      ID: 124
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 84 StructureType noalg.map.group[string]string
+      Pointee: 125 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -273,14 +294,119 @@ Types:
       Pointee: 43 GoStringDataType string.str
     - __kind: PointerType
       ID: 51
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.721824e+06
+      GoKind: 22
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 65
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.781088e+06
+      GoKind: 22
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 47
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.72144e+06
+      GoKind: 22
+      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 57
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.78032e+06
+      GoKind: 22
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 71
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.853344e+06
+      GoKind: 22
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 59
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.780512e+06
+      GoKind: 22
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 55
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.780128e+06
+      GoKind: 22
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 67
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.852896e+06
+      GoKind: 22
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 75
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.925024e+06
+      GoKind: 22
+      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 69
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.85312e+06
+      GoKind: 22
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 53
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.722016e+06
+      GoKind: 22
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 49
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.721632e+06
+      GoKind: 22
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 61
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.780704e+06
+      GoKind: 22
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 73
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.853568e+06
+      GoKind: 22
+      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 63
+      Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.780896e+06
+      GoKind: 22
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 92
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 71 StructureType table<string,[]string>
+      Pointee: 112 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 70
+      ID: 111
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 81 StructureType table<string,string>
+      Pointee: 122 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -324,12 +450,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 60
+      ID: 101
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
     - __kind: EventRootType
-      ID: 89
+      ID: 130
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -353,7 +479,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 90
+      ID: 131
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -368,27 +494,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 77
+      ID: 118
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 51 PointerType *table<string,[]string>
+      Element: 92 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 87
+      ID: 128
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 70 PointerType *table<string,string>
+      Element: 111 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 74 StructureType noalg.map.group[string][]string
+      Element: 115 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 88
+      ID: 129
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 84 StructureType noalg.map.group[string]string
+      Element: 125 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 95
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -403,9 +529,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 79 GoSliceDataType []string.array
+      Data: 120 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 79
+      ID: 120
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -432,7 +558,7 @@ Types:
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 63
+      ID: 104
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.302496e+06
@@ -445,7 +571,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 59
+      ID: 100
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -474,7 +600,7 @@ Types:
       GoRuntimeType: 594944
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 53
+      ID: 94
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 704864
@@ -483,34 +609,51 @@ Types:
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 77
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.44432e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 46
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 72
+      ID: 113
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 73 PointerType *noalg.map.group[string][]string
+          Type: 114 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 74 StructureType noalg.map.group[string][]string
-      GroupSliceType: 78 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 115 StructureType noalg.map.group[string][]string
+      GroupSliceType: 119 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 82
+      ID: 123
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 83 PointerType *noalg.map.group[string]string
+          Type: 124 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 84 StructureType noalg.map.group[string]string
-      GroupSliceType: 88 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 125 StructureType noalg.map.group[string]string
+      GroupSliceType: 129 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -542,7 +685,7 @@ Types:
       GoRuntimeType: 594048
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 52
+      ID: 93
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.134464e+06
@@ -555,7 +698,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 49
+      ID: 90
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -568,7 +711,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 50 PointerType **table<string,[]string>
+          Type: 91 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -587,10 +730,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 77 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 74 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 118 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 115 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 68
+      ID: 109
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -603,7 +746,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 69 PointerType **table<string,string>
+          Type: 110 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -622,26 +765,78 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 87 GoSliceDataType []*table<string,string>.array
-      GroupType: 84 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 128 GoSliceDataType []*table<string,string>.array
+      GroupType: 125 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 66
+      ID: 107
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.153536e+06
       GoKind: 21
-      HeaderType: 68 GoSwissMapHeaderType map<string,string>
+      HeaderType: 109 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 57
+      ID: 98
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.049376e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 78
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.04784e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 47
+      ID: 88
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.154272e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 90 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.047968e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.048224e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -654,7 +849,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 45 PointerType *net/url.URL
+          Type: 86 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -666,19 +861,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 88 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 52 GoInterfaceType io.ReadCloser
+          Type: 93 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 53 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 94 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 95 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -687,16 +882,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 55 GoMapType net/url.Values
+          Type: 96 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 55 GoMapType net/url.Values
+          Type: 96 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 56 PointerType *mime/multipart.Form
+          Type: 97 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 47 GoMapType net/http.Header
+          Type: 88 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -705,30 +900,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 58 PointerType *crypto/tls.ConnectionState
+          Type: 99 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 60 GoChannelType <-chan struct {}
+          Type: 101 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 61 PointerType *net/http.Response
+          Type: 102 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 63 GoInterfaceType context.Context
+          Type: 104 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 64 PointerType *net/http.pattern
+          Type: 105 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 95 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 66 GoMapType map[string]string
+          Type: 107 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 62
+      ID: 103
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -745,40 +940,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 65
+      ID: 83
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 106
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 46
+      ID: 85
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 87
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 55
+      ID: 96
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.927712e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 90 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 75
+      ID: 116
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 76 StructureType noalg.struct { key string; elem []string }
+      Element: 117 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 85
+      ID: 126
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 86 StructureType noalg.struct { key string; elem string }
+      Element: 127 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 74
+      ID: 115
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -789,9 +992,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 75 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 116 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 84
+      ID: 125
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -802,9 +1005,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 85 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 126 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 76
+      ID: 117
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -815,9 +1018,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 95 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 86
+      ID: 127
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -848,7 +1051,253 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 71
+      ID: 52
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.990688e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 66
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.066816e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 48
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.990176e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 58
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.065664e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 72
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.136544e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 60
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.065952e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 56
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 2.065376e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 68
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 2.135904e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 76
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.198528e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 70
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.136224e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 54
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.990944e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 50
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.990432e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 62
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.06624e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 74
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.136864e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 64
+      Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.066528e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 112
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -870,9 +1319,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 72 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 113 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 81
+      ID: 122
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -894,7 +1343,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 82 GoSwissMapGroupsType groupReference<string,string>
+          Type: 123 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -937,6 +1386,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595072
       GoKind: 26
-MaxTypeID: 90
+MaxTypeID: 131
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x139d860", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 195 EventRootType Probe[main.HandleHTTP]
+          Type: 82 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 196 EventRootType Probe[main.LookAtTheRequest]
+          Type: 83 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -121,126 +129,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 101
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      Pointee: 102 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 90
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 91 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 144
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 145 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 142
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 46 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 104
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 100 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 111
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 110 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 95
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 94 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 178
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 177 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 113
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 112 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 115
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 114 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 171
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 170 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 180
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 179 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 155
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 154 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 167
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 166 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 169
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 168 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 173
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 172 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 81
+      ID: 79
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 80 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 163
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 162 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 452512
-      GoKind: 22
-      Pointee: 97 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 99
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 98 GoSliceDataType []uint8.array
+      Pointee: 78 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -248,11 +140,6 @@ Types:
       GoRuntimeType: 372640
       GoKind: 22
       Pointee: 4 BaseType bool
-    - __kind: PointerType
-      ID: 86
-      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 51
       Name: '*bucket<string,[]string>'
@@ -276,54 +163,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 62 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 102
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 1.90528e+06
-      GoKind: 22
-      Pointee: 109 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 136
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 395040
-      GoKind: 22
-      Pointee: 137 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 147
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.717248e+06
-      GoKind: 22
-      Pointee: 148 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 123
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 408800
-      GoKind: 22
-      Pointee: 124 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 130
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 408992
-      GoKind: 22
-      Pointee: 131 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 133
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.009728e+06
-      GoKind: 22
-      Pointee: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 182
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 62 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -345,11 +185,6 @@ Types:
       GoRuntimeType: 372576
       GoKind: 22
       Pointee: 17 BaseType float64
-    - __kind: PointerType
-      ID: 84
-      Name: '*hash<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 85 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 49
       Name: '*hash<string,[]string>'
@@ -396,62 +231,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 119
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.231104e+06
-      GoKind: 22
-      Pointee: 120 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 150
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 397856
-      GoKind: 22
-      Pointee: 151 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 153
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 152 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 91
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 837376
-      GoKind: 22
-      Pointee: 93 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 59
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 60 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 139
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 1.974144e+06
-      GoKind: 22
-      Pointee: 140 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 184
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 187
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 145
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.095776e+06
-      GoKind: 22
-      Pointee: 176 StructureType net.IPNet
+      Pointee: 60 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -465,35 +250,21 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 65 StructureType net/http.Response
+      Pointee: 65 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 67
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 68 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 189
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 364000
-      GoKind: 22
-      Pointee: 190 StructureType net/http.segment
+      Pointee: 68 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 46
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 47 StructureType net/url.URL
-    - __kind: PointerType
-      ID: 74
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.114208e+06
-      GoKind: 22
-      Pointee: 75 StructureType net/url.Userinfo
+      Pointee: 47 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 53
       Name: '*runtime.mapextra'
@@ -513,27 +284,6 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 44 GoStringDataType string.str
-    - __kind: PointerType
-      ID: 126
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.421216e+06
-      GoKind: 22
-      Pointee: 127 StructureType time.Location
-    - __kind: PointerType
-      ID: 157
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 367072
-      GoKind: 22
-      Pointee: 158 StructureType time.zone
-    - __kind: PointerType
-      ID: 160
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 367136
-      GoKind: 22
-      Pointee: 161 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -582,7 +332,7 @@ Types:
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: EventRootType
-      ID: 195
+      ID: 82
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -606,7 +356,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 196
+      ID: 83
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -621,7 +371,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 76
+      ID: 74
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -629,314 +379,23 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 100
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 469536
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 101 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 110 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 110
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 102 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 457376
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 94 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 94
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 91 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 143
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 481568
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 144 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 177 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 145 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 141
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 481504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 142 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 174 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 46 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 103
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 469664
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 104 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 112 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 112
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 100 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 452832
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 106 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 114 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 114
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 97 GoSliceHeaderType []uint8
-    - __kind: GoSliceDataType
-      ID: 92
-      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 2048
-      Element: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 79
+      ID: 77
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 52 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 81
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 73 GoHMapBucketType bucket<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 135
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 470816
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 136 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 170 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 137 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 146
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 481632
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 147 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 179 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 179
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 148 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 122
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 481888
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 123 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 154 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 154
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 124 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 129
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 481376
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 130 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 166 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 131 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 132
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 481440
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 133 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 168 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 168
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 77
+      ID: 75
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 138
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 454048
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 139 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 172 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 140 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 188
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 454816
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 189 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 191 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 190 StructureType net/http.segment
     - __kind: GoSliceHeaderType
       ID: 57
       Name: '[]string'
@@ -953,94 +412,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 80 GoSliceDataType []string.array
+      Data: 78 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 156
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 459040
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 157 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 162 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 158 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 159
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 459104
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 160 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 164 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 161 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 463552
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 98 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 98
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 88
-      Name: '[]val<[]*mime/multipart.FileHeader>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 89 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: ArrayType
-      ID: 78
+      ID: 76
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 57 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 193
+      ID: 80
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1053,38 +439,19 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 87
-      Name: bucket<string,[]*mime/multipart.FileHeader>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 76 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 77 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 88 ArrayType []val<[]*mime/multipart.FileHeader>
-        - Name: overflow
-          Offset: 328
-          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 89 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: GoHMapBucketType
       ID: 52
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 74 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 75 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 78 ArrayType []val<[]string>
+          Type: 76 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 51 PointerType *bucket<string,[]string>
@@ -1097,13 +464,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 74 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 75 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 193 ArrayType []val<string>
+          Type: 80 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 72 PointerType *bucket<string,string>
@@ -1153,334 +520,10 @@ Types:
       GoRuntimeType: 1.399456e+06
       GoKind: 25
       RawFields: []
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 62
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.1e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 7 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 7 BaseType uint16
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 11 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 100 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 103 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 105 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 107 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyCurveID
-          Offset: 186
-          Type: 108 BaseType crypto/tls.CurveID
-    - __kind: BaseType
-      ID: 108
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 766048
-      GoKind: 9
-    - __kind: StructureType
-      ID: 109
-      Name: crypto/x509.Certificate
-      ByteSize: 1352
-      GoRuntimeType: 2.234656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 116 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 117 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 118 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 9 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 119 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 121 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 121 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 125 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 125 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 128 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 129 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 129 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 135 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 9 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 57 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 57 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 57 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 57 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 138 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 141 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 57 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 57 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 143 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 143 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 57 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 57 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 57 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 57 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 57 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 146 GoSliceHeaderType []crypto/x509.OID
-    - __kind: BaseType
-      ID: 137
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 537280
-      GoKind: 2
-    - __kind: BaseType
-      ID: 128
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 537216
-      GoKind: 2
-    - __kind: StructureType
-      ID: 148
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.717472e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 97 GoSliceHeaderType []uint8
-    - __kind: BaseType
-      ID: 117
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 768448
-      GoKind: 2
-    - __kind: BaseType
-      ID: 116
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.070976e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 124
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.316256e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 118 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 131
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.455008e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 97 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 121
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.046944e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 57 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 57 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 57 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 57 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 57 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 57 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 57 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 11 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 11 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 122 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 122 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 134
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.009856e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 27 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 181
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 9 BaseType int
     - __kind: GoInterfaceType
       ID: 18
       Name: error
@@ -1512,12 +555,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 634112
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 107
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 960256
-      GoKind: 19
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -1531,40 +568,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: GoHMapHeaderType
-      ID: 85
-      Name: hash<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 53 PointerType *runtime.mapextra
-      BucketType: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 92 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
       ID: 50
       Name: hash<string,[]string>
@@ -1598,7 +601,7 @@ Types:
           Offset: 40
           Type: 53 PointerType *runtime.mapextra
       BucketType: 52 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 79 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 77 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 71
       Name: hash<string,string>
@@ -1632,7 +635,7 @@ Types:
           Offset: 40
           Type: 53 PointerType *runtime.mapextra
       BucketType: 73 GoHMapBucketType bucket<string,string>
-      BucketsType: 194 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 81 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1663,19 +666,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 533632
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 118
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 785376
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 55
       Name: io.ReadCloser
@@ -1690,165 +680,16 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 83
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 887296
-      GoKind: 21
-      HeaderType: 85 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 82
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 882496
-      GoKind: 21
-      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoMapType
       ID: 69
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
       HeaderType: 71 GoHMapHeaderType hash<string,string>
-    - __kind: StructureType
-      ID: 120
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.308416e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 149 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 151
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 537536
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.21424e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 150 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 152 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 152
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 151 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 93
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.838016e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 96 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 13 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 13 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 60
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.294336e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 82 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 83 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 140
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 1.94816e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 183 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 183
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 185
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 975808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 186 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 186
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 176
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.275936e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 140 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 185 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 48
       Name: net/http.Header
@@ -1941,55 +782,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 69 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 65
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.064832e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 9 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 11 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 9 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 9 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 48 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 57 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 48 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 61 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2003,107 +799,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 68
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.701568e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 188 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 190
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.416032e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 96
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.595904e+06
-      GoKind: 21
-      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 47
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 1.986272e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 74 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 11 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 11 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 11 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 75
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.432736e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 58
       Name: net/url.Values
@@ -2133,85 +836,6 @@ Types:
       ID: 44
       Name: string.str
       ByteSize: 2048
-    - __kind: StructureType
-      ID: 127
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.833984e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 156 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 159 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 11 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 157 PointerType *time.zone
-    - __kind: StructureType
-      ID: 125
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.215168e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 10 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 13 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 126 PointerType *time.Location
-    - __kind: StructureType
-      ID: 158
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.421024e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 9 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 161
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.623328e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 13 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -2254,6 +878,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534656
       GoKind: 26
-MaxTypeID: 196
+MaxTypeID: 83
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 82 EventRootType Probe[main.HandleHTTP]
+          Type: 123 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 83 EventRootType Probe[main.LookAtTheRequest]
+          Type: 124 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -129,10 +129,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 79
+      ID: 120
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 78 GoSliceDataType []string.array
+      Pointee: 119 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -141,15 +141,15 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 51
+      ID: 92
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 52 GoHMapBucketType bucket<string,[]string>
+      Pointee: 93 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 72
+      ID: 113
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 73 GoHMapBucketType bucket<string,string>
+      Pointee: 114 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*bytes.Buffer'
@@ -158,12 +158,12 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 61
+      ID: 102
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 62 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 103 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -186,15 +186,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 49
+      ID: 46
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.361664e+06
+      GoKind: 22
+      Pointee: 47 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+    - __kind: PointerType
+      ID: 90
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 50 GoHMapHeaderType hash<string,[]string>
+      Pointee: 91 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 70
+      ID: 111
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 71 GoHMapHeaderType hash<string,string>
+      Pointee: 112 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -231,12 +238,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 59
+      ID: 100
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 60 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 101 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -245,33 +252,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 64
+      ID: 105
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 65 UnresolvedPointeeType net/http.Response
+      Pointee: 106 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 67
+      ID: 83
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.832832e+06
+      GoKind: 22
+      Pointee: 84 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 108
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 68 UnresolvedPointeeType net/http.pattern
+      Pointee: 109 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 46
+      ID: 85
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.059008e+06
+      GoKind: 22
+      Pointee: 86 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 87
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 47 UnresolvedPointeeType net/url.URL
+      Pointee: 88 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 53
+      ID: 94
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 54 UnresolvedPointeeType runtime.mapextra
+      Pointee: 95 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -284,6 +305,111 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 44 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 52
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.495904e+06
+      GoKind: 22
+      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 66
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.61568e+06
+      GoKind: 22
+      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 48
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.49552e+06
+      GoKind: 22
+      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 58
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.614912e+06
+      GoKind: 22
+      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 72
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.684896e+06
+      GoKind: 22
+      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 60
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.615104e+06
+      GoKind: 22
+      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 56
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.61472e+06
+      GoKind: 22
+      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 68
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.684448e+06
+      GoKind: 22
+      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 76
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.750176e+06
+      GoKind: 22
+      Pointee: 77 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 70
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.684672e+06
+      GoKind: 22
+      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 54
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.496096e+06
+      GoKind: 22
+      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 50
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.495712e+06
+      GoKind: 22
+      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 62
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.615296e+06
+      GoKind: 22
+      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 74
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.68512e+06
+      GoKind: 22
+      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 64
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.615488e+06
+      GoKind: 22
+      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -327,12 +453,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 63
+      ID: 104
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: EventRootType
-      ID: 82
+      ID: 123
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -356,7 +482,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 83
+      ID: 124
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -371,7 +497,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 74
+      ID: 115
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -380,24 +506,24 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 77
+      ID: 118
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 52 GoHMapBucketType bucket<string,[]string>
+      Element: 93 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 81
+      ID: 122
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 73 GoHMapBucketType bucket<string,string>
+      Element: 114 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 75
+      ID: 116
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 57
+      ID: 98
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -412,21 +538,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 78 GoSliceDataType []string.array
+      Data: 119 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 76
+      ID: 117
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 57 GoSliceHeaderType []string
+      Element: 98 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 80
+      ID: 121
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -439,41 +565,41 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 52
+      ID: 93
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 74 ArrayType [8]uint8
+          Type: 115 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 75 ArrayType []key<string>
+          Type: 116 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 76 ArrayType []val<[]string>
+          Type: 117 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 51 PointerType *bucket<string,[]string>
+          Type: 92 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 57 GoSliceHeaderType []string
+      ValueType: 98 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 73
+      ID: 114
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 74 ArrayType [8]uint8
+          Type: 115 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 75 ArrayType []key<string>
+          Type: 116 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 80 ArrayType []val<string>
+          Type: 121 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 72 PointerType *bucket<string,string>
+          Type: 113 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
@@ -493,7 +619,7 @@ Types:
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 66
+      ID: 107
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187104e+06
@@ -521,7 +647,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 62
+      ID: 103
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -550,11 +676,28 @@ Types:
       GoRuntimeType: 534528
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 97
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
       GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 78
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.235648e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 47
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -569,7 +712,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 50
+      ID: 91
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -590,20 +733,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 51 PointerType *bucket<string,[]string>
+          Type: 92 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 51 PointerType *bucket<string,[]string>
+          Type: 92 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 53 PointerType *runtime.mapextra
-      BucketType: 52 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 77 GoSliceDataType []bucket<string,[]string>.array
+          Type: 94 PointerType *runtime.mapextra
+      BucketType: 93 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 118 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 71
+      ID: 112
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -624,18 +767,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 72 PointerType *bucket<string,string>
+          Type: 113 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 72 PointerType *bucket<string,string>
+          Type: 113 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 53 PointerType *runtime.mapextra
-      BucketType: 73 GoHMapBucketType bucket<string,string>
-      BucketsType: 81 GoSliceDataType []bucket<string,string>.array
+          Type: 94 PointerType *runtime.mapextra
+      BucketType: 114 GoHMapBucketType bucket<string,string>
+      BucketsType: 122 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -667,7 +810,7 @@ Types:
       GoRuntimeType: 533632
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 96
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067136e+06
@@ -680,23 +823,75 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 69
+      ID: 110
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 71 GoHMapHeaderType hash<string,string>
+      HeaderType: 112 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 60
+      ID: 101
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 983104
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 981696
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 48
+      ID: 89
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.91744e+06
       GoKind: 21
-      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 91 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 82
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 981824
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 982080
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -709,7 +904,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 46 PointerType *net/url.URL
+          Type: 87 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -721,19 +916,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 48 GoMapType net/http.Header
+          Type: 89 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 96 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 97 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 57 GoSliceHeaderType []string
+          Type: 98 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -742,16 +937,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 58 GoMapType net/url.Values
+          Type: 99 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 58 GoMapType net/url.Values
+          Type: 99 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 59 PointerType *mime/multipart.Form
+          Type: 100 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 48 GoMapType net/http.Header
+          Type: 89 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -760,30 +955,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 61 PointerType *crypto/tls.ConnectionState
+          Type: 102 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 63 GoChannelType <-chan struct {}
+          Type: 104 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 64 PointerType *net/http.Response
+          Type: 105 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 66 GoInterfaceType context.Context
+          Type: 107 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 67 PointerType *net/http.pattern
+          Type: 108 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 57 GoSliceHeaderType []string
+          Type: 98 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 69 GoMapType map[string]string
+          Type: 110 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 65
+      ID: 106
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -800,22 +995,30 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 68
+      ID: 84
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 109
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 47
+      ID: 86
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 88
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 58
+      ID: 99
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.670784e+06
       GoKind: 21
-      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 91 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 54
+      ID: 95
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -836,6 +1039,252 @@ Types:
       ID: 44
       Name: string.str
       ByteSize: 2048
+    - __kind: StructureType
+      ID: 53
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.810144e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 67
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.885248e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 49
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.809632e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 59
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 1.884096e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 73
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.9472e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 61
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.884384e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 57
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 1.883808e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 69
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 1.94656e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 77
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.005088e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 71
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.94688e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 55
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.8104e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 51
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.809888e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 63
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 1.884672e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 75
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.94752e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 65
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.88496e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -878,6 +1327,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534656
       GoKind: 26
-MaxTypeID: 83
+MaxTypeID: 124
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 214 EventRootType Probe[main.HandleHTTP]
+          Type: 90 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 215 EventRootType Probe[main.LookAtTheRequest]
+          Type: 91 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -121,35 +129,6 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 109
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 110 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 97
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 98 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 152
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 153 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 150
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 46 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 88
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 89 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 51
       Name: '**table<string,[]string>'
       ByteSize: 8
@@ -160,108 +139,10 @@ Types:
       ByteSize: 8
       Pointee: 71 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 112
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 119
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 118 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 102 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 186
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 185 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 121
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 123
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 122 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 182
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 191
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 190 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 166
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 178
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 180
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 184
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 83
+      ID: 81
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 82 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 174
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 173 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 176
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 175 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 114
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 478304
-      GoKind: 22
-      Pointee: 105 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 107
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 106 GoSliceDataType []uint8.array
+      Pointee: 80 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -282,61 +163,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 60 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 110
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.031072e+06
-      GoKind: 22
-      Pointee: 117 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 144
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 420256
-      GoKind: 22
-      Pointee: 145 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 155
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.938912e+06
-      GoKind: 22
-      Pointee: 156 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 158
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 420320
-      GoKind: 22
-      Pointee: 159 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 131
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 434080
-      GoKind: 22
-      Pointee: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 138
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 434272
-      GoKind: 22
-      Pointee: 139 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 141
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.044704e+06
-      GoKind: 22
-      Pointee: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 195
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 60 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -394,11 +221,6 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 86
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 87 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 49
       Name: '*map<string,[]string>'
       ByteSize: 8
@@ -409,62 +231,12 @@ Types:
       ByteSize: 8
       Pointee: 69 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 127
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.365472e+06
-      GoKind: 22
-      Pointee: 128 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 161
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 423200
-      GoKind: 22
-      Pointee: 162 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 164
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 163 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 98
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 902912
-      GoKind: 22
-      Pointee: 101 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 57
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 58 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 147
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.13488e+06
-      GoKind: 22
-      Pointee: 148 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 197
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 200
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 199 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 153
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.174624e+06
-      GoKind: 22
-      Pointee: 187 StructureType net.IPNet
+      Pointee: 58 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -478,50 +250,31 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 63 StructureType net/http.Response
+      Pointee: 63 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 65
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 66 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 202
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 388640
-      GoKind: 22
-      Pointee: 203 StructureType net/http.segment
+      Pointee: 66 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 46
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 47 StructureType net/url.URL
+      Pointee: 47 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 72
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.19216e+06
-      GoKind: 22
-      Pointee: 73 StructureType net/url.Userinfo
-    - __kind: PointerType
-      ID: 92
-      Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
-      ByteSize: 8
-      Pointee: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 76
+      ID: 74
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 77 StructureType noalg.map.group[string][]string
+      Pointee: 75 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 208
+      ID: 84
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[string]string
+      Pointee: 85 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -535,41 +288,15 @@ Types:
       ByteSize: 8
       Pointee: 44 GoStringDataType string.str
     - __kind: PointerType
-      ID: 89
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 90 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 52
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 74 StructureType table<string,[]string>
+      Pointee: 72 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 71
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 206 StructureType table<string,string>
-    - __kind: PointerType
-      ID: 134
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.602944e+06
-      GoKind: 22
-      Pointee: 135 StructureType time.Location
-    - __kind: PointerType
-      ID: 168
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 391776
-      GoKind: 22
-      Pointee: 169 StructureType time.zone
-    - __kind: PointerType
-      ID: 171
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 391840
-      GoKind: 22
-      Pointee: 172 StructureType time.zoneTrans
+      Pointee: 82 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -618,7 +345,7 @@ Types:
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: EventRootType
-      ID: 214
+      ID: 90
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -642,7 +369,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 215
+      ID: 91
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -656,344 +383,26 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-    - __kind: GoSliceHeaderType
-      ID: 108
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 498464
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 109 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 118
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 110 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 96
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 483904
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 97 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 102 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 102
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 98 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 151
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 512000
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 152 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 188 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 188
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 153 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 511936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 150 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 185 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 185
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 46 PointerType *net/url.URL
-    - __kind: GoSliceDataType
-      ID: 99
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 89 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 52 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 88
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 71 PointerType *table<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 111
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 498592
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 112 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 120
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 113
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 478688
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 114 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 122 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 122
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 105 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 143
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 499936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 144 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 181
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 145 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 154
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 512064
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 155 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 190 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 190
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 156 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 157
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 512128
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 158 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 159 StructureType crypto/x509.PolicyMapping
-    - __kind: GoSliceHeaderType
-      ID: 130
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 512576
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 131 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 137
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 511808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 138 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 139 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 140
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 511872
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 141 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 179
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 146
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 479648
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 147 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 183 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 183
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 148 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 201
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 481280
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 202 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 204 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 204
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 203 StructureType net/http.segment
-    - __kind: GoSliceDataType
-      ID: 100
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 81
+      ID: 79
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 77 StructureType noalg.map.group[string][]string
+      Element: 75 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 89
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[string]string
+      Element: 85 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 55
       Name: '[]string'
@@ -1010,78 +419,12 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 82 GoSliceDataType []string.array
+      Data: 80 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 82
+      ID: 80
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 167
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 485952
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 168 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 173 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 173
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 169 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 170
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 486016
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 171 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 175 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 172 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 491680
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 106 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 106
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1132,368 +475,10 @@ Types:
       GoRuntimeType: 1.580704e+06
       GoKind: 25
       RawFields: []
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 60
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.232384e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 108 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 111 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 113 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 115 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyCurveID
-          Offset: 186
-          Type: 116 BaseType crypto/tls.CurveID
-    - __kind: BaseType
-      ID: 116
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 829664
-      GoKind: 9
-    - __kind: StructureType
-      ID: 117
-      Name: crypto/x509.Certificate
-      ByteSize: 1424
-      GoRuntimeType: 2.377888e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 124 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 125 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 126 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 7 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 127 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 129 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 129 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 133 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 133 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 136 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 143 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 7 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 55 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 55 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 55 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 55 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 146 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 149 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 55 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 55 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 151 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 151 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 55 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 55 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 55 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 55 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 55 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 154 GoSliceHeaderType []crypto/x509.OID
-        - Name: InhibitAnyPolicy
-          Offset: 1352
-          Type: 7 BaseType int
-        - Name: InhibitAnyPolicyZero
-          Offset: 1360
-          Type: 4 BaseType bool
-        - Name: InhibitPolicyMapping
-          Offset: 1368
-          Type: 7 BaseType int
-        - Name: InhibitPolicyMappingZero
-          Offset: 1376
-          Type: 4 BaseType bool
-        - Name: RequireExplicitPolicy
-          Offset: 1384
-          Type: 7 BaseType int
-        - Name: RequireExplicitPolicyZero
-          Offset: 1392
-          Type: 4 BaseType bool
-        - Name: PolicyMappings
-          Offset: 1400
-          Type: 157 GoSliceHeaderType []crypto/x509.PolicyMapping
-    - __kind: BaseType
-      ID: 145
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 583360
-      GoKind: 2
-    - __kind: BaseType
-      ID: 136
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 583296
-      GoKind: 2
-    - __kind: StructureType
-      ID: 156
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.939168e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 105 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 159
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.480928e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 156 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 156 StructureType crypto/x509.OID
-    - __kind: BaseType
-      ID: 125
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 832064
-      GoKind: 2
-    - __kind: BaseType
-      ID: 124
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.105248e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 132
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.492608e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 126 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 139
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.63616e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 105 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 129
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.177504e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 55 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 55 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 55 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 55 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 55 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 55 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 55 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 9 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 9 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 142
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.044832e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 27 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 7 BaseType int
     - __kind: GoInterfaceType
       ID: 13
       Name: error
@@ -1525,12 +510,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 687968
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 115
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 995552
-      GoKind: 19
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -1545,47 +524,33 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 91
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 92 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 100 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
-    - __kind: GoSwissMapGroupsType
-      ID: 75
+      ID: 73
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 76 PointerType *noalg.map.group[string][]string
+          Type: 74 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 77 StructureType noalg.map.group[string][]string
-      GroupSliceType: 81 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 75 StructureType noalg.map.group[string][]string
+      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 83
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[string]string
+          Type: 84 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 85 StructureType noalg.map.group[string]string
+      GroupSliceType: 89 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1616,19 +581,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 579712
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 126
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 849280
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 53
       Name: io.ReadCloser
@@ -1642,38 +594,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: GoSwissMapHeaderType
-      ID: 87
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 88 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 99 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 50
       Name: map<string,[]string>
@@ -1704,8 +624,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 80 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 77 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 78 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 75 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 69
       Name: map<string,string>
@@ -1736,22 +656,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 209 StructureType noalg.map.group[string]string
-    - __kind: GoMapType
-      ID: 85
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.123296e+06
-      GoKind: 21
-      HeaderType: 87 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 84
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.118688e+06
-      GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
+      TablePtrSliceType: 88 GoSliceDataType []*table<string,string>.array
+      GroupType: 85 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 67
       Name: map[string]string
@@ -1759,145 +665,10 @@ Types:
       GoRuntimeType: 1.119712e+06
       GoKind: 21
       HeaderType: 69 GoSwissMapHeaderType map<string,string>
-    - __kind: StructureType
-      ID: 128
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.483968e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 160 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 162
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 583552
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 160
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.346272e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 161 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 163 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 163
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 162 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 101
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.962912e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 104 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 12 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 12 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 58
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.467968e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 84 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 85 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 148
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.109952e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 196 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 198
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.011424e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 199 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 199
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 187
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.449408e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 148 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 198 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 48
       Name: net/http.Header
@@ -1990,55 +761,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 67 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 63
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.195808e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 7 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 7 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 48 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 53 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 12 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 55 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 48 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 59 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2052,107 +778,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 66
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.818656e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 201 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 203
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.59776e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 104
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.808832e+06
-      GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 47
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.113024e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 72 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 9 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 9 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 73
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.61408e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 56
       Name: net/url.Values
@@ -2161,47 +794,25 @@ Types:
       GoKind: 21
       HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 94
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 694016
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 95 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 78
+      ID: 76
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 79 StructureType noalg.struct { key string; elem []string }
+      Element: 77 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 210
+      ID: 86
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key string; elem string }
+      Element: 87 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 93
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.290528e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 94 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 77
+      ID: 75
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -2212,9 +823,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 78 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 76 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 209
+      ID: 85
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -2225,22 +836,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 86 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 95
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.2904e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 96 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 79
+      ID: 77
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -2253,7 +851,7 @@ Types:
           Offset: 16
           Type: 55 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 211
+      ID: 87
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -2284,31 +882,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 90
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 91 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 74
+      ID: 72
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2330,9 +904,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 75 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 73 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 206
+      ID: 82
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2354,86 +928,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: StructureType
-      ID: 135
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.958592e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 167 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 170 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 9 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 12 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 12 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 168 PointerType *time.zone
-    - __kind: StructureType
-      ID: 133
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.349088e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 12 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 134 PointerType *time.Location
-    - __kind: StructureType
-      ID: 169
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.602752e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 172
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.73712e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 12 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
+          Type: 83 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -2476,6 +971,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580736
       GoKind: 26
-MaxTypeID: 215
+MaxTypeID: 91
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 90 EventRootType Probe[main.HandleHTTP]
+          Type: 131 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 91 EventRootType Probe[main.LookAtTheRequest]
+          Type: 132 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -129,20 +129,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 51
+      ID: 92
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 52 PointerType *table<string,[]string>
+      Pointee: 93 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 70
+      ID: 111
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 71 PointerType *table<string,string>
+      Pointee: 112 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 81
+      ID: 122
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 80 GoSliceDataType []string.array
+      Pointee: 121 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -158,12 +158,12 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 59
+      ID: 100
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 60 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 101 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -185,6 +185,13 @@ Types:
       GoRuntimeType: 397216
       GoKind: 22
       Pointee: 18 BaseType float64
+    - __kind: PointerType
+      ID: 46
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.539904e+06
+      GoKind: 22
+      Pointee: 47 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -221,22 +228,22 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 49
+      ID: 90
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 50 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 91 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 68
+      ID: 109
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 69 GoSwissMapHeaderType map<string,string>
+      Pointee: 110 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 57
+      ID: 98
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 58 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 99 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -245,36 +252,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 62
+      ID: 103
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 63 UnresolvedPointeeType net/http.Response
+      Pointee: 104 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 65
+      ID: 83
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.99632e+06
+      GoKind: 22
+      Pointee: 84 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 106
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 66 UnresolvedPointeeType net/http.pattern
+      Pointee: 107 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 46
+      ID: 85
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.189984e+06
+      GoKind: 22
+      Pointee: 86 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 87
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 47 UnresolvedPointeeType net/url.URL
+      Pointee: 88 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 74
+      ID: 115
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 75 StructureType noalg.map.group[string][]string
+      Pointee: 116 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 84
+      ID: 125
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 85 StructureType noalg.map.group[string]string
+      Pointee: 126 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -289,14 +310,119 @@ Types:
       Pointee: 44 GoStringDataType string.str
     - __kind: PointerType
       ID: 52
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.677056e+06
+      GoKind: 22
+      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 66
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.729472e+06
+      GoKind: 22
+      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 48
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.676672e+06
+      GoKind: 22
+      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 58
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.728704e+06
+      GoKind: 22
+      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 72
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.800096e+06
+      GoKind: 22
+      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 60
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.728896e+06
+      GoKind: 22
+      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 56
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.728512e+06
+      GoKind: 22
+      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 68
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.799648e+06
+      GoKind: 22
+      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 76
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.869504e+06
+      GoKind: 22
+      Pointee: 77 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 70
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.799872e+06
+      GoKind: 22
+      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 54
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.677248e+06
+      GoKind: 22
+      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 50
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.676864e+06
+      GoKind: 22
+      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 62
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.729088e+06
+      GoKind: 22
+      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 74
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.80032e+06
+      GoKind: 22
+      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 64
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.72928e+06
+      GoKind: 22
+      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 93
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 72 StructureType table<string,[]string>
+      Pointee: 113 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 71
+      ID: 112
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 82 StructureType table<string,string>
+      Pointee: 123 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -340,12 +466,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 61
+      ID: 102
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: EventRootType
-      ID: 90
+      ID: 131
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -369,7 +495,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 91
+      ID: 132
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -384,27 +510,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 52 PointerType *table<string,[]string>
+      Element: 93 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 88
+      ID: 129
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 71 PointerType *table<string,string>
+      Element: 112 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 79
+      ID: 120
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 75 StructureType noalg.map.group[string][]string
+      Element: 116 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 89
+      ID: 130
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 85 StructureType noalg.map.group[string]string
+      Element: 126 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 96
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -419,9 +545,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 80 GoSliceDataType []string.array
+      Data: 121 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 80
+      ID: 121
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -448,7 +574,7 @@ Types:
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 105
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.267616e+06
@@ -476,7 +602,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 60
+      ID: 101
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -505,11 +631,28 @@ Types:
       GoRuntimeType: 580608
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 54
+      ID: 95
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
       GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 78
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.40832e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 47
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -524,33 +667,33 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 73
+      ID: 114
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 74 PointerType *noalg.map.group[string][]string
+          Type: 115 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 75 StructureType noalg.map.group[string][]string
-      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 116 StructureType noalg.map.group[string][]string
+      GroupSliceType: 120 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 83
+      ID: 124
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 84 PointerType *noalg.map.group[string]string
+          Type: 125 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 85 StructureType noalg.map.group[string]string
-      GroupSliceType: 89 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 126 StructureType noalg.map.group[string]string
+      GroupSliceType: 130 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -582,7 +725,7 @@ Types:
       GoRuntimeType: 579712
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 53
+      ID: 94
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10128e+06
@@ -595,7 +738,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 50
+      ID: 91
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -608,7 +751,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 51 PointerType **table<string,[]string>
+          Type: 92 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -624,10 +767,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 78 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 75 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 119 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 116 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 69
+      ID: 110
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -640,7 +783,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 70 PointerType **table<string,string>
+          Type: 111 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -656,26 +799,78 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 88 GoSliceDataType []*table<string,string>.array
-      GroupType: 85 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 129 GoSliceDataType []*table<string,string>.array
+      GroupType: 126 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 67
+      ID: 108
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119712e+06
       GoKind: 21
-      HeaderType: 69 GoSwissMapHeaderType map<string,string>
+      HeaderType: 110 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 58
+      ID: 99
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.019104e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.017696e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 48
+      ID: 89
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.088128e+06
       GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 91 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 82
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.017824e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.01808e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -688,7 +883,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 46 PointerType *net/url.URL
+          Type: 87 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -700,19 +895,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 48 GoMapType net/http.Header
+          Type: 89 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 53 GoInterfaceType io.ReadCloser
+          Type: 94 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 54 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 95 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 55 GoSliceHeaderType []string
+          Type: 96 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -721,16 +916,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 56 GoMapType net/url.Values
+          Type: 97 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 56 GoMapType net/url.Values
+          Type: 97 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 57 PointerType *mime/multipart.Form
+          Type: 98 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 48 GoMapType net/http.Header
+          Type: 89 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -739,30 +934,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 59 PointerType *crypto/tls.ConnectionState
+          Type: 100 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 61 GoChannelType <-chan struct {}
+          Type: 102 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 62 PointerType *net/http.Response
+          Type: 103 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 64 GoInterfaceType context.Context
+          Type: 105 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 65 PointerType *net/http.pattern
+          Type: 106 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 55 GoSliceHeaderType []string
+          Type: 96 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 67 GoMapType map[string]string
+          Type: 108 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 63
+      ID: 104
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -779,40 +974,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 66
+      ID: 84
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 107
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 47
+      ID: 86
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 88
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 56
+      ID: 97
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.871296e+06
       GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 91 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 76
+      ID: 117
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 77 StructureType noalg.struct { key string; elem []string }
+      Element: 118 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 86
+      ID: 127
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 87 StructureType noalg.struct { key string; elem string }
+      Element: 128 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 75
+      ID: 116
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -823,9 +1026,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 76 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 117 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 85
+      ID: 126
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -836,9 +1039,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 86 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 127 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 77
+      ID: 118
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -849,9 +1052,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 55 GoSliceHeaderType []string
+          Type: 96 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 87
+      ID: 128
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -882,7 +1085,253 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 72
+      ID: 53
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.9328e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 67
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.010432e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 49
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.932288e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 59
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.00928e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 73
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.071712e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 61
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.009568e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 57
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 2.008992e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 69
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 2.071072e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 77
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.131456e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 71
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.071392e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 55
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.933056e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 51
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.932544e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 63
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.009856e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 75
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.072032e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 65
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.010144e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 113
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -904,9 +1353,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 73 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 114 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 82
+      ID: 123
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -928,7 +1377,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 83 GoSwissMapGroupsType groupReference<string,string>
+          Type: 124 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -971,6 +1420,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580736
       GoKind: 26
-MaxTypeID: 91
+MaxTypeID: 132
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 213 EventRootType Probe[main.HandleHTTP]
+          Type: 88 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 214 EventRootType Probe[main.LookAtTheRequest]
+          Type: 89 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -114,35 +122,6 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 108
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 109 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 95
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 96 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 151
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 152 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 149
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 44 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 86
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 87 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 49
       Name: '**table<string,[]string>'
       ByteSize: 8
@@ -153,108 +132,10 @@ Types:
       ByteSize: 8
       Pointee: 69 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 111
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 107 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 118
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 117 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 101
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 100 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 188
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 187 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 120
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 119 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 121 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 181
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 190
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 189 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 177
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 204
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 203 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 81
+      ID: 79
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 80 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 173
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 172 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 113
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 481600
-      GoKind: 22
-      Pointee: 103 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 105
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 104 GoSliceDataType []uint8.array
+      Pointee: 78 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -275,61 +156,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 58 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 109
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.043968e+06
-      GoKind: 22
-      Pointee: 116 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 143
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 423552
-      GoKind: 22
-      Pointee: 144 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 154
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.954336e+06
-      GoKind: 22
-      Pointee: 155 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 157
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 423616
-      GoKind: 22
-      Pointee: 158 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 130
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 437312
-      GoKind: 22
-      Pointee: 131 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 137
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 437504
-      GoKind: 22
-      Pointee: 138 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 140
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.053408e+06
-      GoKind: 22
-      Pointee: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 194
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 193 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 58 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -387,11 +214,6 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 84
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 47
       Name: '*map<string,[]string>'
       ByteSize: 8
@@ -402,62 +224,12 @@ Types:
       ByteSize: 8
       Pointee: 67 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 126
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.382336e+06
-      GoKind: 22
-      Pointee: 127 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 160
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 426432
-      GoKind: 22
-      Pointee: 161 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 163
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 162 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 96
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 909888
-      GoKind: 22
-      Pointee: 99 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 55
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 56 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 146
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.150176e+06
-      GoKind: 22
-      Pointee: 147 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 196
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 195 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 199
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 198 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 152
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.18336e+06
-      GoKind: 22
-      Pointee: 186 StructureType net.IPNet
+      Pointee: 56 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -471,50 +243,31 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.718816e+06
       GoKind: 22
-      Pointee: 61 StructureType net/http.Response
+      Pointee: 61 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 63
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608608e+06
       GoKind: 22
-      Pointee: 64 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 201
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 391808
-      GoKind: 22
-      Pointee: 202 StructureType net/http.segment
+      Pointee: 64 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 44
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 45 StructureType net/url.URL
+      Pointee: 45 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 70
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.200768e+06
-      GoKind: 22
-      Pointee: 71 StructureType net/url.Userinfo
-    - __kind: PointerType
-      ID: 90
-      Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
-      ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 74
+      ID: 72
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 75 StructureType noalg.map.group[string][]string
+      Pointee: 73 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 207
+      ID: 82
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 208 StructureType noalg.map.group[string]string
+      Pointee: 83 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -528,41 +281,15 @@ Types:
       ByteSize: 8
       Pointee: 42 GoStringDataType string.str
     - __kind: PointerType
-      ID: 87
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 88 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 50
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 72 StructureType table<string,[]string>
+      Pointee: 70 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 69
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 205 StructureType table<string,string>
-    - __kind: PointerType
-      ID: 133
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.6136e+06
-      GoKind: 22
-      Pointee: 134 StructureType time.Location
-    - __kind: PointerType
-      ID: 167
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 394880
-      GoKind: 22
-      Pointee: 168 StructureType time.zone
-    - __kind: PointerType
-      ID: 170
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 394944
-      GoKind: 22
-      Pointee: 171 StructureType time.zoneTrans
+      Pointee: 80 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -611,7 +338,7 @@ Types:
       GoRuntimeType: 597696
       GoKind: 18
     - __kind: EventRootType
-      ID: 213
+      ID: 88
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -635,7 +362,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 214
+      ID: 89
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -649,344 +376,26 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-    - __kind: GoSliceHeaderType
-      ID: 107
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 502496
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 108 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 117 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 117
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 109 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 94
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 487328
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 95 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 100 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 100
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 96 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 150
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 504096
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 151 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 187 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 187
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 152 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 148
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 504032
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 149 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 184 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 44 PointerType *net/url.URL
-    - __kind: GoSliceDataType
-      ID: 97
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 87 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 78
+      ID: 76
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 50 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 86
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 69 PointerType *table<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 110
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 502560
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 111 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 119 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 119
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 107 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 112
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 481920
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 113 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 121 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 121
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 103 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 142
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 503968
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 143 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 180 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 144 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 153
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 504160
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 154 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 189 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 189
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 155 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 156
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 504224
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 157 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 158 StructureType crypto/x509.PolicyMapping
-    - __kind: GoSliceHeaderType
-      ID: 129
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 517440
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 130 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 164 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 131 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 136
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 503840
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 137 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 176
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 138 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 139
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 503904
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 140 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 145
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 482944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 146 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 182 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 147 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 200
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 484640
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 201 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 203 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 203
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 202 StructureType net/http.segment
-    - __kind: GoSliceDataType
-      ID: 98
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 79
+      ID: 77
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 75 StructureType noalg.map.group[string][]string
+      Element: 73 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 87
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 208 StructureType noalg.map.group[string]string
+      Element: 83 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]string'
@@ -1003,78 +412,12 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 80 GoSliceDataType []string.array
+      Data: 78 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 166
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 489504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 167 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 172 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 168 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 169
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 489568
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 170 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 174 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 171 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 103
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 495296
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 104 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 104
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1110,377 +453,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 58
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.262752e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: CurveID
-          Offset: 6
-          Type: 106 BaseType crypto/tls.CurveID
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 107 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 110 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 112 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 114 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyPeerSignatureAlgorithm
-          Offset: 186
-          Type: 115 BaseType crypto/tls.SignatureScheme
-    - __kind: BaseType
-      ID: 106
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 835040
-      GoKind: 9
-    - __kind: BaseType
-      ID: 115
-      Name: crypto/tls.SignatureScheme
-      ByteSize: 2
-      GoRuntimeType: 835136
-      GoKind: 9
-    - __kind: StructureType
-      ID: 116
-      Name: crypto/x509.Certificate
-      ByteSize: 1424
-      GoRuntimeType: 2.3936e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 123 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 124 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 125 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 7 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 126 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 128 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 128 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 132 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 132 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 135 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 136 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 136 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 142 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 7 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 53 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 53 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 53 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 53 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 145 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 148 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 53 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 53 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 150 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 150 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 53 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 53 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 53 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 53 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 53 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 153 GoSliceHeaderType []crypto/x509.OID
-        - Name: InhibitAnyPolicy
-          Offset: 1352
-          Type: 7 BaseType int
-        - Name: InhibitAnyPolicyZero
-          Offset: 1360
-          Type: 4 BaseType bool
-        - Name: InhibitPolicyMapping
-          Offset: 1368
-          Type: 7 BaseType int
-        - Name: InhibitPolicyMappingZero
-          Offset: 1376
-          Type: 4 BaseType bool
-        - Name: RequireExplicitPolicy
-          Offset: 1384
-          Type: 7 BaseType int
-        - Name: RequireExplicitPolicyZero
-          Offset: 1392
-          Type: 4 BaseType bool
-        - Name: PolicyMappings
-          Offset: 1400
-          Type: 156 GoSliceHeaderType []crypto/x509.PolicyMapping
-    - __kind: BaseType
-      ID: 144
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 588160
-      GoKind: 2
-    - __kind: BaseType
-      ID: 135
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 588096
-      GoKind: 2
-    - __kind: StructureType
-      ID: 155
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.954592e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 103 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 158
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.491232e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 155 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 155 StructureType crypto/x509.OID
-    - __kind: BaseType
-      ID: 124
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 837632
-      GoKind: 2
-    - __kind: BaseType
-      ID: 123
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.114432e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 131
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.502912e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 125 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 138
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.647008e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 103 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 128
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.192768e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 53 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 53 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 53 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 53 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 53 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 53 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 53 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 9 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 9 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 129 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 129 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 141
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.053536e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 26 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 193 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 193
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 7 BaseType int
     - __kind: GoInterfaceType
       ID: 13
       Name: error
@@ -1512,12 +488,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 693344
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 114
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.003296e+06
-      GoKind: 19
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -1532,47 +502,33 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 89
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 90 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 98 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
-    - __kind: GoSwissMapGroupsType
-      ID: 73
+      ID: 71
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 74 PointerType *noalg.map.group[string][]string
+          Type: 72 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 75 StructureType noalg.map.group[string][]string
-      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 73 StructureType noalg.map.group[string][]string
+      GroupSliceType: 77 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 206
+      ID: 81
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 207 PointerType *noalg.map.group[string]string
+          Type: 82 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 208 StructureType noalg.map.group[string]string
-      GroupSliceType: 212 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 83 StructureType noalg.map.group[string]string
+      GroupSliceType: 87 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1603,19 +559,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 584512
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 125
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 854848
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 51
       Name: io.ReadCloser
@@ -1629,41 +572,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: GoSwissMapHeaderType
-      ID: 85
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 86 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 97 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 48
       Name: map<string,[]string>
@@ -1697,8 +605,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 78 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 75 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 76 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 73 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 67
       Name: map<string,string>
@@ -1732,22 +640,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 211 GoSliceDataType []*table<string,string>.array
-      GroupType: 208 StructureType noalg.map.group[string]string
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.132352e+06
-      GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 82
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.128e+06
-      GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      TablePtrSliceType: 86 GoSliceDataType []*table<string,string>.array
+      GroupType: 83 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 65
       Name: map[string]string
@@ -1755,145 +649,10 @@ Types:
       GoRuntimeType: 1.129024e+06
       GoKind: 21
       HeaderType: 67 GoSwissMapHeaderType map<string,string>
-    - __kind: StructureType
-      ID: 127
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.494272e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 159 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 161
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 588352
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 159
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.361856e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 160 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 162 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 162
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 161 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 99
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.977856e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 102 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 12 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 12 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 56
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.478112e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 82 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 83 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 147
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.124512e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 195 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 197
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.019744e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 198 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 198
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 186
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.458912e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 147 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 197 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 46
       Name: net/http.Header
@@ -1986,55 +745,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 65 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 61
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.210656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 7 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 7 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 46 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 12 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 53 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 46 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 57 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2048,107 +762,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 64
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.833632e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 200 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 202
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.608416e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 102
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.823584e+06
-      GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 45
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.127584e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 70 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 9 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 9 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 71
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.624928e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 54
       Name: net/url.Values
@@ -2157,47 +778,25 @@ Types:
       GoKind: 21
       HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 92
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 699200
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 76
+      ID: 74
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 77 StructureType noalg.struct { key string; elem []string }
+      Element: 75 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 209
+      ID: 84
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 210 StructureType noalg.struct { key string; elem string }
+      Element: 85 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 91
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.29952e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 75
+      ID: 73
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -2208,9 +807,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 76 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 74 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 208
+      ID: 83
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -2221,22 +820,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 209 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 84 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 93
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.299392e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 94 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 77
+      ID: 75
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -2249,7 +835,7 @@ Types:
           Offset: 16
           Type: 53 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 210
+      ID: 85
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -2280,31 +866,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 88
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 72
+      ID: 70
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2326,9 +888,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 73 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 71 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 205
+      ID: 80
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2350,86 +912,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 206 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: StructureType
-      ID: 134
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.973536e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 166 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 169 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 9 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 12 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 12 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 167 PointerType *time.zone
-    - __kind: StructureType
-      ID: 132
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.364704e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 12 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 133 PointerType *time.Location
-    - __kind: StructureType
-      ID: 168
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.613408e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 171
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.750848e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 12 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
+          Type: 81 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -2472,6 +955,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585536
       GoKind: 26
-MaxTypeID: 214
+MaxTypeID: 89
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x182c9a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 88 EventRootType Probe[main.HandleHTTP]
+          Type: 129 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 89 EventRootType Probe[main.LookAtTheRequest]
+          Type: 130 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -122,20 +122,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 49
+      ID: 90
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 50 PointerType *table<string,[]string>
+      Pointee: 91 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 68
+      ID: 109
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 69 PointerType *table<string,string>
+      Pointee: 110 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 79
+      ID: 120
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 78 GoSliceDataType []string.array
+      Pointee: 119 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -151,12 +151,12 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 57
+      ID: 98
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 58 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 99 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -178,6 +178,13 @@ Types:
       GoRuntimeType: 400256
       GoKind: 22
       Pointee: 15 BaseType float64
+    - __kind: PointerType
+      ID: 44
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.550528e+06
+      GoKind: 22
+      Pointee: 45 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -214,22 +221,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 47
+      ID: 88
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 48 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 89 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 66
+      ID: 107
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 67 GoSwissMapHeaderType map<string,string>
+      Pointee: 108 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 55
+      ID: 96
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 56 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 97 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -238,36 +245,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 60
+      ID: 101
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718816e+06
       GoKind: 22
-      Pointee: 61 UnresolvedPointeeType net/http.Response
+      Pointee: 102 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 63
+      ID: 81
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.010368e+06
+      GoKind: 22
+      Pointee: 82 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 104
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608608e+06
       GoKind: 22
-      Pointee: 64 UnresolvedPointeeType net/http.pattern
+      Pointee: 105 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 44
+      ID: 83
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.218272e+06
+      GoKind: 22
+      Pointee: 84 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 85
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 45 UnresolvedPointeeType net/url.URL
+      Pointee: 86 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 72
+      ID: 113
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 73 StructureType noalg.map.group[string][]string
+      Pointee: 114 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 82
+      ID: 123
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 83 StructureType noalg.map.group[string]string
+      Pointee: 124 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -282,14 +303,119 @@ Types:
       Pointee: 42 GoStringDataType string.str
     - __kind: PointerType
       ID: 50
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.68848e+06
+      GoKind: 22
+      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 64
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.74224e+06
+      GoKind: 22
+      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 46
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.688096e+06
+      GoKind: 22
+      Pointee: 47 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 56
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.741472e+06
+      GoKind: 22
+      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 70
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.814048e+06
+      GoKind: 22
+      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 58
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.741664e+06
+      GoKind: 22
+      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 54
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.74128e+06
+      GoKind: 22
+      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 66
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.8136e+06
+      GoKind: 22
+      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 74
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.882912e+06
+      GoKind: 22
+      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 68
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.813824e+06
+      GoKind: 22
+      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 52
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.688672e+06
+      GoKind: 22
+      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 48
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.688288e+06
+      GoKind: 22
+      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 60
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.741856e+06
+      GoKind: 22
+      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 72
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.814272e+06
+      GoKind: 22
+      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 62
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.742048e+06
+      GoKind: 22
+      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 91
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 70 StructureType table<string,[]string>
+      Pointee: 111 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 69
+      ID: 110
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 80 StructureType table<string,string>
+      Pointee: 121 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -333,12 +459,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 59
+      ID: 100
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
     - __kind: EventRootType
-      ID: 88
+      ID: 129
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -362,7 +488,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 89
+      ID: 130
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -377,27 +503,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 76
+      ID: 117
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 50 PointerType *table<string,[]string>
+      Element: 91 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 86
+      ID: 127
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 69 PointerType *table<string,string>
+      Element: 110 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 77
+      ID: 118
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 73 StructureType noalg.map.group[string][]string
+      Element: 114 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 87
+      ID: 128
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 83 StructureType noalg.map.group[string]string
+      Element: 124 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 94
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -412,9 +538,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 78 GoSliceDataType []string.array
+      Data: 119 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -441,7 +567,7 @@ Types:
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 62
+      ID: 103
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276992e+06
@@ -454,7 +580,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 58
+      ID: 99
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -483,11 +609,28 @@ Types:
       GoRuntimeType: 585408
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 52
+      ID: 93
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693344
       GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 76
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.417952e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 45
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -502,33 +645,33 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 71
+      ID: 112
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 72 PointerType *noalg.map.group[string][]string
+          Type: 113 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 73 StructureType noalg.map.group[string][]string
-      GroupSliceType: 77 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 114 StructureType noalg.map.group[string][]string
+      GroupSliceType: 118 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 81
+      ID: 122
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 82 PointerType *noalg.map.group[string]string
+          Type: 123 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 83 StructureType noalg.map.group[string]string
-      GroupSliceType: 87 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 124 StructureType noalg.map.group[string]string
+      GroupSliceType: 128 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -560,7 +703,7 @@ Types:
       GoRuntimeType: 584512
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 51
+      ID: 92
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -573,7 +716,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 48
+      ID: 89
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -586,7 +729,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 49 PointerType **table<string,[]string>
+          Type: 90 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -605,10 +748,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 76 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 73 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 117 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 114 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 67
+      ID: 108
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -621,7 +764,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 68 PointerType **table<string,string>
+          Type: 109 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -640,26 +783,78 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 86 GoSliceDataType []*table<string,string>.array
-      GroupType: 83 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 127 GoSliceDataType []*table<string,string>.array
+      GroupType: 124 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 65
+      ID: 106
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.129024e+06
       GoKind: 21
-      HeaderType: 67 GoSwissMapHeaderType map<string,string>
+      HeaderType: 108 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 56
+      ID: 97
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.027552e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 77
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.026016e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 46
+      ID: 87
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.101632e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 89 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.026144e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 78
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.0264e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -672,7 +867,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 44 PointerType *net/url.URL
+          Type: 85 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -684,19 +879,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 87 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 92 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 93 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 53 GoSliceHeaderType []string
+          Type: 94 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -705,16 +900,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 54 GoMapType net/url.Values
+          Type: 95 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 54 GoMapType net/url.Values
+          Type: 95 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 55 PointerType *mime/multipart.Form
+          Type: 96 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 46 GoMapType net/http.Header
+          Type: 87 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -723,30 +918,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 57 PointerType *crypto/tls.ConnectionState
+          Type: 98 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 59 GoChannelType <-chan struct {}
+          Type: 100 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 60 PointerType *net/http.Response
+          Type: 101 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 62 GoInterfaceType context.Context
+          Type: 103 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 63 PointerType *net/http.pattern
+          Type: 104 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 53 GoSliceHeaderType []string
+          Type: 94 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 65 GoMapType map[string]string
+          Type: 106 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 61
+      ID: 102
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -763,40 +958,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 64
+      ID: 82
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 105
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 45
+      ID: 84
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 86
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 54
+      ID: 95
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.885152e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 89 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 74
+      ID: 115
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 75 StructureType noalg.struct { key string; elem []string }
+      Element: 116 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 84
+      ID: 125
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 85 StructureType noalg.struct { key string; elem string }
+      Element: 126 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 73
+      ID: 114
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -807,9 +1010,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 74 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 115 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 83
+      ID: 124
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -820,9 +1023,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 84 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 125 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 75
+      ID: 116
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -833,9 +1036,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 53 GoSliceHeaderType []string
+          Type: 94 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 85
+      ID: 126
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -866,7 +1069,253 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 70
+      ID: 51
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.947456e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 65
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.023616e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 47
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.946944e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 57
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.022464e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 71
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.085568e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 59
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.022752e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 55
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 2.022176e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 78 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 67
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 2.084928e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 75
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.1464e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 69
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.085248e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 53
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.947712e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 49
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.9472e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 61
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.02304e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 73
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.085888e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 63
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.023328e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 111
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -888,9 +1337,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 71 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 112 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 80
+      ID: 121
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -912,7 +1361,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 81 GoSwissMapGroupsType groupReference<string,string>
+          Type: 122 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -955,6 +1404,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585536
       GoKind: 26
-MaxTypeID: 89
+MaxTypeID: 130
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x182c9a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 82 EventRootType Probe[main.HandleHTTP]
+          Type: 123 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 83 EventRootType Probe[main.LookAtTheRequest]
+          Type: 124 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -129,10 +129,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 79
+      ID: 120
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 78 GoSliceDataType []string.array
+      Pointee: 119 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -141,15 +141,15 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 51
+      ID: 92
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 52 GoHMapBucketType bucket<string,[]string>
+      Pointee: 93 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 72
+      ID: 113
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 73 GoHMapBucketType bucket<string,string>
+      Pointee: 114 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*bytes.Buffer'
@@ -158,12 +158,12 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 61
+      ID: 102
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 62 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 103 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -186,15 +186,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 49
+      ID: 46
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.362016e+06
+      GoKind: 22
+      Pointee: 47 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+    - __kind: PointerType
+      ID: 90
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 50 GoHMapHeaderType hash<string,[]string>
+      Pointee: 91 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 70
+      ID: 111
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 71 GoHMapHeaderType hash<string,string>
+      Pointee: 112 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -231,12 +238,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 59
+      ID: 100
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 60 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 101 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -245,33 +252,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 64
+      ID: 105
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 65 UnresolvedPointeeType net/http.Response
+      Pointee: 106 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 67
+      ID: 83
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.833376e+06
+      GoKind: 22
+      Pointee: 84 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 108
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 68 UnresolvedPointeeType net/http.pattern
+      Pointee: 109 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 46
+      ID: 85
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.059552e+06
+      GoKind: 22
+      Pointee: 86 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 87
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 47 UnresolvedPointeeType net/url.URL
+      Pointee: 88 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 53
+      ID: 94
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 54 UnresolvedPointeeType runtime.mapextra
+      Pointee: 95 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -284,6 +305,111 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 44 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 52
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.496256e+06
+      GoKind: 22
+      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 66
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.616224e+06
+      GoKind: 22
+      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 48
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.495872e+06
+      GoKind: 22
+      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 58
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.615456e+06
+      GoKind: 22
+      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 72
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.68544e+06
+      GoKind: 22
+      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 60
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.615648e+06
+      GoKind: 22
+      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 56
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.615264e+06
+      GoKind: 22
+      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 68
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.684992e+06
+      GoKind: 22
+      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 76
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.75072e+06
+      GoKind: 22
+      Pointee: 77 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 70
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.685216e+06
+      GoKind: 22
+      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 54
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.496448e+06
+      GoKind: 22
+      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 50
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.496064e+06
+      GoKind: 22
+      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 62
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.61584e+06
+      GoKind: 22
+      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 74
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.685664e+06
+      GoKind: 22
+      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 64
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.616032e+06
+      GoKind: 22
+      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -327,12 +453,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 63
+      ID: 104
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: EventRootType
-      ID: 82
+      ID: 123
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -356,7 +482,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 83
+      ID: 124
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -371,7 +497,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 74
+      ID: 115
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -380,24 +506,24 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 77
+      ID: 118
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 52 GoHMapBucketType bucket<string,[]string>
+      Element: 93 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 81
+      ID: 122
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 73 GoHMapBucketType bucket<string,string>
+      Element: 114 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 75
+      ID: 116
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 57
+      ID: 98
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -412,21 +538,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 78 GoSliceDataType []string.array
+      Data: 119 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 76
+      ID: 117
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 57 GoSliceHeaderType []string
+      Element: 98 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 80
+      ID: 121
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -439,41 +565,41 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 52
+      ID: 93
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 74 ArrayType [8]uint8
+          Type: 115 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 75 ArrayType []key<string>
+          Type: 116 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 76 ArrayType []val<[]string>
+          Type: 117 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 51 PointerType *bucket<string,[]string>
+          Type: 92 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 57 GoSliceHeaderType []string
+      ValueType: 98 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 73
+      ID: 114
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 74 ArrayType [8]uint8
+          Type: 115 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 75 ArrayType []key<string>
+          Type: 116 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 80 ArrayType []val<string>
+          Type: 121 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 72 PointerType *bucket<string,string>
+          Type: 113 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
@@ -493,7 +619,7 @@ Types:
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 66
+      ID: 107
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187296e+06
@@ -521,7 +647,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 62
+      ID: 103
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -550,11 +676,28 @@ Types:
       GoRuntimeType: 534720
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 97
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
       GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 78
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.23584e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 47
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -569,7 +712,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 50
+      ID: 91
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -590,20 +733,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 51 PointerType *bucket<string,[]string>
+          Type: 92 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 51 PointerType *bucket<string,[]string>
+          Type: 92 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 53 PointerType *runtime.mapextra
-      BucketType: 52 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 77 GoSliceDataType []bucket<string,[]string>.array
+          Type: 94 PointerType *runtime.mapextra
+      BucketType: 93 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 118 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 71
+      ID: 112
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -624,18 +767,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 72 PointerType *bucket<string,string>
+          Type: 113 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 72 PointerType *bucket<string,string>
+          Type: 113 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 53 PointerType *runtime.mapextra
-      BucketType: 73 GoHMapBucketType bucket<string,string>
-      BucketsType: 81 GoSliceDataType []bucket<string,string>.array
+          Type: 94 PointerType *runtime.mapextra
+      BucketType: 114 GoHMapBucketType bucket<string,string>
+      BucketsType: 122 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -667,7 +810,7 @@ Types:
       GoRuntimeType: 533824
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 96
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067328e+06
@@ -680,23 +823,75 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 69
+      ID: 110
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 71 GoHMapHeaderType hash<string,string>
+      HeaderType: 112 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 60
+      ID: 101
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 983296
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 981888
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 48
+      ID: 89
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.917984e+06
       GoKind: 21
-      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 91 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 82
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 982016
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 982272
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -709,7 +904,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 46 PointerType *net/url.URL
+          Type: 87 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -721,19 +916,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 48 GoMapType net/http.Header
+          Type: 89 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 96 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 97 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 57 GoSliceHeaderType []string
+          Type: 98 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -742,16 +937,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 58 GoMapType net/url.Values
+          Type: 99 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 58 GoMapType net/url.Values
+          Type: 99 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 59 PointerType *mime/multipart.Form
+          Type: 100 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 48 GoMapType net/http.Header
+          Type: 89 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -760,30 +955,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 61 PointerType *crypto/tls.ConnectionState
+          Type: 102 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 63 GoChannelType <-chan struct {}
+          Type: 104 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 64 PointerType *net/http.Response
+          Type: 105 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 66 GoInterfaceType context.Context
+          Type: 107 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 67 PointerType *net/http.pattern
+          Type: 108 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 57 GoSliceHeaderType []string
+          Type: 98 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 69 GoMapType map[string]string
+          Type: 110 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 65
+      ID: 106
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -800,22 +995,30 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 68
+      ID: 84
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 109
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 47
+      ID: 86
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 88
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 58
+      ID: 99
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.671328e+06
       GoKind: 21
-      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 91 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 54
+      ID: 95
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -836,6 +1039,252 @@ Types:
       ID: 44
       Name: string.str
       ByteSize: 2048
+    - __kind: StructureType
+      ID: 53
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.810688e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 67
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.885792e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 49
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.810176e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 59
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 1.88464e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 73
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.947744e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 61
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.884928e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 57
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 1.884352e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 69
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 1.947104e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 77
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.005632e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 71
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.947424e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 55
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.810944e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 51
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.810432e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 63
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 1.885216e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 75
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 1.948064e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 65
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 1.885504e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -878,6 +1327,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534848
       GoKind: 26
-MaxTypeID: 83
+MaxTypeID: 124
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 195 EventRootType Probe[main.HandleHTTP]
+          Type: 82 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 196 EventRootType Probe[main.LookAtTheRequest]
+          Type: 83 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -121,125 +129,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 101
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      Pointee: 102 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 90
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 91 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 144
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 145 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 142
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 46 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 104
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 100 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 111
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 110 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 95
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 94 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 178
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 177 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 113
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 112 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 115
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 114 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 171
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 170 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 180
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 179 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 155
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 154 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 167
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 166 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 169
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 168 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 173
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 172 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 81
+      ID: 79
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 80 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 163
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 162 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 452640
-      GoKind: 22
-      Pointee: 97 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 99
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 98 GoSliceDataType []uint8.array
+      Pointee: 78 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -247,11 +140,6 @@ Types:
       GoRuntimeType: 372704
       GoKind: 22
       Pointee: 4 BaseType bool
-    - __kind: PointerType
-      ID: 86
-      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 51
       Name: '*bucket<string,[]string>'
@@ -275,54 +163,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 62 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 102
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 1.905824e+06
-      GoKind: 22
-      Pointee: 109 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 136
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 395104
-      GoKind: 22
-      Pointee: 137 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 147
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.717792e+06
-      GoKind: 22
-      Pointee: 148 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 123
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 408928
-      GoKind: 22
-      Pointee: 124 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 130
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 409120
-      GoKind: 22
-      Pointee: 131 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 133
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.00992e+06
-      GoKind: 22
-      Pointee: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 182
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 62 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -344,11 +185,6 @@ Types:
       GoRuntimeType: 372640
       GoKind: 22
       Pointee: 17 BaseType float64
-    - __kind: PointerType
-      ID: 84
-      Name: '*hash<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 85 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 49
       Name: '*hash<string,[]string>'
@@ -395,62 +231,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 119
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.231648e+06
-      GoKind: 22
-      Pointee: 120 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 150
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 397920
-      GoKind: 22
-      Pointee: 151 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 153
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 152 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 91
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 837472
-      GoKind: 22
-      Pointee: 93 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 59
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 60 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 139
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 1.974688e+06
-      GoKind: 22
-      Pointee: 140 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 184
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 187
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 145
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.095968e+06
-      GoKind: 22
-      Pointee: 176 StructureType net.IPNet
+      Pointee: 60 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -464,35 +250,21 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 65 StructureType net/http.Response
+      Pointee: 65 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 67
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 68 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 189
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 364064
-      GoKind: 22
-      Pointee: 190 StructureType net/http.segment
+      Pointee: 68 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 46
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 47 StructureType net/url.URL
-    - __kind: PointerType
-      ID: 74
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.1144e+06
-      GoKind: 22
-      Pointee: 75 StructureType net/url.Userinfo
+      Pointee: 47 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 53
       Name: '*runtime.mapextra'
@@ -512,27 +284,6 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 44 GoStringDataType string.str
-    - __kind: PointerType
-      ID: 126
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.421568e+06
-      GoKind: 22
-      Pointee: 127 StructureType time.Location
-    - __kind: PointerType
-      ID: 157
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 367136
-      GoKind: 22
-      Pointee: 158 StructureType time.zone
-    - __kind: PointerType
-      ID: 160
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 367200
-      GoKind: 22
-      Pointee: 161 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -581,7 +332,7 @@ Types:
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: EventRootType
-      ID: 195
+      ID: 82
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -605,7 +356,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 196
+      ID: 83
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -620,7 +371,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 76
+      ID: 74
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -628,314 +379,23 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 100
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 469664
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 101 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 110 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 110
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 102 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 457504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 94 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 94
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 91 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 143
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 481696
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 144 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 177 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 145 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 141
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 481632
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 142 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 174 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 46 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 103
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 469792
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 104 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 112 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 112
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 100 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 452960
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 106 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 114 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 114
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 97 GoSliceHeaderType []uint8
-    - __kind: GoSliceDataType
-      ID: 92
-      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 2048
-      Element: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 79
+      ID: 77
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 52 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 81
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 73 GoHMapBucketType bucket<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 135
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 470944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 136 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 170 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 137 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 146
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 481760
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 147 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 179 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 179
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 148 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 122
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 482016
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 123 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 154 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 154
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 124 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 129
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 481504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 130 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 166 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 131 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 132
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 481568
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 133 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 168 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 168
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 77
+      ID: 75
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 138
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 454176
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 139 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 172 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 140 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 188
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 454944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 189 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 191 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 190 StructureType net/http.segment
     - __kind: GoSliceHeaderType
       ID: 57
       Name: '[]string'
@@ -952,94 +412,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 80 GoSliceDataType []string.array
+      Data: 78 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 156
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 459168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 157 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 162 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 158 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 159
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 459232
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 160 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 164 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 161 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 463616
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 98 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 98
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 88
-      Name: '[]val<[]*mime/multipart.FileHeader>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 89 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: ArrayType
-      ID: 78
+      ID: 76
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 57 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 193
+      ID: 80
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1052,38 +439,19 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 87
-      Name: bucket<string,[]*mime/multipart.FileHeader>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 76 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 77 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 88 ArrayType []val<[]*mime/multipart.FileHeader>
-        - Name: overflow
-          Offset: 328
-          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 89 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: GoHMapBucketType
       ID: 52
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 74 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 75 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 78 ArrayType []val<[]string>
+          Type: 76 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 51 PointerType *bucket<string,[]string>
@@ -1096,13 +464,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 74 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 75 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 193 ArrayType []val<string>
+          Type: 80 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 72 PointerType *bucket<string,string>
@@ -1152,334 +520,10 @@ Types:
       GoRuntimeType: 1.399808e+06
       GoKind: 25
       RawFields: []
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 62
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.100544e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 7 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 7 BaseType uint16
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 11 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 100 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 103 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 105 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 107 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyCurveID
-          Offset: 186
-          Type: 108 BaseType crypto/tls.CurveID
-    - __kind: BaseType
-      ID: 108
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 766144
-      GoKind: 9
-    - __kind: StructureType
-      ID: 109
-      Name: crypto/x509.Certificate
-      ByteSize: 1352
-      GoRuntimeType: 2.2352e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 116 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 117 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 118 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 9 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 119 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 121 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 121 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 125 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 125 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 128 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 129 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 129 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 135 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 9 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 57 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 57 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 57 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 57 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 138 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 141 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 57 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 57 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 143 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 143 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 57 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 57 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 57 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 57 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 57 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 146 GoSliceHeaderType []crypto/x509.OID
-    - __kind: BaseType
-      ID: 137
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 537472
-      GoKind: 2
-    - __kind: BaseType
-      ID: 128
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 537408
-      GoKind: 2
-    - __kind: StructureType
-      ID: 148
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.718016e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 97 GoSliceHeaderType []uint8
-    - __kind: BaseType
-      ID: 117
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 768544
-      GoKind: 2
-    - __kind: BaseType
-      ID: 116
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.071168e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 124
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.316608e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 118 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 131
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.45536e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 97 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 121
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.047488e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 57 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 57 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 57 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 57 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 57 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 57 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 57 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 11 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 11 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 122 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 122 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 134
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.010048e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 28 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 181
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 9 BaseType int
     - __kind: GoInterfaceType
       ID: 18
       Name: error
@@ -1511,12 +555,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 634400
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 107
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 960448
-      GoKind: 19
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -1530,40 +568,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: GoHMapHeaderType
-      ID: 85
-      Name: hash<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 53 PointerType *runtime.mapextra
-      BucketType: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 92 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
       ID: 50
       Name: hash<string,[]string>
@@ -1597,7 +601,7 @@ Types:
           Offset: 40
           Type: 53 PointerType *runtime.mapextra
       BucketType: 52 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 79 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 77 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 71
       Name: hash<string,string>
@@ -1631,7 +635,7 @@ Types:
           Offset: 40
           Type: 53 PointerType *runtime.mapextra
       BucketType: 73 GoHMapBucketType bucket<string,string>
-      BucketsType: 194 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 81 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1662,19 +666,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 533824
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 118
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 785472
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 55
       Name: io.ReadCloser
@@ -1689,165 +680,16 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 83
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 887392
-      GoKind: 21
-      HeaderType: 85 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 82
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 882592
-      GoKind: 21
-      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoMapType
       ID: 69
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
       HeaderType: 71 GoHMapHeaderType hash<string,string>
-    - __kind: StructureType
-      ID: 120
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.308608e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 149 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 151
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 537728
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.214784e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 150 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 152 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 152
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 151 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 93
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.83856e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 96 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 14 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 97 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 14 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 60
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.294528e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 82 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 83 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 140
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 1.948704e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 183 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 183
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 185
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 976000
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 186 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 186
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 176
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.276128e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 140 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 185 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 48
       Name: net/http.Header
@@ -1940,55 +782,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 69 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 65
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.065376e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 9 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 11 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 9 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 9 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 48 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 14 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 57 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 48 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 61 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2002,107 +799,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 68
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.702112e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 188 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 190
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.416384e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 96
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.596448e+06
-      GoKind: 21
-      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 47
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 1.986816e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 74 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 11 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 11 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 11 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 75
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.433088e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 11 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 58
       Name: net/url.Values
@@ -2132,85 +836,6 @@ Types:
       ID: 44
       Name: string.str
       ByteSize: 2048
-    - __kind: StructureType
-      ID: 127
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.834528e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 156 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 159 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 11 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 14 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 14 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 157 PointerType *time.zone
-    - __kind: StructureType
-      ID: 125
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.215712e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 10 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 14 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 126 PointerType *time.Location
-    - __kind: StructureType
-      ID: 158
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.421376e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 9 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 161
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.623872e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 14 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -2253,6 +878,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534848
       GoKind: 26
-MaxTypeID: 196
+MaxTypeID: 83
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 90 EventRootType Probe[main.HandleHTTP]
+          Type: 131 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 91 EventRootType Probe[main.LookAtTheRequest]
+          Type: 132 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -129,20 +129,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 51
+      ID: 92
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 52 PointerType *table<string,[]string>
+      Pointee: 93 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 70
+      ID: 111
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 71 PointerType *table<string,string>
+      Pointee: 112 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 81
+      ID: 122
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 80 GoSliceDataType []string.array
+      Pointee: 121 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -158,12 +158,12 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 59
+      ID: 100
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 60 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 101 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -185,6 +185,13 @@ Types:
       GoRuntimeType: 397120
       GoKind: 22
       Pointee: 18 BaseType float64
+    - __kind: PointerType
+      ID: 46
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.53936e+06
+      GoKind: 22
+      Pointee: 47 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -221,22 +228,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 49
+      ID: 90
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 50 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 91 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 68
+      ID: 109
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 69 GoSwissMapHeaderType map<string,string>
+      Pointee: 110 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 57
+      ID: 98
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 58 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 99 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -245,36 +252,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 62
+      ID: 103
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 63 UnresolvedPointeeType net/http.Response
+      Pointee: 104 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 65
+      ID: 83
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.995552e+06
+      GoKind: 22
+      Pointee: 84 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 106
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 66 UnresolvedPointeeType net/http.pattern
+      Pointee: 107 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 46
+      ID: 85
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.189216e+06
+      GoKind: 22
+      Pointee: 86 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 87
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 47 UnresolvedPointeeType net/url.URL
+      Pointee: 88 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 74
+      ID: 115
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 75 StructureType noalg.map.group[string][]string
+      Pointee: 116 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 84
+      ID: 125
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 85 StructureType noalg.map.group[string]string
+      Pointee: 126 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -289,14 +310,119 @@ Types:
       Pointee: 44 GoStringDataType string.str
     - __kind: PointerType
       ID: 52
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.676512e+06
+      GoKind: 22
+      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 66
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.728928e+06
+      GoKind: 22
+      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 48
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.676128e+06
+      GoKind: 22
+      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 58
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.72816e+06
+      GoKind: 22
+      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 72
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.799552e+06
+      GoKind: 22
+      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 60
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.728352e+06
+      GoKind: 22
+      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 56
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.727968e+06
+      GoKind: 22
+      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 68
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.799104e+06
+      GoKind: 22
+      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 76
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.868736e+06
+      GoKind: 22
+      Pointee: 77 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 70
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.799328e+06
+      GoKind: 22
+      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 54
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.676704e+06
+      GoKind: 22
+      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 50
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.67632e+06
+      GoKind: 22
+      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 62
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.728544e+06
+      GoKind: 22
+      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 74
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.799776e+06
+      GoKind: 22
+      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 64
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.728736e+06
+      GoKind: 22
+      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 93
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 72 StructureType table<string,[]string>
+      Pointee: 113 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 71
+      ID: 112
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 82 StructureType table<string,string>
+      Pointee: 123 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -340,12 +466,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 61
+      ID: 102
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: EventRootType
-      ID: 90
+      ID: 131
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -369,7 +495,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 91
+      ID: 132
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -384,27 +510,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 52 PointerType *table<string,[]string>
+      Element: 93 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 88
+      ID: 129
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 71 PointerType *table<string,string>
+      Element: 112 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 79
+      ID: 120
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 75 StructureType noalg.map.group[string][]string
+      Element: 116 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 89
+      ID: 130
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 85 StructureType noalg.map.group[string]string
+      Element: 126 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 96
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -419,9 +545,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 80 GoSliceDataType []string.array
+      Data: 121 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 80
+      ID: 121
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -448,7 +574,7 @@ Types:
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 105
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.266912e+06
@@ -476,7 +602,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 60
+      ID: 101
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -505,11 +631,28 @@ Types:
       GoRuntimeType: 580384
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 54
+      ID: 95
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
       GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 78
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.407616e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 47
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -524,33 +667,33 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 73
+      ID: 114
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 74 PointerType *noalg.map.group[string][]string
+          Type: 115 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 75 StructureType noalg.map.group[string][]string
-      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 116 StructureType noalg.map.group[string][]string
+      GroupSliceType: 120 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 83
+      ID: 124
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 84 PointerType *noalg.map.group[string]string
+          Type: 125 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 85 StructureType noalg.map.group[string]string
-      GroupSliceType: 89 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 126 StructureType noalg.map.group[string]string
+      GroupSliceType: 130 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -582,7 +725,7 @@ Types:
       GoRuntimeType: 579488
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 53
+      ID: 94
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.100576e+06
@@ -595,7 +738,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 50
+      ID: 91
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -608,7 +751,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 51 PointerType **table<string,[]string>
+          Type: 92 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -624,10 +767,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 78 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 75 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 119 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 116 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 69
+      ID: 110
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -640,7 +783,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 70 PointerType **table<string,string>
+          Type: 111 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -656,26 +799,78 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 88 GoSliceDataType []*table<string,string>.array
-      GroupType: 85 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 129 GoSliceDataType []*table<string,string>.array
+      GroupType: 126 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 67
+      ID: 108
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119008e+06
       GoKind: 21
-      HeaderType: 69 GoSwissMapHeaderType map<string,string>
+      HeaderType: 110 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 58
+      ID: 99
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 81
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.0184e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.016992e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 48
+      ID: 89
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.08736e+06
       GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 91 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 82
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.01712e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.017376e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -688,7 +883,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 46 PointerType *net/url.URL
+          Type: 87 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -700,19 +895,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 48 GoMapType net/http.Header
+          Type: 89 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 53 GoInterfaceType io.ReadCloser
+          Type: 94 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 54 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 95 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 55 GoSliceHeaderType []string
+          Type: 96 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -721,16 +916,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 56 GoMapType net/url.Values
+          Type: 97 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 56 GoMapType net/url.Values
+          Type: 97 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 57 PointerType *mime/multipart.Form
+          Type: 98 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 48 GoMapType net/http.Header
+          Type: 89 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -739,30 +934,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 59 PointerType *crypto/tls.ConnectionState
+          Type: 100 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 61 GoChannelType <-chan struct {}
+          Type: 102 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 62 PointerType *net/http.Response
+          Type: 103 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 64 GoInterfaceType context.Context
+          Type: 105 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 65 PointerType *net/http.pattern
+          Type: 106 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 55 GoSliceHeaderType []string
+          Type: 96 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 67 GoMapType map[string]string
+          Type: 108 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 63
+      ID: 104
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -779,40 +974,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 66
+      ID: 84
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 107
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 47
+      ID: 86
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 88
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 56
+      ID: 97
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.870528e+06
       GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 91 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 76
+      ID: 117
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 77 StructureType noalg.struct { key string; elem []string }
+      Element: 118 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 86
+      ID: 127
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 87 StructureType noalg.struct { key string; elem string }
+      Element: 128 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 75
+      ID: 116
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -823,9 +1026,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 76 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 117 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 85
+      ID: 126
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -836,9 +1039,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 86 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 127 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 77
+      ID: 118
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -849,9 +1052,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 55 GoSliceHeaderType []string
+          Type: 96 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 87
+      ID: 128
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -882,7 +1085,253 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 72
+      ID: 53
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.932032e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 67
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.009664e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 49
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.93152e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 59
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.008512e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 73
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.070944e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 61
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.0088e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 57
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 2.008224e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 69
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 2.070304e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 77
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.130688e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 71
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.070624e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 55
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.932288e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 51
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.931776e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 63
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.009088e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 75
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.071264e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 81 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 65
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.009376e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 82 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 113
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -904,9 +1353,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 73 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 114 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 82
+      ID: 123
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -928,7 +1377,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 83 GoSwissMapGroupsType groupReference<string,string>
+          Type: 124 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -971,6 +1420,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580512
       GoKind: 26
-MaxTypeID: 91
+MaxTypeID: 132
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 214 EventRootType Probe[main.HandleHTTP]
+          Type: 90 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 215 EventRootType Probe[main.LookAtTheRequest]
+          Type: 91 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -121,34 +129,6 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 109
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 110 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 97
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 98 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 152
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 153 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 150
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 46 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 88
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 89 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 51
       Name: '**table<string,[]string>'
       ByteSize: 8
@@ -159,108 +139,10 @@ Types:
       ByteSize: 8
       Pointee: 71 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 112
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 119
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 118 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 102 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 186
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 185 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 121
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 123
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 122 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 182
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 191
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 190 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 166
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 178
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 180
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 184
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 83
+      ID: 81
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 82 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 174
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 173 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 176
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 175 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 114
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 478144
-      GoKind: 22
-      Pointee: 105 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 107
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 106 GoSliceDataType []uint8.array
+      Pointee: 80 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -281,61 +163,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 60 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 110
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.030304e+06
-      GoKind: 22
-      Pointee: 117 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 144
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 420160
-      GoKind: 22
-      Pointee: 145 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 155
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.938144e+06
-      GoKind: 22
-      Pointee: 156 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 158
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 420224
-      GoKind: 22
-      Pointee: 159 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 131
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 433984
-      GoKind: 22
-      Pointee: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 138
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 434176
-      GoKind: 22
-      Pointee: 139 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 141
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.044e+06
-      GoKind: 22
-      Pointee: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 195
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 60 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -393,11 +221,6 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 86
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 87 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 49
       Name: '*map<string,[]string>'
       ByteSize: 8
@@ -408,62 +231,12 @@ Types:
       ByteSize: 8
       Pointee: 69 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 127
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.364704e+06
-      GoKind: 22
-      Pointee: 128 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 161
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 423040
-      GoKind: 22
-      Pointee: 162 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 164
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 163 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 98
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 902304
-      GoKind: 22
-      Pointee: 101 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 57
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 58 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 147
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.134112e+06
-      GoKind: 22
-      Pointee: 148 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 197
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 200
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 199 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 153
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.17392e+06
-      GoKind: 22
-      Pointee: 187 StructureType net.IPNet
+      Pointee: 58 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -477,50 +250,31 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 63 StructureType net/http.Response
+      Pointee: 63 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 65
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 66 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 202
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 388544
-      GoKind: 22
-      Pointee: 203 StructureType net/http.segment
+      Pointee: 66 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 46
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 47 StructureType net/url.URL
+      Pointee: 47 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 72
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.191456e+06
-      GoKind: 22
-      Pointee: 73 StructureType net/url.Userinfo
-    - __kind: PointerType
-      ID: 92
-      Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
-      ByteSize: 8
-      Pointee: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 76
+      ID: 74
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 77 StructureType noalg.map.group[string][]string
+      Pointee: 75 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 208
+      ID: 84
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[string]string
+      Pointee: 85 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -534,41 +288,15 @@ Types:
       ByteSize: 8
       Pointee: 44 GoStringDataType string.str
     - __kind: PointerType
-      ID: 89
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 90 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 52
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 74 StructureType table<string,[]string>
+      Pointee: 72 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 71
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 206 StructureType table<string,string>
-    - __kind: PointerType
-      ID: 134
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.6024e+06
-      GoKind: 22
-      Pointee: 135 StructureType time.Location
-    - __kind: PointerType
-      ID: 168
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 391680
-      GoKind: 22
-      Pointee: 169 StructureType time.zone
-    - __kind: PointerType
-      ID: 171
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 391744
-      GoKind: 22
-      Pointee: 172 StructureType time.zoneTrans
+      Pointee: 82 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -617,7 +345,7 @@ Types:
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: EventRootType
-      ID: 214
+      ID: 90
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -641,7 +369,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 215
+      ID: 91
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -655,344 +383,26 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-    - __kind: GoSliceHeaderType
-      ID: 108
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 498304
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 109 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 118
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 110 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 96
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 483744
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 97 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 102 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 102
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 98 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 151
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 511840
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 152 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 188 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 188
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 153 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 511776
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 150 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 185 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 185
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 46 PointerType *net/url.URL
-    - __kind: GoSliceDataType
-      ID: 99
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 89 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 52 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 88
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 71 PointerType *table<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 111
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 498432
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 112 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 120
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 113
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 478528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 114 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 122 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 122
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 105 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 143
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 499776
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 144 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 181
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 145 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 154
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 511904
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 155 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 190 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 190
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 156 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 157
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 511968
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 158 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 159 StructureType crypto/x509.PolicyMapping
-    - __kind: GoSliceHeaderType
-      ID: 130
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 512416
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 131 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 137
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 511648
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 138 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 139 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 140
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 511712
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 141 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 179
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 146
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 479488
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 147 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 183 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 183
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 148 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 201
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 481120
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 202 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 204 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 204
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 203 StructureType net/http.segment
-    - __kind: GoSliceDataType
-      ID: 100
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 81
+      ID: 79
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 77 StructureType noalg.map.group[string][]string
+      Element: 75 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 89
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[string]string
+      Element: 85 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 55
       Name: '[]string'
@@ -1009,78 +419,12 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 82 GoSliceDataType []string.array
+      Data: 80 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 82
+      ID: 80
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 167
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 485792
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 168 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 173 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 173
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 169 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 170
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 485856
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 171 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 175 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 172 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 491520
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 106 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 106
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1131,368 +475,10 @@ Types:
       GoRuntimeType: 1.58016e+06
       GoKind: 25
       RawFields: []
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 60
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.231616e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 108 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 111 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 113 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 115 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyCurveID
-          Offset: 186
-          Type: 116 BaseType crypto/tls.CurveID
-    - __kind: BaseType
-      ID: 116
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 829056
-      GoKind: 9
-    - __kind: StructureType
-      ID: 117
-      Name: crypto/x509.Certificate
-      ByteSize: 1424
-      GoRuntimeType: 2.37712e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 124 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 125 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 126 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 7 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 127 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 129 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 129 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 133 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 133 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 136 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 143 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 7 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 55 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 55 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 55 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 55 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 146 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 149 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 55 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 55 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 151 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 151 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 55 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 55 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 55 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 55 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 55 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 154 GoSliceHeaderType []crypto/x509.OID
-        - Name: InhibitAnyPolicy
-          Offset: 1352
-          Type: 7 BaseType int
-        - Name: InhibitAnyPolicyZero
-          Offset: 1360
-          Type: 4 BaseType bool
-        - Name: InhibitPolicyMapping
-          Offset: 1368
-          Type: 7 BaseType int
-        - Name: InhibitPolicyMappingZero
-          Offset: 1376
-          Type: 4 BaseType bool
-        - Name: RequireExplicitPolicy
-          Offset: 1384
-          Type: 7 BaseType int
-        - Name: RequireExplicitPolicyZero
-          Offset: 1392
-          Type: 4 BaseType bool
-        - Name: PolicyMappings
-          Offset: 1400
-          Type: 157 GoSliceHeaderType []crypto/x509.PolicyMapping
-    - __kind: BaseType
-      ID: 145
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 583136
-      GoKind: 2
-    - __kind: BaseType
-      ID: 136
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 583072
-      GoKind: 2
-    - __kind: StructureType
-      ID: 156
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.9384e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 105 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 159
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.480224e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 156 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 156 StructureType crypto/x509.OID
-    - __kind: BaseType
-      ID: 125
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 831456
-      GoKind: 2
-    - __kind: BaseType
-      ID: 124
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.104544e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 132
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.492064e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 126 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 139
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.635616e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 105 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 129
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.176736e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 55 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 55 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 55 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 55 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 55 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 55 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 55 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 9 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 9 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 142
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.044128e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 28 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 7 BaseType int
     - __kind: GoInterfaceType
       ID: 14
       Name: error
@@ -1524,12 +510,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 687840
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 115
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 994848
-      GoKind: 19
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -1544,47 +524,33 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 91
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 92 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 100 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
-    - __kind: GoSwissMapGroupsType
-      ID: 75
+      ID: 73
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 76 PointerType *noalg.map.group[string][]string
+          Type: 74 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 77 StructureType noalg.map.group[string][]string
-      GroupSliceType: 81 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 75 StructureType noalg.map.group[string][]string
+      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 83
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[string]string
+          Type: 84 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 85 StructureType noalg.map.group[string]string
+      GroupSliceType: 89 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1615,19 +581,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 579488
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 126
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 848672
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 53
       Name: io.ReadCloser
@@ -1641,38 +594,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: GoSwissMapHeaderType
-      ID: 87
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 88 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 99 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 50
       Name: map<string,[]string>
@@ -1703,8 +624,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 80 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 77 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 78 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 75 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 69
       Name: map<string,string>
@@ -1735,22 +656,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 209 StructureType noalg.map.group[string]string
-    - __kind: GoMapType
-      ID: 85
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.122592e+06
-      GoKind: 21
-      HeaderType: 87 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 84
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.117984e+06
-      GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
+      TablePtrSliceType: 88 GoSliceDataType []*table<string,string>.array
+      GroupType: 85 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 67
       Name: map[string]string
@@ -1758,145 +665,10 @@ Types:
       GoRuntimeType: 1.119008e+06
       GoKind: 21
       HeaderType: 69 GoSwissMapHeaderType map<string,string>
-    - __kind: StructureType
-      ID: 128
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.483264e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 160 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 162
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 583328
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 160
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.345504e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 161 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 163 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 163
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 162 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 101
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.962144e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 104 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 13 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 105 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 13 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 58
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.467264e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 84 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 85 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 148
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.109184e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 196 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 198
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.01072e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 199 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 199
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 187
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.448704e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 148 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 198 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 48
       Name: net/http.Header
@@ -1989,55 +761,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 67 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 63
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.19504e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 7 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 7 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 48 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 53 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 55 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 48 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 59 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2051,107 +778,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 66
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.818112e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 201 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 203
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.597216e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 104
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.808288e+06
-      GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 47
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.112256e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 72 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 9 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 9 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 73
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.613536e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 56
       Name: net/url.Values
@@ -2160,47 +794,25 @@ Types:
       GoKind: 21
       HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 94
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 693888
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 95 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 78
+      ID: 76
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 79 StructureType noalg.struct { key string; elem []string }
+      Element: 77 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 210
+      ID: 86
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key string; elem string }
+      Element: 87 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 93
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.289824e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 94 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 77
+      ID: 75
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -2211,9 +823,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 78 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 76 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 209
+      ID: 85
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -2224,22 +836,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 86 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 95
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.289696e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 96 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 79
+      ID: 77
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -2252,7 +851,7 @@ Types:
           Offset: 16
           Type: 55 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 211
+      ID: 87
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -2283,31 +882,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 90
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 91 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 74
+      ID: 72
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2329,9 +904,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 75 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 73 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 206
+      ID: 82
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2353,86 +928,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: StructureType
-      ID: 135
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.957824e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 167 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 170 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 9 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 168 PointerType *time.zone
-    - __kind: StructureType
-      ID: 133
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.34832e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 13 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 134 PointerType *time.Location
-    - __kind: StructureType
-      ID: 169
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.602208e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 172
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.736576e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 13 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
+          Type: 83 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2475,6 +971,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580512
       GoKind: 26
-MaxTypeID: 215
+MaxTypeID: 91
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -4,26 +4,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 213 EventRootType Probe[main.HandleHTTP]
+          Type: 88 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b100", Frameless: true}]
           Condition: null
     - id: look_at_the_request
       version: 0
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 214 EventRootType Probe[main.LookAtTheRequest]
+          Type: 89 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b3fc", Frameless: true}]
           Condition: null
 Subprograms:
@@ -108,34 +116,6 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 108
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 109 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 95
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 96 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 151
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 152 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 149
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 44 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 86
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 87 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 49
       Name: '**table<string,[]string>'
       ByteSize: 8
@@ -146,108 +126,10 @@ Types:
       ByteSize: 8
       Pointee: 69 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 111
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 107 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 118
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 117 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 101
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 100 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 188
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 187 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 120
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 119 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 121 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 181
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 190
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 189 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 177
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 204
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 203 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 81
+      ID: 79
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 80 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 173
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 172 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 113
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 481440
-      GoKind: 22
-      Pointee: 103 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 105
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 104 GoSliceDataType []uint8.array
+      Pointee: 78 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -268,61 +150,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 58 StructureType crypto/tls.ConnectionState
-    - __kind: PointerType
-      ID: 109
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.0432e+06
-      GoKind: 22
-      Pointee: 116 StructureType crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 143
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 423456
-      GoKind: 22
-      Pointee: 144 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 154
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.953568e+06
-      GoKind: 22
-      Pointee: 155 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 157
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 423520
-      GoKind: 22
-      Pointee: 158 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 130
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 437216
-      GoKind: 22
-      Pointee: 131 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 137
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 437408
-      GoKind: 22
-      Pointee: 138 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 140
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.052704e+06
-      GoKind: 22
-      Pointee: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 194
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 193 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 58 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -380,11 +208,6 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 84
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 47
       Name: '*map<string,[]string>'
       ByteSize: 8
@@ -395,62 +218,12 @@ Types:
       ByteSize: 8
       Pointee: 67 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 126
-      Name: '*math/big.Int'
-      ByteSize: 8
-      GoRuntimeType: 2.381568e+06
-      GoKind: 22
-      Pointee: 127 StructureType math/big.Int
-    - __kind: PointerType
-      ID: 160
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 426272
-      GoKind: 22
-      Pointee: 161 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 163
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 162 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 96
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 909280
-      GoKind: 22
-      Pointee: 99 StructureType mime/multipart.FileHeader
-    - __kind: PointerType
       ID: 55
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 56 StructureType mime/multipart.Form
-    - __kind: PointerType
-      ID: 146
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.149408e+06
-      GoKind: 22
-      Pointee: 147 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 196
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 195 GoSliceDataType net.IP.array
-    - __kind: PointerType
-      ID: 199
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 198 GoSliceDataType net.IPMask.array
-    - __kind: PointerType
-      ID: 152
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.182656e+06
-      GoKind: 22
-      Pointee: 186 StructureType net.IPNet
+      Pointee: 56 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -464,50 +237,31 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.718272e+06
       GoKind: 22
-      Pointee: 61 StructureType net/http.Response
+      Pointee: 61 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
       ID: 63
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608064e+06
       GoKind: 22
-      Pointee: 64 StructureType net/http.pattern
-    - __kind: PointerType
-      ID: 201
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 391712
-      GoKind: 22
-      Pointee: 202 StructureType net/http.segment
+      Pointee: 64 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 44
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 45 StructureType net/url.URL
+      Pointee: 45 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 70
-      Name: '*net/url.Userinfo'
-      ByteSize: 8
-      GoRuntimeType: 1.200064e+06
-      GoKind: 22
-      Pointee: 71 StructureType net/url.Userinfo
-    - __kind: PointerType
-      ID: 90
-      Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
-      ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 74
+      ID: 72
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 75 StructureType noalg.map.group[string][]string
+      Pointee: 73 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 207
+      ID: 82
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 208 StructureType noalg.map.group[string]string
+      Pointee: 83 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -521,41 +275,15 @@ Types:
       ByteSize: 8
       Pointee: 42 GoStringDataType string.str
     - __kind: PointerType
-      ID: 87
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 88 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
       ID: 50
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 72 StructureType table<string,[]string>
+      Pointee: 70 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 69
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 205 StructureType table<string,string>
-    - __kind: PointerType
-      ID: 133
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.613056e+06
-      GoKind: 22
-      Pointee: 134 StructureType time.Location
-    - __kind: PointerType
-      ID: 167
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 394784
-      GoKind: 22
-      Pointee: 168 StructureType time.zone
-    - __kind: PointerType
-      ID: 170
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 394848
-      GoKind: 22
-      Pointee: 171 StructureType time.zoneTrans
+      Pointee: 80 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -604,7 +332,7 @@ Types:
       GoRuntimeType: 597472
       GoKind: 18
     - __kind: EventRootType
-      ID: 213
+      ID: 88
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -628,7 +356,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 214
+      ID: 89
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -642,344 +370,26 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-    - __kind: GoSliceHeaderType
-      ID: 107
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 502272
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 108 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 117 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 117
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 109 PointerType *crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 94
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 487168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 95 PointerType **mime/multipart.FileHeader
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 100 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 100
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 96 PointerType *mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 150
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 503872
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 151 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 187 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 187
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 152 PointerType *net.IPNet
-    - __kind: GoSliceHeaderType
-      ID: 148
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 503808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 149 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 184 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 44 PointerType *net/url.URL
-    - __kind: GoSliceDataType
-      ID: 97
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 87 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 78
+      ID: 76
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 50 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 86
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 69 PointerType *table<string,string>
-    - __kind: GoSliceHeaderType
-      ID: 110
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 502336
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 111 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 119 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 119
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 107 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 112
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 481760
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 113 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 121 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 121
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 103 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 142
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 503744
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 143 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 180 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 144 BaseType crypto/x509.ExtKeyUsage
-    - __kind: GoSliceHeaderType
-      ID: 153
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 503936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 154 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 189 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 189
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 155 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 156
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 504000
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 157 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 158 StructureType crypto/x509.PolicyMapping
-    - __kind: GoSliceHeaderType
-      ID: 129
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 517280
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 130 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 164 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 131 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 136
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 503616
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 137 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 176
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 138 StructureType crypto/x509/pkix.Extension
-    - __kind: GoSliceHeaderType
-      ID: 139
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 503680
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 140 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 145
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 482784
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 146 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 182 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 147 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 200
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 484480
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 201 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 203 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 203
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 202 StructureType net/http.segment
-    - __kind: GoSliceDataType
-      ID: 98
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 79
+      ID: 77
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 75 StructureType noalg.map.group[string][]string
+      Element: 73 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 87
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 208 StructureType noalg.map.group[string]string
+      Element: 83 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]string'
@@ -996,78 +406,12 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 80 GoSliceDataType []string.array
+      Data: 78 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 80
+      ID: 78
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 166
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 489344
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 167 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 172 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 168 StructureType time.zone
-    - __kind: GoSliceHeaderType
-      ID: 169
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 489408
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 170 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 174 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 171 StructureType time.zoneTrans
-    - __kind: GoSliceHeaderType
-      ID: 103
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 495136
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 104 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 104
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 3 BaseType uint8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1103,377 +447,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 58
       Name: crypto/tls.ConnectionState
-      ByteSize: 192
-      GoRuntimeType: 2.261984e+06
-      GoKind: 25
-      RawFields:
-        - Name: Version
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: HandshakeComplete
-          Offset: 2
-          Type: 4 BaseType bool
-        - Name: DidResume
-          Offset: 3
-          Type: 4 BaseType bool
-        - Name: CipherSuite
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: CurveID
-          Offset: 6
-          Type: 106 BaseType crypto/tls.CurveID
-        - Name: NegotiatedProtocol
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: NegotiatedProtocolIsMutual
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: ServerName
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: PeerCertificates
-          Offset: 48
-          Type: 107 GoSliceHeaderType []*crypto/x509.Certificate
-        - Name: VerifiedChains
-          Offset: 72
-          Type: 110 GoSliceHeaderType [][]*crypto/x509.Certificate
-        - Name: SignedCertificateTimestamps
-          Offset: 96
-          Type: 112 GoSliceHeaderType [][]uint8
-        - Name: OCSPResponse
-          Offset: 120
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: TLSUnique
-          Offset: 144
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: ECHAccepted
-          Offset: 168
-          Type: 4 BaseType bool
-        - Name: ekm
-          Offset: 176
-          Type: 114 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
-        - Name: testingOnlyDidHRR
-          Offset: 184
-          Type: 4 BaseType bool
-        - Name: testingOnlyPeerSignatureAlgorithm
-          Offset: 186
-          Type: 115 BaseType crypto/tls.SignatureScheme
-    - __kind: BaseType
-      ID: 106
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 834432
-      GoKind: 9
-    - __kind: BaseType
-      ID: 115
-      Name: crypto/tls.SignatureScheme
-      ByteSize: 2
-      GoRuntimeType: 834528
-      GoKind: 9
-    - __kind: StructureType
-      ID: 116
-      Name: crypto/x509.Certificate
-      ByteSize: 1424
-      GoRuntimeType: 2.392832e+06
-      GoKind: 25
-      RawFields:
-        - Name: Raw
-          Offset: 0
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: RawTBSCertificate
-          Offset: 24
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: RawSubjectPublicKeyInfo
-          Offset: 48
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: RawSubject
-          Offset: 72
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: RawIssuer
-          Offset: 96
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: Signature
-          Offset: 120
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: SignatureAlgorithm
-          Offset: 144
-          Type: 123 BaseType crypto/x509.SignatureAlgorithm
-        - Name: PublicKeyAlgorithm
-          Offset: 152
-          Type: 124 BaseType crypto/x509.PublicKeyAlgorithm
-        - Name: PublicKey
-          Offset: 160
-          Type: 125 GoEmptyInterfaceType interface {}
-        - Name: Version
-          Offset: 176
-          Type: 7 BaseType int
-        - Name: SerialNumber
-          Offset: 184
-          Type: 126 PointerType *math/big.Int
-        - Name: Issuer
-          Offset: 192
-          Type: 128 StructureType crypto/x509/pkix.Name
-        - Name: Subject
-          Offset: 440
-          Type: 128 StructureType crypto/x509/pkix.Name
-        - Name: NotBefore
-          Offset: 688
-          Type: 132 StructureType time.Time
-        - Name: NotAfter
-          Offset: 712
-          Type: 132 StructureType time.Time
-        - Name: KeyUsage
-          Offset: 736
-          Type: 135 BaseType crypto/x509.KeyUsage
-        - Name: Extensions
-          Offset: 744
-          Type: 136 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: ExtraExtensions
-          Offset: 768
-          Type: 136 GoSliceHeaderType []crypto/x509/pkix.Extension
-        - Name: UnhandledCriticalExtensions
-          Offset: 792
-          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: ExtKeyUsage
-          Offset: 816
-          Type: 142 GoSliceHeaderType []crypto/x509.ExtKeyUsage
-        - Name: UnknownExtKeyUsage
-          Offset: 840
-          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: BasicConstraintsValid
-          Offset: 864
-          Type: 4 BaseType bool
-        - Name: IsCA
-          Offset: 865
-          Type: 4 BaseType bool
-        - Name: MaxPathLen
-          Offset: 872
-          Type: 7 BaseType int
-        - Name: MaxPathLenZero
-          Offset: 880
-          Type: 4 BaseType bool
-        - Name: SubjectKeyId
-          Offset: 888
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: AuthorityKeyId
-          Offset: 912
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: OCSPServer
-          Offset: 936
-          Type: 53 GoSliceHeaderType []string
-        - Name: IssuingCertificateURL
-          Offset: 960
-          Type: 53 GoSliceHeaderType []string
-        - Name: DNSNames
-          Offset: 984
-          Type: 53 GoSliceHeaderType []string
-        - Name: EmailAddresses
-          Offset: 1008
-          Type: 53 GoSliceHeaderType []string
-        - Name: IPAddresses
-          Offset: 1032
-          Type: 145 GoSliceHeaderType []net.IP
-        - Name: URIs
-          Offset: 1056
-          Type: 148 GoSliceHeaderType []*net/url.URL
-        - Name: PermittedDNSDomainsCritical
-          Offset: 1080
-          Type: 4 BaseType bool
-        - Name: PermittedDNSDomains
-          Offset: 1088
-          Type: 53 GoSliceHeaderType []string
-        - Name: ExcludedDNSDomains
-          Offset: 1112
-          Type: 53 GoSliceHeaderType []string
-        - Name: PermittedIPRanges
-          Offset: 1136
-          Type: 150 GoSliceHeaderType []*net.IPNet
-        - Name: ExcludedIPRanges
-          Offset: 1160
-          Type: 150 GoSliceHeaderType []*net.IPNet
-        - Name: PermittedEmailAddresses
-          Offset: 1184
-          Type: 53 GoSliceHeaderType []string
-        - Name: ExcludedEmailAddresses
-          Offset: 1208
-          Type: 53 GoSliceHeaderType []string
-        - Name: PermittedURIDomains
-          Offset: 1232
-          Type: 53 GoSliceHeaderType []string
-        - Name: ExcludedURIDomains
-          Offset: 1256
-          Type: 53 GoSliceHeaderType []string
-        - Name: CRLDistributionPoints
-          Offset: 1280
-          Type: 53 GoSliceHeaderType []string
-        - Name: PolicyIdentifiers
-          Offset: 1304
-          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
-        - Name: Policies
-          Offset: 1328
-          Type: 153 GoSliceHeaderType []crypto/x509.OID
-        - Name: InhibitAnyPolicy
-          Offset: 1352
-          Type: 7 BaseType int
-        - Name: InhibitAnyPolicyZero
-          Offset: 1360
-          Type: 4 BaseType bool
-        - Name: InhibitPolicyMapping
-          Offset: 1368
-          Type: 7 BaseType int
-        - Name: InhibitPolicyMappingZero
-          Offset: 1376
-          Type: 4 BaseType bool
-        - Name: RequireExplicitPolicy
-          Offset: 1384
-          Type: 7 BaseType int
-        - Name: RequireExplicitPolicyZero
-          Offset: 1392
-          Type: 4 BaseType bool
-        - Name: PolicyMappings
-          Offset: 1400
-          Type: 156 GoSliceHeaderType []crypto/x509.PolicyMapping
-    - __kind: BaseType
-      ID: 144
-      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 587936
-      GoKind: 2
-    - __kind: BaseType
-      ID: 135
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 587872
-      GoKind: 2
-    - __kind: StructureType
-      ID: 155
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.953824e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 103 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 158
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.490528e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 155 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 155 StructureType crypto/x509.OID
-    - __kind: BaseType
-      ID: 124
-      Name: crypto/x509.PublicKeyAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 837024
-      GoKind: 2
-    - __kind: BaseType
-      ID: 123
-      Name: crypto/x509.SignatureAlgorithm
-      ByteSize: 8
-      GoRuntimeType: 1.113728e+06
-      GoKind: 2
-    - __kind: StructureType
-      ID: 131
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.502368e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 125 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 138
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.646464e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 103 GoSliceHeaderType []uint8
-    - __kind: StructureType
-      ID: 128
-      Name: crypto/x509/pkix.Name
-      ByteSize: 248
-      GoRuntimeType: 2.192e+06
-      GoKind: 25
-      RawFields:
-        - Name: Country
-          Offset: 0
-          Type: 53 GoSliceHeaderType []string
-        - Name: Organization
-          Offset: 24
-          Type: 53 GoSliceHeaderType []string
-        - Name: OrganizationalUnit
-          Offset: 48
-          Type: 53 GoSliceHeaderType []string
-        - Name: Locality
-          Offset: 72
-          Type: 53 GoSliceHeaderType []string
-        - Name: Province
-          Offset: 96
-          Type: 53 GoSliceHeaderType []string
-        - Name: StreetAddress
-          Offset: 120
-          Type: 53 GoSliceHeaderType []string
-        - Name: PostalCode
-          Offset: 144
-          Type: 53 GoSliceHeaderType []string
-        - Name: SerialNumber
-          Offset: 168
-          Type: 9 GoStringHeaderType string
-        - Name: CommonName
-          Offset: 184
-          Type: 9 GoStringHeaderType string
-        - Name: Names
-          Offset: 200
-          Type: 129 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-        - Name: ExtraNames
-          Offset: 224
-          Type: 129 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: GoSliceHeaderType
-      ID: 141
-      Name: encoding/asn1.ObjectIdentifier
-      ByteSize: 24
-      GoRuntimeType: 1.052832e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 27 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 193 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 193
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 7 BaseType int
     - __kind: GoInterfaceType
       ID: 14
       Name: error
@@ -1505,12 +482,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 693216
       GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 114
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.002592e+06
-      GoKind: 19
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -1525,47 +496,33 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 89
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 90 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 98 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
-    - __kind: GoSwissMapGroupsType
-      ID: 73
+      ID: 71
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 74 PointerType *noalg.map.group[string][]string
+          Type: 72 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 75 StructureType noalg.map.group[string][]string
-      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 73 StructureType noalg.map.group[string][]string
+      GroupSliceType: 77 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 206
+      ID: 81
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 207 PointerType *noalg.map.group[string]string
+          Type: 82 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 208 StructureType noalg.map.group[string]string
-      GroupSliceType: 212 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 83 StructureType noalg.map.group[string]string
+      GroupSliceType: 87 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1596,19 +553,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 584288
       GoKind: 3
-    - __kind: GoEmptyInterfaceType
-      ID: 125
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 854240
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 51
       Name: io.ReadCloser
@@ -1622,41 +566,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: GoSwissMapHeaderType
-      ID: 85
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 86 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 97 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 48
       Name: map<string,[]string>
@@ -1690,8 +599,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 78 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 75 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 76 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 73 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 67
       Name: map<string,string>
@@ -1725,22 +634,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 211 GoSliceDataType []*table<string,string>.array
-      GroupType: 208 StructureType noalg.map.group[string]string
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.131648e+06
-      GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoMapType
-      ID: 82
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.127296e+06
-      GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      TablePtrSliceType: 86 GoSliceDataType []*table<string,string>.array
+      GroupType: 83 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 65
       Name: map[string]string
@@ -1748,145 +643,10 @@ Types:
       GoRuntimeType: 1.12832e+06
       GoKind: 21
       HeaderType: 67 GoSwissMapHeaderType map<string,string>
-    - __kind: StructureType
-      ID: 127
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.493568e+06
-      GoKind: 25
-      RawFields:
-        - Name: neg
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 159 GoSliceHeaderType math/big.nat
-    - __kind: BaseType
-      ID: 161
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 588128
-      GoKind: 7
-    - __kind: GoSliceHeaderType
-      ID: 159
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.361088e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 160 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 162 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 162
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 161 BaseType math/big.Word
-    - __kind: StructureType
-      ID: 99
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.977088e+06
-      GoKind: 25
-      RawFields:
-        - Name: Filename
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 102 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 13 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 103 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 13 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 4 BaseType bool
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 56
       Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.477408e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 82 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 83 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 147
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.123744e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 195 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 197
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.01904e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 5 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 198 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 198
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 3 BaseType uint8
-    - __kind: StructureType
-      ID: 186
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.458208e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 147 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 197 GoSliceHeaderType net.IPMask
+      ByteSize: 8
     - __kind: GoMapType
       ID: 46
       Name: net/http.Header
@@ -1979,55 +739,10 @@ Types:
         - Name: otherValues
           Offset: 296
           Type: 65 GoMapType map[string]string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 61
       Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.209888e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 7 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 7 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 46 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 53 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 4 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 4 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 46 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 37 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 57 PointerType *crypto/tls.ConnectionState
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2041,107 +756,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 64
       Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.833088e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 200 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 202
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.607872e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 4 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 4 BaseType bool
-    - __kind: GoMapType
-      ID: 102
-      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.82304e+06
-      GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 45
       Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.126816e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 70 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 4 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 9 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 9 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 9 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 71
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.624384e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 9 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 4 BaseType bool
+      ByteSize: 8
     - __kind: GoMapType
       ID: 54
       Name: net/url.Values
@@ -2150,47 +772,25 @@ Types:
       GoKind: 21
       HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 92
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 699072
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 76
+      ID: 74
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 77 StructureType noalg.struct { key string; elem []string }
+      Element: 75 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 209
+      ID: 84
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 210 StructureType noalg.struct { key string; elem string }
+      Element: 85 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 91
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.298816e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 75
+      ID: 73
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -2201,9 +801,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 76 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 74 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 208
+      ID: 83
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -2214,22 +814,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 209 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 84 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 93
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.298688e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 94 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 77
+      ID: 75
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -2242,7 +829,7 @@ Types:
           Offset: 16
           Type: 53 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 210
+      ID: 85
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -2273,31 +860,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 88
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 72
+      ID: 70
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2319,9 +882,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 73 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 71 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 205
+      ID: 80
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2343,86 +906,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 206 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: StructureType
-      ID: 134
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.972768e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 166 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 169 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 9 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 13 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 167 PointerType *time.zone
-    - __kind: StructureType
-      ID: 132
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.363936e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 13 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 133 PointerType *time.Location
-    - __kind: StructureType
-      ID: 168
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.612864e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 7 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 171
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.750304e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 13 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 4 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 4 BaseType bool
+          Type: 81 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2465,6 +949,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585312
       GoKind: 26
-MaxTypeID: 214
+MaxTypeID: 89
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x130d980", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 88 EventRootType Probe[main.HandleHTTP]
+          Type: 129 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b100", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 89 EventRootType Probe[main.LookAtTheRequest]
+          Type: 130 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b3fc", Frameless: true}]
           Condition: null
 Subprograms:
@@ -116,20 +116,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 49
+      ID: 90
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 50 PointerType *table<string,[]string>
+      Pointee: 91 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 68
+      ID: 109
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 69 PointerType *table<string,string>
+      Pointee: 110 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 79
+      ID: 120
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 78 GoSliceDataType []string.array
+      Pointee: 119 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -145,12 +145,12 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 57
+      ID: 98
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 58 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 99 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -172,6 +172,13 @@ Types:
       GoRuntimeType: 400160
       GoKind: 22
       Pointee: 16 BaseType float64
+    - __kind: PointerType
+      ID: 44
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.549984e+06
+      GoKind: 22
+      Pointee: 45 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -208,22 +215,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 47
+      ID: 88
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 48 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 89 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 66
+      ID: 107
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 67 GoSwissMapHeaderType map<string,string>
+      Pointee: 108 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 55
+      ID: 96
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 56 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 97 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -232,36 +239,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 60
+      ID: 101
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718272e+06
       GoKind: 22
-      Pointee: 61 UnresolvedPointeeType net/http.Response
+      Pointee: 102 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 63
+      ID: 81
+      Name: '*net/http.http2responseWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.0096e+06
+      GoKind: 22
+      Pointee: 82 UnresolvedPointeeType net/http.http2responseWriter
+    - __kind: PointerType
+      ID: 104
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608064e+06
       GoKind: 22
-      Pointee: 64 UnresolvedPointeeType net/http.pattern
+      Pointee: 105 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 44
+      ID: 83
+      Name: '*net/http.response'
+      ByteSize: 8
+      GoRuntimeType: 2.217504e+06
+      GoKind: 22
+      Pointee: 84 UnresolvedPointeeType net/http.response
+    - __kind: PointerType
+      ID: 85
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 45 UnresolvedPointeeType net/url.URL
+      Pointee: 86 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 72
+      ID: 113
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 73 StructureType noalg.map.group[string][]string
+      Pointee: 114 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 82
+      ID: 123
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 83 StructureType noalg.map.group[string]string
+      Pointee: 124 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -276,14 +297,119 @@ Types:
       Pointee: 42 GoStringDataType string.str
     - __kind: PointerType
       ID: 50
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.687936e+06
+      GoKind: 22
+      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 64
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.741696e+06
+      GoKind: 22
+      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 46
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.687552e+06
+      GoKind: 22
+      Pointee: 47 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+    - __kind: PointerType
+      ID: 56
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.740928e+06
+      GoKind: 22
+      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 70
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.813504e+06
+      GoKind: 22
+      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 58
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.74112e+06
+      GoKind: 22
+      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 54
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.740736e+06
+      GoKind: 22
+      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+    - __kind: PointerType
+      ID: 66
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.813056e+06
+      GoKind: 22
+      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 74
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.882144e+06
+      GoKind: 22
+      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 68
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.81328e+06
+      GoKind: 22
+      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 52
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.688128e+06
+      GoKind: 22
+      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 48
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
+      ByteSize: 8
+      GoRuntimeType: 1.687744e+06
+      GoKind: 22
+      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+    - __kind: PointerType
+      ID: 60
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
+      ByteSize: 8
+      GoRuntimeType: 1.741312e+06
+      GoKind: 22
+      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+    - __kind: PointerType
+      ID: 72
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.813728e+06
+      GoKind: 22
+      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 62
+      Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
+      ByteSize: 8
+      GoRuntimeType: 1.741504e+06
+      GoKind: 22
+      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+    - __kind: PointerType
+      ID: 91
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 70 StructureType table<string,[]string>
+      Pointee: 111 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 69
+      ID: 110
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 80 StructureType table<string,string>
+      Pointee: 121 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -327,12 +453,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 59
+      ID: 100
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
     - __kind: EventRootType
-      ID: 88
+      ID: 129
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -356,7 +482,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 89
+      ID: 130
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -371,27 +497,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 76
+      ID: 117
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 50 PointerType *table<string,[]string>
+      Element: 91 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 86
+      ID: 127
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 69 PointerType *table<string,string>
+      Element: 110 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 77
+      ID: 118
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 73 StructureType noalg.map.group[string][]string
+      Element: 114 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 87
+      ID: 128
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 83 StructureType noalg.map.group[string]string
+      Element: 124 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 94
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -406,9 +532,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 78 GoSliceDataType []string.array
+      Data: 119 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 78
+      ID: 119
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -435,7 +561,7 @@ Types:
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 62
+      ID: 103
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276288e+06
@@ -448,7 +574,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 58
+      ID: 99
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -477,11 +603,28 @@ Types:
       GoRuntimeType: 585184
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 52
+      ID: 93
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693216
       GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 76
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+      ByteSize: 16
+      GoRuntimeType: 1.417248e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 45
+      Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
@@ -496,33 +639,33 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 71
+      ID: 112
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 72 PointerType *noalg.map.group[string][]string
+          Type: 113 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 73 StructureType noalg.map.group[string][]string
-      GroupSliceType: 77 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 114 StructureType noalg.map.group[string][]string
+      GroupSliceType: 118 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 81
+      ID: 122
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 82 PointerType *noalg.map.group[string]string
+          Type: 123 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 83 StructureType noalg.map.group[string]string
-      GroupSliceType: 87 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 124 StructureType noalg.map.group[string]string
+      GroupSliceType: 128 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -554,7 +697,7 @@ Types:
       GoRuntimeType: 584288
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 51
+      ID: 92
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -567,7 +710,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 48
+      ID: 89
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -580,7 +723,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 49 PointerType **table<string,[]string>
+          Type: 90 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -599,10 +742,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 76 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 73 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 117 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 114 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 67
+      ID: 108
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -615,7 +758,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 68 PointerType **table<string,string>
+          Type: 109 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -634,26 +777,78 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 86 GoSliceDataType []*table<string,string>.array
-      GroupType: 83 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 127 GoSliceDataType []*table<string,string>.array
+      GroupType: 124 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 65
+      ID: 106
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.12832e+06
       GoKind: 21
-      HeaderType: 67 GoSwissMapHeaderType map<string,string>
+      HeaderType: 108 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 56
+      ID: 97
       Name: mime/multipart.Form
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 79
+      Name: net/http.CloseNotifier
+      ByteSize: 16
+      GoRuntimeType: 1.026848e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 77
+      Name: net/http.Flusher
+      ByteSize: 16
+      GoRuntimeType: 1.025312e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 46
+      ID: 87
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.100864e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 89 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoInterfaceType
+      ID: 80
+      Name: net/http.Hijacker
+      ByteSize: 16
+      GoRuntimeType: 1.02544e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 78
+      Name: net/http.Pusher
+      ByteSize: 16
+      GoRuntimeType: 1.025696e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -666,7 +861,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 44 PointerType *net/url.URL
+          Type: 85 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -678,19 +873,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 87 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 92 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 93 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 53 GoSliceHeaderType []string
+          Type: 94 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -699,16 +894,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 54 GoMapType net/url.Values
+          Type: 95 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 54 GoMapType net/url.Values
+          Type: 95 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 55 PointerType *mime/multipart.Form
+          Type: 96 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 46 GoMapType net/http.Header
+          Type: 87 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -717,30 +912,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 57 PointerType *crypto/tls.ConnectionState
+          Type: 98 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 59 GoChannelType <-chan struct {}
+          Type: 100 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 60 PointerType *net/http.Response
+          Type: 101 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 62 GoInterfaceType context.Context
+          Type: 103 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 63 PointerType *net/http.pattern
+          Type: 104 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 53 GoSliceHeaderType []string
+          Type: 94 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 65 GoMapType map[string]string
+          Type: 106 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 61
+      ID: 102
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -757,40 +952,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 64
+      ID: 82
+      Name: net/http.http2responseWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 105
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 45
+      ID: 84
+      Name: net/http.response
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 86
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 54
+      ID: 95
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.884384e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 89 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 74
+      ID: 115
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 75 StructureType noalg.struct { key string; elem []string }
+      Element: 116 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 84
+      ID: 125
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 85 StructureType noalg.struct { key string; elem string }
+      Element: 126 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 73
+      ID: 114
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -801,9 +1004,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 74 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 115 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 83
+      ID: 124
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -814,9 +1017,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 84 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 125 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 75
+      ID: 116
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -827,9 +1030,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 53 GoSliceHeaderType []string
+          Type: 94 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 85
+      ID: 126
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -860,7 +1063,253 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 70
+      ID: 51
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      ByteSize: 32
+      GoRuntimeType: 1.946688e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 65
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.022848e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: CloseNotifier
+          Offset: 16
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 47
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      ByteSize: 32
+      GoRuntimeType: 1.946176e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+    - __kind: StructureType
+      ID: 57
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.021696e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 71
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.0848e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 59
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.021984e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 55
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      ByteSize: 48
+      GoRuntimeType: 2.021408e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 78 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 67
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 64
+      GoRuntimeType: 2.08416e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 75
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 80
+      GoRuntimeType: 2.145632e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 48
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 64
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 69
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.08448e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Flusher
+          Offset: 16
+          Type: 77 GoInterfaceType net/http.Flusher
+        - Name: Pusher
+          Offset: 32
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 53
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      ByteSize: 32
+      GoRuntimeType: 1.946944e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Hijacker
+          Offset: 16
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 49
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      ByteSize: 32
+      GoRuntimeType: 1.946432e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Pusher
+    - __kind: StructureType
+      ID: 61
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      ByteSize: 48
+      GoRuntimeType: 2.022272e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+    - __kind: StructureType
+      ID: 73
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      ByteSize: 64
+      GoRuntimeType: 2.08512e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: CloseNotifier
+          Offset: 32
+          Type: 79 GoInterfaceType net/http.CloseNotifier
+        - Name: Hijacker
+          Offset: 48
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 63
+      Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      ByteSize: 48
+      GoRuntimeType: 2.02256e+06
+      GoKind: 25
+      RawFields:
+        - Name: monitoredResponseWriter
+          Offset: 0
+          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+        - Name: Pusher
+          Offset: 16
+          Type: 78 GoInterfaceType net/http.Pusher
+        - Name: Hijacker
+          Offset: 32
+          Type: 80 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 111
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -882,9 +1331,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 71 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 112 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 80
+      ID: 121
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -906,7 +1355,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 81 GoSwissMapGroupsType groupReference<string,string>
+          Type: 122 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -949,6 +1398,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585312
       GoKind: 26
-MaxTypeID: 89
+MaxTypeID: 130
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x130d980", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -3445,7 +3445,7 @@ Types:
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 490272
+      GoRuntimeType: 490464
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
@@ -3522,7 +3522,7 @@ Types:
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 363456
+      GoRuntimeType: 363648
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -3614,21 +3614,21 @@ Types:
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 362368
+      GoRuntimeType: 362560
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 363328
+      GoRuntimeType: 363520
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 363392
+      GoRuntimeType: 363584
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
@@ -3720,147 +3720,147 @@ Types:
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 363008
+      GoRuntimeType: 363200
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 362624
+      GoRuntimeType: 362816
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 362752
+      GoRuntimeType: 362944
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 26
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 362880
+      GoRuntimeType: 363072
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 362496
+      GoRuntimeType: 362688
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
       ID: 90
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 363584
+      GoRuntimeType: 363776
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 356096
+      GoRuntimeType: 356288
       GoKind: 22
       Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
       ID: 262
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 356032
+      GoRuntimeType: 356224
       GoKind: 22
       Pointee: 263 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 355776
+      GoRuntimeType: 355968
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
       ID: 292
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 355712
+      GoRuntimeType: 355904
       GoKind: 22
       Pointee: 293 StructureType main.deepMap8
     - __kind: PointerType
       ID: 301
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 355648
+      GoRuntimeType: 355840
       GoKind: 22
       Pointee: 302 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 356672
+      GoRuntimeType: 356864
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 233
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 356608
+      GoRuntimeType: 356800
       GoKind: 22
       Pointee: 234 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 356352
+      GoRuntimeType: 356544
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 267
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 356288
+      GoRuntimeType: 356480
       GoKind: 22
       Pointee: 268 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 269
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 356224
+      GoRuntimeType: 356416
       GoKind: 22
       Pointee: 270 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 357248
+      GoRuntimeType: 357440
       GoKind: 22
       Pointee: 183 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 252
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 357184
+      GoRuntimeType: 357376
       GoKind: 22
       Pointee: 253 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 356928
+      GoRuntimeType: 357120
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 273
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 356864
+      GoRuntimeType: 357056
       GoKind: 22
       Pointee: 274 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 279
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 356800
+      GoRuntimeType: 356992
       GoKind: 22
       Pointee: 280 StructureType main.deepSlice9
     - __kind: PointerType
@@ -3873,14 +3873,14 @@ Types:
       ID: 86
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 357376
+      GoRuntimeType: 357568
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 159
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 357440
+      GoRuntimeType: 357632
       GoKind: 22
       Pointee: 158 StructureType main.node
     - __kind: PointerType
@@ -3910,7 +3910,7 @@ Types:
       ID: 206
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 355584
+      GoRuntimeType: 355776
       GoKind: 22
       Pointee: 92 StructureType main.structWithMap
     - __kind: PointerType
@@ -3951,14 +3951,14 @@ Types:
       ID: 73
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 366336
+      GoRuntimeType: 366528
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 362432
+      GoRuntimeType: 362624
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
@@ -3970,42 +3970,42 @@ Types:
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 363072
+      GoRuntimeType: 363264
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 362688
+      GoRuntimeType: 362880
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 362816
+      GoRuntimeType: 363008
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 362944
+      GoRuntimeType: 363136
       GoKind: 22
       Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 362560
+      GoRuntimeType: 362752
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 363136
+      GoRuntimeType: 363328
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -5844,7 +5844,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 622752
+      GoRuntimeType: 622944
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5861,7 +5861,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 623904
+      GoRuntimeType: 624096
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5894,7 +5894,7 @@ Types:
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 624000
+      GoRuntimeType: 624192
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5927,7 +5927,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 624096
+      GoRuntimeType: 624288
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5936,7 +5936,7 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 623808
+      GoRuntimeType: 624000
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5945,7 +5945,7 @@ Types:
       ID: 216
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 622368
+      GoRuntimeType: 622560
       GoKind: 17
       Count: 4
       HasCount: true
@@ -5954,7 +5954,7 @@ Types:
       ID: 201
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 622656
+      GoRuntimeType: 622848
       GoKind: 17
       Count: 4
       HasCount: true
@@ -5971,7 +5971,7 @@ Types:
       ID: 186
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 619680
+      GoRuntimeType: 619872
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5980,7 +5980,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 446720
+      GoRuntimeType: 446912
       GoKind: 23
       RawFields:
         - Name: array
@@ -6002,7 +6002,7 @@ Types:
       ID: 250
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 446656
+      GoRuntimeType: 446848
       GoKind: 23
       RawFields:
         - Name: array
@@ -6024,7 +6024,7 @@ Types:
       ID: 271
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 446336
+      GoRuntimeType: 446528
       GoKind: 23
       RawFields:
         - Name: array
@@ -6046,7 +6046,7 @@ Types:
       ID: 277
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 446272
+      GoRuntimeType: 446464
       GoKind: 23
       RawFields:
         - Name: array
@@ -6068,7 +6068,7 @@ Types:
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 447488
+      GoRuntimeType: 447680
       GoKind: 23
       RawFields:
         - Name: array
@@ -6111,7 +6111,7 @@ Types:
       ID: 169
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 454016
+      GoRuntimeType: 454208
       GoKind: 23
       RawFields:
         - Name: array
@@ -6218,7 +6218,7 @@ Types:
       ID: 283
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 454336
+      GoRuntimeType: 454528
       GoKind: 23
       RawFields:
         - Name: array
@@ -6282,7 +6282,7 @@ Types:
       ID: 205
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 446976
+      GoRuntimeType: 447168
       GoKind: 23
       RawFields:
         - Name: array
@@ -6325,7 +6325,7 @@ Types:
       ID: 168
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 454144
+      GoRuntimeType: 454336
       GoKind: 23
       RawFields:
         - Name: array
@@ -6347,7 +6347,7 @@ Types:
       ID: 162
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 453632
+      GoRuntimeType: 453824
       GoKind: 23
       RawFields:
         - Name: array
@@ -6369,7 +6369,7 @@ Types:
       ID: 170
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 452992
+      GoRuntimeType: 453184
       GoKind: 23
       RawFields:
         - Name: array
@@ -6482,7 +6482,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 532128
+      GoRuntimeType: 532320
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 154
@@ -6810,30 +6810,30 @@ Types:
     - __kind: GoChannelType
       ID: 155
       Name: chan bool
-      GoRuntimeType: 543392
+      GoRuntimeType: 543584
       GoKind: 18
     - __kind: GoChannelType
       ID: 82
       Name: chan struct {}
-      GoRuntimeType: 542304
+      GoRuntimeType: 542496
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 531936
+      GoRuntimeType: 532128
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 531872
+      GoRuntimeType: 532064
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 983744
+      GoRuntimeType: 983936
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6846,19 +6846,19 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 532000
+      GoRuntimeType: 532192
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 532064
+      GoRuntimeType: 532256
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 85
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 445056
+      GoRuntimeType: 445248
       GoKind: 19
     - __kind: GoHMapHeaderType
       ID: 152
@@ -7442,37 +7442,37 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 531680
+      GoRuntimeType: 531872
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 531296
+      GoRuntimeType: 531488
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 531424
+      GoRuntimeType: 531616
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 531552
+      GoRuntimeType: 531744
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 531168
+      GoRuntimeType: 531360
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 83
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 777408
+      GoRuntimeType: 777600
       GoKind: 20
       RawFields:
         - Name: _type
@@ -7485,7 +7485,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 979648
+      GoRuntimeType: 979840
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7516,7 +7516,7 @@ Types:
       ID: 89
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 979264
+      GoRuntimeType: 979456
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7544,7 +7544,7 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.099616e+06
+      GoRuntimeType: 1.100064e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7554,7 +7554,7 @@ Types:
       ID: 190
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.099488e+06
+      GoRuntimeType: 1.099936e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7568,7 +7568,7 @@ Types:
       ID: 76
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.098848e+06
+      GoRuntimeType: 1.099296e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7578,7 +7578,7 @@ Types:
       ID: 293
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.09872e+06
+      GoRuntimeType: 1.099168e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7588,7 +7588,7 @@ Types:
       ID: 302
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.098592e+06
+      GoRuntimeType: 1.09904e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7598,7 +7598,7 @@ Types:
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.100768e+06
+      GoRuntimeType: 1.101216e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7608,7 +7608,7 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.10064e+06
+      GoRuntimeType: 1.101088e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7622,7 +7622,7 @@ Types:
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.1e+06
+      GoRuntimeType: 1.100448e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7632,7 +7632,7 @@ Types:
       ID: 268
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.099872e+06
+      GoRuntimeType: 1.10032e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7642,7 +7642,7 @@ Types:
       ID: 270
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.099744e+06
+      GoRuntimeType: 1.100192e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7652,7 +7652,7 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.10192e+06
+      GoRuntimeType: 1.102368e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7662,7 +7662,7 @@ Types:
       ID: 183
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.101792e+06
+      GoRuntimeType: 1.10224e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7676,7 +7676,7 @@ Types:
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.101152e+06
+      GoRuntimeType: 1.1016e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7686,7 +7686,7 @@ Types:
       ID: 274
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.101024e+06
+      GoRuntimeType: 1.101472e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7696,7 +7696,7 @@ Types:
       ID: 280
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.100896e+06
+      GoRuntimeType: 1.101344e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7711,7 +7711,7 @@ Types:
       ID: 87
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.703616e+06
+      GoRuntimeType: 1.704064e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7733,7 +7733,7 @@ Types:
       ID: 81
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.83008e+06
+      GoRuntimeType: 1.830528e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7761,7 +7761,7 @@ Types:
       ID: 176
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.279488e+06
+      GoRuntimeType: 1.279936e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7774,7 +7774,7 @@ Types:
       ID: 158
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.279328e+06
+      GoRuntimeType: 1.279776e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7796,7 +7796,7 @@ Types:
       ID: 84
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 979392
+      GoRuntimeType: 979584
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7830,7 +7830,7 @@ Types:
       ID: 91
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.098336e+06
+      GoRuntimeType: 1.098784e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7840,7 +7840,7 @@ Types:
       ID: 92
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.098464e+06
+      GoRuntimeType: 1.098912e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -7915,119 +7915,119 @@ Types:
       ID: 150
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 879744
+      GoRuntimeType: 879936
       GoKind: 21
       HeaderType: 152 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
       ID: 145
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 879840
+      GoRuntimeType: 880032
       GoKind: 21
       HeaderType: 147 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
       ID: 113
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 879936
+      GoRuntimeType: 880128
       GoKind: 21
       HeaderType: 115 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
       ID: 125
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 880032
+      GoRuntimeType: 880224
       GoKind: 21
       HeaderType: 127 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 879648
+      GoRuntimeType: 879840
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 256
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 879552
+      GoRuntimeType: 879744
       GoKind: 21
       HeaderType: 258 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 286
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 879072
+      GoRuntimeType: 879264
       GoKind: 21
       HeaderType: 288 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 295
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 878976
+      GoRuntimeType: 879168
       GoKind: 21
       HeaderType: 297 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 93
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 877920
+      GoRuntimeType: 878112
       GoKind: 21
       HeaderType: 95 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
       ID: 304
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 878880
+      GoRuntimeType: 879072
       GoKind: 21
       HeaderType: 306 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 130
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 880128
+      GoRuntimeType: 880320
       GoKind: 21
       HeaderType: 132 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
       ID: 120
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 880224
+      GoRuntimeType: 880416
       GoKind: 21
       HeaderType: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 108
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 880320
+      GoRuntimeType: 880512
       GoKind: 21
       HeaderType: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
       ID: 103
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 880416
+      GoRuntimeType: 880608
       GoKind: 21
       HeaderType: 105 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 98
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 880512
+      GoRuntimeType: 880704
       GoKind: 21
       HeaderType: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 140
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 880608
+      GoRuntimeType: 880800
       GoKind: 21
       HeaderType: 142 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
       ID: 135
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 880704
+      GoRuntimeType: 880896
       GoKind: 21
       HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: UnresolvedPointeeType
@@ -8038,7 +8038,7 @@ Types:
       ID: 11
       Name: string
       ByteSize: 16
-      GoRuntimeType: 531104
+      GoRuntimeType: 531296
       GoKind: 24
       RawFields:
         - Name: str
@@ -8056,7 +8056,7 @@ Types:
       ID: 238
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.280768e+06
+      GoRuntimeType: 1.281216e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -8069,7 +8069,7 @@ Types:
       ID: 239
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.281888e+06
+      GoRuntimeType: 1.282336e+06
       GoKind: 25
       RawFields:
         - Name: done
@@ -8082,7 +8082,7 @@ Types:
       ID: 242
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.420576e+06
+      GoRuntimeType: 1.421024e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -8097,14 +8097,14 @@ Types:
     - __kind: StructureType
       ID: 243
       Name: sync.noCopy
-      GoRuntimeType: 946400
+      GoRuntimeType: 946592
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 246
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.282208e+06
+      GoRuntimeType: 1.282656e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8117,7 +8117,7 @@ Types:
       ID: 240
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.282368e+06
+      GoRuntimeType: 1.282816e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8130,7 +8130,7 @@ Types:
       ID: 244
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.42096e+06
+      GoRuntimeType: 1.421408e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8145,56 +8145,56 @@ Types:
     - __kind: StructureType
       ID: 245
       Name: sync/atomic.align64
-      GoRuntimeType: 946592
+      GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 241
       Name: sync/atomic.noCopy
-      GoRuntimeType: 946496
+      GoRuntimeType: 946688
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 531744
+      GoRuntimeType: 531936
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 531360
+      GoRuntimeType: 531552
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 531488
+      GoRuntimeType: 531680
       GoKind: 10
     - __kind: BaseType
       ID: 10
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 531616
+      GoRuntimeType: 531808
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 531232
+      GoRuntimeType: 531424
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 531808
+      GoRuntimeType: 532000
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 532192
+      GoRuntimeType: 532384
       GoKind: 26
 MaxTypeID: 425
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 406 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd07b2a", Frameless: false}]
+        - ID: 98
+          Type: 408 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd07bca", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 362 EventRootType Probe[main.testAny]
+          Type: 363 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04b4a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 364 EventRootType Probe[main.testAnyPtr]
+          Type: 365 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04bea", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 324 EventRootType Probe[main.testArrayOfArrays]
+          Type: 325 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 326 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 327 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -78,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 371 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xd052a0", Frameless: true}]
+        - ID: 63
+          Type: 373 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xd05340", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 325 EventRootType Probe[main.testArrayOfStrings]
+          Type: 326 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 344 EventRootType Probe[main.testBigStruct]
+          Type: 345 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03700", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 313 EventRootType Probe[main.testBoolArray]
+          Type: 314 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 310 EventRootType Probe[main.testByteArray]
+          Type: 311 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02de0", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 387 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xd06de0", Frameless: true}]
+        - ID: 79
+          Type: 389 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xd06e80", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -162,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 385 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xd06a00", Frameless: true}]
+        - ID: 77
+          Type: 387 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xd06aa0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -176,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 395 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xd071a0", Frameless: true}]
+        - ID: 87
+          Type: 397 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xd07240", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 349 EventRootType Probe[main.testDeepMap1]
+          Type: 350 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03ae0", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 350 EventRootType Probe[main.testDeepMap7]
+          Type: 351 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b00", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 345 EventRootType Probe[main.testDeepPtr1]
+          Type: 346 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd037c0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 346 EventRootType Probe[main.testDeepPtr7]
+          Type: 347 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd037e0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 347 EventRootType Probe[main.testDeepSlice1]
+          Type: 348 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd03960", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 348 EventRootType Probe[main.testDeepSlice7]
+          Type: 349 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd03980", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -292,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 397 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
+        - ID: 89
+          Type: 399 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd07780", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -306,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 400 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd07740", Frameless: true}]
+        - ID: 92
+          Type: 402 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -320,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 414 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd07c60", Frameless: true}]
+        - ID: 106
+          Type: 416 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd07d00", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 416 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd08060", Frameless: true}]
+        - ID: 108
+          Type: 418 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd08100", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 417 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xd08080", Frameless: true}]
+        - ID: 109
+          Type: 419 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xd08120", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 363 EventRootType Probe[main.testError]
+          Type: 364 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04bc0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 354 EventRootType Probe[main.testEsotericHeap]
+          Type: 355 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd040ca", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 353 EventRootType Probe[main.testEsotericStack]
+          Type: 354 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd03fae", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 359 EventRootType Probe[main.testFrameless]
+          Type: 360 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 360 EventRootType Probe[main.testFramelessArray]
+          Type: 361 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04844", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 355 EventRootType Probe[main.testInlinedBA]
+          Type: 356 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd0450a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 356 EventRootType Probe[main.testInlinedBB]
+          Type: 357 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd045ae", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 357 EventRootType Probe[main.testInlinedBBA]
+          Type: 358 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd0468a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 419 EventRootType Probe[main.testInlinedBBB]
+        - ID: 111
+          Type: 421 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd04606", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 358 EventRootType Probe[main.testInlinedBC]
+          Type: 359 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd0470e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 420 EventRootType Probe[main.testInlinedBCA]
+        - ID: 112
+          Type: 422 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd04713", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 421 EventRootType Probe[main.testInlinedBCB]
+        - ID: 113
+          Type: 423 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd047c6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 418 EventRootType Probe[main.testInlinedPrint]
+        - ID: 110
+          Type: 420 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0436a"
               Frameless: false
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 422 EventRootType Probe[main.testInlinedSq]
+        - ID: 114
+          Type: 424 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04821", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 114
-          Type: 423 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 115
+          Type: 425 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04865"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 316 EventRootType Probe[main.testInt16Array]
+          Type: 317 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 317 EventRootType Probe[main.testInt32Array]
+          Type: 318 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 318 EventRootType Probe[main.testInt64Array]
+          Type: 319 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 315 EventRootType Probe[main.testInt8Array]
+          Type: 316 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 314 EventRootType Probe[main.testIntArray]
+          Type: 315 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 361 EventRootType Probe[main.testInterface]
+          Type: 362 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04b20", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -671,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 389 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xd06fc0", Frameless: true}]
+        - ID: 81
+          Type: 391 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xd07060", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -685,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 369 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xd05260", Frameless: true}]
+        - ID: 61
+          Type: 371 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xd05300", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -699,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 375 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xd05320", Frameless: true}]
+        - ID: 67
+          Type: 377 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xd053c0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -713,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 373 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xd052e0", Frameless: true}]
+        - ID: 65
+          Type: 375 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xd05380", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -727,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 384 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xd05440", Frameless: true}]
+        - ID: 76
+          Type: 386 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xd054e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -741,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 383 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xd05420", Frameless: true}]
+        - ID: 75
+          Type: 385 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xd054c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -755,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 374 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xd05300", Frameless: true}]
+        - ID: 66
+          Type: 376 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd053a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -769,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 382 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xd05400", Frameless: true}]
+        - ID: 74
+          Type: 384 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xd054a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -783,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 381 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xd053e0", Frameless: true}]
+        - ID: 73
+          Type: 383 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xd05480", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -797,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 367 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xd05220", Frameless: true}]
+        - ID: 59
+          Type: 369 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xd052c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -811,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 368 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xd05240", Frameless: true}]
+        - ID: 60
+          Type: 370 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xd052e0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -825,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 366 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xd05200", Frameless: true}]
+        - ID: 58
+          Type: 368 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xd052a0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -839,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 376 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xd05340", Frameless: true}]
+        - ID: 68
+          Type: 378 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xd053e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -853,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 379 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xd053a0", Frameless: true}]
+        - ID: 71
+          Type: 381 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xd05440", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -867,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 380 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xd053c0", Frameless: true}]
+        - ID: 72
+          Type: 382 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xd05460", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -881,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 377 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xd05360", Frameless: true}]
+        - ID: 69
+          Type: 379 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xd05400", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -895,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 378 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xd05380", Frameless: true}]
+        - ID: 70
+          Type: 380 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xd05420", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -909,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 412 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd07c20", Frameless: true}]
+        - ID: 104
+          Type: 414 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd07cc0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -923,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 386 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xd06bc0", Frameless: true}]
+        - ID: 78
+          Type: 388 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xd06c60", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -937,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 394 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xd07160", Frameless: true}]
+        - ID: 86
+          Type: 396 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xd07200", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -951,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 404 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
+        - ID: 96
+          Type: 406 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd07860", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -965,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 401 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd07760", Frameless: true}]
+        - ID: 93
+          Type: 403 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd07800", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -979,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 403 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd077a0", Frameless: true}]
+        - ID: 95
+          Type: 405 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd07840", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -993,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 411 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd07c00", Frameless: true}]
+        - ID: 103
+          Type: 413 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd07ca0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1007,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 390 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
+        - ID: 82
+          Type: 392 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xd07080", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1021,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 372 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xd052c0", Frameless: true}]
+        - ID: 64
+          Type: 374 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xd05360", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1035,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 388 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
+        - ID: 80
+          Type: 390 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xd07040", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 311 EventRootType Probe[main.testRuneArray]
+          Type: 312 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 330 EventRootType Probe[main.testSingleBool]
+          Type: 331 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 328 EventRootType Probe[main.testSingleByte]
+          Type: 329 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd033c0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 341 EventRootType Probe[main.testSingleFloat32]
+          Type: 342 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 342 EventRootType Probe[main.testSingleFloat64]
+          Type: 343 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 331 EventRootType Probe[main.testSingleInt]
+          Type: 332 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 333 EventRootType Probe[main.testSingleInt16]
+          Type: 334 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 334 EventRootType Probe[main.testSingleInt32]
+          Type: 335 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 335 EventRootType Probe[main.testSingleInt64]
+          Type: 336 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 332 EventRootType Probe[main.testSingleInt8]
+          Type: 333 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 329 EventRootType Probe[main.testSingleRune]
+          Type: 330 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd033e0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1203,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 407 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd07b80", Frameless: true}]
+        - ID: 99
+          Type: 409 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd07c20", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 336 EventRootType Probe[main.testSingleUint]
+          Type: 337 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 338 EventRootType Probe[main.testSingleUint16]
+          Type: 339 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 339 EventRootType Probe[main.testSingleUint32]
+          Type: 340 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 340 EventRootType Probe[main.testSingleUint64]
+          Type: 341 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 337 EventRootType Probe[main.testSingleUint8]
+          Type: 338 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1287,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 398 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd07700", Frameless: true}]
+        - ID: 90
+          Type: 400 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd077a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1301,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 370 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xd05280", Frameless: true}]
+        - ID: 62
+          Type: 372 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xd05320", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 312 EventRootType Probe[main.testStringArray]
+          Type: 313 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1329,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 393 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xd07120", Frameless: true}]
+        - ID: 85
+          Type: 395 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xd071c0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1343,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 402 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd07780", Frameless: true}]
+        - ID: 94
+          Type: 404 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd07820", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 351 EventRootType Probe[main.testStringType1]
+          Type: 352 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 352 EventRootType Probe[main.testStringType2]
+          Type: 353 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 415 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd07ee0", Frameless: true}]
+        - ID: 107
+          Type: 417 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd07f80", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1405,11 +1405,28 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 399 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd07720", Frameless: true}]
+        - ID: 91
+          Type: 401 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
+          Condition: null
+    - id: testStructWithAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithAny}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 56}
+      events:
+        - ID: 56
+          Type: 366 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xd04c40", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1419,11 +1436,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 365 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xd051e0", Frameless: true}]
+        - ID: 57
+          Type: 367 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xd05280", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1433,11 +1450,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 408 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd07ba0", Frameless: true}]
+        - ID: 100
+          Type: 410 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd07c40", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1447,11 +1464,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 409 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd07bc0", Frameless: true}]
+        - ID: 101
+          Type: 411 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd07c60", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1461,11 +1478,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 410 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd07be0", Frameless: true}]
+        - ID: 102
+          Type: 412 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd07c80", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1478,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 343 EventRootType Probe[main.testTypeAlias]
+          Type: 344 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1492,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 321 EventRootType Probe[main.testUint16Array]
+          Type: 322 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1506,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 322 EventRootType Probe[main.testUint32Array]
+          Type: 323 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1520,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 323 EventRootType Probe[main.testUint64Array]
+          Type: 324 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1534,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 320 EventRootType Probe[main.testUint8Array]
+          Type: 321 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1548,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 319 EventRootType Probe[main.testUintArray]
+          Type: 320 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1559,11 +1576,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 392 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xd07040", Frameless: true}]
+        - ID: 84
+          Type: 394 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xd070e0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1573,11 +1590,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 396 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd076c0", Frameless: true}]
+        - ID: 88
+          Type: 398 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd07760", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1587,11 +1604,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 413 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd07c40", Frameless: true}]
+        - ID: 105
+          Type: 415 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd07ce0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1601,11 +1618,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 391 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xd07000", Frameless: true}]
+        - ID: 83
+          Type: 393 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xd070a0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1618,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 327 EventRootType Probe[main.testVeryLargeArray]
+          Type: 328 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1629,11 +1646,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 405 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
+        - ID: 97
+          Type: 407 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd07880", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2442,308 +2459,324 @@ Subprograms:
           IsParameter: true
           IsReturn: true
     - ID: 56
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd051e0..0xd051e1]
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xd04c40..0xd04c41]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 91 StructureType main.structWithMap
+          Type: 91 StructureType main.structWithAny
           Locations:
-            - Range: 0xd051e0..0xd051e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd04c40..0xd04c41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd05200..0xd05201]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 97 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xd05200..0xd05201
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd05220..0xd05221]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 102 GoMapType map[string]int
-          Locations:
-            - Range: 0xd05220..0xd05221
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd05240..0xd05241]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 107 GoMapType map[string][]string
-          Locations:
-            - Range: 0xd05240..0xd05241
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd05260..0xd05261]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 112 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xd05260..0xd05261
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testSmallMap
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0xd05280..0xd05281]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 102 GoMapType map[string]int
+        - Name: s
+          Type: 92 StructureType main.structWithMap
           Locations:
             - Range: 0xd05280..0xd05281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testArrayOfMaps
+    - ID: 58
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xd052a0..0xd052a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 117 ArrayType [2]map[string]int
+          Type: 98 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd052a0..0xd052a1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testPointerToMap
+    - ID: 59
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xd052c0..0xd052c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 PointerType *map[string]int
+          Type: 103 GoMapType map[string]int
           Locations:
             - Range: 0xd052c0..0xd052c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapIntToInt
+    - ID: 60
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xd052e0..0xd052e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 92 GoMapType map[int]int
+          Type: 108 GoMapType map[string][]string
           Locations:
             - Range: 0xd052e0..0xd052e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapMassive
+    - ID: 61
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xd05300..0xd05301]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 119 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 113 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd05300..0xd05301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapEmbeddedMaps
+    - ID: 62
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xd05320..0xd05321]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 119 GoMapType map[string][]main.structWithMap
+          Type: 103 GoMapType map[string]int
           Locations:
             - Range: 0xd05320..0xd05321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithLinkedList
+    - ID: 63
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xd05340..0xd05341]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 124 GoMapType map[bool]main.node
+          Type: 118 ArrayType [2]map[string]int
           Locations:
             - Range: 0xd05340..0xd05341
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValue
+    - ID: 64
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xd05360..0xd05361]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 129 GoMapType map[int]uint8
+          Type: 119 PointerType *map[string]int
           Locations:
             - Range: 0xd05360..0xd05361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallValueMassive
+    - ID: 65
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xd05380..0xd05381]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 129 GoMapType map[int]uint8
+        - Name: m
+          Type: 93 GoMapType map[int]int
           Locations:
             - Range: 0xd05380..0xd05381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 66
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xd053a0..0xd053a1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 134 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd053a0..0xd053a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 67
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xd053c0..0xd053c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 134 GoMapType map[uint8]uint8
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd053c0..0xd053c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeySmallValue
+    - ID: 68
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xd053e0..0xd053e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 134 GoMapType map[uint8]uint8
+          Type: 125 GoMapType map[bool]main.node
           Locations:
             - Range: 0xd053e0..0xd053e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 69
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xd05400..0xd05401]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 139 GoMapType map[uint8][4]int
+          Type: 130 GoMapType map[int]uint8
           Locations:
             - Range: 0xd05400..0xd05401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeySmallValue
+    - ID: 70
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xd05420..0xd05421]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 144 GoMapType map[[4]int]uint8
+        - Name: redactMyEntries
+          Type: 130 GoMapType map[int]uint8
           Locations:
             - Range: 0xd05420..0xd05421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xd05440..0xd05441]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[[4]int][4]int
+          Type: 135 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd05440..0xd05441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 72
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xd05460..0xd05461]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 135 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd05460..0xd05461
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xd05480..0xd05481]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 135 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd05480..0xd05481
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xd054a0..0xd054a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 140 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xd054a0..0xd054a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xd054c0..0xd054c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xd054c0..0xd054c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 76
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xd054e0..0xd054e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 150 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xd054e0..0xd054e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 77
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd06a00..0xd06a01]
+      OutOfLinePCRanges: [0xd06aa0..0xd06aa1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06a00..0xd06a01
+            - Range: 0xd06aa0..0xd06aa1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06a00..0xd06a01
+            - Range: 0xd06aa0..0xd06aa1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd06a00..0xd06a01
+            - Range: 0xd06aa0..0xd06aa1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd06bc0..0xd06bc1]
+      OutOfLinePCRanges: [0xd06c60..0xd06c61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd06bc0..0xd06bc1
+            - Range: 0xd06c60..0xd06c61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06bc0..0xd06bc1
+            - Range: 0xd06c60..0xd06c61
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd06bc0..0xd06bc1
+            - Range: 0xd06c60..0xd06c61
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd06bc0..0xd06bc1
+            - Range: 0xd06c60..0xd06c61
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06bc0..0xd06bc1
+            - Range: 0xd06c60..0xd06c61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2751,39 +2784,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd06de0..0xd06de1]
+      OutOfLinePCRanges: [0xd06e80..0xd06e81]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 154 GoChannelType chan bool
+          Type: 155 GoChannelType chan bool
           Locations:
-            - Range: 0xd06de0..0xd06de1
+            - Range: 0xd06e80..0xd06e81
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd06fa0..0xd06fa1]
+      OutOfLinePCRanges: [0xd07040..0xd07041]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 PointerType *main.structWithTwoValues
+          Type: 156 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd06fa0..0xd06fa1
+            - Range: 0xd07040..0xd07041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd06fc0..0xd06fc1]
+      OutOfLinePCRanges: [0xd07060..0xd07061]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 157 StructureType main.node
+          Type: 158 StructureType main.node
           Locations:
-            - Range: 0xd06fc0..0xd06fc1
+            - Range: 0xd07060..0xd07061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2791,112 +2824,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
+      OutOfLinePCRanges: [0xd07080..0xd07081]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 158 PointerType *main.node
+          Type: 159 PointerType *main.node
           Locations:
-            - Range: 0xd06fe0..0xd06fe1
+            - Range: 0xd07080..0xd07081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd07000..0xd07001]
+      OutOfLinePCRanges: [0xd070a0..0xd070a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xd07000..0xd07001
+            - Range: 0xd070a0..0xd070a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd07040..0xd07041]
+      OutOfLinePCRanges: [0xd070e0..0xd070e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xd07040..0xd07041
+            - Range: 0xd070e0..0xd070e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd07120..0xd07121]
+      OutOfLinePCRanges: [0xd071c0..0xd071c1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xd07120..0xd07121
+            - Range: 0xd071c0..0xd071c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd07160..0xd07161]
+      OutOfLinePCRanges: [0xd07200..0xd07201]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0xd07160..0xd07161
+            - Range: 0xd07200..0xd07201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd07160..0xd07161
+            - Range: 0xd07200..0xd07201
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd071a0..0xd071a1]
+      OutOfLinePCRanges: [0xd07240..0xd07241]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 159 PointerType *main.t
+          Type: 160 PointerType *main.t
           Locations:
-            - Range: 0xd071a0..0xd071a1
+            - Range: 0xd07240..0xd07241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd076c0..0xd076c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 161 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd076c0..0xd076c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 88
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd076e0..0xd076e1]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xd07760..0xd07761]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 161 GoSliceHeaderType []uint
+          Type: 162 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd076e0..0xd076e1
+            - Range: 0xd07760..0xd07761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2907,105 +2922,12 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd07700..0xd07701]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 162 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xd07700..0xd07701
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 90
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd07720..0xd07721]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 164 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd07720..0xd07721
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd07720..0xd07721
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 91
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd07740..0xd07741]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 164 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd07740..0xd07741
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd07740..0xd07741
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd07760..0xd07761]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 164 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd07760..0xd07761
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd07760..0xd07761
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 93
-      Name: main.testStringSlice
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd07780..0xd07781]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 167 GoSliceHeaderType []string
+        - Name: u
+          Type: 162 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd07780..0xd07781
               Pieces:
@@ -3017,22 +2939,133 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSliceWithOtherParams
+    - ID: 90
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xd077a0..0xd077a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 163 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xd077a0..0xd077a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xd077c0..0xd077c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 165 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd077c0..0xd077c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd077c0..0xd077c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xd077e0..0xd077e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 165 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd077e0..0xd077e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd077e0..0xd077e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd07800..0xd07801]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 165 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd07800..0xd07801
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd07800..0xd07801
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xd07820..0xd07821]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 168 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xd07820..0xd07821
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xd07840..0xd07841]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd077a0..0xd077a1
+            - Range: 0xd07840..0xd07841
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 168 GoSliceHeaderType []bool
+          Type: 169 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd077a0..0xd077a1
+            - Range: 0xd07840..0xd07841
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3045,37 +3078,19 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd077a0..0xd077a1
+            - Range: 0xd07840..0xd07841
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 95
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd077c0..0xd077c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 169 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xd077c0..0xd077c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 96
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd077e0..0xd077e1]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xd07860..0xd07861]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []uint
+          Type: 170 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd077e0..0xd077e1
+            - Range: 0xd07860..0xd07861
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3086,119 +3101,35 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 97
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd07880..0xd07881]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 162 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd07880..0xd07881
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0xd07b20..0xd07b72]
+      OutOfLinePCRanges: [0xd07bc0..0xd07c12]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd07b20..0xd07b72, Pieces: []}]
+          Locations: [{Range: 0xd07bc0..0xd07c12, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0xd07b80..0xd07b81]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd07b80..0xd07b81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd07ba0..0xd07ba1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd07ba0..0xd07ba1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: y
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd07ba0..0xd07ba1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: z
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd07ba0..0xd07ba1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd07bc0..0xd07bdf]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 170 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0xd07bc0..0xd07bdf
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 101
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd07be0..0xd07be1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 171 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xd07be0..0xd07be1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 102
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd07c00..0xd07c01]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 172 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0xd07c00..0xd07c01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 103
-      Name: main.testMassiveString
+      Name: main.testSingleString
       OutOfLinePCRanges: [0xd07c20..0xd07c21]
       InlinePCRanges: []
       Variables:
@@ -3213,8 +3144,8 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
-      Name: main.testUnitializedString
+    - ID: 100
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0xd07c40..0xd07c41]
       InlinePCRanges: []
       Variables:
@@ -3229,15 +3160,101 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd07c60..0xd07c61]
+        - Name: y
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd07c40..0xd07c41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd07c40..0xd07c41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 101
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0xd07c60..0xd07c7f]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 171 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0xd07c60..0xd07c7f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 102
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0xd07c80..0xd07c81]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 172 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0xd07c80..0xd07c81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xd07ca0..0xd07ca1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 173 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0xd07ca0..0xd07ca1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 104
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xd07cc0..0xd07cc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07c60..0xd07c61
+            - Range: 0xd07cc0..0xd07cc1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xd07ce0..0xd07ce1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd07ce0..0xd07ce1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3246,14 +3263,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 106
-      Name: main.testStruct
-      OutOfLinePCRanges: [0xd07ee0..0xd07f03]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xd07d00..0xd07d01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 174 StructureType main.aStruct
+          Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07ee0..0xd07f03
+            - Range: 0xd07d00..0xd07d01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 107
+      Name: main.testStruct
+      OutOfLinePCRanges: [0xd07f80..0xd07fa3]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 175 StructureType main.aStruct
+          Locations:
+            - Range: 0xd07f80..0xd07fa3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3271,29 +3304,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd08060..0xd08061]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 176 StructureType main.emptyStruct
-          Locations: [{Range: 0xd08060..0xd08061, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 108
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd08080..0xd08081]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0xd08100..0xd08101]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 177 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0xd08080..0xd08081
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 177 StructureType main.emptyStruct
+          Locations: [{Range: 0xd08100..0xd08101, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 109
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0xd08120..0xd08121]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 178 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0xd08120..0xd08121
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 110
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd04360..0xd043c2]
       InlinePCRanges:
@@ -3323,28 +3356,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04606..0xd0463e]
           RootRanges: [0xd045a0..0xd04665]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04713..0xd04751]
           RootRanges: [0xd04700..0xd0480e]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd047c6..0xd047fe]
           RootRanges: [0xd04700..0xd0480e]
       Variables: []
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3358,7 +3391,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 115
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3383,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 250
+      ID: 251
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 251 PointerType *main.deepSlice3
+      Pointee: 252 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 271
+      ID: 272
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 272 PointerType *main.deepSlice8
+      Pointee: 273 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 277
+      ID: 278
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 278 PointerType *main.deepSlice9
+      Pointee: 279 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3404,458 +3437,458 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 246
+      ID: 247
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 159 PointerType *main.t
+      Pointee: 160 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 490208
+      GoRuntimeType: 490272
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 184
+      ID: 185
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 184 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 254
+      ID: 255
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 254 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 275
+      ID: 276
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 275 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 281
+      ID: 282
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 281 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*string.array
+      Pointee: 181 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 223
+      ID: 224
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType [][]uint.array
+      Pointee: 223 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 229
+      ID: 230
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 228 GoSliceDataType []bool.array
+      Pointee: 229 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 284
+      ID: 285
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType []interface {}.array
+      Pointee: 284 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 265
+      ID: 266
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []main.structWithMap.array
+      Pointee: 265 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 225
+      ID: 226
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 225 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 227
+      ID: 228
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []string.array
+      Pointee: 227 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 163
+      ID: 164
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 161 GoSliceHeaderType []uint
+      Pointee: 162 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 221
+      ID: 222
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType []uint.array
+      Pointee: 221 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 231
+      ID: 232
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType []uint16.array
+      Pointee: 231 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 363392
+      GoRuntimeType: 363456
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 152
+      ID: 153
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 153 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 154 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 147
+      ID: 148
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 148 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 149 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 115
+      ID: 116
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 117 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 127
+      ID: 128
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 128 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 129 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '*bucket<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 258
+      ID: 259
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 259 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 260 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 288
+      ID: 289
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 289 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 290 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 297
+      ID: 298
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 298 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 299 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 95
+      ID: 96
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 96 GoHMapBucketType bucket<int,int>
+      Pointee: 97 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 306
+      ID: 307
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 307 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 308 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
-      ID: 132
+      ID: 133
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 133 GoHMapBucketType bucket<int,uint8>
+      Pointee: 134 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 122
+      ID: 123
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 110
+      ID: 111
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 111 GoHMapBucketType bucket<string,[]string>
+      Pointee: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 105
+      ID: 106
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 106 GoHMapBucketType bucket<string,int>
+      Pointee: 107 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 100
+      ID: 101
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 101 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 102 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 142
+      ID: 143
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 143 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 144 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 137
+      ID: 138
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 138 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 362304
+      GoRuntimeType: 362368
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 363264
+      GoRuntimeType: 363328
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 363328
+      GoRuntimeType: 363392
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 151 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 152 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 146 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 147 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 114 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 115 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 126 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 127 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*hash<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 256
+      ID: 257
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 257 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 258 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 286
+      ID: 287
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 287 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 288 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 295
+      ID: 296
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 296 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 297 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 94 GoHMapHeaderType hash<int,int>
+      Pointee: 95 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 305 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 306 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 131 GoHMapHeaderType hash<int,uint8>
+      Pointee: 132 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 121 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 109 GoHMapHeaderType hash<string,[]string>
+      Pointee: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 104 GoHMapHeaderType hash<string,int>
+      Pointee: 105 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 99 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 141 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 142 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 136 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 362944
+      GoRuntimeType: 363008
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 362560
+      GoRuntimeType: 362624
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 362688
+      GoRuntimeType: 362752
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 26
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 362816
+      GoRuntimeType: 362880
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 362432
+      GoRuntimeType: 362496
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
       ID: 90
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 363520
+      GoRuntimeType: 363584
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 188
+      ID: 189
       Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 356096
+      GoKind: 22
+      Pointee: 190 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 262
+      Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356032
       GoKind: 22
-      Pointee: 189 StructureType main.deepMap2
-    - __kind: PointerType
-      ID: 261
-      Name: '*main.deepMap3'
-      ByteSize: 8
-      GoRuntimeType: 355968
-      GoKind: 22
-      Pointee: 262 UnresolvedPointeeType main.deepMap3
+      Pointee: 263 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 355712
+      GoRuntimeType: 355776
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 291
+      ID: 292
       Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 355712
+      GoKind: 22
+      Pointee: 293 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 301
+      Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355648
       GoKind: 22
-      Pointee: 292 StructureType main.deepMap8
-    - __kind: PointerType
-      ID: 300
-      Name: '*main.deepMap9'
-      ByteSize: 8
-      GoRuntimeType: 355584
-      GoKind: 22
-      Pointee: 301 StructureType main.deepMap9
+      Pointee: 302 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 356608
+      GoRuntimeType: 356672
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 232
+      ID: 233
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 356544
+      GoRuntimeType: 356608
       GoKind: 22
-      Pointee: 233 UnresolvedPointeeType main.deepPtr3
+      Pointee: 234 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 356288
+      GoRuntimeType: 356352
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 266
+      ID: 267
       Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 356288
+      GoKind: 22
+      Pointee: 268 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 269
+      Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 267 StructureType main.deepPtr8
-    - __kind: PointerType
-      ID: 268
-      Name: '*main.deepPtr9'
-      ByteSize: 8
-      GoRuntimeType: 356160
-      GoKind: 22
-      Pointee: 269 StructureType main.deepPtr9
+      Pointee: 270 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 357184
+      GoRuntimeType: 357248
       GoKind: 22
-      Pointee: 182 StructureType main.deepSlice2
+      Pointee: 183 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 251
+      ID: 252
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 357120
+      GoRuntimeType: 357184
       GoKind: 22
-      Pointee: 252 UnresolvedPointeeType main.deepSlice3
+      Pointee: 253 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 356864
+      GoRuntimeType: 356928
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 272
+      ID: 273
       Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 356864
+      GoKind: 22
+      Pointee: 274 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 279
+      Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 273 StructureType main.deepSlice8
+      Pointee: 280 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 278
-      Name: '*main.deepSlice9'
-      ByteSize: 8
-      GoRuntimeType: 356736
-      GoKind: 22
-      Pointee: 279 StructureType main.deepSlice9
-    - __kind: PointerType
-      ID: 177
+      ID: 178
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 176 StructureType main.emptyStruct
+      Pointee: 177 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 86
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 357312
+      GoRuntimeType: 357376
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 158
+      ID: 159
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 357376
+      GoRuntimeType: 357440
       GoKind: 22
-      Pointee: 157 StructureType main.node
+      Pointee: 158 StructureType main.node
     - __kind: PointerType
-      ID: 172
+      ID: 173
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 173 StructureType main.oneStringStruct
+      Pointee: 174 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
@@ -3863,123 +3896,123 @@ Types:
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 235
+      ID: 236
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 234 GoStringDataType main.stringType1.str
+      Pointee: 235 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 236 UnresolvedPointeeType main.stringType2
+      Pointee: 237 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 205
+      ID: 206
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 355520
+      GoRuntimeType: 355584
       GoKind: 22
-      Pointee: 91 StructureType main.structWithMap
+      Pointee: 92 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 165
+      ID: 166
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 166 StructureType main.structWithNoStrings
+      Pointee: 167 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 155
+      ID: 156
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 156 StructureType main.structWithTwoValues
+      Pointee: 157 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 159
+      ID: 160
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 160 GoSliceHeaderType main.t
+      Pointee: 161 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 248
+      ID: 249
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType main.t.array
+      Pointee: 248 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 171
+      ID: 172
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 170 StructureType main.threeStringStruct
+      Pointee: 171 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 102 GoMapType map[string]int
+      Pointee: 103 GoMapType map[string]int
     - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 366272
+      GoRuntimeType: 366336
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 362368
+      GoRuntimeType: 362432
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 179
+      ID: 180
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 178 GoStringDataType string.str
+      Pointee: 179 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 363008
+      GoRuntimeType: 363072
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 362624
+      GoRuntimeType: 362688
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 362752
+      GoRuntimeType: 362816
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 362880
+      GoRuntimeType: 362944
       GoKind: 22
       Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 362496
+      GoRuntimeType: 362560
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 363072
+      GoRuntimeType: 363136
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 406
+      ID: 408
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 364
+      ID: 365
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3994,7 +4027,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 363
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4009,7 +4042,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
+      ID: 327
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4024,7 +4057,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 324
+      ID: 325
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4039,7 +4072,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 371
+      ID: 373
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4047,14 +4080,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 117 ArrayType [2]map[string]int
+            Type: 118 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 326
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4069,7 +4102,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 344
+      ID: 345
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4084,7 +4117,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 313
+      ID: 314
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4099,7 +4132,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 310
+      ID: 311
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4114,7 +4147,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 387
+      ID: 389
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4122,14 +4155,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 154 GoChannelType chan bool
+            Type: 155 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: c}
+                  Variable: {subprogram: 79, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 385
+      ID: 387
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4140,7 +4173,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: w}
+                  Variable: {subprogram: 77, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4149,7 +4182,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: x}
+                  Variable: {subprogram: 77, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4158,11 +4191,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: y}
+                  Variable: {subprogram: 77, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 395
+      ID: 397
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4170,14 +4203,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 159 PointerType *main.t
+            Type: 160 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: t}
+                  Variable: {subprogram: 87, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 349
+      ID: 350
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4192,7 +4225,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 351
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4207,7 +4240,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 346
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4222,7 +4255,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 347
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4237,7 +4270,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 348
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4252,7 +4285,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 348
+      ID: 349
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4267,7 +4300,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 400
+      ID: 402
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4275,10 +4308,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []main.structWithNoStrings
+            Type: 165 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4287,11 +4320,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 397
+      ID: 399
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4299,14 +4332,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []uint
+            Type: 162 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 414
+      ID: 416
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4317,11 +4350,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 417
+      ID: 419
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4329,14 +4362,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 177 PointerType *main.emptyStruct
+            Type: 178 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 109, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 416
+      ID: 418
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4344,14 +4377,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 176 StructureType main.emptyStruct
+            Type: 177 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 363
+      ID: 364
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4366,7 +4399,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 355
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4381,7 +4414,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 354
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4396,7 +4429,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 360
+      ID: 361
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4411,7 +4444,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 359
+      ID: 360
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4426,7 +4459,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 355
+      ID: 356
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4441,7 +4474,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 357
+      ID: 358
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4456,10 +4489,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 419
+      ID: 421
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 356
+      ID: 357
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4483,16 +4516,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 420
+      ID: 422
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 421
+      ID: 423
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 358
+      ID: 359
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 418
+      ID: 420
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4503,11 +4536,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 424
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4518,11 +4551,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: x}
+                  Variable: {subprogram: 114, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 423
+      ID: 425
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4533,11 +4566,11 @@ Types:
             Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: a}
+                  Variable: {subprogram: 115, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 316
+      ID: 317
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4552,7 +4585,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 317
+      ID: 318
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4567,7 +4600,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 318
+      ID: 319
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4582,7 +4615,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 316
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4597,7 +4630,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 314
+      ID: 315
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4612,7 +4645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 361
+      ID: 362
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4627,7 +4660,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 389
+      ID: 391
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4635,14 +4668,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 157 StructureType main.node
+            Type: 158 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 369
+      ID: 371
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4650,14 +4683,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 112 GoMapType map[[4]string][2]int
+            Type: 113 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 377
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4665,14 +4698,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 119 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 373
+      ID: 375
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4680,14 +4713,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 92 GoMapType map[int]int
+            Type: 93 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 384
+      ID: 386
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4695,14 +4728,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 149 GoMapType map[[4]int][4]int
+            Type: 150 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 383
+      ID: 385
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4710,14 +4743,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 144 GoMapType map[[4]int]uint8
+            Type: 145 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 376
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4725,14 +4758,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 119 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 384
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4740,14 +4773,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 139 GoMapType map[uint8][4]int
+            Type: 140 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 383
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4755,14 +4788,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 GoMapType map[uint8]uint8
+            Type: 135 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 369
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4770,14 +4803,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 102 GoMapType map[string]int
+            Type: 103 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 368
+      ID: 370
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4785,14 +4818,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 107 GoMapType map[string][]string
+            Type: 108 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 368
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4800,14 +4833,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 97 GoMapType map[string]main.nestedStruct
+            Type: 98 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 376
+      ID: 378
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4815,14 +4848,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 124 GoMapType map[bool]main.node
+            Type: 125 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 382
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4830,14 +4863,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 GoMapType map[uint8]uint8
+            Type: 135 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 379
+      ID: 381
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4845,14 +4878,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 GoMapType map[uint8]uint8
+            Type: 135 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 380
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4860,14 +4893,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 129 GoMapType map[int]uint8
+            Type: 130 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 377
+      ID: 379
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4875,14 +4908,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 129 GoMapType map[int]uint8
+            Type: 130 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 412
+      ID: 414
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4893,11 +4926,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 386
+      ID: 388
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4908,7 +4941,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4917,7 +4950,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: b}
+                  Variable: {subprogram: 78, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4926,7 +4959,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: c}
+                  Variable: {subprogram: 78, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4935,7 +4968,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 3, name: d}
+                  Variable: {subprogram: 78, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4944,11 +4977,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 4, name: e}
+                  Variable: {subprogram: 78, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 394
+      ID: 396
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4959,7 +4992,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4968,11 +5001,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: a}
+                  Variable: {subprogram: 86, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 401
+      ID: 403
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4980,10 +5013,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []main.structWithNoStrings
+            Type: 165 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4992,11 +5025,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 403
+      ID: 405
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5007,16 +5040,16 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: a}
+                  Variable: {subprogram: 95, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 168 GoSliceHeaderType []bool
+            Type: 169 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: s}
+                  Variable: {subprogram: 95, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5025,11 +5058,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 2, name: x}
+                  Variable: {subprogram: 95, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 404
+      ID: 406
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5037,14 +5070,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 169 GoSliceHeaderType []uint16
+            Type: 170 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 411
+      ID: 413
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5052,14 +5085,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 172 PointerType *main.oneStringStruct
+            Type: 173 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: a}
+                  Variable: {subprogram: 103, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 390
+      ID: 392
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5067,14 +5100,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 158 PointerType *main.node
+            Type: 159 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 374
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5082,14 +5115,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 PointerType *map[string]int
+            Type: 119 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 388
+      ID: 390
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5097,14 +5130,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 PointerType *main.structWithTwoValues
+            Type: 156 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 312
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5119,7 +5152,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 331
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5134,7 +5167,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 328
+      ID: 329
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5149,7 +5182,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 341
+      ID: 342
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5164,7 +5197,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 342
+      ID: 343
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5179,7 +5212,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 334
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5194,7 +5227,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 334
+      ID: 335
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5209,7 +5242,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 335
+      ID: 336
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5224,7 +5257,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 333
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5239,7 +5272,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 331
+      ID: 332
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5254,7 +5287,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 330
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5269,7 +5302,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 407
+      ID: 409
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5280,11 +5313,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 338
+      ID: 339
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5299,7 +5332,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 339
+      ID: 340
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5314,7 +5347,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 340
+      ID: 341
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5329,7 +5362,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 338
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5344,7 +5377,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 336
+      ID: 337
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5359,7 +5392,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 398
+      ID: 400
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5367,14 +5400,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType [][]uint
+            Type: 163 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: u}
+                  Variable: {subprogram: 90, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 370
+      ID: 372
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5382,14 +5415,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 102 GoMapType map[string]int
+            Type: 103 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 313
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5404,7 +5437,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 393
+      ID: 395
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5415,11 +5448,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 402
+      ID: 404
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5427,14 +5460,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 167 GoSliceHeaderType []string
+            Type: 168 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: s}
+                  Variable: {subprogram: 94, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 351
+      ID: 352
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5449,7 +5482,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 353
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5464,7 +5497,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 399
+      ID: 401
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5472,10 +5505,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []main.structWithNoStrings
+            Type: 165 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5484,11 +5517,26 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 366
+      Name: Probe[main.testStructWithAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 91 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 367
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5496,14 +5544,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 91 StructureType main.structWithMap
+            Type: 92 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 415
+      ID: 417
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5511,14 +5559,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 174 StructureType main.aStruct
+            Type: 175 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 410
+      ID: 412
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5526,14 +5574,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 171 PointerType *main.threeStringStruct
+            Type: 172 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 409
+      ID: 411
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5541,14 +5589,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 StructureType main.threeStringStruct
+            Type: 171 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 408
+      ID: 410
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5559,7 +5607,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5568,7 +5616,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: y}
+                  Variable: {subprogram: 100, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5577,11 +5625,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: z}
+                  Variable: {subprogram: 100, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 343
+      ID: 344
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5596,7 +5644,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 321
+      ID: 322
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5611,7 +5659,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 322
+      ID: 323
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5626,7 +5674,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 324
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5641,7 +5689,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 321
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5656,7 +5704,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 319
+      ID: 320
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5671,7 +5719,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 392
+      ID: 394
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5682,11 +5730,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 396
+      ID: 398
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5694,14 +5742,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []uint
+            Type: 162 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 413
+      ID: 415
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5712,11 +5760,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 391
+      ID: 393
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5727,11 +5775,11 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 328
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5746,7 +5794,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 405
+      ID: 407
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5754,10 +5802,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []uint
+            Type: 162 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: xs}
+                  Variable: {subprogram: 97, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5796,7 +5844,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 622688
+      GoRuntimeType: 622752
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5813,7 +5861,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 623840
+      GoRuntimeType: 623904
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5835,18 +5883,18 @@ Types:
       HasCount: true
       Element: 14 BaseType int8
     - __kind: ArrayType
-      ID: 117
+      ID: 118
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 102 GoMapType map[string]int
+      Element: 103 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 623936
+      GoRuntimeType: 624000
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5879,7 +5927,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 624032
+      GoRuntimeType: 624096
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5888,25 +5936,25 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 623744
+      GoRuntimeType: 623808
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 215
+      ID: 216
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 622304
+      GoRuntimeType: 622368
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 200
+      ID: 201
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 622592
+      GoRuntimeType: 622656
       GoKind: 17
       Count: 4
       HasCount: true
@@ -5920,10 +5968,10 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 185
+      ID: 186
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 619616
+      GoRuntimeType: 619680
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5932,7 +5980,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 446656
+      GoRuntimeType: 446720
       GoKind: 23
       RawFields:
         - Name: array
@@ -5944,83 +5992,83 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 183 GoSliceDataType []*main.deepSlice2.array
+      Data: 184 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 184
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 249
+      ID: 250
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 446592
+      GoRuntimeType: 446656
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 250 PointerType **main.deepSlice3
+          Type: 251 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 253 GoSliceDataType []*main.deepSlice3.array
+      Data: 254 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 254
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 251 PointerType *main.deepSlice3
+      Element: 252 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 270
+      ID: 271
       Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 446336
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 272 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 275 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 275
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 273 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 277
+      Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446272
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 271 PointerType **main.deepSlice8
+          Type: 278 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 274 GoSliceDataType []*main.deepSlice8.array
+      Data: 281 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 274
-      Name: '[]*main.deepSlice8.array'
-      ByteSize: 2048
-      Element: 272 PointerType *main.deepSlice8
-    - __kind: GoSliceHeaderType
-      ID: 276
-      Name: '[]*main.deepSlice9'
-      ByteSize: 24
-      GoRuntimeType: 446208
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 277 PointerType **main.deepSlice9
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 280 GoSliceDataType []*main.deepSlice9.array
-    - __kind: GoSliceDataType
-      ID: 280
+      ID: 281
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 278 PointerType *main.deepSlice9
+      Element: 279 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 447424
+      GoRuntimeType: 447488
       GoKind: 23
       RawFields:
         - Name: array
@@ -6032,38 +6080,38 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 180 GoSliceDataType []*string.array
+      Data: 181 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 181
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 163
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *[]uint
+          Type: 164 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 222 GoSliceDataType [][]uint.array
+      Data: 223 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 223
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 161 GoSliceHeaderType []uint
+      Element: 162 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 169
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 453952
+      GoRuntimeType: 454016
       GoKind: 23
       RawFields:
         - Name: array
@@ -6075,102 +6123,102 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 228 GoSliceDataType []bool.array
+      Data: 229 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 229
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 220
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 153 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 154 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 219
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 148 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 149 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 203
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 117 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 210
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 128 GoHMapBucketType bucket<bool,main.node>
+      Element: 129 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]bucket<int,*main.deepMap2>.array'
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 264
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 259 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 260 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 294
       Name: '[]bucket<int,*main.deepMap8>.array'
       ByteSize: 2048
-      Element: 289 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 290 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 303
       Name: '[]bucket<int,*main.deepMap9>.array'
       ByteSize: 2048
-      Element: 298 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 299 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 193
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 96 GoHMapBucketType bucket<int,int>
+      Element: 97 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 309
+      ID: 310
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
-      Element: 307 GoHMapBucketType bucket<int,interface {}>
+      Element: 308 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 212
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 133 GoHMapBucketType bucket<int,uint8>
+      Element: 134 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 207
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 199
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 111 GoHMapBucketType bucket<string,[]string>
+      Element: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 197
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 106 GoHMapBucketType bucket<string,int>
+      Element: 107 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 196
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 101 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 102 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 217
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 143 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 144 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 214
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 138 GoHMapBucketType bucket<uint8,uint8>
+      Element: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 282
+      ID: 283
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 454272
+      GoRuntimeType: 454336
       GoKind: 23
       RawFields:
         - Name: array
@@ -6182,102 +6230,102 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 283 GoSliceDataType []interface {}.array
+      Data: 284 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 217
+      ID: 218
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 215 ArrayType [4]int
+      Element: 216 ArrayType [4]int
     - __kind: ArrayType
-      ID: 199
+      ID: 200
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 200 ArrayType [4]string
+      Element: 201 ArrayType [4]string
     - __kind: ArrayType
-      ID: 207
+      ID: 208
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 186
+      ID: 187
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 193
+      ID: 194
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 212
+      ID: 213
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 204
+      ID: 205
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 446912
+      GoRuntimeType: 446976
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *main.structWithMap
+          Type: 206 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 264 GoSliceDataType []main.structWithMap.array
+      Data: 265 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 265
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 91 StructureType main.structWithMap
+      Element: 92 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 165
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *main.structWithNoStrings
+          Type: 166 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 224 GoSliceDataType []main.structWithNoStrings.array
+      Data: 225 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 225
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 166 StructureType main.structWithNoStrings
+      Element: 167 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 168
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 454080
+      GoRuntimeType: 454144
       GoKind: 23
       RawFields:
         - Name: array
@@ -6289,17 +6337,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 226 GoSliceDataType []string.array
+      Data: 227 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 227
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 162
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 453568
+      GoRuntimeType: 453632
       GoKind: 23
       RawFields:
         - Name: array
@@ -6311,17 +6359,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 220 GoSliceDataType []uint.array
+      Data: 221 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 221
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 15 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 170
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 452928
+      GoRuntimeType: 452992
       GoKind: 23
       RawFields:
         - Name: array
@@ -6333,98 +6381,98 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 230 GoSliceDataType []uint16.array
+      Data: 231 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 231
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 187
+      ID: 188
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 188 PointerType *main.deepMap2
+      Element: 189 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 260
+      ID: 261
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 261 PointerType *main.deepMap3
+      Element: 262 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 290
+      ID: 291
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 291 PointerType *main.deepMap8
+      Element: 292 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 299
+      ID: 300
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 300 PointerType *main.deepMap9
+      Element: 301 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 201
+      ID: 202
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 214
+      ID: 215
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 215 ArrayType [4]int
+      Element: 216 ArrayType [4]int
     - __kind: ArrayType
-      ID: 203
+      ID: 204
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 204 GoSliceHeaderType []main.structWithMap
+      Element: 205 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 197
+      ID: 198
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 167 GoSliceHeaderType []string
+      Element: 168 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 191
+      ID: 192
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 308
+      ID: 309
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 194
+      ID: 195
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 175 StructureType main.nestedStruct
+      Element: 176 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 208
+      ID: 209
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 157 StructureType main.node
+      Element: 158 StructureType main.node
     - __kind: ArrayType
-      ID: 210
+      ID: 211
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -6434,84 +6482,84 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 532064
+      GoRuntimeType: 532128
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 153
+      ID: 154
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 217 ArrayType []key<[4]int>
+          Type: 218 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 214 ArrayType []val<[4]int>
+          Type: 215 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 152 PointerType *bucket<[4]int,[4]int>
-      KeyType: 215 ArrayType [4]int
-      ValueType: 215 ArrayType [4]int
+          Type: 153 PointerType *bucket<[4]int,[4]int>
+      KeyType: 216 ArrayType [4]int
+      ValueType: 216 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 148
+      ID: 149
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 217 ArrayType []key<[4]int>
+          Type: 218 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 210 ArrayType []val<uint8>
+          Type: 211 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 147 PointerType *bucket<[4]int,uint8>
-      KeyType: 215 ArrayType [4]int
+          Type: 148 PointerType *bucket<[4]int,uint8>
+      KeyType: 216 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 116
+      ID: 117
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 199 ArrayType []key<[4]string>
+          Type: 200 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 201 ArrayType []val<[2]int>
+          Type: 202 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 115 PointerType *bucket<[4]string,[2]int>
-      KeyType: 200 ArrayType [4]string
+          Type: 116 PointerType *bucket<[4]string,[2]int>
+      KeyType: 201 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 128
+      ID: 129
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 207 ArrayType []key<bool>
+          Type: 208 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 208 ArrayType []val<main.node>
+          Type: 209 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 127 PointerType *bucket<bool,main.node>
+          Type: 128 PointerType *bucket<bool,main.node>
       KeyType: 4 BaseType bool
-      ValueType: 157 StructureType main.node
+      ValueType: 158 StructureType main.node
     - __kind: GoHMapBucketType
       ID: 72
       Name: bucket<int,*main.deepMap2>
@@ -6519,273 +6567,273 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 187 ArrayType []val<*main.deepMap2>
+          Type: 188 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 71 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 188 PointerType *main.deepMap2
+      ValueType: 189 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 259
+      ID: 260
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 260 ArrayType []val<*main.deepMap3>
+          Type: 261 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 258 PointerType *bucket<int,*main.deepMap3>
+          Type: 259 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 261 PointerType *main.deepMap3
+      ValueType: 262 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 289
+      ID: 290
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 290 ArrayType []val<*main.deepMap8>
+          Type: 291 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 288 PointerType *bucket<int,*main.deepMap8>
+          Type: 289 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 291 PointerType *main.deepMap8
+      ValueType: 292 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 298
+      ID: 299
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 299 ArrayType []val<*main.deepMap9>
+          Type: 300 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 297 PointerType *bucket<int,*main.deepMap9>
+          Type: 298 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 300 PointerType *main.deepMap9
+      ValueType: 301 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
-      ID: 96
+      ID: 97
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 191 ArrayType []val<int>
+          Type: 192 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 95 PointerType *bucket<int,int>
+          Type: 96 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 307
+      ID: 308
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 308 ArrayType []val<interface {}>
+          Type: 309 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 306 PointerType *bucket<int,interface {}>
+          Type: 307 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 133
+      ID: 134
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 210 ArrayType []val<uint8>
+          Type: 211 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 132 PointerType *bucket<int,uint8>
+          Type: 133 PointerType *bucket<int,uint8>
       KeyType: 9 BaseType int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 123
+      ID: 124
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 193 ArrayType []key<string>
+          Type: 194 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 203 ArrayType []val<[]main.structWithMap>
+          Type: 204 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 122 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 204 GoSliceHeaderType []main.structWithMap
+      ValueType: 205 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 111
+      ID: 112
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 193 ArrayType []key<string>
+          Type: 194 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 197 ArrayType []val<[]string>
+          Type: 198 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 110 PointerType *bucket<string,[]string>
+          Type: 111 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 167 GoSliceHeaderType []string
+      ValueType: 168 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 106
+      ID: 107
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 193 ArrayType []key<string>
+          Type: 194 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 191 ArrayType []val<int>
+          Type: 192 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 105 PointerType *bucket<string,int>
+          Type: 106 PointerType *bucket<string,int>
       KeyType: 11 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 101
+      ID: 102
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 193 ArrayType []key<string>
+          Type: 194 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 194 ArrayType []val<main.nestedStruct>
+          Type: 195 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 100 PointerType *bucket<string,main.nestedStruct>
+          Type: 101 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 175 StructureType main.nestedStruct
+      ValueType: 176 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 143
+      ID: 144
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 212 ArrayType []key<uint8>
+          Type: 213 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 214 ArrayType []val<[4]int>
+          Type: 215 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 142 PointerType *bucket<uint8,[4]int>
+          Type: 143 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 215 ArrayType [4]int
+      ValueType: 216 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 138
+      ID: 139
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 212 ArrayType []key<uint8>
+          Type: 213 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 210 ArrayType []val<uint8>
+          Type: 211 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 137 PointerType *bucket<uint8,uint8>
+          Type: 138 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 154
+      ID: 155
       Name: chan bool
-      GoRuntimeType: 543328
+      GoRuntimeType: 543392
       GoKind: 18
     - __kind: GoChannelType
       ID: 82
       Name: chan struct {}
-      GoRuntimeType: 542240
+      GoRuntimeType: 542304
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 531872
+      GoRuntimeType: 531936
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 531808
+      GoRuntimeType: 531872
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 983680
+      GoRuntimeType: 983744
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6798,22 +6846,22 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 531936
+      GoRuntimeType: 532000
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 532000
+      GoRuntimeType: 532064
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 85
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 444992
+      GoRuntimeType: 445056
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 151
+      ID: 152
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -6834,20 +6882,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 152 PointerType *bucket<[4]int,[4]int>
+          Type: 153 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 152 PointerType *bucket<[4]int,[4]int>
+          Type: 153 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 153 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 219 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketType: 154 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 220 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 146
+      ID: 147
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -6868,20 +6916,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 147 PointerType *bucket<[4]int,uint8>
+          Type: 148 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 147 PointerType *bucket<[4]int,uint8>
+          Type: 148 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 148 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 218 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketType: 149 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 219 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 114
+      ID: 115
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -6902,20 +6950,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 115 PointerType *bucket<[4]string,[2]int>
+          Type: 116 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 115 PointerType *bucket<[4]string,[2]int>
+          Type: 116 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 116 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 202 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketType: 117 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 203 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 126
+      ID: 127
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -6936,18 +6984,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 127 PointerType *bucket<bool,main.node>
+          Type: 128 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 127 PointerType *bucket<bool,main.node>
+          Type: 128 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 128 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 209 GoSliceDataType []bucket<bool,main.node>.array
+      BucketType: 129 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 210 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 70
       Name: hash<int,*main.deepMap2>
@@ -6981,9 +7029,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 190 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 191 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 257
+      ID: 258
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -7004,20 +7052,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 258 PointerType *bucket<int,*main.deepMap3>
+          Type: 259 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 258 PointerType *bucket<int,*main.deepMap3>
+          Type: 259 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 259 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 263 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 260 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 264 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 287
+      ID: 288
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -7038,20 +7086,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 288 PointerType *bucket<int,*main.deepMap8>
+          Type: 289 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 288 PointerType *bucket<int,*main.deepMap8>
+          Type: 289 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 289 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 293 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 290 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 294 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 296
+      ID: 297
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -7072,20 +7120,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 297 PointerType *bucket<int,*main.deepMap9>
+          Type: 298 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 297 PointerType *bucket<int,*main.deepMap9>
+          Type: 298 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 298 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 302 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 299 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 303 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
-      ID: 94
+      ID: 95
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -7106,20 +7154,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 95 PointerType *bucket<int,int>
+          Type: 96 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 95 PointerType *bucket<int,int>
+          Type: 96 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 96 GoHMapBucketType bucket<int,int>
-      BucketsType: 192 GoSliceDataType []bucket<int,int>.array
+      BucketType: 97 GoHMapBucketType bucket<int,int>
+      BucketsType: 193 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 305
+      ID: 306
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -7140,20 +7188,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 306 PointerType *bucket<int,interface {}>
+          Type: 307 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 306 PointerType *bucket<int,interface {}>
+          Type: 307 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 307 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 309 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 308 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 310 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 131
+      ID: 132
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -7174,20 +7222,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 132 PointerType *bucket<int,uint8>
+          Type: 133 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 132 PointerType *bucket<int,uint8>
+          Type: 133 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 133 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 211 GoSliceDataType []bucket<int,uint8>.array
+      BucketType: 134 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 212 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 121
+      ID: 122
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -7208,20 +7256,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 122 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 122 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 206 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketType: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 207 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 109
+      ID: 110
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -7242,20 +7290,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 110 PointerType *bucket<string,[]string>
+          Type: 111 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 110 PointerType *bucket<string,[]string>
+          Type: 111 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 111 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 198 GoSliceDataType []bucket<string,[]string>.array
+      BucketType: 112 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 199 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 104
+      ID: 105
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -7276,20 +7324,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 105 PointerType *bucket<string,int>
+          Type: 106 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 105 PointerType *bucket<string,int>
+          Type: 106 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 106 GoHMapBucketType bucket<string,int>
-      BucketsType: 196 GoSliceDataType []bucket<string,int>.array
+      BucketType: 107 GoHMapBucketType bucket<string,int>
+      BucketsType: 197 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 99
+      ID: 100
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -7310,20 +7358,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 100 PointerType *bucket<string,main.nestedStruct>
+          Type: 101 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 100 PointerType *bucket<string,main.nestedStruct>
+          Type: 101 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 101 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 195 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketType: 102 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 196 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 141
+      ID: 142
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -7344,20 +7392,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 142 PointerType *bucket<uint8,[4]int>
+          Type: 143 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 142 PointerType *bucket<uint8,[4]int>
+          Type: 143 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 143 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 216 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketType: 144 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 217 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 136
+      ID: 137
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -7378,53 +7426,53 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 137 PointerType *bucket<uint8,uint8>
+          Type: 138 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 137 PointerType *bucket<uint8,uint8>
+          Type: 138 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 138 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 213 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketType: 139 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 214 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 531616
+      GoRuntimeType: 531680
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 531232
+      GoRuntimeType: 531296
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 531360
+      GoRuntimeType: 531424
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 531488
+      GoRuntimeType: 531552
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 531104
+      GoRuntimeType: 531168
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 83
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 777344
+      GoRuntimeType: 777408
       GoKind: 20
       RawFields:
         - Name: _type
@@ -7437,7 +7485,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 979584
+      GoRuntimeType: 979648
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7447,7 +7495,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 174
+      ID: 175
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -7463,12 +7511,12 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 175 StructureType main.nestedStruct
+          Type: 176 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 89
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 979200
+      GoRuntimeType: 979264
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7496,61 +7544,61 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.099424e+06
+      GoRuntimeType: 1.099616e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 189
+      ID: 190
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.099296e+06
+      GoRuntimeType: 1.099488e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 255 GoMapType map[int]*main.deepMap3
+          Type: 256 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 262
+      ID: 263
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
       ID: 76
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.098656e+06
+      GoRuntimeType: 1.098848e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 285 GoMapType map[int]*main.deepMap8
+          Type: 286 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 292
+      ID: 293
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.098528e+06
+      GoRuntimeType: 1.09872e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 294 GoMapType map[int]*main.deepMap9
+          Type: 295 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 301
+      ID: 302
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.0984e+06
+      GoRuntimeType: 1.098592e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 303 GoMapType map[int]interface {}
+          Type: 304 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.100576e+06
+      GoRuntimeType: 1.100768e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7560,41 +7608,41 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.100448e+06
+      GoRuntimeType: 1.10064e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 232 PointerType *main.deepPtr3
+          Type: 233 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 233
+      ID: 234
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.099808e+06
+      GoRuntimeType: 1.1e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 266 PointerType *main.deepPtr8
+          Type: 267 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 267
+      ID: 268
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.09968e+06
+      GoRuntimeType: 1.099872e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 268 PointerType *main.deepPtr9
+          Type: 269 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 269
+      ID: 270
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.099552e+06
+      GoRuntimeType: 1.099744e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7604,58 +7652,58 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.101728e+06
+      GoRuntimeType: 1.10192e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 182
+      ID: 183
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.1016e+06
+      GoRuntimeType: 1.101792e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 249 GoSliceHeaderType []*main.deepSlice3
+          Type: 250 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 252
+      ID: 253
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.10096e+06
+      GoRuntimeType: 1.101152e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 270 GoSliceHeaderType []*main.deepSlice8
+          Type: 271 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 273
+      ID: 274
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.100832e+06
+      GoRuntimeType: 1.101024e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 276 GoSliceHeaderType []*main.deepSlice9
+          Type: 277 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 279
+      ID: 280
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.100704e+06
+      GoRuntimeType: 1.100896e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 282 GoSliceHeaderType []interface {}
+          Type: 283 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 176
+      ID: 177
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7663,7 +7711,7 @@ Types:
       ID: 87
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.703424e+06
+      GoRuntimeType: 1.703616e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7671,21 +7719,21 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 237 StructureType sync.Mutex
+          Type: 238 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 238 StructureType sync.Once
+          Type: 239 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 241 StructureType sync.WaitGroup
+          Type: 242 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 245 StructureType sync/atomic.Int32
+          Type: 246 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.829888e+06
+      GoRuntimeType: 1.83008e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7710,10 +7758,10 @@ Types:
           Offset: 56
           Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 175
+      ID: 176
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.279296e+06
+      GoRuntimeType: 1.279488e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7723,10 +7771,10 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 157
+      ID: 158
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.279136e+06
+      GoRuntimeType: 1.279328e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7734,9 +7782,9 @@ Types:
           Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 158 PointerType *main.node
+          Type: 159 PointerType *main.node
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7748,7 +7796,7 @@ Types:
       ID: 84
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 979328
+      GoRuntimeType: 979392
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7765,31 +7813,41 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 235 PointerType *main.stringType1.str
+          Type: 236 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 234 GoStringDataType main.stringType1.str
+      Data: 235 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 234
+      ID: 235
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 236
+      ID: 237
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
       ID: 91
+      Name: main.structWithAny
+      ByteSize: 16
+      GoRuntimeType: 1.098336e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 83 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 92
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.098272e+06
+      GoRuntimeType: 1.098464e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 92 GoMapType map[int]int
+          Type: 93 GoMapType map[int]int
     - __kind: StructureType
-      ID: 166
+      ID: 167
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7801,7 +7859,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 156
+      ID: 157
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7813,28 +7871,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 161
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 246 PointerType **main.t
+          Type: 247 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType main.t.array
+      Data: 248 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 248
       Name: main.t.array
       ByteSize: 2048
-      Element: 159 PointerType *main.t
+      Element: 160 PointerType *main.t
     - __kind: StructureType
-      ID: 170
+      ID: 171
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7854,124 +7912,124 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 149
+      ID: 150
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 879680
+      GoRuntimeType: 879744
       GoKind: 21
-      HeaderType: 151 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 152 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 144
+      ID: 145
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 879776
+      GoRuntimeType: 879840
       GoKind: 21
-      HeaderType: 146 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 147 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 112
+      ID: 113
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 879872
+      GoRuntimeType: 879936
       GoKind: 21
-      HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 115 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 124
+      ID: 125
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 879968
+      GoRuntimeType: 880032
       GoKind: 21
-      HeaderType: 126 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 127 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 879584
+      GoRuntimeType: 879648
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 255
+      ID: 256
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 879488
+      GoRuntimeType: 879552
       GoKind: 21
-      HeaderType: 257 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 258 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 285
+      ID: 286
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 879008
+      GoRuntimeType: 879072
       GoKind: 21
-      HeaderType: 287 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 288 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 294
+      ID: 295
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 878912
+      GoRuntimeType: 878976
       GoKind: 21
-      HeaderType: 296 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 297 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 92
+      ID: 93
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 877856
+      GoRuntimeType: 877920
       GoKind: 21
-      HeaderType: 94 GoHMapHeaderType hash<int,int>
+      HeaderType: 95 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 303
+      ID: 304
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 878816
+      GoRuntimeType: 878880
       GoKind: 21
-      HeaderType: 305 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 306 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
-      ID: 129
+      ID: 130
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 880064
+      GoRuntimeType: 880128
       GoKind: 21
-      HeaderType: 131 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 132 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 119
+      ID: 120
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 880160
+      GoRuntimeType: 880224
       GoKind: 21
-      HeaderType: 121 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 107
+      ID: 108
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 880256
+      GoRuntimeType: 880320
       GoKind: 21
-      HeaderType: 109 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 102
+      ID: 103
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 880352
+      GoRuntimeType: 880416
       GoKind: 21
-      HeaderType: 104 GoHMapHeaderType hash<string,int>
+      HeaderType: 105 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 97
+      ID: 98
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 880448
+      GoRuntimeType: 880512
       GoKind: 21
-      HeaderType: 99 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 139
+      ID: 140
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 880544
+      GoRuntimeType: 880608
       GoKind: 21
-      HeaderType: 141 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 142 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 134
+      ID: 135
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 880640
+      GoRuntimeType: 880704
       GoKind: 21
-      HeaderType: 136 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: UnresolvedPointeeType
       ID: 74
       Name: runtime.mapextra
@@ -7980,25 +8038,25 @@ Types:
       ID: 11
       Name: string
       ByteSize: 16
-      GoRuntimeType: 531040
+      GoRuntimeType: 531104
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 179 PointerType *string.str
+          Type: 180 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 178 GoStringDataType string.str
+      Data: 179 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 178
+      ID: 179
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 237
+      ID: 238
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.280576e+06
+      GoRuntimeType: 1.280768e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -8008,136 +8066,136 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 238
+      ID: 239
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.281696e+06
+      GoRuntimeType: 1.281888e+06
       GoKind: 25
       RawFields:
         - Name: done
           Offset: 0
-          Type: 239 StructureType sync/atomic.Uint32
+          Type: 240 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 237 StructureType sync.Mutex
+          Type: 238 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 241
+      ID: 242
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.420384e+06
+      GoRuntimeType: 1.420576e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 242 StructureType sync.noCopy
+          Type: 243 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 243 StructureType sync/atomic.Uint64
+          Type: 244 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 242
+      ID: 243
       Name: sync.noCopy
-      GoRuntimeType: 946336
+      GoRuntimeType: 946400
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 245
+      ID: 246
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.282016e+06
+      GoRuntimeType: 1.282208e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 240 StructureType sync/atomic.noCopy
+          Type: 241 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 239
+      ID: 240
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.282176e+06
+      GoRuntimeType: 1.282368e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 240 StructureType sync/atomic.noCopy
+          Type: 241 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 243
+      ID: 244
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.420768e+06
+      GoRuntimeType: 1.42096e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 240 StructureType sync/atomic.noCopy
+          Type: 241 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 244 StructureType sync/atomic.align64
+          Type: 245 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 244
+      ID: 245
       Name: sync/atomic.align64
-      GoRuntimeType: 946528
+      GoRuntimeType: 946592
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 240
+      ID: 241
       Name: sync/atomic.noCopy
-      GoRuntimeType: 946432
+      GoRuntimeType: 946496
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 531680
+      GoRuntimeType: 531744
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 531296
+      GoRuntimeType: 531360
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 531424
+      GoRuntimeType: 531488
       GoKind: 10
     - __kind: BaseType
       ID: 10
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 531552
+      GoRuntimeType: 531616
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 531168
+      GoRuntimeType: 531232
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 531744
+      GoRuntimeType: 531808
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 532128
+      GoRuntimeType: 532192
       GoKind: 26
-MaxTypeID: 423
+MaxTypeID: 425
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1755760", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 408 EventRootType Probe[main.stackC]
+          Type: 1054 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd07bca", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 363 EventRootType Probe[main.testAny]
+          Type: 1009 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04b4a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 365 EventRootType Probe[main.testAnyPtr]
+          Type: 1011 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04bea", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 325 EventRootType Probe[main.testArrayOfArrays]
+          Type: 971 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 327 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 973 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 373 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1019 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd05340", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 326 EventRootType Probe[main.testArrayOfStrings]
+          Type: 972 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 345 EventRootType Probe[main.testBigStruct]
+          Type: 991 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03700", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 314 EventRootType Probe[main.testBoolArray]
+          Type: 960 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 311 EventRootType Probe[main.testByteArray]
+          Type: 957 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02de0", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 389 EventRootType Probe[main.testChannel]
+          Type: 1035 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd06e80", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 387 EventRootType Probe[main.testCombinedByte]
+          Type: 1033 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd06aa0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 397 EventRootType Probe[main.testCycle]
+          Type: 1043 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd07240", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 350 EventRootType Probe[main.testDeepMap1]
+          Type: 996 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03ae0", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 351 EventRootType Probe[main.testDeepMap7]
+          Type: 997 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b00", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 346 EventRootType Probe[main.testDeepPtr1]
+          Type: 992 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd037c0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 347 EventRootType Probe[main.testDeepPtr7]
+          Type: 993 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd037e0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 348 EventRootType Probe[main.testDeepSlice1]
+          Type: 994 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd03960", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 349 EventRootType Probe[main.testDeepSlice7]
+          Type: 995 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd03980", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 399 EventRootType Probe[main.testEmptySlice]
+          Type: 1045 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd07780", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 402 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1048 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 416 EventRootType Probe[main.testEmptyString]
+          Type: 1062 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd07d00", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -337,7 +337,7 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - ID: 108
-          Type: 418 EventRootType Probe[main.testEmptyStruct]
+          Type: 1064 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd08100", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -350,7 +350,7 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - ID: 109
-          Type: 419 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1065 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd08120", Frameless: true}]
           Condition: null
     - id: testError
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 364 EventRootType Probe[main.testError]
+          Type: 1010 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04bc0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 355 EventRootType Probe[main.testEsotericHeap]
+          Type: 1001 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd040ca", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 354 EventRootType Probe[main.testEsotericStack]
+          Type: 1000 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd03fae", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 360 EventRootType Probe[main.testFrameless]
+          Type: 1006 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 361 EventRootType Probe[main.testFramelessArray]
+          Type: 1007 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04844", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 356 EventRootType Probe[main.testInlinedBA]
+          Type: 1002 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd0450a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 357 EventRootType Probe[main.testInlinedBB]
+          Type: 1003 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd045ae", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 358 EventRootType Probe[main.testInlinedBBA]
+          Type: 1004 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd0468a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -476,7 +476,7 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - ID: 111
-          Type: 421 EventRootType Probe[main.testInlinedBBB]
+          Type: 1067 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd04606", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 359 EventRootType Probe[main.testInlinedBC]
+          Type: 1005 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd0470e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -504,7 +504,7 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - ID: 112
-          Type: 422 EventRootType Probe[main.testInlinedBCA]
+          Type: 1068 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd04713", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -518,7 +518,7 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - ID: 113
-          Type: 423 EventRootType Probe[main.testInlinedBCB]
+          Type: 1069 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd047c6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - ID: 110
-          Type: 420 EventRootType Probe[main.testInlinedPrint]
+          Type: 1066 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0436a"
               Frameless: false
@@ -557,7 +557,7 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - ID: 114
-          Type: 424 EventRootType Probe[main.testInlinedSq]
+          Type: 1070 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04821", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -572,7 +572,7 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - ID: 115
-          Type: 425 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1071 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04865"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 317 EventRootType Probe[main.testInt16Array]
+          Type: 963 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 318 EventRootType Probe[main.testInt32Array]
+          Type: 964 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 319 EventRootType Probe[main.testInt64Array]
+          Type: 965 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 316 EventRootType Probe[main.testInt8Array]
+          Type: 962 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 315 EventRootType Probe[main.testIntArray]
+          Type: 961 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 362 EventRootType Probe[main.testInterface]
+          Type: 1008 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04b20", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 391 EventRootType Probe[main.testLinkedList]
+          Type: 1037 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd07060", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 371 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1017 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd05300", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 377 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1023 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd053c0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 375 EventRootType Probe[main.testMapIntToInt]
+          Type: 1021 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd05380", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 386 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1032 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd054e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 385 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1031 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd054c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 376 EventRootType Probe[main.testMapMassive]
+          Type: 1022 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd053a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 384 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1030 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd054a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 383 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1029 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd05480", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 369 EventRootType Probe[main.testMapStringToInt]
+          Type: 1015 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd052c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 370 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1016 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd052e0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 368 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1014 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd052a0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 378 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1024 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd053e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 381 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1027 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd05440", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 382 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1028 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd05460", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 379 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1025 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd05400", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 380 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1026 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd05420", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 414 EventRootType Probe[main.testMassiveString]
+          Type: 1060 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd07cc0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 388 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1034 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd06c60", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 396 EventRootType Probe[main.testNilPointer]
+          Type: 1042 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd07200", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 406 EventRootType Probe[main.testNilSlice]
+          Type: 1052 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd07860", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 403 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1049 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd07800", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 405 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1051 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd07840", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 413 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1059 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd07ca0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 392 EventRootType Probe[main.testPointerLoop]
+          Type: 1038 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07080", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 374 EventRootType Probe[main.testPointerToMap]
+          Type: 1020 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd05360", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 390 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1036 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd07040", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 312 EventRootType Probe[main.testRuneArray]
+          Type: 958 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 331 EventRootType Probe[main.testSingleBool]
+          Type: 977 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 329 EventRootType Probe[main.testSingleByte]
+          Type: 975 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd033c0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 342 EventRootType Probe[main.testSingleFloat32]
+          Type: 988 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 343 EventRootType Probe[main.testSingleFloat64]
+          Type: 989 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 332 EventRootType Probe[main.testSingleInt]
+          Type: 978 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 334 EventRootType Probe[main.testSingleInt16]
+          Type: 980 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 335 EventRootType Probe[main.testSingleInt32]
+          Type: 981 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 336 EventRootType Probe[main.testSingleInt64]
+          Type: 982 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 333 EventRootType Probe[main.testSingleInt8]
+          Type: 979 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 330 EventRootType Probe[main.testSingleRune]
+          Type: 976 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd033e0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 409 EventRootType Probe[main.testSingleString]
+          Type: 1055 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd07c20", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 337 EventRootType Probe[main.testSingleUint]
+          Type: 983 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 339 EventRootType Probe[main.testSingleUint16]
+          Type: 985 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 340 EventRootType Probe[main.testSingleUint32]
+          Type: 986 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 341 EventRootType Probe[main.testSingleUint64]
+          Type: 987 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 338 EventRootType Probe[main.testSingleUint8]
+          Type: 984 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 400 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1046 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd077a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 372 EventRootType Probe[main.testSmallMap]
+          Type: 1018 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd05320", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 313 EventRootType Probe[main.testStringArray]
+          Type: 959 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 395 EventRootType Probe[main.testStringPointer]
+          Type: 1041 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd071c0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 404 EventRootType Probe[main.testStringSlice]
+          Type: 1050 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd07820", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 352 EventRootType Probe[main.testStringType1]
+          Type: 998 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 353 EventRootType Probe[main.testStringType2]
+          Type: 999 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1394,7 +1394,7 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - ID: 107
-          Type: 417 EventRootType Probe[main.testStruct]
+          Type: 1063 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd07f80", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 401 EventRootType Probe[main.testStructSlice]
+          Type: 1047 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,7 +1425,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 366 EventRootType Probe[main.testStructWithAny]
+          Type: 1012 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xd04c40", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1439,7 +1439,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 367 EventRootType Probe[main.testStructWithMap]
+          Type: 1013 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05280", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1453,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 410 EventRootType Probe[main.testThreeStrings]
+          Type: 1056 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd07c40", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1467,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 411 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1057 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd07c60", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1481,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 412 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1058 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd07c80", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 344 EventRootType Probe[main.testTypeAlias]
+          Type: 990 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 322 EventRootType Probe[main.testUint16Array]
+          Type: 968 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 323 EventRootType Probe[main.testUint32Array]
+          Type: 969 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 324 EventRootType Probe[main.testUint64Array]
+          Type: 970 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 321 EventRootType Probe[main.testUint8Array]
+          Type: 967 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 320 EventRootType Probe[main.testUintArray]
+          Type: 966 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1579,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 394 EventRootType Probe[main.testUintPointer]
+          Type: 1040 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd070e0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1593,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 398 EventRootType Probe[main.testUintSlice]
+          Type: 1044 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd07760", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1607,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 415 EventRootType Probe[main.testUnitializedString]
+          Type: 1061 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd07ce0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1621,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 393 EventRootType Probe[main.testUnsafePointer]
+          Type: 1039 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd070a0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 328 EventRootType Probe[main.testVeryLargeArray]
+          Type: 974 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1649,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 407 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1053 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd07880", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3416,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 251
+      ID: 897
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 252 PointerType *main.deepSlice3
+      Pointee: 898 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 272
+      ID: 918
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 273 PointerType *main.deepSlice8
+      Pointee: 919 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 278
+      ID: 924
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 279 PointerType *main.deepSlice9
+      Pointee: 925 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3437,7 +3437,7 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 247
+      ID: 893
       Name: '**main.t'
       ByteSize: 8
       Pointee: 160 PointerType *main.t
@@ -3454,20 +3454,20 @@ Types:
       ByteSize: 8
       Pointee: 184 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 255
+      ID: 901
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 900 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 276
+      ID: 922
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 275 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 921 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 282
+      ID: 928
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 281 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 927 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 182
       Name: '*[]*string.array'
@@ -3484,15 +3484,20 @@ Types:
       ByteSize: 8
       Pointee: 229 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 285
+      ID: 684
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 683 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 931
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType []interface {}.array
+      Pointee: 930 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 266
+      ID: 912
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []main.structWithMap.array
+      Pointee: 911 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 226
       Name: '*[]main.structWithNoStrings.array'
@@ -3518,6 +3523,72 @@ Types:
       Name: '*[]uint16.array'
       ByteSize: 8
       Pointee: 231 GoSliceDataType []uint16.array
+    - __kind: PointerType
+      ID: 682
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 681 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 809
+      Name: '*archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.848384e+06
+      GoKind: 22
+      Pointee: 810 UnresolvedPointeeType archive/tar.Writer
+    - __kind: PointerType
+      ID: 458
+      Name: '*archive/tar.headerError'
+      ByteSize: 8
+      GoRuntimeType: 858336
+      GoKind: 22
+      Pointee: 459 GoSliceHeaderType archive/tar.headerError
+    - __kind: PointerType
+      ID: 461
+      Name: '*archive/tar.headerError.array'
+      ByteSize: 8
+      Pointee: 460 GoSliceDataType archive/tar.headerError.array
+    - __kind: PointerType
+      ID: 749
+      Name: '*archive/tar.regFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.252928e+06
+      GoKind: 22
+      Pointee: 750 UnresolvedPointeeType archive/tar.regFileWriter
+    - __kind: PointerType
+      ID: 697
+      Name: '*archive/zip.countWriter'
+      ByteSize: 8
+      GoRuntimeType: 858528
+      GoKind: 22
+      Pointee: 698 UnresolvedPointeeType archive/zip.countWriter
+    - __kind: PointerType
+      ID: 699
+      Name: '*archive/zip.dirWriter'
+      ByteSize: 8
+      GoRuntimeType: 858624
+      GoKind: 22
+      Pointee: 700 StructureType archive/zip.dirWriter
+    - __kind: PointerType
+      ID: 796
+      Name: '*archive/zip.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.772672e+06
+      GoKind: 22
+      Pointee: 797 UnresolvedPointeeType archive/zip.fileWriter
+    - __kind: PointerType
+      ID: 725
+      Name: '*archive/zip.nopCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.016448e+06
+      GoKind: 22
+      Pointee: 726 StructureType archive/zip.nopCloser
+    - __kind: PointerType
+      ID: 727
+      Name: '*archive/zip.pooledFlateWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.016704e+06
+      GoKind: 22
+      Pointee: 728 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3551,30 +3622,30 @@ Types:
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 259
+      ID: 905
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 260 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 906 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 289
+      ID: 935
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 290 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 936 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 298
+      ID: 944
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 299 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 945 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 96
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 97 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 307
+      ID: 953
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 308 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 954 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 133
       Name: '*bucket<int,uint8>'
@@ -3590,6 +3661,11 @@ Types:
       Name: '*bucket<string,[]string>'
       ByteSize: 8
       Pointee: 112 GoHMapBucketType bucket<string,[]string>
+    - __kind: PointerType
+      ID: 650
+      Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 106
       Name: '*bucket<string,int>'
@@ -3611,12 +3687,414 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
+      ID: 773
+      Name: '*bufio.Reader'
+      ByteSize: 8
+      GoRuntimeType: 2.028864e+06
+      GoKind: 22
+      Pointee: 774 UnresolvedPointeeType bufio.Reader
+    - __kind: PointerType
+      ID: 798
+      Name: '*bufio.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.814112e+06
+      GoKind: 22
+      Pointee: 799 UnresolvedPointeeType bufio.Writer
+    - __kind: PointerType
+      ID: 845
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.121824e+06
+      GoKind: 22
+      Pointee: 846 UnresolvedPointeeType bytes.Buffer
+    - __kind: PointerType
+      ID: 371
+      Name: '*compress/flate.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 840960
+      GoKind: 22
+      Pointee: 266 BaseType compress/flate.CorruptInputError
+    - __kind: PointerType
+      ID: 372
+      Name: '*compress/flate.InternalError'
+      ByteSize: 8
+      GoRuntimeType: 841056
+      GoKind: 22
+      Pointee: 267 GoStringHeaderType compress/flate.InternalError
+    - __kind: PointerType
+      ID: 269
+      Name: '*compress/flate.InternalError.str'
+      ByteSize: 8
+      Pointee: 268 GoStringDataType compress/flate.InternalError.str
+    - __kind: PointerType
+      ID: 747
+      Name: '*compress/flate.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.243168e+06
+      GoKind: 22
+      Pointee: 748 UnresolvedPointeeType compress/flate.Writer
+    - __kind: PointerType
+      ID: 693
+      Name: '*compress/flate.dictWriter'
+      ByteSize: 8
+      GoRuntimeType: 841152
+      GoKind: 22
+      Pointee: 694 UnresolvedPointeeType compress/flate.dictWriter
+    - __kind: PointerType
+      ID: 769
+      Name: '*compress/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.599296e+06
+      GoKind: 22
+      Pointee: 770 UnresolvedPointeeType compress/gzip.Writer
+    - __kind: PointerType
+      ID: 602
+      Name: '*context.deadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.1176e+06
+      GoKind: 22
+      Pointee: 603 StructureType context.deadlineExceededError
+    - __kind: PointerType
+      ID: 451
+      Name: '*crypto/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 853248
+      GoKind: 22
+      Pointee: 280 BaseType crypto/aes.KeySizeError
+    - __kind: PointerType
+      ID: 452
+      Name: '*crypto/des.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 853440
+      GoKind: 22
+      Pointee: 281 BaseType crypto/des.KeySizeError
+    - __kind: PointerType
+      ID: 759
+      Name: '*crypto/hmac.hmac'
+      ByteSize: 8
+      GoRuntimeType: 1.37344e+06
+      GoKind: 22
+      Pointee: 760 UnresolvedPointeeType crypto/hmac.hmac
+    - __kind: PointerType
+      ID: 784
+      Name: '*crypto/md5.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.678304e+06
+      GoKind: 22
+      Pointee: 785 UnresolvedPointeeType crypto/md5.digest
+    - __kind: PointerType
+      ID: 453
+      Name: '*crypto/rc4.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 853728
+      GoKind: 22
+      Pointee: 282 BaseType crypto/rc4.KeySizeError
+    - __kind: PointerType
+      ID: 792
+      Name: '*crypto/sha1.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.769856e+06
+      GoKind: 22
+      Pointee: 793 UnresolvedPointeeType crypto/sha1.digest
+    - __kind: PointerType
+      ID: 786
+      Name: '*crypto/sha256.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.678752e+06
+      GoKind: 22
+      Pointee: 787 UnresolvedPointeeType crypto/sha256.digest
+    - __kind: PointerType
+      ID: 788
+      Name: '*crypto/sha512.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.6792e+06
+      GoKind: 22
+      Pointee: 789 UnresolvedPointeeType crypto/sha512.digest
+    - __kind: PointerType
+      ID: 377
+      Name: '*crypto/tls.AlertError'
+      ByteSize: 8
+      GoRuntimeType: 842592
+      GoKind: 22
+      Pointee: 270 BaseType crypto/tls.AlertError
+    - __kind: PointerType
+      ID: 542
+      Name: '*crypto/tls.CertificateVerificationError'
+      ByteSize: 8
+      GoRuntimeType: 1.004288e+06
+      GoKind: 22
+      Pointee: 543 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+    - __kind: PointerType
+      ID: 871
+      Name: '*crypto/tls.Conn'
+      ByteSize: 8
+      GoRuntimeType: 2.230944e+06
+      GoKind: 22
+      Pointee: 872 UnresolvedPointeeType crypto/tls.Conn
+    - __kind: PointerType
+      ID: 375
+      Name: '*crypto/tls.ECHRejectionError'
+      ByteSize: 8
+      GoRuntimeType: 842400
+      GoKind: 22
+      Pointee: 376 UnresolvedPointeeType crypto/tls.ECHRejectionError
+    - __kind: PointerType
+      ID: 373
+      Name: '*crypto/tls.RecordHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 842304
+      GoKind: 22
+      Pointee: 374 StructureType crypto/tls.RecordHeaderError
+    - __kind: PointerType
+      ID: 541
+      Name: '*crypto/tls.alert'
+      ByteSize: 8
+      GoRuntimeType: 1.002624e+06
+      GoKind: 22
+      Pointee: 498 BaseType crypto/tls.alert
+    - __kind: PointerType
+      ID: 757
+      Name: '*crypto/tls.cthWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.37056e+06
+      GoKind: 22
+      Pointee: 758 UnresolvedPointeeType crypto/tls.cthWrapper
+    - __kind: PointerType
+      ID: 764
+      Name: '*crypto/tls.finishedHash'
+      ByteSize: 8
+      GoRuntimeType: 1.449632e+06
+      GoKind: 22
+      Pointee: 765 UnresolvedPointeeType crypto/tls.finishedHash
+    - __kind: PointerType
+      ID: 637
+      Name: '*crypto/tls.permanentError'
+      ByteSize: 8
+      GoRuntimeType: 1.243488e+06
+      GoKind: 22
+      Pointee: 638 UnresolvedPointeeType crypto/tls.permanentError
+    - __kind: PointerType
+      ID: 652
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.905536e+06
+      GoKind: 22
+      Pointee: 653 UnresolvedPointeeType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 447
+      Name: '*crypto/x509.CertificateInvalidError'
+      ByteSize: 8
+      GoRuntimeType: 852192
+      GoKind: 22
+      Pointee: 448 StructureType crypto/x509.CertificateInvalidError
+    - __kind: PointerType
+      ID: 441
+      Name: '*crypto/x509.ConstraintViolationError'
+      ByteSize: 8
+      GoRuntimeType: 851712
+      GoKind: 22
+      Pointee: 442 StructureType crypto/x509.ConstraintViolationError
+    - __kind: PointerType
+      ID: 443
+      Name: '*crypto/x509.HostnameError'
+      ByteSize: 8
+      GoRuntimeType: 851808
+      GoKind: 22
+      Pointee: 444 StructureType crypto/x509.HostnameError
+    - __kind: PointerType
+      ID: 440
+      Name: '*crypto/x509.InsecureAlgorithmError'
+      ByteSize: 8
+      GoRuntimeType: 851616
+      GoKind: 22
+      Pointee: 279 BaseType crypto/x509.InsecureAlgorithmError
+    - __kind: PointerType
+      ID: 547
+      Name: '*crypto/x509.SystemRootsError'
+      ByteSize: 8
+      GoRuntimeType: 1.010176e+06
+      GoKind: 22
+      Pointee: 548 StructureType crypto/x509.SystemRootsError
+    - __kind: PointerType
+      ID: 449
+      Name: '*crypto/x509.UnhandledCriticalExtension'
+      ByteSize: 8
+      GoRuntimeType: 852288
+      GoKind: 22
+      Pointee: 450 StructureType crypto/x509.UnhandledCriticalExtension
+    - __kind: PointerType
+      ID: 445
+      Name: '*crypto/x509.UnknownAuthorityError'
+      ByteSize: 8
+      GoRuntimeType: 852096
+      GoKind: 22
+      Pointee: 446 StructureType crypto/x509.UnknownAuthorityError
+    - __kind: PointerType
+      ID: 462
+      Name: '*encoding/asn1.StructuralError'
+      ByteSize: 8
+      GoRuntimeType: 858816
+      GoKind: 22
+      Pointee: 463 StructureType encoding/asn1.StructuralError
+    - __kind: PointerType
+      ID: 466
+      Name: '*encoding/asn1.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 859008
+      GoKind: 22
+      Pointee: 467 StructureType encoding/asn1.SyntaxError
+    - __kind: PointerType
+      ID: 464
+      Name: '*encoding/asn1.invalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 858912
+      GoKind: 22
+      Pointee: 465 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+    - __kind: PointerType
+      ID: 363
+      Name: '*encoding/base64.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 839232
+      GoKind: 22
+      Pointee: 264 BaseType encoding/base64.CorruptInputError
+    - __kind: PointerType
+      ID: 715
+      Name: '*encoding/base64.encoder'
+      ByteSize: 8
+      GoRuntimeType: 999424
+      GoKind: 22
+      Pointee: 716 UnresolvedPointeeType encoding/base64.encoder
+    - __kind: PointerType
+      ID: 366
+      Name: '*encoding/hex.InvalidByteError'
+      ByteSize: 8
+      GoRuntimeType: 840096
+      GoKind: 22
+      Pointee: 265 BaseType encoding/hex.InvalidByteError
+    - __kind: PointerType
+      ID: 334
+      Name: '*encoding/json.InvalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 833952
+      GoKind: 22
+      Pointee: 335 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+    - __kind: PointerType
+      ID: 533
+      Name: '*encoding/json.MarshalerError'
+      ByteSize: 8
+      GoRuntimeType: 995072
+      GoKind: 22
+      Pointee: 534 UnresolvedPointeeType encoding/json.MarshalerError
+    - __kind: PointerType
+      ID: 326
+      Name: '*encoding/json.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 833568
+      GoKind: 22
+      Pointee: 327 UnresolvedPointeeType encoding/json.SyntaxError
+    - __kind: PointerType
+      ID: 332
+      Name: '*encoding/json.UnmarshalTypeError'
+      ByteSize: 8
+      GoRuntimeType: 833856
+      GoKind: 22
+      Pointee: 333 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+    - __kind: PointerType
+      ID: 330
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 833760
+      GoKind: 22
+      Pointee: 331 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 328
+      Name: '*encoding/json.UnsupportedValueError'
+      ByteSize: 8
+      GoRuntimeType: 833664
+      GoKind: 22
+      Pointee: 329 UnresolvedPointeeType encoding/json.UnsupportedValueError
+    - __kind: PointerType
+      ID: 851
+      Name: '*encoding/json.encodeState'
+      ByteSize: 8
+      GoRuntimeType: 2.147392e+06
+      GoKind: 22
+      Pointee: 852 UnresolvedPointeeType encoding/json.encodeState
+    - __kind: PointerType
+      ID: 336
+      Name: '*encoding/json.jsonError'
+      ByteSize: 8
+      GoRuntimeType: 834336
+      GoKind: 22
+      Pointee: 337 StructureType encoding/json.jsonError
+    - __kind: PointerType
+      ID: 723
+      Name: '*encoding/pem.lineBreaker'
+      ByteSize: 8
+      GoRuntimeType: 1.012992e+06
+      GoKind: 22
+      Pointee: 724 UnresolvedPointeeType encoding/pem.lineBreaker
+    - __kind: PointerType
+      ID: 435
+      Name: '*encoding/xml.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 850656
+      GoKind: 22
+      Pointee: 436 UnresolvedPointeeType encoding/xml.SyntaxError
+    - __kind: PointerType
+      ID: 433
+      Name: '*encoding/xml.TagPathError'
+      ByteSize: 8
+      GoRuntimeType: 850560
+      GoKind: 22
+      Pointee: 434 UnresolvedPointeeType encoding/xml.TagPathError
+    - __kind: PointerType
+      ID: 437
+      Name: '*encoding/xml.UnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 850752
+      GoKind: 22
+      Pointee: 276 GoStringHeaderType encoding/xml.UnmarshalError
+    - __kind: PointerType
+      ID: 278
+      Name: '*encoding/xml.UnmarshalError.str'
+      ByteSize: 8
+      Pointee: 277 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: PointerType
+      ID: 438
+      Name: '*encoding/xml.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 850848
+      GoKind: 22
+      Pointee: 439 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 829
+      Name: '*encoding/xml.printer'
+      ByteSize: 8
+      GoRuntimeType: 2.017344e+06
+      GoKind: 22
+      Pointee: 830 UnresolvedPointeeType encoding/xml.printer
+    - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 362560
       GoKind: 22
       Pointee: 18 GoInterfaceType error
+    - __kind: PointerType
+      ID: 304
+      Name: '*errors.errorString'
+      ByteSize: 8
+      GoRuntimeType: 824256
+      GoKind: 22
+      Pointee: 305 UnresolvedPointeeType errors.errorString
+    - __kind: PointerType
+      ID: 500
+      Name: '*errors.joinError'
+      ByteSize: 8
+      GoRuntimeType: 979712
+      GoKind: 22
+      Pointee: 501 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -3631,6 +4109,807 @@ Types:
       GoRuntimeType: 363584
       GoKind: 22
       Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 839
+      Name: '*fmt.pp'
+      ByteSize: 8
+      GoRuntimeType: 2.11312e+06
+      GoKind: 22
+      Pointee: 840 UnresolvedPointeeType fmt.pp
+    - __kind: PointerType
+      ID: 502
+      Name: '*fmt.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 981504
+      GoKind: 22
+      Pointee: 503 UnresolvedPointeeType fmt.wrapError
+    - __kind: PointerType
+      ID: 504
+      Name: '*fmt.wrapErrors'
+      ByteSize: 8
+      GoRuntimeType: 981632
+      GoKind: 22
+      Pointee: 505 UnresolvedPointeeType fmt.wrapErrors
+    - __kind: PointerType
+      ID: 364
+      Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 839616
+      GoKind: 22
+      Pointee: 365 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+    - __kind: PointerType
+      ID: 345
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 836736
+      GoKind: 22
+      Pointee: 346 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+    - __kind: PointerType
+      ID: 347
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 836832
+      GoKind: 22
+      Pointee: 348 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+    - __kind: PointerType
+      ID: 665
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
+      ByteSize: 8
+      GoRuntimeType: 836544
+      GoKind: 22
+      Pointee: 666 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+    - __kind: PointerType
+      ID: 351
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
+      ByteSize: 8
+      GoRuntimeType: 837120
+      GoKind: 22
+      Pointee: 352 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+    - __kind: PointerType
+      ID: 667
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
+      ByteSize: 8
+      GoRuntimeType: 836640
+      GoKind: 22
+      Pointee: 668 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+    - __kind: PointerType
+      ID: 349
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
+      ByteSize: 8
+      GoRuntimeType: 836928
+      GoKind: 22
+      Pointee: 258 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+    - __kind: PointerType
+      ID: 260
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
+      ByteSize: 8
+      Pointee: 259 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: PointerType
+      ID: 344
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
+      ByteSize: 8
+      GoRuntimeType: 836448
+      GoKind: 22
+      Pointee: 255 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+    - __kind: PointerType
+      ID: 257
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
+      ByteSize: 8
+      Pointee: 256 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: PointerType
+      ID: 350
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
+      ByteSize: 8
+      GoRuntimeType: 837024
+      GoKind: 22
+      Pointee: 261 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+    - __kind: PointerType
+      ID: 263
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
+      ByteSize: 8
+      Pointee: 262 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: PointerType
+      ID: 737
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.12336e+06
+      GoKind: 22
+      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+    - __kind: PointerType
+      ID: 817
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.920544e+06
+      GoKind: 22
+      Pointee: 818 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+    - __kind: PointerType
+      ID: 456
+      Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
+      ByteSize: 8
+      GoRuntimeType: 857280
+      GoKind: 22
+      Pointee: 457 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+    - __kind: PointerType
+      ID: 611
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
+      ByteSize: 8
+      GoRuntimeType: 1.126688e+06
+      GoKind: 22
+      Pointee: 612 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+    - __kind: PointerType
+      ID: 847
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
+      ByteSize: 8
+      GoRuntimeType: 2.12336e+06
+      GoKind: 22
+      Pointee: 848 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+    - __kind: PointerType
+      ID: 384
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
+      ByteSize: 8
+      GoRuntimeType: 846144
+      GoKind: 22
+      Pointee: 385 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+    - __kind: PointerType
+      ID: 391
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
+      ByteSize: 8
+      GoRuntimeType: 847200
+      GoKind: 22
+      Pointee: 392 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+    - __kind: PointerType
+      ID: 386
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
+      ByteSize: 8
+      GoRuntimeType: 846912
+      GoKind: 22
+      Pointee: 275 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+    - __kind: PointerType
+      ID: 389
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
+      ByteSize: 8
+      GoRuntimeType: 847104
+      GoKind: 22
+      Pointee: 390 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+    - __kind: PointerType
+      ID: 387
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
+      ByteSize: 8
+      GoRuntimeType: 847008
+      GoKind: 22
+      Pointee: 388 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+    - __kind: PointerType
+      ID: 407
+      Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
+      ByteSize: 8
+      GoRuntimeType: 849120
+      GoKind: 22
+      Pointee: 408 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+    - __kind: PointerType
+      ID: 411
+      Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
+      ByteSize: 8
+      GoRuntimeType: 849312
+      GoKind: 22
+      Pointee: 412 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+    - __kind: PointerType
+      ID: 409
+      Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
+      ByteSize: 8
+      GoRuntimeType: 849216
+      GoKind: 22
+      Pointee: 410 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+    - __kind: PointerType
+      ID: 405
+      Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
+      ByteSize: 8
+      GoRuntimeType: 849024
+      GoKind: 22
+      Pointee: 406 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+    - __kind: PointerType
+      ID: 686
+      Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 8
+      Pointee: 685 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: PointerType
+      ID: 419
+      Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
+      ByteSize: 8
+      GoRuntimeType: 849696
+      GoKind: 22
+      Pointee: 420 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+    - __kind: PointerType
+      ID: 413
+      Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
+      ByteSize: 8
+      GoRuntimeType: 849408
+      GoKind: 22
+      Pointee: 414 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+    - __kind: PointerType
+      ID: 417
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
+      ByteSize: 8
+      GoRuntimeType: 849600
+      GoKind: 22
+      Pointee: 418 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+    - __kind: PointerType
+      ID: 415
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
+      ByteSize: 8
+      GoRuntimeType: 849504
+      GoKind: 22
+      Pointee: 416 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+    - __kind: PointerType
+      ID: 421
+      Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
+      ByteSize: 8
+      GoRuntimeType: 849792
+      GoKind: 22
+      Pointee: 422 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+    - __kind: PointerType
+      ID: 427
+      Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
+      ByteSize: 8
+      GoRuntimeType: 850080
+      GoKind: 22
+      Pointee: 428 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+    - __kind: PointerType
+      ID: 429
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
+      ByteSize: 8
+      GoRuntimeType: 850176
+      GoKind: 22
+      Pointee: 430 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+    - __kind: PointerType
+      ID: 425
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
+      ByteSize: 8
+      GoRuntimeType: 849984
+      GoKind: 22
+      Pointee: 426 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+    - __kind: PointerType
+      ID: 423
+      Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
+      ByteSize: 8
+      GoRuntimeType: 849888
+      GoKind: 22
+      Pointee: 424 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+    - __kind: PointerType
+      ID: 431
+      Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
+      ByteSize: 8
+      GoRuntimeType: 850368
+      GoKind: 22
+      Pointee: 432 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+    - __kind: PointerType
+      ID: 353
+      Name: '*github.com/cihub/seelog.baseError'
+      ByteSize: 8
+      GoRuntimeType: 838272
+      GoKind: 22
+      Pointee: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: PointerType
+      ID: 776
+      Name: '*github.com/cihub/seelog.bufferedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.675392e+06
+      GoKind: 22
+      Pointee: 777 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+    - __kind: PointerType
+      ID: 355
+      Name: '*github.com/cihub/seelog.cannotOpenFileError'
+      ByteSize: 8
+      GoRuntimeType: 838368
+      GoKind: 22
+      Pointee: 356 StructureType github.com/cihub/seelog.cannotOpenFileError
+    - __kind: PointerType
+      ID: 755
+      Name: '*github.com/cihub/seelog.connWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.36944e+06
+      GoKind: 22
+      Pointee: 756 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+    - __kind: PointerType
+      ID: 711
+      Name: '*github.com/cihub/seelog.consoleWriter'
+      ByteSize: 8
+      GoRuntimeType: 998400
+      GoKind: 22
+      Pointee: 712 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+    - __kind: PointerType
+      ID: 745
+      Name: '*github.com/cihub/seelog.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.241248e+06
+      GoKind: 22
+      Pointee: 746 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+    - __kind: PointerType
+      ID: 359
+      Name: '*github.com/cihub/seelog.missingArgumentError'
+      ByteSize: 8
+      GoRuntimeType: 838560
+      GoKind: 22
+      Pointee: 360 StructureType github.com/cihub/seelog.missingArgumentError
+    - __kind: PointerType
+      ID: 807
+      Name: '*github.com/cihub/seelog.rollingFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.838592e+06
+      GoKind: 22
+      Pointee: 808 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+    - __kind: PointerType
+      ID: 822
+      Name: '*github.com/cihub/seelog.rollingFileWriterSize'
+      ByteSize: 8
+      GoRuntimeType: 1.992e+06
+      GoKind: 22
+      Pointee: 819 StructureType github.com/cihub/seelog.rollingFileWriterSize
+    - __kind: PointerType
+      ID: 821
+      Name: '*github.com/cihub/seelog.rollingFileWriterTime'
+      ByteSize: 8
+      GoRuntimeType: 1.991616e+06
+      GoKind: 22
+      Pointee: 820 StructureType github.com/cihub/seelog.rollingFileWriterTime
+    - __kind: PointerType
+      ID: 713
+      Name: '*github.com/cihub/seelog.smtpWriter'
+      ByteSize: 8
+      GoRuntimeType: 998528
+      GoKind: 22
+      Pointee: 714 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+    - __kind: PointerType
+      ID: 357
+      Name: '*github.com/cihub/seelog.unexpectedAttributeError'
+      ByteSize: 8
+      GoRuntimeType: 838464
+      GoKind: 22
+      Pointee: 358 StructureType github.com/cihub/seelog.unexpectedAttributeError
+    - __kind: PointerType
+      ID: 361
+      Name: '*github.com/cihub/seelog.unexpectedChildElementError'
+      ByteSize: 8
+      GoRuntimeType: 838656
+      GoKind: 22
+      Pointee: 362 StructureType github.com/cihub/seelog.unexpectedChildElementError
+    - __kind: PointerType
+      ID: 780
+      Name: '*github.com/cihub/seelog/archive/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.67696e+06
+      GoKind: 22
+      Pointee: 781 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+    - __kind: PointerType
+      ID: 813
+      Name: '*github.com/cihub/seelog/archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.874464e+06
+      GoKind: 22
+      Pointee: 814 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+    - __kind: PointerType
+      ID: 815
+      Name: '*github.com/cihub/seelog/archive/zip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.905216e+06
+      GoKind: 22
+      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+    - __kind: PointerType
+      ID: 642
+      Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
+      ByteSize: 8
+      GoRuntimeType: 1.255328e+06
+      GoKind: 22
+      Pointee: 643 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+    - __kind: PointerType
+      ID: 555
+      Name: '*github.com/go-viper/mapstructure/v2.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.024384e+06
+      GoKind: 22
+      Pointee: 556 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+    - __kind: PointerType
+      ID: 553
+      Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.024256e+06
+      GoKind: 22
+      Pointee: 554 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+    - __kind: PointerType
+      ID: 557
+      Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.028352e+06
+      GoKind: 22
+      Pointee: 558 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 559
+      Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
+      ByteSize: 8
+      GoRuntimeType: 1.02848e+06
+      GoKind: 22
+      Pointee: 560 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+    - __kind: PointerType
+      ID: 766
+      Name: '*github.com/gogo/protobuf/proto.textWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.47728e+06
+      GoKind: 22
+      Pointee: 767 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+    - __kind: PointerType
+      ID: 549
+      Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.010944e+06
+      GoKind: 22
+      Pointee: 550 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 367
+      Name: '*github.com/google/uuid.invalidLengthError'
+      ByteSize: 8
+      GoRuntimeType: 840288
+      GoKind: 22
+      Pointee: 368 StructureType github.com/google/uuid.invalidLengthError
+    - __kind: PointerType
+      ID: 863
+      Name: '*github.com/json-iterator/go.Stream'
+      ByteSize: 8
+      GoRuntimeType: 2.210048e+06
+      GoKind: 22
+      Pointee: 864 UnresolvedPointeeType github.com/json-iterator/go.Stream
+    - __kind: PointerType
+      ID: 613
+      Name: '*github.com/pkg/errors.fundamental'
+      ByteSize: 8
+      GoRuntimeType: 1.13488e+06
+      GoKind: 22
+      Pointee: 614 UnresolvedPointeeType github.com/pkg/errors.fundamental
+    - __kind: PointerType
+      ID: 586
+      Name: '*github.com/tinylib/msgp/msgp.ArrayError'
+      ByteSize: 8
+      GoRuntimeType: 1.11376e+06
+      GoKind: 22
+      Pointee: 587 StructureType github.com/tinylib/msgp/msgp.ArrayError
+    - __kind: PointerType
+      ID: 580
+      Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
+      ByteSize: 8
+      GoRuntimeType: 1.113376e+06
+      GoKind: 22
+      Pointee: 581 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+    - __kind: PointerType
+      ID: 519
+      Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
+      ByteSize: 8
+      GoRuntimeType: 988928
+      GoKind: 22
+      Pointee: 520 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+    - __kind: PointerType
+      ID: 592
+      Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.114144e+06
+      GoKind: 22
+      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+    - __kind: PointerType
+      ID: 518
+      Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
+      ByteSize: 8
+      GoRuntimeType: 988800
+      GoKind: 22
+      Pointee: 497 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+    - __kind: PointerType
+      ID: 584
+      Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
+      ByteSize: 8
+      GoRuntimeType: 1.113632e+06
+      GoKind: 22
+      Pointee: 585 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+    - __kind: PointerType
+      ID: 582
+      Name: '*github.com/tinylib/msgp/msgp.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.113504e+06
+      GoKind: 22
+      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.TypeError
+    - __kind: PointerType
+      ID: 590
+      Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
+      ByteSize: 8
+      GoRuntimeType: 1.114016e+06
+      GoKind: 22
+      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+    - __kind: PointerType
+      ID: 588
+      Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.113888e+06
+      GoKind: 22
+      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+    - __kind: PointerType
+      ID: 867
+      Name: '*github.com/tinylib/msgp/msgp.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.221088e+06
+      GoKind: 22
+      Pointee: 868 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+    - __kind: PointerType
+      ID: 596
+      Name: '*github.com/tinylib/msgp/msgp.errFatal'
+      ByteSize: 8
+      GoRuntimeType: 1.114528e+06
+      GoKind: 22
+      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.errFatal
+    - __kind: PointerType
+      ID: 523
+      Name: '*github.com/tinylib/msgp/msgp.errRecursion'
+      ByteSize: 8
+      GoRuntimeType: 989184
+      GoKind: 22
+      Pointee: 524 StructureType github.com/tinylib/msgp/msgp.errRecursion
+    - __kind: PointerType
+      ID: 521
+      Name: '*github.com/tinylib/msgp/msgp.errShort'
+      ByteSize: 8
+      GoRuntimeType: 989056
+      GoKind: 22
+      Pointee: 522 StructureType github.com/tinylib/msgp/msgp.errShort
+    - __kind: PointerType
+      ID: 594
+      Name: '*github.com/tinylib/msgp/msgp.errWrapped'
+      ByteSize: 8
+      GoRuntimeType: 1.1144e+06
+      GoKind: 22
+      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.errWrapped
+    - __kind: PointerType
+      ID: 478
+      Name: '*go.opentelemetry.io/otel/trace.errorConst'
+      ByteSize: 8
+      GoRuntimeType: 870912
+      GoKind: 22
+      Pointee: 287 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+    - __kind: PointerType
+      ID: 289
+      Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
+      ByteSize: 8
+      Pointee: 288 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: PointerType
+      ID: 655
+      Name: '*go.uber.org/multierr.multiError'
+      ByteSize: 8
+      GoRuntimeType: 1.475744e+06
+      GoKind: 22
+      Pointee: 656 UnresolvedPointeeType go.uber.org/multierr.multiError
+    - __kind: PointerType
+      ID: 563
+      Name: '*go.uber.org/zap.errArrayElem'
+      ByteSize: 8
+      GoRuntimeType: 1.043328e+06
+      GoKind: 22
+      Pointee: 564 StructureType go.uber.org/zap.errArrayElem
+    - __kind: PointerType
+      ID: 743
+      Name: '*go.uber.org/zap.nopCloserSink'
+      ByteSize: 8
+      GoRuntimeType: 1.173792e+06
+      GoKind: 22
+      Pointee: 744 StructureType go.uber.org/zap.nopCloserSink
+    - __kind: PointerType
+      ID: 827
+      Name: '*go.uber.org/zap/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.006976e+06
+      GoKind: 22
+      Pointee: 828 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+    - __kind: PointerType
+      ID: 729
+      Name: '*go.uber.org/zap/zapcore.writerWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.045632e+06
+      GoKind: 22
+      Pointee: 730 StructureType go.uber.org/zap/zapcore.writerWrapper
+    - __kind: PointerType
+      ID: 479
+      Name: '*golang.org/x/net/http2.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 872160
+      GoKind: 22
+      Pointee: 290 BaseType golang.org/x/net/http2.ConnectionError
+    - __kind: PointerType
+      ID: 621
+      Name: '*golang.org/x/net/http2.StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.175456e+06
+      GoKind: 22
+      Pointee: 622 StructureType golang.org/x/net/http2.StreamError
+    - __kind: PointerType
+      ID: 482
+      Name: '*golang.org/x/net/http2.connError'
+      ByteSize: 8
+      GoRuntimeType: 872448
+      GoKind: 22
+      Pointee: 483 StructureType golang.org/x/net/http2.connError
+    - __kind: PointerType
+      ID: 481
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 872352
+      GoKind: 22
+      Pointee: 294 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 296
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 295 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 485
+      Name: '*golang.org/x/net/http2.headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 872640
+      GoKind: 22
+      Pointee: 300 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+    - __kind: PointerType
+      ID: 302
+      Name: '*golang.org/x/net/http2.headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 301 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: PointerType
+      ID: 484
+      Name: '*golang.org/x/net/http2.headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 872544
+      GoKind: 22
+      Pointee: 297 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+    - __kind: PointerType
+      ID: 299
+      Name: '*golang.org/x/net/http2.headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 298 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: PointerType
+      ID: 480
+      Name: '*golang.org/x/net/http2.pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 872256
+      GoKind: 22
+      Pointee: 291 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+    - __kind: PointerType
+      ID: 293
+      Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 292 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 825
+      Name: '*golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.005056e+06
+      GoKind: 22
+      Pointee: 826 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 486
+      Name: '*golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 872736
+      GoKind: 22
+      Pointee: 487 StructureType golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 488
+      Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 872832
+      GoKind: 22
+      Pointee: 303 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 474
+      Name: '*google.golang.org/grpc.dropError'
+      ByteSize: 8
+      GoRuntimeType: 866304
+      GoKind: 22
+      Pointee: 475 StructureType google.golang.org/grpc.dropError
+    - __kind: PointerType
+      ID: 619
+      Name: '*google.golang.org/grpc/internal/status.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.172384e+06
+      GoKind: 22
+      Pointee: 620 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+    - __kind: PointerType
+      ID: 644
+      Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 1.262688e+06
+      GoKind: 22
+      Pointee: 645 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+    - __kind: PointerType
+      ID: 476
+      Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
+      ByteSize: 8
+      GoRuntimeType: 869184
+      GoKind: 22
+      Pointee: 477 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+    - __kind: PointerType
+      ID: 790
+      Name: '*google.golang.org/grpc/internal/transport.bufConn'
+      ByteSize: 8
+      GoRuntimeType: 1.68368e+06
+      GoKind: 22
+      Pointee: 791 StructureType google.golang.org/grpc/internal/transport.bufConn
+    - __kind: PointerType
+      ID: 741
+      Name: '*google.golang.org/grpc/internal/transport.bufWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.168928e+06
+      GoKind: 22
+      Pointee: 742 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+    - __kind: PointerType
+      ID: 561
+      Name: '*google.golang.org/grpc/internal/transport.ioError'
+      ByteSize: 8
+      GoRuntimeType: 1.037568e+06
+      GoKind: 22
+      Pointee: 562 StructureType google.golang.org/grpc/internal/transport.ioError
+    - __kind: PointerType
+      ID: 701
+      Name: '*google.golang.org/grpc/mem.writer'
+      ByteSize: 8
+      GoRuntimeType: 869280
+      GoKind: 22
+      Pointee: 702 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+    - __kind: PointerType
+      ID: 454
+      Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
+      ByteSize: 8
+      GoRuntimeType: 855168
+      GoKind: 22
+      Pointee: 455 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+    - __kind: PointerType
+      ID: 551
+      Name: '*google.golang.org/protobuf/internal/errors.prefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.0144e+06
+      GoKind: 22
+      Pointee: 552 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+    - __kind: PointerType
+      ID: 617
+      Name: '*google.golang.org/protobuf/internal/errors.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.14064e+06
+      GoKind: 22
+      Pointee: 618 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+    - __kind: PointerType
+      ID: 615
+      Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
+      ByteSize: 8
+      GoRuntimeType: 1.140384e+06
+      GoKind: 22
+      Pointee: 616 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+    - __kind: PointerType
+      ID: 468
+      Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
+      ByteSize: 8
+      GoRuntimeType: 859872
+      GoKind: 22
+      Pointee: 469 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+    - __kind: PointerType
+      ID: 470
+      Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
+      ByteSize: 8
+      GoRuntimeType: 859968
+      GoKind: 22
+      Pointee: 471 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+    - __kind: PointerType
+      ID: 399
+      Name: '*gopkg.in/yaml%2ev3.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 847584
+      GoKind: 22
+      Pointee: 400 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+    - __kind: PointerType
+      ID: 778
+      Name: '*hash/crc32.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.676064e+06
+      GoKind: 22
+      Pointee: 779 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 151
       Name: '*hash<[4]int,[4]int>'
@@ -3657,30 +4936,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 257
+      ID: 903
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 258 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 904 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 287
+      ID: 933
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 288 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 934 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 296
+      ID: 942
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 297 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 943 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 95 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 305
+      ID: 951
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 306 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 952 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '*hash<int,uint8>'
@@ -3696,6 +4975,11 @@ Types:
       Name: '*hash<string,[]string>'
       ByteSize: 8
       Pointee: 110 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 648
+      Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 649 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '*hash<string,int>'
@@ -3716,6 +5000,13 @@ Types:
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
       Pointee: 137 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: PointerType
+      ID: 489
+      Name: '*html/template.Error'
+      ByteSize: 8
+      GoRuntimeType: 873600
+      GoKind: 22
+      Pointee: 490 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -3759,6 +5050,83 @@ Types:
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
+      ID: 369
+      Name: '*internal/bisect.parseError'
+      ByteSize: 8
+      GoRuntimeType: 840672
+      GoKind: 22
+      Pointee: 370 UnresolvedPointeeType internal/bisect.parseError
+    - __kind: PointerType
+      ID: 687
+      Name: '*internal/godebug.runtimeStderr'
+      ByteSize: 8
+      GoRuntimeType: 828864
+      GoKind: 22
+      Pointee: 688 UnresolvedPointeeType internal/godebug.runtimeStderr
+    - __kind: PointerType
+      ID: 578
+      Name: '*internal/poll.DeadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.112608e+06
+      GoKind: 22
+      Pointee: 579 UnresolvedPointeeType internal/poll.DeadlineExceededError
+    - __kind: PointerType
+      ID: 869
+      Name: '*internal/poll.FD'
+      ByteSize: 8
+      GoRuntimeType: 2.22576e+06
+      GoKind: 22
+      Pointee: 870 UnresolvedPointeeType internal/poll.FD
+    - __kind: PointerType
+      ID: 576
+      Name: '*internal/poll.errNetClosing'
+      ByteSize: 8
+      GoRuntimeType: 1.11248e+06
+      GoKind: 22
+      Pointee: 577 StructureType internal/poll.errNetClosing
+    - __kind: PointerType
+      ID: 306
+      Name: '*internal/reflectlite.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 828000
+      GoKind: 22
+      Pointee: 307 UnresolvedPointeeType internal/reflectlite.ValueError
+    - __kind: PointerType
+      ID: 733
+      Name: '*io.PipeWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.103648e+06
+      GoKind: 22
+      Pointee: 734 UnresolvedPointeeType io.PipeWriter
+    - __kind: PointerType
+      ID: 731
+      Name: '*io.discard'
+      ByteSize: 8
+      GoRuntimeType: 1.103264e+06
+      GoKind: 22
+      Pointee: 732 StructureType io.discard
+    - __kind: PointerType
+      ID: 705
+      Name: '*io.multiWriter'
+      ByteSize: 8
+      GoRuntimeType: 979968
+      GoKind: 22
+      Pointee: 706 UnresolvedPointeeType io.multiWriter
+    - __kind: PointerType
+      ID: 574
+      Name: '*io/fs.PathError'
+      ByteSize: 8
+      GoRuntimeType: 1.112224e+06
+      GoKind: 22
+      Pointee: 575 UnresolvedPointeeType io/fs.PathError
+    - __kind: PointerType
+      ID: 782
+      Name: '*log/slog/internal/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 1.677184e+06
+      GoKind: 22
+      Pointee: 783 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+    - __kind: PointerType
       ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
@@ -3766,12 +5134,12 @@ Types:
       GoKind: 22
       Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 262
+      ID: 908
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 263 UnresolvedPointeeType main.deepMap3
+      Pointee: 909 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -3780,19 +5148,19 @@ Types:
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 292
+      ID: 938
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 355904
       GoKind: 22
-      Pointee: 293 StructureType main.deepMap8
+      Pointee: 939 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 301
+      ID: 947
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355840
       GoKind: 22
-      Pointee: 302 StructureType main.deepMap9
+      Pointee: 948 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3801,12 +5169,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 233
+      ID: 873
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 234 UnresolvedPointeeType main.deepPtr3
+      Pointee: 874 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3815,19 +5183,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 267
+      ID: 913
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356480
       GoKind: 22
-      Pointee: 268 StructureType main.deepPtr8
+      Pointee: 914 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 269
+      ID: 915
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356416
       GoKind: 22
-      Pointee: 270 StructureType main.deepPtr9
+      Pointee: 916 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3836,12 +5204,12 @@ Types:
       GoKind: 22
       Pointee: 183 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 252
+      ID: 898
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357376
       GoKind: 22
-      Pointee: 253 UnresolvedPointeeType main.deepSlice3
+      Pointee: 899 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3850,19 +5218,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 273
+      ID: 919
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357056
       GoKind: 22
-      Pointee: 274 StructureType main.deepSlice8
+      Pointee: 920 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 279
+      ID: 925
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 356992
       GoKind: 22
-      Pointee: 280 StructureType main.deepSlice9
+      Pointee: 926 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 178
       Name: '*main.emptyStruct'
@@ -3877,6 +5245,13 @@ Types:
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
+      ID: 889
+      Name: '*main.firstBehavior'
+      ByteSize: 8
+      GoRuntimeType: 823968
+      GoKind: 22
+      Pointee: 890 StructureType main.firstBehavior
+    - __kind: PointerType
       ID: 159
       Name: '*main.node'
       ByteSize: 8
@@ -3890,22 +5265,36 @@ Types:
       GoKind: 22
       Pointee: 174 StructureType main.oneStringStruct
     - __kind: PointerType
+      ID: 891
+      Name: '*main.secondBehavior'
+      ByteSize: 8
+      GoRuntimeType: 824064
+      GoKind: 22
+      Pointee: 892 StructureType main.secondBehavior
+    - __kind: PointerType
+      ID: 878
+      Name: '*main.somethingImpl'
+      ByteSize: 8
+      GoRuntimeType: 824160
+      GoKind: 22
+      Pointee: 879 UnresolvedPointeeType main.somethingImpl
+    - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
       ByteSize: 8
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 236
+      ID: 876
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 235 GoStringDataType main.stringType1.str
+      Pointee: 875 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 237 UnresolvedPointeeType main.stringType2
+      Pointee: 877 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 206
       Name: '*main.structWithMap'
@@ -3931,10 +5320,10 @@ Types:
       GoKind: 22
       Pointee: 161 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 249
+      ID: 895
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType main.t.array
+      Pointee: 894 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 172
       Name: '*main.threeStringStruct'
@@ -3948,12 +5337,606 @@ Types:
       GoKind: 22
       Pointee: 103 GoMapType map[string]int
     - __kind: PointerType
+      ID: 403
+      Name: '*math/big.ErrNaN'
+      ByteSize: 8
+      GoRuntimeType: 848448
+      GoKind: 22
+      Pointee: 404 StructureType math/big.ErrNaN
+    - __kind: PointerType
+      ID: 695
+      Name: '*mime/multipart.writerOnly·1'
+      ByteSize: 8
+      GoRuntimeType: 843072
+      GoKind: 22
+      Pointee: 696 StructureType mime/multipart.writerOnly·1
+    - __kind: PointerType
+      ID: 605
+      Name: '*net.AddrError'
+      ByteSize: 8
+      GoRuntimeType: 1.120928e+06
+      GoKind: 22
+      Pointee: 606 UnresolvedPointeeType net.AddrError
+    - __kind: PointerType
+      ID: 631
+      Name: '*net.DNSError'
+      ByteSize: 8
+      GoRuntimeType: 1.239488e+06
+      GoKind: 22
+      Pointee: 632 UnresolvedPointeeType net.DNSError
+    - __kind: PointerType
+      ID: 833
+      Name: '*net.IPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.085792e+06
+      GoKind: 22
+      Pointee: 834 UnresolvedPointeeType net.IPConn
+    - __kind: PointerType
+      ID: 629
+      Name: '*net.OpError'
+      ByteSize: 8
+      GoRuntimeType: 1.239168e+06
+      GoKind: 22
+      Pointee: 630 UnresolvedPointeeType net.OpError
+    - __kind: PointerType
+      ID: 607
+      Name: '*net.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.121056e+06
+      GoKind: 22
+      Pointee: 608 UnresolvedPointeeType net.ParseError
+    - __kind: PointerType
+      ID: 843
+      Name: '*net.TCPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.115168e+06
+      GoKind: 22
+      Pointee: 844 UnresolvedPointeeType net.TCPConn
+    - __kind: PointerType
+      ID: 853
+      Name: '*net.UDPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.160128e+06
+      GoKind: 22
+      Pointee: 854 UnresolvedPointeeType net.UDPConn
+    - __kind: PointerType
+      ID: 841
+      Name: '*net.UnixConn'
+      ByteSize: 8
+      GoRuntimeType: 2.114656e+06
+      GoKind: 22
+      Pointee: 842 UnresolvedPointeeType net.UnixConn
+    - __kind: PointerType
+      ID: 604
+      Name: '*net.UnknownNetworkError'
+      ByteSize: 8
+      GoRuntimeType: 1.12016e+06
+      GoKind: 22
+      Pointee: 567 GoStringHeaderType net.UnknownNetworkError
+    - __kind: PointerType
+      ID: 569
+      Name: '*net.UnknownNetworkError.str'
+      ByteSize: 8
+      Pointee: 568 GoStringDataType net.UnknownNetworkError.str
+    - __kind: PointerType
+      ID: 535
+      Name: '*net.canceledError'
+      ByteSize: 8
+      GoRuntimeType: 995840
+      GoKind: 22
+      Pointee: 536 StructureType net.canceledError
+    - __kind: PointerType
+      ID: 811
+      Name: '*net.conn'
+      ByteSize: 8
+      GoRuntimeType: 1.87216e+06
+      GoKind: 22
+      Pointee: 812 UnresolvedPointeeType net.conn
+    - __kind: PointerType
+      ID: 674
+      Name: '*net.dialResult·1'
+      ByteSize: 8
+      GoRuntimeType: 1.716384e+06
+      GoKind: 22
+      Pointee: 675 StructureType net.dialResult·1
+    - __kind: PointerType
+      ID: 855
+      Name: '*net.netFD'
+      ByteSize: 8
+      GoRuntimeType: 2.164384e+06
+      GoKind: 22
+      Pointee: 856 UnresolvedPointeeType net.netFD
+    - __kind: PointerType
+      ID: 338
+      Name: '*net.notFoundError'
+      ByteSize: 8
+      GoRuntimeType: 835296
+      GoKind: 22
+      Pointee: 339 UnresolvedPointeeType net.notFoundError
+    - __kind: PointerType
+      ID: 340
+      Name: '*net.result·2'
+      ByteSize: 8
+      GoRuntimeType: 835968
+      GoKind: 22
+      Pointee: 341 StructureType net.result·2
+    - __kind: PointerType
+      ID: 837
+      Name: '*net.tcpConnWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.09968e+06
+      GoKind: 22
+      Pointee: 838 StructureType net.tcpConnWithoutReadFrom
+    - __kind: PointerType
+      ID: 835
+      Name: '*net.tcpConnWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.0992e+06
+      GoKind: 22
+      Pointee: 836 StructureType net.tcpConnWithoutWriteTo
+    - __kind: PointerType
+      ID: 609
+      Name: '*net.temporaryError'
+      ByteSize: 8
+      GoRuntimeType: 1.121696e+06
+      GoKind: 22
+      Pointee: 610 UnresolvedPointeeType net.temporaryError
+    - __kind: PointerType
+      ID: 633
+      Name: '*net.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.239648e+06
+      GoKind: 22
+      Pointee: 634 UnresolvedPointeeType net.timeoutError
+    - __kind: PointerType
+      ID: 525
+      Name: '*net/http.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 991616
+      GoKind: 22
+      Pointee: 526 UnresolvedPointeeType net/http.ProtocolError
+    - __kind: PointerType
+      ID: 689
+      Name: '*net/http.bufioFlushWriter'
+      ByteSize: 8
+      GoRuntimeType: 831168
+      GoKind: 22
+      Pointee: 690 StructureType net/http.bufioFlushWriter
+    - __kind: PointerType
+      ID: 315
+      Name: '*net/http.http2ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 831840
+      GoKind: 22
+      Pointee: 236 BaseType net/http.http2ConnectionError
+    - __kind: PointerType
+      ID: 316
+      Name: '*net/http.http2GoAwayError'
+      ByteSize: 8
+      GoRuntimeType: 831936
+      GoKind: 22
+      Pointee: 317 StructureType net/http.http2GoAwayError
+    - __kind: PointerType
+      ID: 625
+      Name: '*net/http.http2StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.235328e+06
+      GoKind: 22
+      Pointee: 626 StructureType net/http.http2StreamError
+    - __kind: PointerType
+      ID: 320
+      Name: '*net/http.http2connError'
+      ByteSize: 8
+      GoRuntimeType: 832416
+      GoKind: 22
+      Pointee: 321 StructureType net/http.http2connError
+    - __kind: PointerType
+      ID: 751
+      Name: '*net/http.http2dataBuffer'
+      ByteSize: 8
+      GoRuntimeType: 1.36608e+06
+      GoKind: 22
+      Pointee: 752 UnresolvedPointeeType net/http.http2dataBuffer
+    - __kind: PointerType
+      ID: 319
+      Name: '*net/http.http2duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 832320
+      GoKind: 22
+      Pointee: 240 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 242
+      Name: '*net/http.http2duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 241 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 323
+      Name: '*net/http.http2headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 832608
+      GoKind: 22
+      Pointee: 246 GoStringHeaderType net/http.http2headerFieldNameError
+    - __kind: PointerType
+      ID: 248
+      Name: '*net/http.http2headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 247 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: PointerType
+      ID: 322
+      Name: '*net/http.http2headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 832512
+      GoKind: 22
+      Pointee: 243 GoStringHeaderType net/http.http2headerFieldValueError
+    - __kind: PointerType
+      ID: 245
+      Name: '*net/http.http2headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 244 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: PointerType
+      ID: 600
+      Name: '*net/http.http2httpError'
+      ByteSize: 8
+      GoRuntimeType: 1.116704e+06
+      GoKind: 22
+      Pointee: 601 UnresolvedPointeeType net/http.http2httpError
+    - __kind: PointerType
+      ID: 531
+      Name: '*net/http.http2noCachedConnError'
+      ByteSize: 8
+      GoRuntimeType: 992256
+      GoKind: 22
+      Pointee: 532 StructureType net/http.http2noCachedConnError
+    - __kind: PointerType
+      ID: 802
+      Name: '*net/http.http2pipe'
+      ByteSize: 8
+      GoRuntimeType: 1.81616e+06
+      GoKind: 22
+      Pointee: 803 UnresolvedPointeeType net/http.http2pipe
+    - __kind: PointerType
+      ID: 318
+      Name: '*net/http.http2pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 832224
+      GoKind: 22
+      Pointee: 237 GoStringHeaderType net/http.http2pseudoHeaderError
+    - __kind: PointerType
+      ID: 239
+      Name: '*net/http.http2pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 238 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 691
+      Name: '*net/http.http2stickyErrWriter'
+      ByteSize: 8
+      GoRuntimeType: 832704
+      GoKind: 22
+      Pointee: 692 StructureType net/http.http2stickyErrWriter
+    - __kind: PointerType
+      ID: 527
+      Name: '*net/http.nothingWrittenError'
+      ByteSize: 8
+      GoRuntimeType: 991872
+      GoKind: 22
+      Pointee: 528 StructureType net/http.nothingWrittenError
+    - __kind: PointerType
+      ID: 753
+      Name: '*net/http.persistConn'
+      ByteSize: 8
+      GoRuntimeType: 2.030112e+06
+      GoKind: 22
+      Pointee: 754 UnresolvedPointeeType net/http.persistConn
+    - __kind: PointerType
+      ID: 709
+      Name: '*net/http.persistConnWriter'
+      ByteSize: 8
+      GoRuntimeType: 991744
+      GoKind: 22
+      Pointee: 710 StructureType net/http.persistConnWriter
+    - __kind: PointerType
+      ID: 735
+      Name: '*net/http.readWriteCloserBody'
+      ByteSize: 8
+      GoRuntimeType: 1.11568e+06
+      GoKind: 22
+      Pointee: 736 StructureType net/http.readWriteCloserBody
+    - __kind: PointerType
+      ID: 324
+      Name: '*net/http.requestBodyReadError'
+      ByteSize: 8
+      GoRuntimeType: 832800
+      GoKind: 22
+      Pointee: 325 StructureType net/http.requestBodyReadError
+    - __kind: PointerType
+      ID: 627
+      Name: '*net/http.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.236448e+06
+      GoKind: 22
+      Pointee: 628 UnresolvedPointeeType net/http.timeoutError
+    - __kind: PointerType
+      ID: 598
+      Name: '*net/http.tlsHandshakeTimeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.116576e+06
+      GoKind: 22
+      Pointee: 599 StructureType net/http.tlsHandshakeTimeoutError
+    - __kind: PointerType
+      ID: 529
+      Name: '*net/http.transportReadFromServerError'
+      ByteSize: 8
+      GoRuntimeType: 992000
+      GoKind: 22
+      Pointee: 530 StructureType net/http.transportReadFromServerError
+    - __kind: PointerType
+      ID: 313
+      Name: '*net/http.unsupportedTEError'
+      ByteSize: 8
+      GoRuntimeType: 831072
+      GoKind: 22
+      Pointee: 314 UnresolvedPointeeType net/http.unsupportedTEError
+    - __kind: PointerType
+      ID: 804
+      Name: '*net/http/internal.FlushAfterChunkWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.817696e+06
+      GoKind: 22
+      Pointee: 805 StructureType net/http/internal.FlushAfterChunkWriter
+    - __kind: PointerType
+      ID: 719
+      Name: '*net/http/internal.chunkedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.005312e+06
+      GoKind: 22
+      Pointee: 720 UnresolvedPointeeType net/http/internal.chunkedWriter
+    - __kind: PointerType
+      ID: 395
+      Name: '*net/netip.parseAddrError'
+      ByteSize: 8
+      GoRuntimeType: 847392
+      GoKind: 22
+      Pointee: 396 StructureType net/netip.parseAddrError
+    - __kind: PointerType
+      ID: 393
+      Name: '*net/netip.parsePrefixError'
+      ByteSize: 8
+      GoRuntimeType: 847296
+      GoKind: 22
+      Pointee: 394 StructureType net/netip.parsePrefixError
+    - __kind: PointerType
+      ID: 761
+      Name: '*net/smtp.Client'
+      ByteSize: 8
+      GoRuntimeType: 1.979776e+06
+      GoKind: 22
+      Pointee: 762 UnresolvedPointeeType net/smtp.Client
+    - __kind: PointerType
+      ID: 721
+      Name: '*net/smtp.dataCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.010432e+06
+      GoKind: 22
+      Pointee: 722 StructureType net/smtp.dataCloser
+    - __kind: PointerType
+      ID: 379
+      Name: '*net/textproto.Error'
+      ByteSize: 8
+      GoRuntimeType: 843264
+      GoKind: 22
+      Pointee: 380 UnresolvedPointeeType net/textproto.Error
+    - __kind: PointerType
+      ID: 378
+      Name: '*net/textproto.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 843168
+      GoKind: 22
+      Pointee: 271 GoStringHeaderType net/textproto.ProtocolError
+    - __kind: PointerType
+      ID: 273
+      Name: '*net/textproto.ProtocolError.str'
+      ByteSize: 8
+      Pointee: 272 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: PointerType
+      ID: 717
+      Name: '*net/textproto.dotWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.004672e+06
+      GoKind: 22
+      Pointee: 718 UnresolvedPointeeType net/textproto.dotWriter
+    - __kind: PointerType
+      ID: 635
+      Name: '*net/url.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.239968e+06
+      GoKind: 22
+      Pointee: 636 UnresolvedPointeeType net/url.Error
+    - __kind: PointerType
+      ID: 342
+      Name: '*net/url.EscapeError'
+      ByteSize: 8
+      GoRuntimeType: 836064
+      GoKind: 22
+      Pointee: 249 GoStringHeaderType net/url.EscapeError
+    - __kind: PointerType
+      ID: 251
+      Name: '*net/url.EscapeError.str'
+      ByteSize: 8
+      Pointee: 250 GoStringDataType net/url.EscapeError.str
+    - __kind: PointerType
+      ID: 343
+      Name: '*net/url.InvalidHostError'
+      ByteSize: 8
+      GoRuntimeType: 836160
+      GoKind: 22
+      Pointee: 252 GoStringHeaderType net/url.InvalidHostError
+    - __kind: PointerType
+      ID: 254
+      Name: '*net/url.InvalidHostError.str'
+      ByteSize: 8
+      Pointee: 253 GoStringDataType net/url.InvalidHostError.str
+    - __kind: PointerType
+      ID: 861
+      Name: '*os.File'
+      ByteSize: 8
+      GoRuntimeType: 2.201632e+06
+      GoKind: 22
+      Pointee: 862 UnresolvedPointeeType os.File
+    - __kind: PointerType
+      ID: 506
+      Name: '*os.LinkError'
+      ByteSize: 8
+      GoRuntimeType: 982784
+      GoKind: 22
+      Pointee: 507 UnresolvedPointeeType os.LinkError
+    - __kind: PointerType
+      ID: 570
+      Name: '*os.SyscallError'
+      ByteSize: 8
+      GoRuntimeType: 1.105184e+06
+      GoKind: 22
+      Pointee: 571 UnresolvedPointeeType os.SyscallError
+    - __kind: PointerType
+      ID: 859
+      Name: '*os.fileWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.198688e+06
+      GoKind: 22
+      Pointee: 860 StructureType os.fileWithoutReadFrom
+    - __kind: PointerType
+      ID: 857
+      Name: '*os.fileWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.197952e+06
+      GoKind: 22
+      Pointee: 858 StructureType os.fileWithoutWriteTo
+    - __kind: PointerType
+      ID: 537
+      Name: '*os/exec.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.001344e+06
+      GoKind: 22
+      Pointee: 538 UnresolvedPointeeType os/exec.Error
+    - __kind: PointerType
+      ID: 677
+      Name: '*os/exec.ExitError'
+      ByteSize: 8
+      GoRuntimeType: 1.951744e+06
+      GoKind: 22
+      Pointee: 678 UnresolvedPointeeType os/exec.ExitError
+    - __kind: PointerType
+      ID: 739
+      Name: '*os/exec.prefixSuffixSaver'
+      ByteSize: 8
+      GoRuntimeType: 1.127712e+06
+      GoKind: 22
+      Pointee: 740 UnresolvedPointeeType os/exec.prefixSuffixSaver
+    - __kind: PointerType
+      ID: 539
+      Name: '*os/exec.wrappedError'
+      ByteSize: 8
+      GoRuntimeType: 1.001472e+06
+      GoKind: 22
+      Pointee: 540 StructureType os/exec.wrappedError
+    - __kind: PointerType
+      ID: 473
+      Name: '*os/user.UnknownGroupIdError'
+      ByteSize: 8
+      GoRuntimeType: 864384
+      GoKind: 22
+      Pointee: 284 GoStringHeaderType os/user.UnknownGroupIdError
+    - __kind: PointerType
+      ID: 286
+      Name: '*os/user.UnknownGroupIdError.str'
+      ByteSize: 8
+      Pointee: 285 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: PointerType
+      ID: 472
+      Name: '*os/user.UnknownUserIdError'
+      ByteSize: 8
+      GoRuntimeType: 864288
+      GoKind: 22
+      Pointee: 283 BaseType os/user.UnknownUserIdError
+    - __kind: PointerType
+      ID: 308
+      Name: '*reflect.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 828768
+      GoKind: 22
+      Pointee: 309 UnresolvedPointeeType reflect.ValueError
+    - __kind: PointerType
+      ID: 401
+      Name: '*regexp/syntax.Error'
+      ByteSize: 8
+      GoRuntimeType: 848064
+      GoKind: 22
+      Pointee: 402 UnresolvedPointeeType regexp/syntax.Error
+    - __kind: PointerType
+      ID: 509
+      Name: '*runtime.PanicNilError'
+      ByteSize: 8
+      GoRuntimeType: 984320
+      GoKind: 22
+      Pointee: 510 UnresolvedPointeeType runtime.PanicNilError
+    - __kind: PointerType
+      ID: 514
+      Name: '*runtime.TypeAssertionError'
+      ByteSize: 8
+      GoRuntimeType: 986240
+      GoKind: 22
+      Pointee: 515 UnresolvedPointeeType runtime.TypeAssertionError
+    - __kind: PointerType
+      ID: 511
+      Name: '*runtime.boundsError'
+      ByteSize: 8
+      GoRuntimeType: 984448
+      GoKind: 22
+      Pointee: 512 StructureType runtime.boundsError
+    - __kind: PointerType
+      ID: 572
+      Name: '*runtime.errorAddressString'
+      ByteSize: 8
+      GoRuntimeType: 1.11056e+06
+      GoKind: 22
+      Pointee: 573 StructureType runtime.errorAddressString
+    - __kind: PointerType
+      ID: 508
+      Name: '*runtime.errorString'
+      ByteSize: 8
+      GoRuntimeType: 984064
+      GoKind: 22
+      Pointee: 491 GoStringHeaderType runtime.errorString
+    - __kind: PointerType
+      ID: 493
+      Name: '*runtime.errorString.str'
+      ByteSize: 8
+      Pointee: 492 GoStringDataType runtime.errorString.str
+    - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 366528
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
+    - __kind: PointerType
+      ID: 513
+      Name: '*runtime.plainError'
+      ByteSize: 8
+      GoRuntimeType: 985984
+      GoKind: 22
+      Pointee: 494 GoStringHeaderType runtime.plainError
+    - __kind: PointerType
+      ID: 496
+      Name: '*runtime.plainError.str'
+      ByteSize: 8
+      Pointee: 495 GoStringDataType runtime.plainError.str
+    - __kind: PointerType
+      ID: 516
+      Name: '*strconv.NumError'
+      ByteSize: 8
+      GoRuntimeType: 986496
+      GoKind: 22
+      Pointee: 517 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3966,6 +5949,74 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 179 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 800
+      Name: '*strings.Builder'
+      ByteSize: 8
+      GoRuntimeType: 1.81488e+06
+      GoKind: 22
+      Pointee: 801 UnresolvedPointeeType strings.Builder
+    - __kind: PointerType
+      ID: 707
+      Name: '*strings.appendSliceWriter'
+      ByteSize: 8
+      GoRuntimeType: 986624
+      GoKind: 22
+      Pointee: 708 UnresolvedPointeeType strings.appendSliceWriter
+    - __kind: PointerType
+      ID: 703
+      Name: '*struct { io.Writer }'
+      ByteSize: 8
+      GoRuntimeType: 919904
+      GoKind: 22
+      Pointee: 704 StructureType struct { io.Writer }
+    - __kind: PointerType
+      ID: 624
+      Name: '*syscall.Errno'
+      ByteSize: 8
+      GoRuntimeType: 1.234688e+06
+      GoKind: 22
+      Pointee: 623 BaseType syscall.Errno
+    - __kind: PointerType
+      ID: 831
+      Name: '*text/tabwriter.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.017728e+06
+      GoKind: 22
+      Pointee: 832 UnresolvedPointeeType text/tabwriter.Writer
+    - __kind: PointerType
+      ID: 565
+      Name: '*text/template.ExecError'
+      ByteSize: 8
+      GoRuntimeType: 1.047168e+06
+      GoKind: 22
+      Pointee: 566 StructureType text/template.ExecError
+    - __kind: PointerType
+      ID: 640
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.4312e+06
+      GoKind: 22
+      Pointee: 641 UnresolvedPointeeType time.Location
+    - __kind: PointerType
+      ID: 311
+      Name: '*time.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 829632
+      GoKind: 22
+      Pointee: 312 UnresolvedPointeeType time.ParseError
+    - __kind: PointerType
+      ID: 310
+      Name: '*time.fileSizeError'
+      ByteSize: 8
+      GoRuntimeType: 829536
+      GoKind: 22
+      Pointee: 233 GoStringHeaderType time.fileSizeError
+    - __kind: PointerType
+      ID: 235
+      Name: '*time.fileSizeError.str'
+      ByteSize: 8
+      Pointee: 234 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4008,11 +6059,60 @@ Types:
       GoRuntimeType: 363328
       GoKind: 22
       Pointee: 1 BaseType uintptr
+    - __kind: PointerType
+      ID: 794
+      Name: '*vendor/golang.org/x/crypto/sha3.state'
+      ByteSize: 8
+      GoRuntimeType: 1.771136e+06
+      GoKind: 22
+      Pointee: 795 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+    - __kind: PointerType
+      ID: 397
+      Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
+      ByteSize: 8
+      GoRuntimeType: 847488
+      GoKind: 22
+      Pointee: 398 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+    - __kind: PointerType
+      ID: 823
+      Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 1.994304e+06
+      GoKind: 22
+      Pointee: 824 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 381
+      Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 843648
+      GoKind: 22
+      Pointee: 382 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 383
+      Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 843744
+      GoKind: 22
+      Pointee: 274 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 544
+      Name: '*vendor/golang.org/x/net/idna.labelError'
+      ByteSize: 8
+      GoRuntimeType: 1.005056e+06
+      GoKind: 22
+      Pointee: 545 StructureType vendor/golang.org/x/net/idna.labelError
+    - __kind: PointerType
+      ID: 546
+      Name: '*vendor/golang.org/x/net/idna.runeError'
+      ByteSize: 8
+      GoRuntimeType: 1.005184e+06
+      GoKind: 22
+      Pointee: 499 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 408
+      ID: 1054
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 365
+      ID: 1011
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4027,7 +6127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 1009
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4042,7 +6142,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
+      ID: 973
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4057,7 +6157,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 325
+      ID: 971
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4072,7 +6172,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 373
+      ID: 1019
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4087,7 +6187,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
+      ID: 972
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4102,7 +6202,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 345
+      ID: 991
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4117,7 +6217,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 314
+      ID: 960
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4132,7 +6232,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 311
+      ID: 957
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4147,7 +6247,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 389
+      ID: 1035
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4162,7 +6262,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 387
+      ID: 1033
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4195,7 +6295,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 397
+      ID: 1043
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4210,7 +6310,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 996
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4225,7 +6325,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 997
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4240,7 +6340,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 992
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4255,7 +6355,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 993
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4270,7 +6370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 348
+      ID: 994
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4285,7 +6385,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 349
+      ID: 995
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4300,7 +6400,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 402
+      ID: 1048
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4324,7 +6424,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 399
+      ID: 1045
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4339,7 +6439,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 416
+      ID: 1062
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4354,7 +6454,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 419
+      ID: 1065
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4369,7 +6469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 418
+      ID: 1064
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4384,7 +6484,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 364
+      ID: 1010
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4399,7 +6499,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 355
+      ID: 1001
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4414,7 +6514,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 1000
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4429,7 +6529,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 361
+      ID: 1007
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4444,7 +6544,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 360
+      ID: 1006
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4459,7 +6559,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 356
+      ID: 1002
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4474,7 +6574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 358
+      ID: 1004
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4489,10 +6589,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 421
+      ID: 1067
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 357
+      ID: 1003
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4516,16 +6616,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 1068
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 423
+      ID: 1069
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 359
+      ID: 1005
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 420
+      ID: 1066
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4540,7 +6640,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 424
+      ID: 1070
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4555,7 +6655,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 425
+      ID: 1071
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4570,7 +6670,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 317
+      ID: 963
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4585,7 +6685,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 318
+      ID: 964
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4600,7 +6700,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 965
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4615,7 +6715,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 316
+      ID: 962
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4630,7 +6730,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 315
+      ID: 961
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4645,7 +6745,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 362
+      ID: 1008
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4660,7 +6760,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 391
+      ID: 1037
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4675,7 +6775,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 371
+      ID: 1017
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4690,7 +6790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 377
+      ID: 1023
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4705,7 +6805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 1021
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4720,7 +6820,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 386
+      ID: 1032
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4735,7 +6835,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 385
+      ID: 1031
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4750,7 +6850,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 376
+      ID: 1022
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4765,7 +6865,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 384
+      ID: 1030
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4780,7 +6880,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 383
+      ID: 1029
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4795,7 +6895,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 369
+      ID: 1015
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4810,7 +6910,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 370
+      ID: 1016
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4825,7 +6925,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 368
+      ID: 1014
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4840,7 +6940,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 1024
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4855,7 +6955,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 1028
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4870,7 +6970,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 1027
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4885,7 +6985,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 1026
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4900,7 +7000,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 379
+      ID: 1025
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4915,7 +7015,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 414
+      ID: 1060
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4930,7 +7030,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 388
+      ID: 1034
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4981,7 +7081,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 396
+      ID: 1042
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5005,7 +7105,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 403
+      ID: 1049
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5029,7 +7129,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 405
+      ID: 1051
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5062,7 +7162,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 406
+      ID: 1052
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5077,7 +7177,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 413
+      ID: 1059
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5092,7 +7192,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 392
+      ID: 1038
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5107,7 +7207,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 1020
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5122,7 +7222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 390
+      ID: 1036
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5137,7 +7237,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 958
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5152,7 +7252,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 977
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5167,7 +7267,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 329
+      ID: 975
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5182,7 +7282,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 342
+      ID: 988
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5197,7 +7297,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 343
+      ID: 989
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5212,7 +7312,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 980
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5227,7 +7327,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 335
+      ID: 981
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5242,7 +7342,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 336
+      ID: 982
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5257,7 +7357,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 979
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5272,7 +7372,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 332
+      ID: 978
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5287,7 +7387,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 976
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5302,7 +7402,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 409
+      ID: 1055
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5317,7 +7417,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 339
+      ID: 985
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5332,7 +7432,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 340
+      ID: 986
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5347,7 +7447,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 341
+      ID: 987
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5362,7 +7462,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 984
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5377,7 +7477,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 337
+      ID: 983
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5392,7 +7492,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 400
+      ID: 1046
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5407,7 +7507,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 372
+      ID: 1018
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5422,7 +7522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
+      ID: 959
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5437,7 +7537,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 395
+      ID: 1041
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5452,7 +7552,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 404
+      ID: 1050
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5467,7 +7567,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 352
+      ID: 998
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5482,7 +7582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 999
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5497,7 +7597,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 401
+      ID: 1047
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5521,7 +7621,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 1012
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5536,7 +7636,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 367
+      ID: 1013
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5551,7 +7651,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 417
+      ID: 1063
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5566,7 +7666,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 412
+      ID: 1058
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5581,7 +7681,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 411
+      ID: 1057
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5596,7 +7696,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 410
+      ID: 1056
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5629,7 +7729,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 344
+      ID: 990
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5644,7 +7744,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 322
+      ID: 968
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5659,7 +7759,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 323
+      ID: 969
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5674,7 +7774,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 970
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5689,7 +7789,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 321
+      ID: 967
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5704,7 +7804,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 320
+      ID: 966
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5719,7 +7819,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 394
+      ID: 1040
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5734,7 +7834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 398
+      ID: 1044
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5749,7 +7849,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 415
+      ID: 1061
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5764,7 +7864,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 393
+      ID: 1039
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5779,7 +7879,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 974
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5794,7 +7894,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 407
+      ID: 1053
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5968,6 +8068,15 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
+      ID: 669
+      Name: '[5]uint8'
+      ByteSize: 5
+      GoRuntimeType: 623904
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 3 BaseType uint8
+    - __kind: ArrayType
       ID: 186
       Name: '[8]uint8'
       ByteSize: 8
@@ -5999,7 +8108,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 250
+      ID: 896
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446848
@@ -6007,21 +8116,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 251 PointerType **main.deepSlice3
+          Type: 897 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 254 GoSliceDataType []*main.deepSlice3.array
+      Data: 900 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 900
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 252 PointerType *main.deepSlice3
+      Element: 898 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 271
+      ID: 917
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446528
@@ -6029,21 +8138,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 272 PointerType **main.deepSlice8
+          Type: 918 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 275 GoSliceDataType []*main.deepSlice8.array
+      Data: 921 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 921
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 273 PointerType *main.deepSlice8
+      Element: 919 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 277
+      ID: 923
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446464
@@ -6051,19 +8160,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 278 PointerType **main.deepSlice9
+          Type: 924 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 281 GoSliceDataType []*main.deepSlice9.array
+      Data: 927 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 927
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 279 PointerType *main.deepSlice9
+      Element: 925 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6155,30 +8264,30 @@ Types:
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 910
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 260 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 906 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 940
       Name: '[]bucket<int,*main.deepMap8>.array'
       ByteSize: 2048
-      Element: 290 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 936 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 303
+      ID: 949
       Name: '[]bucket<int,*main.deepMap9>.array'
       ByteSize: 2048
-      Element: 299 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 945 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 193
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 97 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 310
+      ID: 956
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
-      Element: 308 GoHMapBucketType bucket<int,interface {}>
+      Element: 954 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
       ID: 212
       Name: '[]bucket<int,uint8>.array'
@@ -6194,6 +8303,11 @@ Types:
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 112 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 680
+      Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
+      ByteSize: 2048
+      Element: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 197
       Name: '[]bucket<string,int>.array'
@@ -6215,7 +8329,29 @@ Types:
       ByteSize: 2048
       Element: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 283
+      ID: 664
+      Name: '[]float64'
+      ByteSize: 24
+      GoRuntimeType: 454080
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 25 PointerType *float64
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 683 GoSliceDataType []float64.array
+    - __kind: GoSliceDataType
+      ID: 683
+      Name: '[]float64.array'
+      ByteSize: 2048
+      Element: 17 BaseType float64
+    - __kind: GoSliceHeaderType
+      ID: 929
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454528
@@ -6230,9 +8366,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 284 GoSliceDataType []interface {}.array
+      Data: 930 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 930
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
@@ -6294,9 +8430,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 265 GoSliceDataType []main.structWithMap.array
+      Data: 911 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 911
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 92 StructureType main.structWithMap
@@ -6387,6 +8523,28 @@ Types:
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
+    - __kind: GoSliceHeaderType
+      ID: 658
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 453056
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 681 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 681
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 3 BaseType uint8
     - __kind: ArrayType
       ID: 188
       Name: '[]val<*main.deepMap2>'
@@ -6395,26 +8553,26 @@ Types:
       HasCount: true
       Element: 189 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 261
+      ID: 907
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 262 PointerType *main.deepMap3
+      Element: 908 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 291
+      ID: 937
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 292 PointerType *main.deepMap8
+      Element: 938 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 300
+      ID: 946
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 301 PointerType *main.deepMap9
+      Element: 947 PointerType *main.deepMap9
     - __kind: ArrayType
       ID: 202
       Name: '[]val<[2]int>'
@@ -6444,6 +8602,13 @@ Types:
       HasCount: true
       Element: 168 GoSliceHeaderType []string
     - __kind: ArrayType
+      ID: 679
+      Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: ArrayType
       ID: 192
       Name: '[]val<int>'
       ByteSize: 64
@@ -6451,7 +8616,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 309
+      ID: 955
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
@@ -6478,6 +8643,64 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 810
+      Name: archive/tar.Writer
+      ByteSize: 8
+    - __kind: GoSliceHeaderType
+      ID: 459
+      Name: archive/tar.headerError
+      ByteSize: 24
+      GoRuntimeType: 858432
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 22 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 460 GoSliceDataType archive/tar.headerError.array
+    - __kind: GoSliceDataType
+      ID: 460
+      Name: archive/tar.headerError.array
+      ByteSize: 2048
+      Element: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 750
+      Name: archive/tar.regFileWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 698
+      Name: archive/zip.countWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 700
+      Name: archive/zip.dirWriter
+      GoRuntimeType: 1.078272e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 797
+      Name: archive/zip.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 726
+      Name: archive/zip.nopCloser
+      ByteSize: 16
+      GoRuntimeType: 1.37616e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 728
+      Name: archive/zip.pooledFlateWriter
+      ByteSize: 8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -6580,7 +8803,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 189 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 260
+      ID: 906
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
@@ -6592,14 +8815,14 @@ Types:
           Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 261 ArrayType []val<*main.deepMap3>
+          Type: 907 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 259 PointerType *bucket<int,*main.deepMap3>
+          Type: 905 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 262 PointerType *main.deepMap3
+      ValueType: 908 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 290
+      ID: 936
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
@@ -6611,14 +8834,14 @@ Types:
           Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 291 ArrayType []val<*main.deepMap8>
+          Type: 937 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 289 PointerType *bucket<int,*main.deepMap8>
+          Type: 935 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 292 PointerType *main.deepMap8
+      ValueType: 938 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 299
+      ID: 945
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
@@ -6630,12 +8853,12 @@ Types:
           Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 300 ArrayType []val<*main.deepMap9>
+          Type: 946 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 298 PointerType *bucket<int,*main.deepMap9>
+          Type: 944 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 301 PointerType *main.deepMap9
+      ValueType: 947 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 97
       Name: bucket<int,int>
@@ -6656,7 +8879,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 308
+      ID: 954
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
@@ -6668,10 +8891,10 @@ Types:
           Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 309 ArrayType []val<interface {}>
+          Type: 955 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 307 PointerType *bucket<int,interface {}>
+          Type: 953 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -6731,6 +8954,25 @@ Types:
           Type: 111 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 168 GoSliceHeaderType []string
+    - __kind: GoHMapBucketType
+      ID: 651
+      Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 186 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 194 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 679 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: overflow
+          Offset: 328
+          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 107
       Name: bucket<string,int>
@@ -6807,6 +9049,18 @@ Types:
           Type: 138 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 774
+      Name: bufio.Reader
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 799
+      Name: bufio.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 846
+      Name: bytes.Buffer
+      ByteSize: 8
     - __kind: GoChannelType
       ID: 155
       Name: chan bool
@@ -6829,6 +9083,337 @@ Types:
       ByteSize: 8
       GoRuntimeType: 532064
       GoKind: 15
+    - __kind: BaseType
+      ID: 266
+      Name: compress/flate.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 764544
+      GoKind: 6
+    - __kind: GoStringHeaderType
+      ID: 267
+      Name: compress/flate.InternalError
+      ByteSize: 16
+      GoRuntimeType: 764640
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 269 PointerType *compress/flate.InternalError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 268 GoStringDataType compress/flate.InternalError.str
+    - __kind: GoStringDataType
+      ID: 268
+      Name: compress/flate.InternalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 748
+      Name: compress/flate.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 694
+      Name: compress/flate.dictWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 770
+      Name: compress/gzip.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 603
+      Name: context.deadlineExceededError
+      GoRuntimeType: 1.296096e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 280
+      Name: crypto/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 767136
+      GoKind: 2
+    - __kind: BaseType
+      ID: 281
+      Name: crypto/des.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 767232
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 760
+      Name: crypto/hmac.hmac
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 785
+      Name: crypto/md5.digest
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 282
+      Name: crypto/rc4.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 767328
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 793
+      Name: crypto/sha1.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 787
+      Name: crypto/sha256.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 789
+      Name: crypto/sha512.digest
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 270
+      Name: crypto/tls.AlertError
+      ByteSize: 1
+      GoRuntimeType: 765120
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 543
+      Name: crypto/tls.CertificateVerificationError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 872
+      Name: crypto/tls.Conn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 376
+      Name: crypto/tls.ECHRejectionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 374
+      Name: crypto/tls.RecordHeaderError
+      ByteSize: 40
+      GoRuntimeType: 1.60448e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: RecordHeader
+          Offset: 16
+          Type: 669 ArrayType [5]uint8
+        - Name: Conn
+          Offset: 24
+          Type: 670 GoInterfaceType net.Conn
+    - __kind: BaseType
+      ID: 498
+      Name: crypto/tls.alert
+      ByteSize: 1
+      GoRuntimeType: 951296
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 758
+      Name: crypto/tls.cthWrapper
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 765
+      Name: crypto/tls.finishedHash
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 638
+      Name: crypto/tls.permanentError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 653
+      Name: crypto/x509.Certificate
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 448
+      Name: crypto/x509.CertificateInvalidError
+      ByteSize: 32
+      GoRuntimeType: 1.607552e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 652 PointerType *crypto/x509.Certificate
+        - Name: Reason
+          Offset: 8
+          Type: 672 BaseType crypto/x509.InvalidReason
+        - Name: Detail
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 442
+      Name: crypto/x509.ConstraintViolationError
+      GoRuntimeType: 1.075584e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 444
+      Name: crypto/x509.HostnameError
+      ByteSize: 24
+      GoRuntimeType: 1.408512e+06
+      GoKind: 25
+      RawFields:
+        - Name: Certificate
+          Offset: 0
+          Type: 652 PointerType *crypto/x509.Certificate
+        - Name: Host
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 279
+      Name: crypto/x509.InsecureAlgorithmError
+      ByteSize: 8
+      GoRuntimeType: 766752
+      GoKind: 2
+    - __kind: BaseType
+      ID: 672
+      Name: crypto/x509.InvalidReason
+      ByteSize: 8
+      GoRuntimeType: 537568
+      GoKind: 2
+    - __kind: StructureType
+      ID: 548
+      Name: crypto/x509.SystemRootsError
+      ByteSize: 16
+      GoRuntimeType: 1.37248e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 450
+      Name: crypto/x509.UnhandledCriticalExtension
+      GoRuntimeType: 1.07584e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 446
+      Name: crypto/x509.UnknownAuthorityError
+      ByteSize: 32
+      GoRuntimeType: 1.60736e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 652 PointerType *crypto/x509.Certificate
+        - Name: hintErr
+          Offset: 8
+          Type: 18 GoInterfaceType error
+        - Name: hintCert
+          Offset: 24
+          Type: 652 PointerType *crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 463
+      Name: encoding/asn1.StructuralError
+      ByteSize: 16
+      GoRuntimeType: 1.253568e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 467
+      Name: encoding/asn1.SyntaxError
+      ByteSize: 16
+      GoRuntimeType: 1.253728e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 465
+      Name: encoding/asn1.invalidUnmarshalError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 264
+      Name: encoding/base64.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 764160
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 716
+      Name: encoding/base64.encoder
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 265
+      Name: encoding/hex.InvalidByteError
+      ByteSize: 1
+      GoRuntimeType: 764352
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 335
+      Name: encoding/json.InvalidUnmarshalError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 534
+      Name: encoding/json.MarshalerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 327
+      Name: encoding/json.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 333
+      Name: encoding/json.UnmarshalTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 331
+      Name: encoding/json.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 329
+      Name: encoding/json.UnsupportedValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 852
+      Name: encoding/json.encodeState
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 337
+      Name: encoding/json.jsonError
+      ByteSize: 16
+      GoRuntimeType: 1.238208e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 724
+      Name: encoding/pem.lineBreaker
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 436
+      Name: encoding/xml.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 434
+      Name: encoding/xml.TagPathError
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 276
+      Name: encoding/xml.UnmarshalError
+      ByteSize: 16
+      GoRuntimeType: 766656
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 278 PointerType *encoding/xml.UnmarshalError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 277 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: GoStringDataType
+      ID: 277
+      Name: encoding/xml.UnmarshalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 439
+      Name: encoding/xml.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 830
+      Name: encoding/xml.printer
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 18
       Name: error
@@ -6842,6 +9427,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 305
+      Name: errors.errorString
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 501
+      Name: errors.joinError
+      ByteSize: 8
     - __kind: BaseType
       ID: 16
       Name: float32
@@ -6854,12 +9447,1066 @@ Types:
       ByteSize: 8
       GoRuntimeType: 532256
       GoKind: 14
+    - __kind: UnresolvedPointeeType
+      ID: 840
+      Name: fmt.pp
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 503
+      Name: fmt.wrapError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 505
+      Name: fmt.wrapErrors
+      ByteSize: 8
     - __kind: GoSubroutineType
       ID: 85
       Name: func()
       ByteSize: 8
       GoRuntimeType: 445248
       GoKind: 19
+    - __kind: UnresolvedPointeeType
+      ID: 365
+      Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 346
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      ByteSize: 216
+      GoRuntimeType: 1.602752e+06
+      GoKind: 25
+      RawFields:
+        - Name: Metric
+          Offset: 0
+          Type: 662 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+        - Name: ChannelSize
+          Offset: 192
+          Type: 9 BaseType int
+        - Name: Msg
+          Offset: 200
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 348
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 666
+      Name: github.com/DataDog/datadog-go/v5/statsd.Event
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 352
+      Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      GoRuntimeType: 1.072e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 668
+      Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 258
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      ByteSize: 16
+      GoRuntimeType: 763584
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 260 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 259 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: GoStringDataType
+      ID: 259
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 662
+      Name: github.com/DataDog/datadog-go/v5/statsd.metric
+      ByteSize: 192
+      GoRuntimeType: 2.073568e+06
+      GoKind: 25
+      RawFields:
+        - Name: metricType
+          Offset: 0
+          Type: 663 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+        - Name: namespace
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+        - Name: globalTags
+          Offset: 24
+          Type: 168 GoSliceHeaderType []string
+        - Name: name
+          Offset: 48
+          Type: 11 GoStringHeaderType string
+        - Name: fvalue
+          Offset: 64
+          Type: 17 BaseType float64
+        - Name: fvalues
+          Offset: 72
+          Type: 664 GoSliceHeaderType []float64
+        - Name: ivalue
+          Offset: 96
+          Type: 13 BaseType int64
+        - Name: svalue
+          Offset: 104
+          Type: 11 GoStringHeaderType string
+        - Name: evalue
+          Offset: 120
+          Type: 665 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+        - Name: scvalue
+          Offset: 128
+          Type: 667 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+        - Name: tags
+          Offset: 136
+          Type: 168 GoSliceHeaderType []string
+        - Name: stags
+          Offset: 160
+          Type: 11 GoStringHeaderType string
+        - Name: rate
+          Offset: 176
+          Type: 17 BaseType float64
+        - Name: timestamp
+          Offset: 184
+          Type: 13 BaseType int64
+    - __kind: BaseType
+      ID: 663
+      Name: github.com/DataDog/datadog-go/v5/statsd.metricType
+      ByteSize: 8
+      GoRuntimeType: 534112
+      GoKind: 2
+    - __kind: GoStringHeaderType
+      ID: 255
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      ByteSize: 16
+      GoRuntimeType: 763488
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 257 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 256 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: GoStringDataType
+      ID: 256
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 261
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      ByteSize: 16
+      GoRuntimeType: 763680
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 263 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 262 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: GoStringDataType
+      ID: 262
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 738
+      Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 818
+      Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 457
+      Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 612
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 848
+      Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 385
+      Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 392
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      GoRuntimeType: 1.074816e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 275
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      ByteSize: 8
+      GoRuntimeType: 765792
+      GoKind: 2
+    - __kind: StructureType
+      ID: 390
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      GoRuntimeType: 1.074688e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 388
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      ByteSize: 32
+      GoRuntimeType: 1.406592e+06
+      GoKind: 25
+      RawFields:
+        - Name: OS
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Arch
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 408
+      Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      ByteSize: 32
+      GoRuntimeType: 1.407392e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 412
+      Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      ByteSize: 32
+      GoRuntimeType: 1.606784e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Size
+          Offset: 16
+          Type: 13 BaseType int64
+        - Name: MaxSize
+          Offset: 24
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 410
+      Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      ByteSize: 16
+      GoRuntimeType: 1.247968e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 406
+      Name: github.com/DataDog/go-tuf/client.ErrNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.247648e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 647
+      Name: github.com/DataDog/go-tuf/data.Hashes
+      ByteSize: 8
+      GoRuntimeType: 1.135136e+06
+      GoKind: 21
+      HeaderType: 649 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+    - __kind: GoSliceHeaderType
+      ID: 671
+      Name: github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 24
+      GoRuntimeType: 1.008768e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 685 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: GoSliceDataType
+      ID: 685
+      Name: github.com/DataDog/go-tuf/data.HexBytes.array
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: StructureType
+      ID: 420
+      Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      ByteSize: 16
+      GoRuntimeType: 1.407712e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 647 GoMapType github.com/DataDog/go-tuf/data.Hashes
+        - Name: Actual
+          Offset: 8
+          Type: 647 GoMapType github.com/DataDog/go-tuf/data.Hashes
+    - __kind: StructureType
+      ID: 414
+      Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      ByteSize: 16
+      GoRuntimeType: 1.248128e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 418
+      Name: github.com/DataDog/go-tuf/util.ErrWrongHash
+      ByteSize: 64
+      GoRuntimeType: 1.606976e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Expected
+          Offset: 16
+          Type: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+        - Name: Actual
+          Offset: 40
+          Type: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: StructureType
+      ID: 416
+      Name: github.com/DataDog/go-tuf/util.ErrWrongLength
+      ByteSize: 16
+      GoRuntimeType: 1.407552e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Actual
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 422
+      Name: github.com/DataDog/go-tuf/verify.ErrExpired
+      ByteSize: 24
+      GoRuntimeType: 1.248288e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expired
+          Offset: 0
+          Type: 639 StructureType time.Time
+    - __kind: StructureType
+      ID: 428
+      Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
+      ByteSize: 16
+      GoRuntimeType: 1.408032e+06
+      GoKind: 25
+      RawFields:
+        - Name: Actual
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Current
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 430
+      Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
+      ByteSize: 16
+      GoRuntimeType: 1.248608e+06
+      GoKind: 25
+      RawFields:
+        - Name: KeyID
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 426
+      Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      ByteSize: 16
+      GoRuntimeType: 1.407872e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: Actual
+          Offset: 8
+          Type: 9 BaseType int
+    - __kind: StructureType
+      ID: 424
+      Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      ByteSize: 16
+      GoRuntimeType: 1.248448e+06
+      GoKind: 25
+      RawFields:
+        - Name: Role
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 432
+      Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      ByteSize: 16
+      GoRuntimeType: 1.408192e+06
+      GoKind: 25
+      RawFields:
+        - Name: Given
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Expected
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 354
+      Name: github.com/cihub/seelog.baseError
+      ByteSize: 16
+      GoRuntimeType: 1.240448e+06
+      GoKind: 25
+      RawFields:
+        - Name: message
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 777
+      Name: github.com/cihub/seelog.bufferedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 356
+      Name: github.com/cihub/seelog.cannotOpenFileError
+      ByteSize: 16
+      GoRuntimeType: 1.240608e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 756
+      Name: github.com/cihub/seelog.connWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 712
+      Name: github.com/cihub/seelog.consoleWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 746
+      Name: github.com/cihub/seelog.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 360
+      Name: github.com/cihub/seelog.missingArgumentError
+      ByteSize: 16
+      GoRuntimeType: 1.240928e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 808
+      Name: github.com/cihub/seelog.rollingFileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 819
+      Name: github.com/cihub/seelog.rollingFileWriterSize
+      ByteSize: 16
+      GoRuntimeType: 1.96784e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 807 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: maxFileSize
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 820
+      Name: github.com/cihub/seelog.rollingFileWriterTime
+      ByteSize: 40
+      GoRuntimeType: 1.991232e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 807 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: timePattern
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+        - Name: currentTimeFileName
+          Offset: 24
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 714
+      Name: github.com/cihub/seelog.smtpWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 358
+      Name: github.com/cihub/seelog.unexpectedAttributeError
+      ByteSize: 16
+      GoRuntimeType: 1.240768e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: StructureType
+      ID: 362
+      Name: github.com/cihub/seelog.unexpectedChildElementError
+      ByteSize: 16
+      GoRuntimeType: 1.241088e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 781
+      Name: github.com/cihub/seelog/archive/gzip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 814
+      Name: github.com/cihub/seelog/archive/tar.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 816
+      Name: github.com/cihub/seelog/archive/zip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 643
+      Name: github.com/go-viper/mapstructure/v2.DecodeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 556
+      Name: github.com/go-viper/mapstructure/v2.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 554
+      Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 558
+      Name: github.com/gogo/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 560
+      Name: github.com/gogo/protobuf/proto.invalidUTF8Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 767
+      Name: github.com/gogo/protobuf/proto.textWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 550
+      Name: github.com/golang/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 368
+      Name: github.com/google/uuid.invalidLengthError
+      ByteSize: 8
+      GoRuntimeType: 1.242048e+06
+      GoKind: 25
+      RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
+    - __kind: UnresolvedPointeeType
+      ID: 864
+      Name: github.com/json-iterator/go.Stream
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 614
+      Name: github.com/pkg/errors.fundamental
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 587
+      Name: github.com/tinylib/msgp/msgp.ArrayError
+      ByteSize: 24
+      GoRuntimeType: 1.711456e+06
+      GoKind: 25
+      RawFields:
+        - Name: Wanted
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Got
+          Offset: 4
+          Type: 2 BaseType uint32
+        - Name: ctx
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 581
+      Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 520
+      Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
+      ByteSize: 2
+      GoRuntimeType: 1.509248e+06
+      GoKind: 25
+      RawFields:
+        - Name: Got
+          Offset: 0
+          Type: 14 BaseType int8
+        - Name: Want
+          Offset: 1
+          Type: 14 BaseType int8
+    - __kind: StructureType
+      ID: 593
+      Name: github.com/tinylib/msgp/msgp.IntOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.711904e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 497
+      Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
+      ByteSize: 1
+      GoRuntimeType: 948704
+      GoKind: 8
+    - __kind: StructureType
+      ID: 585
+      Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
+      ByteSize: 32
+      GoRuntimeType: 1.711232e+06
+      GoKind: 25
+      RawFields:
+        - Name: Nanos
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: FieldLength
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 673
+      Name: github.com/tinylib/msgp/msgp.Type
+      ByteSize: 1
+      GoRuntimeType: 761760
+      GoKind: 8
+    - __kind: StructureType
+      ID: 583
+      Name: github.com/tinylib/msgp/msgp.TypeError
+      ByteSize: 24
+      GoRuntimeType: 1.711008e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 673 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: Encoded
+          Offset: 1
+          Type: 673 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: ctx
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 591
+      Name: github.com/tinylib/msgp/msgp.UintBelowZero
+      ByteSize: 24
+      GoRuntimeType: 1.6296e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: ctx
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 589
+      Name: github.com/tinylib/msgp/msgp.UintOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.71168e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 10 BaseType uint64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 868
+      Name: github.com/tinylib/msgp/msgp.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 597
+      Name: github.com/tinylib/msgp/msgp.errFatal
+      ByteSize: 16
+      GoRuntimeType: 1.43216e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctx
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 524
+      Name: github.com/tinylib/msgp/msgp.errRecursion
+      GoRuntimeType: 1.194976e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 522
+      Name: github.com/tinylib/msgp/msgp.errShort
+      GoRuntimeType: 1.194848e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 595
+      Name: github.com/tinylib/msgp/msgp.errWrapped
+      ByteSize: 32
+      GoRuntimeType: 1.629792e+06
+      GoKind: 25
+      RawFields:
+        - Name: cause
+          Offset: 0
+          Type: 18 GoInterfaceType error
+        - Name: ctx
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 287
+      Name: go.opentelemetry.io/otel/trace.errorConst
+      ByteSize: 16
+      GoRuntimeType: 769152
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 289 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 288 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: GoStringDataType
+      ID: 288
+      Name: go.opentelemetry.io/otel/trace.errorConst.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 656
+      Name: go.uber.org/multierr.multiError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 564
+      Name: go.uber.org/zap.errArrayElem
+      ByteSize: 16
+      GoRuntimeType: 1.265408e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 744
+      Name: go.uber.org/zap.nopCloserSink
+      ByteSize: 16
+      GoRuntimeType: 1.486112e+06
+      GoKind: 25
+      RawFields:
+        - Name: WriteSyncer
+          Offset: 0
+          Type: 768 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+    - __kind: UnresolvedPointeeType
+      ID: 828
+      Name: go.uber.org/zap/buffer.Buffer
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 768
+      Name: go.uber.org/zap/zapcore.WriteSyncer
+      ByteSize: 16
+      GoRuntimeType: 1.085696e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 730
+      Name: go.uber.org/zap/zapcore.writerWrapper
+      ByteSize: 16
+      GoRuntimeType: 1.38096e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 290
+      Name: golang.org/x/net/http2.ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 769728
+      GoKind: 10
+    - __kind: BaseType
+      ID: 654
+      Name: golang.org/x/net/http2.ErrCode
+      ByteSize: 4
+      GoRuntimeType: 961952
+      GoKind: 10
+    - __kind: StructureType
+      ID: 622
+      Name: golang.org/x/net/http2.StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.749984e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 654 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 483
+      Name: golang.org/x/net/http2.connError
+      ByteSize: 24
+      GoRuntimeType: 1.415392e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 654 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 294
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 769920
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 296 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 295 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 295
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 300
+      Name: golang.org/x/net/http2.headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 770112
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 302 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 301 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 301
+      Name: golang.org/x/net/http2.headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 297
+      Name: golang.org/x/net/http2.headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 770016
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 299 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 298 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 298
+      Name: golang.org/x/net/http2.headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 291
+      Name: golang.org/x/net/http2.pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 769824
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 293 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 292 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 292
+      Name: golang.org/x/net/http2.pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 826
+      Name: golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 487
+      Name: golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.266048e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: BaseType
+      ID: 303
+      Name: golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 770208
+      GoKind: 2
+    - __kind: StructureType
+      ID: 475
+      Name: google.golang.org/grpc.dropError
+      ByteSize: 16
+      GoRuntimeType: 1.261088e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 620
+      Name: google.golang.org/grpc/internal/status.Error
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 645
+      Name: google.golang.org/grpc/internal/transport.ConnectionError
+      ByteSize: 40
+      GoRuntimeType: 1.775744e+06
+      GoKind: 25
+      RawFields:
+        - Name: Desc
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: temp
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: err
+          Offset: 24
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 477
+      Name: google.golang.org/grpc/internal/transport.NewStreamError
+      ByteSize: 24
+      GoRuntimeType: 1.414912e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+        - Name: AllowTransparentRetry
+          Offset: 16
+          Type: 4 BaseType bool
+    - __kind: StructureType
+      ID: 791
+      Name: google.golang.org/grpc/internal/transport.bufConn
+      ByteSize: 32
+      GoRuntimeType: 1.829216e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 670 GoInterfaceType net.Conn
+        - Name: r
+          Offset: 16
+          Type: 806 GoInterfaceType io.Reader
+    - __kind: UnresolvedPointeeType
+      ID: 742
+      Name: google.golang.org/grpc/internal/transport.bufWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 562
+      Name: google.golang.org/grpc/internal/transport.ioError
+      ByteSize: 16
+      GoRuntimeType: 1.37856e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 702
+      Name: google.golang.org/grpc/mem.writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 455
+      Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 552
+      Name: google.golang.org/protobuf/internal/errors.prefixError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 618
+      Name: google.golang.org/protobuf/internal/errors.wrapError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 616
+      Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      GoRuntimeType: 1.325696e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 469
+      Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.254368e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 471
+      Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
+      ByteSize: 16
+      GoRuntimeType: 1.254528e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 400
+      Name: gopkg.in/yaml%2ev3.TypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 779
+      Name: hash/crc32.digest
+      ByteSize: 8
     - __kind: GoHMapHeaderType
       ID: 152
       Name: hash<[4]int,[4]int>
@@ -7031,7 +10678,7 @@ Types:
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
       BucketsType: 191 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 258
+      ID: 904
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -7052,20 +10699,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 259 PointerType *bucket<int,*main.deepMap3>
+          Type: 905 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 259 PointerType *bucket<int,*main.deepMap3>
+          Type: 905 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 260 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 264 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 906 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 910 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 288
+      ID: 934
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -7086,20 +10733,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 289 PointerType *bucket<int,*main.deepMap8>
+          Type: 935 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 289 PointerType *bucket<int,*main.deepMap8>
+          Type: 935 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 290 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 294 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 936 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 940 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 297
+      ID: 943
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -7120,18 +10767,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 298 PointerType *bucket<int,*main.deepMap9>
+          Type: 944 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 298 PointerType *bucket<int,*main.deepMap9>
+          Type: 944 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 299 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 303 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 945 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 949 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 95
       Name: hash<int,int>
@@ -7167,7 +10814,7 @@ Types:
       BucketType: 97 GoHMapBucketType bucket<int,int>
       BucketsType: 193 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 306
+      ID: 952
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -7188,18 +10835,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 307 PointerType *bucket<int,interface {}>
+          Type: 953 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 307 PointerType *bucket<int,interface {}>
+          Type: 953 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 308 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 310 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 954 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 956 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 132
       Name: hash<int,uint8>
@@ -7302,6 +10949,40 @@ Types:
           Type: 73 PointerType *runtime.mapextra
       BucketType: 112 GoHMapBucketType bucket<string,[]string>
       BucketsType: 199 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: GoHMapHeaderType
+      ID: 649
+      Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 680 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 105
       Name: hash<string,int>
@@ -7438,6 +11119,10 @@ Types:
           Type: 73 PointerType *runtime.mapextra
       BucketType: 139 GoHMapBucketType bucket<uint8,uint8>
       BucketsType: 214 GoSliceDataType []bucket<uint8,uint8>.array
+    - __kind: UnresolvedPointeeType
+      ID: 490
+      Name: html/template.Error
+      ByteSize: 8
     - __kind: BaseType
       ID: 9
       Name: int
@@ -7481,6 +11166,75 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 370
+      Name: internal/bisect.parseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 688
+      Name: internal/godebug.runtimeStderr
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 579
+      Name: internal/poll.DeadlineExceededError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 870
+      Name: internal/poll.FD
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 577
+      Name: internal/poll.errNetClosing
+      GoRuntimeType: 1.293056e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 307
+      Name: internal/reflectlite.ValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 734
+      Name: io.PipeWriter
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 775
+      Name: io.ReadWriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.103392e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 806
+      Name: io.Reader
+      ByteSize: 16
+      GoRuntimeType: 980096
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 763
+      Name: io.WriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.068416e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 55
       Name: io.Writer
@@ -7494,6 +11248,24 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 732
+      Name: io.discard
+      GoRuntimeType: 1.280416e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 706
+      Name: io.multiWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 575
+      Name: io/fs.PathError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 783
+      Name: log/slog/internal/buffer.Buffer
+      ByteSize: 8
     - __kind: StructureType
       ID: 175
       Name: main.aStruct
@@ -7559,9 +11331,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 256 GoMapType map[int]*main.deepMap3
+          Type: 902 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 263
+      ID: 909
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7573,9 +11345,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 286 GoMapType map[int]*main.deepMap8
+          Type: 932 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 293
+      ID: 939
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.099168e+06
@@ -7583,9 +11355,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 295 GoMapType map[int]*main.deepMap9
+          Type: 941 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 302
+      ID: 948
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.09904e+06
@@ -7593,7 +11365,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 304 GoMapType map[int]interface {}
+          Type: 950 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7613,9 +11385,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 233 PointerType *main.deepPtr3
+          Type: 873 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 234
+      ID: 874
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7627,9 +11399,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 267 PointerType *main.deepPtr8
+          Type: 913 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 268
+      ID: 914
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.10032e+06
@@ -7637,9 +11409,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 269 PointerType *main.deepPtr9
+          Type: 915 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 270
+      ID: 916
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.100192e+06
@@ -7667,9 +11439,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 250 GoSliceHeaderType []*main.deepSlice3
+          Type: 896 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 253
+      ID: 899
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7681,9 +11453,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 271 GoSliceHeaderType []*main.deepSlice8
+          Type: 917 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 274
+      ID: 920
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.101472e+06
@@ -7691,9 +11463,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 277 GoSliceHeaderType []*main.deepSlice9
+          Type: 923 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 280
+      ID: 926
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101344e+06
@@ -7701,7 +11473,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 283 GoSliceHeaderType []interface {}
+          Type: 929 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 177
       Name: main.emptyStruct
@@ -7719,16 +11491,16 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 238 StructureType sync.Mutex
+          Type: 880 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 239 StructureType sync.Once
+          Type: 881 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 242 StructureType sync.WaitGroup
+          Type: 884 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 246 StructureType sync/atomic.Int32
+          Type: 888 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
@@ -7757,6 +11529,16 @@ Types:
         - Name: foo
           Offset: 56
           Type: 85 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 890
+      Name: main.firstBehavior
+      ByteSize: 16
+      GoRuntimeType: 1.231488e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
       ID: 176
       Name: main.nestedStruct
@@ -7792,6 +11574,13 @@ Types:
         - Name: a
           Offset: 0
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 892
+      Name: main.secondBehavior
+      ByteSize: 8
+      GoRuntimeType: 1.231648e+06
+      GoKind: 25
+      RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: GoInterfaceType
       ID: 84
       Name: main.something
@@ -7805,6 +11594,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 879
+      Name: main.somethingImpl
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 78
       Name: main.stringType1
@@ -7813,17 +11606,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 236 PointerType *main.stringType1.str
+          Type: 876 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 235 GoStringDataType main.stringType1.str
+      Data: 875 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 235
+      ID: 875
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 237
+      ID: 877
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -7878,16 +11671,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 247 PointerType **main.t
+          Type: 893 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 248 GoSliceDataType main.t.array
+      Data: 894 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 894
       Name: main.t.array
       ByteSize: 2048
       Element: 160 PointerType *main.t
@@ -7947,26 +11740,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 256
+      ID: 902
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879744
       GoKind: 21
-      HeaderType: 258 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 904 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 286
+      ID: 932
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879264
       GoKind: 21
-      HeaderType: 288 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 934 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 295
+      ID: 941
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879168
       GoKind: 21
-      HeaderType: 297 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 943 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 93
       Name: map[int]int
@@ -7975,12 +11768,12 @@ Types:
       GoKind: 21
       HeaderType: 95 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 304
+      ID: 950
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879072
       GoKind: 21
-      HeaderType: 306 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 952 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 130
       Name: map[int]uint8
@@ -8030,9 +11823,768 @@ Types:
       GoRuntimeType: 880896
       GoKind: 21
       HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: StructureType
+      ID: 404
+      Name: math/big.ErrNaN
+      ByteSize: 16
+      GoRuntimeType: 1.247328e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 696
+      Name: mime/multipart.writerOnly·1
+      ByteSize: 16
+      GoRuntimeType: 1.244128e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 606
+      Name: net.AddrError
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 670
+      Name: net.Conn
+      ByteSize: 16
+      GoRuntimeType: 1.405312e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 632
+      Name: net.DNSError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 834
+      Name: net.IPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 630
+      Name: net.OpError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 608
+      Name: net.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 844
+      Name: net.TCPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 854
+      Name: net.UDPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 842
+      Name: net.UnixConn
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 567
+      Name: net.UnknownNetworkError
+      ByteSize: 16
+      GoRuntimeType: 1.071616e+06
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 569 PointerType *net.UnknownNetworkError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 568 GoStringDataType net.UnknownNetworkError.str
+    - __kind: GoStringDataType
+      ID: 568
+      Name: net.UnknownNetworkError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 536
+      Name: net.canceledError
+      GoRuntimeType: 1.195872e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 812
+      Name: net.conn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 675
+      Name: net.dialResult·1
+      ByteSize: 40
+      GoRuntimeType: 1.967136e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 670 GoInterfaceType net.Conn
+        - Name: error
+          Offset: 16
+          Type: 18 GoInterfaceType error
+        - Name: primary
+          Offset: 32
+          Type: 4 BaseType bool
+        - Name: done
+          Offset: 33
+          Type: 4 BaseType bool
+    - __kind: UnresolvedPointeeType
+      ID: 856
+      Name: net.netFD
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 850
+      Name: net.noReadFrom
+      GoRuntimeType: 1.071872e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 849
+      Name: net.noWriteTo
+      GoRuntimeType: 1.071744e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 339
+      Name: net.notFoundError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 341
+      Name: net.result·2
+      ByteSize: 112
+      GoRuntimeType: 1.60256e+06
+      GoKind: 25
+      RawFields:
+        - Name: p
+          Offset: 0
+          Type: 657 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+        - Name: server
+          Offset: 80
+          Type: 11 GoStringHeaderType string
+        - Name: error
+          Offset: 96
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 838
+      Name: net.tcpConnWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.143456e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 850 StructureType net.noReadFrom
+        - Name: TCPConn
+          Offset: 0
+          Type: 843 PointerType *net.TCPConn
+    - __kind: StructureType
+      ID: 836
+      Name: net.tcpConnWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.142912e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 849 StructureType net.noWriteTo
+        - Name: TCPConn
+          Offset: 0
+          Type: 843 PointerType *net.TCPConn
+    - __kind: UnresolvedPointeeType
+      ID: 610
+      Name: net.temporaryError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 634
+      Name: net.timeoutError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 526
+      Name: net/http.ProtocolError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 690
+      Name: net/http.bufioFlushWriter
+      ByteSize: 16
+      GoRuntimeType: 1.235648e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 236
+      Name: net/http.http2ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 762240
+      GoKind: 10
+    - __kind: BaseType
+      ID: 646
+      Name: net/http.http2ErrCode
+      ByteSize: 4
+      GoRuntimeType: 948800
+      GoKind: 10
+    - __kind: StructureType
+      ID: 317
+      Name: net/http.http2GoAwayError
+      ByteSize: 24
+      GoRuntimeType: 1.60064e+06
+      GoKind: 25
+      RawFields:
+        - Name: LastStreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: ErrCode
+          Offset: 4
+          Type: 646 BaseType net/http.http2ErrCode
+        - Name: DebugData
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 626
+      Name: net/http.http2StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.766016e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 646 BaseType net/http.http2ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 321
+      Name: net/http.http2connError
+      ByteSize: 24
+      GoRuntimeType: 1.404832e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 646 BaseType net/http.http2ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 752
+      Name: net/http.http2dataBuffer
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 240
+      Name: net/http.http2duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 762432
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 242 PointerType *net/http.http2duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 241 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 241
+      Name: net/http.http2duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 246
+      Name: net/http.http2headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 762624
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 248 PointerType *net/http.http2headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 247 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 247
+      Name: net/http.http2headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 243
+      Name: net/http.http2headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 762528
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 245 PointerType *net/http.http2headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 244 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 244
+      Name: net/http.http2headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 601
+      Name: net/http.http2httpError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 532
+      Name: net/http.http2noCachedConnError
+      GoRuntimeType: 1.195232e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 803
+      Name: net/http.http2pipe
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 237
+      Name: net/http.http2pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 762336
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 239 PointerType *net/http.http2pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 238 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 238
+      Name: net/http.http2pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 692
+      Name: net/http.http2stickyErrWriter
+      ByteSize: 32
+      GoRuntimeType: 1.601408e+06
+      GoKind: 25
+      RawFields:
+        - Name: conn
+          Offset: 0
+          Type: 670 GoInterfaceType net.Conn
+        - Name: timeout
+          Offset: 16
+          Type: 771 BaseType time.Duration
+        - Name: err
+          Offset: 24
+          Type: 33 PointerType *error
+    - __kind: ArrayType
+      ID: 772
+      Name: net/http.incomparable
+      GoRuntimeType: 830880
+      GoKind: 17
+      HasCount: true
+      Element: 85 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 528
+      Name: net/http.nothingWrittenError
+      ByteSize: 16
+      GoRuntimeType: 1.36672e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 754
+      Name: net/http.persistConn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 710
+      Name: net/http.persistConnWriter
+      ByteSize: 8
+      GoRuntimeType: 1.36656e+06
+      GoKind: 25
+      RawFields:
+        - Name: pc
+          Offset: 0
+          Type: 753 PointerType *net/http.persistConn
+    - __kind: StructureType
+      ID: 736
+      Name: net/http.readWriteCloserBody
+      ByteSize: 24
+      GoRuntimeType: 1.672704e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 772 ArrayType net/http.incomparable
+        - Name: br
+          Offset: 0
+          Type: 773 PointerType *bufio.Reader
+        - Name: ReadWriteCloser
+          Offset: 8
+          Type: 775 GoInterfaceType io.ReadWriteCloser
+    - __kind: StructureType
+      ID: 325
+      Name: net/http.requestBodyReadError
+      ByteSize: 16
+      GoRuntimeType: 1.236608e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 628
+      Name: net/http.timeoutError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 599
+      Name: net/http.tlsHandshakeTimeoutError
+      GoRuntimeType: 1.295776e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 530
+      Name: net/http.transportReadFromServerError
+      ByteSize: 16
+      GoRuntimeType: 1.36688e+06
+      GoKind: 25
+      RawFields:
+        - Name: err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 314
+      Name: net/http.unsupportedTEError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 805
+      Name: net/http/internal.FlushAfterChunkWriter
+      ByteSize: 8
+      GoRuntimeType: 1.904256e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 798 PointerType *bufio.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 720
+      Name: net/http/internal.chunkedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 396
+      Name: net/netip.parseAddrError
+      ByteSize: 48
+      GoRuntimeType: 1.6064e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+        - Name: at
+          Offset: 32
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 394
+      Name: net/netip.parsePrefixError
+      ByteSize: 32
+      GoRuntimeType: 1.406752e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 762
+      Name: net/smtp.Client
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 722
+      Name: net/smtp.dataCloser
+      ByteSize: 24
+      GoRuntimeType: 1.408672e+06
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 761 PointerType *net/smtp.Client
+        - Name: WriteCloser
+          Offset: 8
+          Type: 763 GoInterfaceType io.WriteCloser
+    - __kind: UnresolvedPointeeType
+      ID: 380
+      Name: net/textproto.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 271
+      Name: net/textproto.ProtocolError
+      ByteSize: 16
+      GoRuntimeType: 765216
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 273 PointerType *net/textproto.ProtocolError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 272 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: GoStringDataType
+      ID: 272
+      Name: net/textproto.ProtocolError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 718
+      Name: net/textproto.dotWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 636
+      Name: net/url.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 249
+      Name: net/url.EscapeError
+      ByteSize: 16
+      GoRuntimeType: 763200
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 251 PointerType *net/url.EscapeError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 250 GoStringDataType net/url.EscapeError.str
+    - __kind: GoStringDataType
+      ID: 250
+      Name: net/url.EscapeError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 252
+      Name: net/url.InvalidHostError
+      ByteSize: 16
+      GoRuntimeType: 763296
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 254 PointerType *net/url.InvalidHostError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 253 GoStringDataType net/url.InvalidHostError.str
+    - __kind: GoStringDataType
+      ID: 253
+      Name: net/url.InvalidHostError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 862
+      Name: os.File
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 507
+      Name: os.LinkError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 571
+      Name: os.SyscallError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 860
+      Name: os.fileWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.211648e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 866 StructureType os.noReadFrom
+        - Name: File
+          Offset: 0
+          Type: 861 PointerType *os.File
+    - __kind: StructureType
+      ID: 858
+      Name: os.fileWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.210848e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 865 StructureType os.noWriteTo
+        - Name: File
+          Offset: 0
+          Type: 861 PointerType *os.File
+    - __kind: StructureType
+      ID: 866
+      Name: os.noReadFrom
+      GoRuntimeType: 1.069312e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 865
+      Name: os.noWriteTo
+      GoRuntimeType: 1.069184e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 538
+      Name: os/exec.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 678
+      Name: os/exec.ExitError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 740
+      Name: os/exec.prefixSuffixSaver
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 540
+      Name: os/exec.wrappedError
+      ByteSize: 32
+      GoRuntimeType: 1.509824e+06
+      GoKind: 25
+      RawFields:
+        - Name: prefix
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: err
+          Offset: 16
+          Type: 18 GoInterfaceType error
+    - __kind: GoStringHeaderType
+      ID: 284
+      Name: os/user.UnknownGroupIdError
+      ByteSize: 16
+      GoRuntimeType: 768384
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 286 PointerType *os/user.UnknownGroupIdError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 285 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: GoStringDataType
+      ID: 285
+      Name: os/user.UnknownGroupIdError.str
+      ByteSize: 2048
+    - __kind: BaseType
+      ID: 283
+      Name: os/user.UnknownUserIdError
+      ByteSize: 8
+      GoRuntimeType: 768288
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 309
+      Name: reflect.ValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 402
+      Name: regexp/syntax.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 510
+      Name: runtime.PanicNilError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 515
+      Name: runtime.TypeAssertionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 512
+      Name: runtime.boundsError
+      ByteSize: 24
+      GoRuntimeType: 1.755584e+06
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: y
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: signed
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: code
+          Offset: 17
+          Type: 676 BaseType runtime.boundsErrorCode
+    - __kind: BaseType
+      ID: 676
+      Name: runtime.boundsErrorCode
+      ByteSize: 1
+      GoRuntimeType: 532448
+      GoKind: 8
+    - __kind: StructureType
+      ID: 573
+      Name: runtime.errorAddressString
+      ByteSize: 24
+      GoRuntimeType: 1.626528e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: addr
+          Offset: 16
+          Type: 1 BaseType uintptr
+    - __kind: GoStringHeaderType
+      ID: 491
+      Name: runtime.errorString
+      ByteSize: 16
+      GoRuntimeType: 947648
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 493 PointerType *runtime.errorString.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 492 GoStringDataType runtime.errorString.str
+    - __kind: GoStringDataType
+      ID: 492
+      Name: runtime.errorString.str
+      ByteSize: 2048
     - __kind: UnresolvedPointeeType
       ID: 74
       Name: runtime.mapextra
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 494
+      Name: runtime.plainError
+      ByteSize: 16
+      GoRuntimeType: 948224
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 496 PointerType *runtime.plainError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 495 GoStringDataType runtime.plainError.str
+    - __kind: GoStringDataType
+      ID: 495
+      Name: runtime.plainError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 517
+      Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
@@ -8052,8 +12604,26 @@ Types:
       ID: 179
       Name: string.str
       ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 801
+      Name: strings.Builder
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 708
+      Name: strings.appendSliceWriter
+      ByteSize: 8
     - __kind: StructureType
-      ID: 238
+      ID: 704
+      Name: struct { io.Writer }
+      ByteSize: 16
+      GoRuntimeType: 1.272576e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 880
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281216e+06
@@ -8066,7 +12636,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 239
+      ID: 881
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282336e+06
@@ -8074,12 +12644,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 240 StructureType sync/atomic.Uint32
+          Type: 882 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 238 StructureType sync.Mutex
+          Type: 880 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 242
+      ID: 884
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421024e+06
@@ -8087,21 +12657,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 243 StructureType sync.noCopy
+          Type: 885 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 244 StructureType sync/atomic.Uint64
+          Type: 886 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 243
+      ID: 885
       Name: sync.noCopy
       GoRuntimeType: 946592
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 246
+      ID: 888
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282656e+06
@@ -8109,12 +12679,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 241 StructureType sync/atomic.noCopy
+          Type: 883 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 240
+      ID: 882
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.282816e+06
@@ -8122,12 +12692,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 241 StructureType sync/atomic.noCopy
+          Type: 883 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 244
+      ID: 886
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.421408e+06
@@ -8135,25 +12705,96 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 241 StructureType sync/atomic.noCopy
+          Type: 883 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 245 StructureType sync/atomic.align64
+          Type: 887 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 245
+      ID: 887
       Name: sync/atomic.align64
       GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 241
+      ID: 883
       Name: sync/atomic.noCopy
       GoRuntimeType: 946688
       GoKind: 25
       RawFields: []
+    - __kind: BaseType
+      ID: 623
+      Name: syscall.Errno
+      ByteSize: 8
+      GoRuntimeType: 1.194464e+06
+      GoKind: 12
+    - __kind: UnresolvedPointeeType
+      ID: 832
+      Name: text/tabwriter.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 566
+      Name: text/template.ExecError
+      ByteSize: 32
+      GoRuntimeType: 1.51424e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 18 GoInterfaceType error
+    - __kind: BaseType
+      ID: 771
+      Name: time.Duration
+      ByteSize: 8
+      GoRuntimeType: 1.781856e+06
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 641
+      Name: time.Location
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 312
+      Name: time.ParseError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 639
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.223872e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 10 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 13 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 640 PointerType *time.Location
+    - __kind: GoStringHeaderType
+      ID: 233
+      Name: time.fileSizeError
+      ByteSize: 16
+      GoRuntimeType: 761376
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 235 PointerType *time.fileSizeError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 234 GoStringDataType time.fileSizeError.str
+    - __kind: GoStringDataType
+      ID: 234
+      Name: time.fileSizeError.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -8196,6 +12837,124 @@ Types:
       ByteSize: 8
       GoRuntimeType: 532384
       GoKind: 26
-MaxTypeID: 425
+    - __kind: UnresolvedPointeeType
+      ID: 795
+      Name: vendor/golang.org/x/crypto/sha3.state
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 657
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
+      ByteSize: 80
+      GoRuntimeType: 1.925984e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 658 GoSliceHeaderType []uint8
+        - Name: header
+          Offset: 24
+          Type: 659 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+        - Name: section
+          Offset: 36
+          Type: 660 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+        - Name: off
+          Offset: 40
+          Type: 9 BaseType int
+        - Name: index
+          Offset: 48
+          Type: 9 BaseType int
+        - Name: resHeaderValid
+          Offset: 56
+          Type: 4 BaseType bool
+        - Name: resHeaderOffset
+          Offset: 64
+          Type: 9 BaseType int
+        - Name: resHeaderType
+          Offset: 72
+          Type: 661 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+        - Name: resHeaderLength
+          Offset: 74
+          Type: 7 BaseType uint16
+    - __kind: BaseType
+      ID: 661
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Type
+      ByteSize: 2
+      GoRuntimeType: 952928
+      GoKind: 9
+    - __kind: StructureType
+      ID: 659
+      Name: vendor/golang.org/x/net/dns/dnsmessage.header
+      ByteSize: 12
+      GoRuntimeType: 1.792352e+06
+      GoKind: 25
+      RawFields:
+        - Name: id
+          Offset: 0
+          Type: 7 BaseType uint16
+        - Name: bits
+          Offset: 2
+          Type: 7 BaseType uint16
+        - Name: questions
+          Offset: 4
+          Type: 7 BaseType uint16
+        - Name: answers
+          Offset: 6
+          Type: 7 BaseType uint16
+        - Name: authorities
+          Offset: 8
+          Type: 7 BaseType uint16
+        - Name: additionals
+          Offset: 10
+          Type: 7 BaseType uint16
+    - __kind: UnresolvedPointeeType
+      ID: 398
+      Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 660
+      Name: vendor/golang.org/x/net/dns/dnsmessage.section
+      ByteSize: 1
+      GoRuntimeType: 536032
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 824
+      Name: vendor/golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 382
+      Name: vendor/golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.244448e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: BaseType
+      ID: 274
+      Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 765312
+      GoKind: 2
+    - __kind: StructureType
+      ID: 545
+      Name: vendor/golang.org/x/net/idna.labelError
+      ByteSize: 32
+      GoRuntimeType: 1.510016e+06
+      GoKind: 25
+      RawFields:
+        - Name: label
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: code_
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 499
+      Name: vendor/golang.org/x/net/idna.runeError
+      ByteSize: 4
+      GoRuntimeType: 951776
+      GoKind: 5
+MaxTypeID: 1071
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1755760", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 405 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd079aa", Frameless: false}]
+        - ID: 97
+          Type: 406 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd07b2a", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -26,7 +26,21 @@ Probes:
       events:
         - ID: 53
           Type: 362 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xd04b8a", Frameless: false}]
+          InjectionPoints: [{PC: "0xd04b4a", Frameless: false}]
+          Condition: null
+    - id: testAnyPtr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAnyPtr}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 55}
+      events:
+        - ID: 55
+          Type: 364 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xd04bea", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -64,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 370 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xd05120", Frameless: true}]
+        - ID: 62
+          Type: 371 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xd052a0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 386 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xd06c60", Frameless: true}]
+        - ID: 78
+          Type: 387 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xd06de0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 384 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xd06880", Frameless: true}]
+        - ID: 76
+          Type: 385 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xd06a00", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 394 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xd07020", Frameless: true}]
+        - ID: 86
+          Type: 395 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xd071a0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -278,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 396 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd07560", Frameless: true}]
+        - ID: 88
+          Type: 397 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 399 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd075c0", Frameless: true}]
+        - ID: 91
+          Type: 400 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd07740", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -306,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 413 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd07ae0", Frameless: true}]
+        - ID: 105
+          Type: 414 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd07c60", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -320,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 415 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd07ee0", Frameless: true}]
+        - ID: 107
+          Type: 416 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd08060", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -333,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 416 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xd07f00", Frameless: true}]
+        - ID: 108
+          Type: 417 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xd08080", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -351,7 +365,7 @@ Probes:
       events:
         - ID: 54
           Type: 363 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xd04c00", Frameless: true}]
+          InjectionPoints: [{PC: "0xd04bc0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -459,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 418 EventRootType Probe[main.testInlinedBBB]
+        - ID: 110
+          Type: 419 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd04606", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -487,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 419 EventRootType Probe[main.testInlinedBCA]
+        - ID: 111
+          Type: 420 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd04713", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -501,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 420 EventRootType Probe[main.testInlinedBCB]
+        - ID: 112
+          Type: 421 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd047c6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -516,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 417 EventRootType Probe[main.testInlinedPrint]
+        - ID: 109
+          Type: 418 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0436a"
               Frameless: false
@@ -540,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 421 EventRootType Probe[main.testInlinedSq]
+        - ID: 113
+          Type: 422 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04821", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -555,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 422 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 114
+          Type: 423 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04865"
               Frameless: false
@@ -647,7 +661,7 @@ Probes:
       events:
         - ID: 52
           Type: 361 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xd04b2a", Frameless: false}]
+          InjectionPoints: [{PC: "0xd04b20", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -657,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 388 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xd06e40", Frameless: true}]
+        - ID: 80
+          Type: 389 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xd06fc0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -671,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 368 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xd050e0", Frameless: true}]
+        - ID: 60
+          Type: 369 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xd05260", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -685,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 374 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xd051a0", Frameless: true}]
+        - ID: 66
+          Type: 375 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xd05320", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -699,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 372 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xd05160", Frameless: true}]
+        - ID: 64
+          Type: 373 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xd052e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -713,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 383 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xd052c0", Frameless: true}]
+        - ID: 75
+          Type: 384 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xd05440", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -727,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 382 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xd052a0", Frameless: true}]
+        - ID: 74
+          Type: 383 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xd05420", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -741,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 373 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xd05180", Frameless: true}]
+        - ID: 65
+          Type: 374 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd05300", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -755,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 381 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xd05280", Frameless: true}]
+        - ID: 73
+          Type: 382 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xd05400", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -769,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 380 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xd05260", Frameless: true}]
+        - ID: 72
+          Type: 381 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xd053e0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -783,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 366 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xd050a0", Frameless: true}]
+        - ID: 58
+          Type: 367 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xd05220", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -797,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 367 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xd050c0", Frameless: true}]
+        - ID: 59
+          Type: 368 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xd05240", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -811,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 365 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xd05080", Frameless: true}]
+        - ID: 57
+          Type: 366 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xd05200", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -825,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 375 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xd051c0", Frameless: true}]
+        - ID: 67
+          Type: 376 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xd05340", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -839,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 378 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xd05220", Frameless: true}]
+        - ID: 70
+          Type: 379 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xd053a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -853,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 379 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xd05240", Frameless: true}]
+        - ID: 71
+          Type: 380 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xd053c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -867,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 376 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xd051e0", Frameless: true}]
+        - ID: 68
+          Type: 377 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xd05360", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -881,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 377 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xd05200", Frameless: true}]
+        - ID: 69
+          Type: 378 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xd05380", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -895,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 411 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd07aa0", Frameless: true}]
+        - ID: 103
+          Type: 412 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd07c20", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -909,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 385 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xd06a40", Frameless: true}]
+        - ID: 77
+          Type: 386 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xd06bc0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -923,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 393 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
+        - ID: 85
+          Type: 394 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xd07160", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -937,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 403 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd07640", Frameless: true}]
+        - ID: 95
+          Type: 404 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -951,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 400 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd075e0", Frameless: true}]
+        - ID: 92
+          Type: 401 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd07760", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -965,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 402 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd07620", Frameless: true}]
+        - ID: 94
+          Type: 403 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd077a0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -979,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 410 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd07a80", Frameless: true}]
+        - ID: 102
+          Type: 411 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd07c00", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -993,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 389 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xd06e60", Frameless: true}]
+        - ID: 81
+          Type: 390 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1007,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 371 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xd05140", Frameless: true}]
+        - ID: 63
+          Type: 372 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xd052c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1021,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 387 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xd06e20", Frameless: true}]
+        - ID: 79
+          Type: 388 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1189,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 406 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd07a00", Frameless: true}]
+        - ID: 98
+          Type: 407 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd07b80", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1273,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 397 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd07580", Frameless: true}]
+        - ID: 89
+          Type: 398 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd07700", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1287,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 369 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xd05100", Frameless: true}]
+        - ID: 61
+          Type: 370 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xd05280", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1315,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 392 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
+        - ID: 84
+          Type: 393 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xd07120", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1329,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 401 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd07600", Frameless: true}]
+        - ID: 93
+          Type: 402 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd07780", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1377,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 414 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd07d60", Frameless: true}]
+        - ID: 106
+          Type: 415 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd07ee0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1391,11 +1405,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 398 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd075a0", Frameless: true}]
+        - ID: 90
+          Type: 399 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd07720", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1405,11 +1419,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 55
-          Type: 364 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xd05060", Frameless: true}]
+        - ID: 56
+          Type: 365 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xd051e0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1419,11 +1433,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 407 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd07a20", Frameless: true}]
+        - ID: 99
+          Type: 408 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd07ba0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1433,11 +1447,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 408 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd07a40", Frameless: true}]
+        - ID: 100
+          Type: 409 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd07bc0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1447,11 +1461,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 409 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd07a60", Frameless: true}]
+        - ID: 101
+          Type: 410 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd07be0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1545,11 +1559,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 391 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xd06ec0", Frameless: true}]
+        - ID: 83
+          Type: 392 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xd07040", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1559,11 +1573,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 395 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd07540", Frameless: true}]
+        - ID: 87
+          Type: 396 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd076c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1573,11 +1587,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 412 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd07ac0", Frameless: true}]
+        - ID: 104
+          Type: 413 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd07c40", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1587,11 +1601,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 390 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xd06e80", Frameless: true}]
+        - ID: 82
+          Type: 391 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xd07000", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1615,11 +1629,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 404 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd07660", Frameless: true}]
+        - ID: 96
+          Type: 405 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2353,46 +2367,35 @@ Subprograms:
           IsReturn: true
     - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0xd04b20..0xd04b63]
+      OutOfLinePCRanges: [0xd04b20..0xd04b21]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 89 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd04b20..0xd04b3f
+            - Range: 0xd04b20..0xd04b21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04b3f..0xd04b42
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-        - Name: ~r0
-          Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd04b20..0xd04b63, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
     - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0xd04b80..0xd04be6]
+      OutOfLinePCRanges: [0xd04b40..0xd04ba6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 83 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd04b80..0xd04ba9
+            - Range: 0xd04b40..0xd04b69
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04ba9..0xd04bae
+            - Range: 0xd04b69..0xd04b6e
               Pieces:
                 - Size: 8
                   Op: null
@@ -2402,18 +2405,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd04b80..0xd04be6, Pieces: []}]
+          Locations: [{Range: 0xd04b40..0xd04ba6, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0xd04c00..0xd04c01]
+      OutOfLinePCRanges: [0xd04bc0..0xd04bc1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd04c00..0xd04c01
+            - Range: 0xd04bc0..0xd04bc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2422,308 +2425,325 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 55
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd05060..0xd05061]
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xd04be0..0xd04c34]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 90 StructureType main.structWithMap
+        - Name: a
+          Type: 90 PointerType *interface {}
           Locations:
-            - Range: 0xd05060..0xd05061
+            - Range: 0xd04be0..0xd04c06
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: ~r0
+          Type: 11 GoStringHeaderType string
+          Locations: [{Range: 0xd04be0..0xd04c34, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 56
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd05080..0xd05081]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 96 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xd05080..0xd05081
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 57
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd050a0..0xd050a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 101 GoMapType map[string]int
-          Locations:
-            - Range: 0xd050a0..0xd050a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd050c0..0xd050c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 106 GoMapType map[string][]string
-          Locations:
-            - Range: 0xd050c0..0xd050c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd050e0..0xd050e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xd050e0..0xd050e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xd05100..0xd05101]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 101 GoMapType map[string]int
-          Locations:
-            - Range: 0xd05100..0xd05101
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xd05120..0xd05121]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xd05120..0xd05121
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xd05140..0xd05141]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 117 PointerType *map[string]int
-          Locations:
-            - Range: 0xd05140..0xd05141
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 63
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xd05160..0xd05161]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 91 GoMapType map[int]int
-          Locations:
-            - Range: 0xd05160..0xd05161
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 64
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xd05180..0xd05181]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 118 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xd05180..0xd05181
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 65
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xd051a0..0xd051a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 118 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xd051a0..0xd051a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 66
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xd051c0..0xd051c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 123 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0xd051c0..0xd051c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallValue
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0xd051e0..0xd051e1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 128 GoMapType map[int]uint8
+        - Name: s
+          Type: 91 StructureType main.structWithMap
           Locations:
             - Range: 0xd051e0..0xd051e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValueMassive
+    - ID: 57
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xd05200..0xd05201]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 128 GoMapType map[int]uint8
+        - Name: m
+          Type: 97 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd05200..0xd05201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 58
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xd05220..0xd05221]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[uint8]uint8
+          Type: 102 GoMapType map[string]int
           Locations:
             - Range: 0xd05220..0xd05221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 59
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xd05240..0xd05241]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[uint8]uint8
+          Type: 107 GoMapType map[string][]string
           Locations:
             - Range: 0xd05240..0xd05241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapSmallKeySmallValue
+    - ID: 60
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xd05260..0xd05261]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[uint8]uint8
+          Type: 112 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd05260..0xd05261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 61
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xd05280..0xd05281]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 138 GoMapType map[uint8][4]int
+          Type: 102 GoMapType map[string]int
           Locations:
             - Range: 0xd05280..0xd05281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapLargeKeySmallValue
+    - ID: 62
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xd052a0..0xd052a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 143 GoMapType map[[4]int]uint8
+          Type: 117 ArrayType [2]map[string]int
           Locations:
             - Range: 0xd052a0..0xd052a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 63
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xd052c0..0xd052c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 148 GoMapType map[[4]int][4]int
+          Type: 118 PointerType *map[string]int
           Locations:
             - Range: 0xd052c0..0xd052c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 64
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0xd052e0..0xd052e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 92 GoMapType map[int]int
+          Locations:
+            - Range: 0xd052e0..0xd052e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 65
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xd05300..0xd05301]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 119 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xd05300..0xd05301
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 66
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xd05320..0xd05321]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 119 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xd05320..0xd05321
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 67
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xd05340..0xd05341]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 124 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0xd05340..0xd05341
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xd05360..0xd05361]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 129 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xd05360..0xd05361
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xd05380..0xd05381]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 129 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xd05380..0xd05381
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xd053a0..0xd053a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 134 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd053a0..0xd053a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xd053c0..0xd053c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 134 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd053c0..0xd053c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xd053e0..0xd053e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 134 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd053e0..0xd053e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xd05400..0xd05401]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 139 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xd05400..0xd05401
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xd05420..0xd05421]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 144 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xd05420..0xd05421
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 75
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xd05440..0xd05441]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 149 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xd05440..0xd05441
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 76
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd06880..0xd06881]
+      OutOfLinePCRanges: [0xd06a00..0xd06a01]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06880..0xd06881
+            - Range: 0xd06a00..0xd06a01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06880..0xd06881
+            - Range: 0xd06a00..0xd06a01
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd06880..0xd06881
+            - Range: 0xd06a00..0xd06a01
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd06a40..0xd06a41]
+      OutOfLinePCRanges: [0xd06bc0..0xd06bc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd06a40..0xd06a41
+            - Range: 0xd06bc0..0xd06bc1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06a40..0xd06a41
+            - Range: 0xd06bc0..0xd06bc1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd06a40..0xd06a41
+            - Range: 0xd06bc0..0xd06bc1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd06a40..0xd06a41
+            - Range: 0xd06bc0..0xd06bc1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06a40..0xd06a41
+            - Range: 0xd06bc0..0xd06bc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2731,39 +2751,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd06c60..0xd06c61]
+      OutOfLinePCRanges: [0xd06de0..0xd06de1]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 153 GoChannelType chan bool
+          Type: 154 GoChannelType chan bool
           Locations:
-            - Range: 0xd06c60..0xd06c61
+            - Range: 0xd06de0..0xd06de1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd06e20..0xd06e21]
+      OutOfLinePCRanges: [0xd06fa0..0xd06fa1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 154 PointerType *main.structWithTwoValues
+          Type: 155 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd06e20..0xd06e21
+            - Range: 0xd06fa0..0xd06fa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd06e40..0xd06e41]
+      OutOfLinePCRanges: [0xd06fc0..0xd06fc1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 156 StructureType main.node
+          Type: 157 StructureType main.node
           Locations:
-            - Range: 0xd06e40..0xd06e41
+            - Range: 0xd06fc0..0xd06fc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2771,112 +2791,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd06e60..0xd06e61]
+      OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 157 PointerType *main.node
+          Type: 158 PointerType *main.node
           Locations:
-            - Range: 0xd06e60..0xd06e61
+            - Range: 0xd06fe0..0xd06fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd06e80..0xd06e81]
+      OutOfLinePCRanges: [0xd07000..0xd07001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xd06e80..0xd06e81
+            - Range: 0xd07000..0xd07001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd06ec0..0xd06ec1]
+      OutOfLinePCRanges: [0xd07040..0xd07041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xd06ec0..0xd06ec1
+            - Range: 0xd07040..0xd07041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd06fa0..0xd06fa1]
+      OutOfLinePCRanges: [0xd07120..0xd07121]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xd06fa0..0xd06fa1
+            - Range: 0xd07120..0xd07121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
+      OutOfLinePCRanges: [0xd07160..0xd07161]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0xd06fe0..0xd06fe1
+            - Range: 0xd07160..0xd07161
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd06fe0..0xd06fe1
+            - Range: 0xd07160..0xd07161
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd07020..0xd07021]
+      OutOfLinePCRanges: [0xd071a0..0xd071a1]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 158 PointerType *main.t
+          Type: 159 PointerType *main.t
           Locations:
-            - Range: 0xd07020..0xd07021
+            - Range: 0xd071a0..0xd071a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd07540..0xd07541]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 160 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd07540..0xd07541
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 87
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd07560..0xd07561]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xd076c0..0xd076c1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 160 GoSliceHeaderType []uint
+          Type: 161 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd07560..0xd07561
+            - Range: 0xd076c0..0xd076c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2887,14 +2889,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd07580..0xd07581]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xd076e0..0xd076e1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 161 GoSliceHeaderType [][]uint
+          Type: 161 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd07580..0xd07581
+            - Range: 0xd076e0..0xd076e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2905,14 +2907,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd075a0..0xd075a1]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xd07700..0xd07701]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 162 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xd075a0..0xd075a1
+            - Range: 0xd07700..0xd07701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2920,24 +2922,17 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd075a0..0xd075a1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 90
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd075c0..0xd075c1]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xd07720..0xd07721]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Type: 164 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd075c0..0xd075c1
+            - Range: 0xd07720..0xd07721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2950,19 +2945,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd075c0..0xd075c1
+            - Range: 0xd07720..0xd07721
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 91
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd075e0..0xd075e1]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xd07740..0xd07741]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Type: 164 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd075e0..0xd075e1
+            - Range: 0xd07740..0xd07741
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2975,19 +2970,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd075e0..0xd075e1
+            - Range: 0xd07740..0xd07741
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd07600..0xd07601]
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd07760..0xd07761]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 166 GoSliceHeaderType []string
+        - Name: xs
+          Type: 164 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd07600..0xd07601
+            - Range: 0xd07760..0xd07761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2997,22 +2992,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd07760..0xd07761
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 93
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xd07780..0xd07781]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 167 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xd07780..0xd07781
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd07620..0xd07621]
+      OutOfLinePCRanges: [0xd077a0..0xd077a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd07620..0xd07621
+            - Range: 0xd077a0..0xd077a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 167 GoSliceHeaderType []bool
+          Type: 168 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd07620..0xd07621
+            - Range: 0xd077a0..0xd077a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3025,37 +3045,19 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd07620..0xd07621
+            - Range: 0xd077a0..0xd077a1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd07640..0xd07641]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 168 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xd07640..0xd07641
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 95
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd07660..0xd07661]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xd077c0..0xd077c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 160 GoSliceHeaderType []uint
+          Type: 169 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd07660..0xd07661
+            - Range: 0xd077c0..0xd077c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3066,24 +3068,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 96
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd077e0..0xd077e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd077e0..0xd077e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 97
       Name: main.stackC
-      OutOfLinePCRanges: [0xd079a0..0xd079f2]
+      OutOfLinePCRanges: [0xd07b20..0xd07b72]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd079a0..0xd079f2, Pieces: []}]
+          Locations: [{Range: 0xd07b20..0xd07b72, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd07a00..0xd07a01]
+      OutOfLinePCRanges: [0xd07b80..0xd07b81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07a00..0xd07a01
+            - Range: 0xd07b80..0xd07b81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3091,15 +3111,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd07a20..0xd07a21]
+      OutOfLinePCRanges: [0xd07ba0..0xd07ba1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07a20..0xd07a21
+            - Range: 0xd07ba0..0xd07ba1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3110,7 +3130,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07a20..0xd07a21
+            - Range: 0xd07ba0..0xd07ba1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3121,7 +3141,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07a20..0xd07a21
+            - Range: 0xd07ba0..0xd07ba1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3129,15 +3149,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 100
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd07a40..0xd07a5f]
+      OutOfLinePCRanges: [0xd07bc0..0xd07bdf]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 169 StructureType main.threeStringStruct
+          Type: 170 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd07a40..0xd07a5f
+            - Range: 0xd07bc0..0xd07bdf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3153,55 +3173,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd07a60..0xd07a61]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 170 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xd07a60..0xd07a61
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 101
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd07a80..0xd07a81]
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0xd07be0..0xd07be1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 171 PointerType *main.oneStringStruct
+          Type: 171 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd07a80..0xd07a81
+            - Range: 0xd07be0..0xd07be1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd07aa0..0xd07aa1]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xd07c00..0xd07c01]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
+        - Name: a
+          Type: 172 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd07aa0..0xd07aa1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07c00..0xd07c01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd07ac0..0xd07ac1]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xd07c20..0xd07c21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07ac0..0xd07ac1
+            - Range: 0xd07c20..0xd07c21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3210,14 +3214,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 104
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd07ae0..0xd07ae1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xd07c40..0xd07c41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07ae0..0xd07ae1
+            - Range: 0xd07c40..0xd07c41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3226,14 +3230,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testStruct
-      OutOfLinePCRanges: [0xd07d60..0xd07d83]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xd07c60..0xd07c61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 173 StructureType main.aStruct
+          Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07d60..0xd07d83
+            - Range: 0xd07c60..0xd07c61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 106
+      Name: main.testStruct
+      OutOfLinePCRanges: [0xd07ee0..0xd07f03]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 174 StructureType main.aStruct
+          Locations:
+            - Range: 0xd07ee0..0xd07f03
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3251,29 +3271,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 106
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd07ee0..0xd07ee1]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 175 StructureType main.emptyStruct
-          Locations: [{Range: 0xd07ee0..0xd07ee1, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 107
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd07f00..0xd07f01]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0xd08060..0xd08061]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 176 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0xd07f00..0xd07f01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 176 StructureType main.emptyStruct
+          Locations: [{Range: 0xd08060..0xd08061, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0xd08080..0xd08081]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 177 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0xd08080..0xd08081
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd04360..0xd043c2]
       InlinePCRanges:
@@ -3303,28 +3323,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 110
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04606..0xd0463e]
           RootRanges: [0xd045a0..0xd04665]
       Variables: []
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04713..0xd04751]
           RootRanges: [0xd04700..0xd0480e]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd047c6..0xd047fe]
           RootRanges: [0xd04700..0xd0480e]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3338,7 +3358,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3363,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 237
+      ID: 238
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 238 PointerType *main.deepSlice3
+      Pointee: 239 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 256
+      ID: 257
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 257 PointerType *main.deepSlice8
+      Pointee: 258 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 262
+      ID: 263
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 263 PointerType *main.deepSlice9
+      Pointee: 264 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3387,7 +3407,7 @@ Types:
       ID: 305
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 158 PointerType *main.t
+      Pointee: 159 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3396,40 +3416,40 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 183
+      ID: 184
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 183 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 241
+      ID: 242
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 241 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 260
+      ID: 261
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 260 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 266
+      ID: 267
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 266 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 180
+      ID: 181
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*string.array
+      Pointee: 180 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 222
+      ID: 223
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType [][]uint.array
+      Pointee: 222 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 228
+      ID: 229
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []bool.array
+      Pointee: 228 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 270
       Name: '*[]interface {}.array'
@@ -3441,30 +3461,30 @@ Types:
       ByteSize: 8
       Pointee: 308 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 224
+      ID: 225
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 223 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 224 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 226
+      ID: 227
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType []string.array
+      Pointee: 226 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 162
+      ID: 163
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 160 GoSliceHeaderType []uint
+      Pointee: 161 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 220
+      ID: 221
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []uint.array
+      Pointee: 220 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 230
+      ID: 231
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType []uint16.array
+      Pointee: 230 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3473,35 +3493,35 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 151
+      ID: 152
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 152 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 153 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 146
+      ID: 147
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 147 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 148 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 114
+      ID: 115
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 115 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 116 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 126
+      ID: 127
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 127 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 128 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '*bucket<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 245
+      ID: 246
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 246 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 247 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
       ID: 274
       Name: '*bucket<int,*main.deepMap8>'
@@ -3513,50 +3533,50 @@ Types:
       ByteSize: 8
       Pointee: 284 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 94
+      ID: 95
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 95 GoHMapBucketType bucket<int,int>
+      Pointee: 96 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
       ID: 292
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
       Pointee: 293 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
-      ID: 131
+      ID: 132
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 132 GoHMapBucketType bucket<int,uint8>
+      Pointee: 133 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 122
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 109
+      ID: 110
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 110 GoHMapBucketType bucket<string,[]string>
+      Pointee: 111 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 104
+      ID: 105
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 105 GoHMapBucketType bucket<string,int>
+      Pointee: 106 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 99
+      ID: 100
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 100 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 101 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 141
+      ID: 142
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 142 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 143 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 136
+      ID: 137
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 138 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -3579,35 +3599,35 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 149
+      ID: 150
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 150 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 151 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 144
+      ID: 145
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 145 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 146 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 112
+      ID: 113
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 113 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 114 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 124
+      ID: 125
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 125 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 126 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*hash<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 243
+      ID: 244
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 244 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 245 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
       ID: 272
       Name: '*hash<int,*main.deepMap8>'
@@ -3619,50 +3639,50 @@ Types:
       ByteSize: 8
       Pointee: 282 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 92
+      ID: 93
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 93 GoHMapHeaderType hash<int,int>
+      Pointee: 94 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
       ID: 290
       Name: '*hash<int,interface {}>'
       ByteSize: 8
       Pointee: 291 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
-      ID: 129
+      ID: 130
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 130 GoHMapHeaderType hash<int,uint8>
+      Pointee: 131 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 120
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 120 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 121 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 107
+      ID: 108
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 108 GoHMapHeaderType hash<string,[]string>
+      Pointee: 109 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 103
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 103 GoHMapHeaderType hash<string,int>
+      Pointee: 104 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 97
+      ID: 98
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 98 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 99 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 139
+      ID: 140
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 140 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 141 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 134
+      ID: 135
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 136 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -3699,26 +3719,26 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 268
+      ID: 90
       Name: '*interface {}'
       ByteSize: 8
       GoRuntimeType: 363520
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 187
+      ID: 188
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 356032
       GoKind: 22
-      Pointee: 188 StructureType main.deepMap2
+      Pointee: 189 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 248
+      ID: 249
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 355968
       GoKind: 22
-      Pointee: 249 UnresolvedPointeeType main.deepMap3
+      Pointee: 250 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -3748,12 +3768,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 231
+      ID: 232
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356544
       GoKind: 22
-      Pointee: 232 UnresolvedPointeeType main.deepPtr3
+      Pointee: 233 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3762,33 +3782,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 251
+      ID: 252
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 252 StructureType main.deepPtr8
+      Pointee: 253 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 253
+      ID: 254
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356160
       GoKind: 22
-      Pointee: 254 StructureType main.deepPtr9
+      Pointee: 255 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 357184
       GoKind: 22
-      Pointee: 181 StructureType main.deepSlice2
+      Pointee: 182 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 238
+      ID: 239
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357120
       GoKind: 22
-      Pointee: 239 UnresolvedPointeeType main.deepSlice3
+      Pointee: 240 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3797,25 +3817,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 257
+      ID: 258
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 258 StructureType main.deepSlice8
+      Pointee: 259 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 263
+      ID: 264
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 356736
       GoKind: 22
-      Pointee: 264 StructureType main.deepSlice9
+      Pointee: 265 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 176
+      ID: 177
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 175 StructureType main.emptyStruct
+      Pointee: 176 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 86
       Name: '*main.esotericHeap'
@@ -3824,18 +3844,18 @@ Types:
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 157
+      ID: 158
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 357376
       GoKind: 22
-      Pointee: 156 StructureType main.node
+      Pointee: 157 StructureType main.node
     - __kind: PointerType
-      ID: 171
+      ID: 172
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 172 StructureType main.oneStringStruct
+      Pointee: 173 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
@@ -3843,57 +3863,57 @@ Types:
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 234
+      ID: 235
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 233 GoStringDataType main.stringType1.str
+      Pointee: 234 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 235 UnresolvedPointeeType main.stringType2
+      Pointee: 236 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 204
+      ID: 205
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 355520
       GoKind: 22
-      Pointee: 90 StructureType main.structWithMap
+      Pointee: 91 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 164
+      ID: 165
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 165 StructureType main.structWithNoStrings
+      Pointee: 166 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 154
+      ID: 155
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 155 StructureType main.structWithTwoValues
+      Pointee: 156 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 158
+      ID: 159
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 159 GoSliceHeaderType main.t
+      Pointee: 160 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 307
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 306 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 170
+      ID: 171
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 169 StructureType main.threeStringStruct
+      Pointee: 170 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 117
+      ID: 118
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 101 GoMapType map[string]int
+      Pointee: 102 GoMapType map[string]int
     - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
@@ -3909,10 +3929,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 178
+      ID: 179
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 177 GoStringDataType string.str
+      Pointee: 178 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -3956,8 +3976,23 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 405
+      ID: 406
       Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 364
+      Name: Probe[main.testAnyPtr]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 90 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 362
       Name: Probe[main.testAny]
@@ -4004,7 +4039,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 370
+      ID: 371
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4012,10 +4047,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 ArrayType [2]map[string]int
+            Type: 117 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4079,7 +4114,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 386
+      ID: 387
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4087,14 +4122,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 153 GoChannelType chan bool
+            Type: 154 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: c}
+                  Variable: {subprogram: 78, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 384
+      ID: 385
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4105,7 +4140,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: w}
+                  Variable: {subprogram: 76, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4114,7 +4149,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 1, name: x}
+                  Variable: {subprogram: 76, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4123,11 +4158,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 2, name: y}
+                  Variable: {subprogram: 76, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 394
+      ID: 395
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4135,10 +4170,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 158 PointerType *main.t
+            Type: 159 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: t}
+                  Variable: {subprogram: 86, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4232,7 +4267,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 399
+      ID: 400
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4240,10 +4275,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 163 GoSliceHeaderType []main.structWithNoStrings
+            Type: 164 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4252,11 +4287,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 396
+      ID: 397
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4264,14 +4299,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType []uint
+            Type: 161 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 413
+      ID: 414
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4282,11 +4317,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 416
+      ID: 417
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4294,14 +4329,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 176 PointerType *main.emptyStruct
+            Type: 177 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 415
+      ID: 416
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4309,10 +4344,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 StructureType main.emptyStruct
+            Type: 176 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: e}
+                  Variable: {subprogram: 107, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -4421,7 +4456,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 418
+      ID: 419
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 356
@@ -4448,16 +4483,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 419
+      ID: 420
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 420
+      ID: 421
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 358
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 417
+      ID: 418
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4468,11 +4503,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 421
+      ID: 422
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4483,11 +4518,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: x}
+                  Variable: {subprogram: 113, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 423
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4498,7 +4533,7 @@ Types:
             Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4592,7 +4627,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 388
+      ID: 389
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4600,14 +4635,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 156 StructureType main.node
+            Type: 157 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 368
+      ID: 369
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4615,14 +4650,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 111 GoMapType map[[4]string][2]int
+            Type: 112 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 375
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4630,14 +4665,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 GoMapType map[string][]main.structWithMap
+            Type: 119 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 373
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4645,14 +4680,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 91 GoMapType map[int]int
+            Type: 92 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 383
+      ID: 384
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4660,14 +4695,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 148 GoMapType map[[4]int][4]int
+            Type: 149 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 383
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4675,14 +4710,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 143 GoMapType map[[4]int]uint8
+            Type: 144 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 373
+      ID: 374
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4690,14 +4725,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 118 GoMapType map[string][]main.structWithMap
+            Type: 119 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 382
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4705,14 +4740,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 138 GoMapType map[uint8][4]int
+            Type: 139 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 381
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4720,14 +4755,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[uint8]uint8
+            Type: 134 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 367
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4735,14 +4770,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 101 GoMapType map[string]int
+            Type: 102 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 368
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4750,14 +4785,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[string][]string
+            Type: 107 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 366
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4765,14 +4800,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 96 GoMapType map[string]main.nestedStruct
+            Type: 97 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 376
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4780,14 +4815,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 123 GoMapType map[bool]main.node
+            Type: 124 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 379
+      ID: 380
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4795,14 +4830,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[uint8]uint8
+            Type: 134 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 379
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4810,14 +4845,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[uint8]uint8
+            Type: 134 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 377
+      ID: 378
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4825,14 +4860,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 128 GoMapType map[int]uint8
+            Type: 129 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 376
+      ID: 377
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4840,14 +4875,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 128 GoMapType map[int]uint8
+            Type: 129 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 411
+      ID: 412
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4858,11 +4893,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 385
+      ID: 386
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4873,7 +4908,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4882,7 +4917,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: b}
+                  Variable: {subprogram: 77, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4891,7 +4926,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: c}
+                  Variable: {subprogram: 77, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4900,7 +4935,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 3, name: d}
+                  Variable: {subprogram: 77, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4909,11 +4944,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 4, name: e}
+                  Variable: {subprogram: 77, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 393
+      ID: 394
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4924,7 +4959,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4933,11 +4968,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: a}
+                  Variable: {subprogram: 85, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 400
+      ID: 401
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4945,10 +4980,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 163 GoSliceHeaderType []main.structWithNoStrings
+            Type: 164 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4957,11 +4992,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 402
+      ID: 403
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4972,16 +5007,16 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 94, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 167 GoSliceHeaderType []bool
+            Type: 168 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: s}
+                  Variable: {subprogram: 94, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -4990,11 +5025,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 2, name: x}
+                  Variable: {subprogram: 94, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 403
+      ID: 404
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5002,14 +5037,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 168 GoSliceHeaderType []uint16
+            Type: 169 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 410
+      ID: 411
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5017,14 +5052,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 171 PointerType *main.oneStringStruct
+            Type: 172 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 389
+      ID: 390
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5032,14 +5067,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 157 PointerType *main.node
+            Type: 158 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 371
+      ID: 372
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5047,14 +5082,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 117 PointerType *map[string]int
+            Type: 118 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 387
+      ID: 388
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5062,10 +5097,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 154 PointerType *main.structWithTwoValues
+            Type: 155 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5234,7 +5269,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 406
+      ID: 407
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5245,7 +5280,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5324,7 +5359,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 397
+      ID: 398
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5332,14 +5367,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType [][]uint
+            Type: 162 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 369
+      ID: 370
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5347,10 +5382,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 101 GoMapType map[string]int
+            Type: 102 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5369,7 +5404,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 392
+      ID: 393
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5380,11 +5415,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 401
+      ID: 402
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5392,10 +5427,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 166 GoSliceHeaderType []string
+            Type: 167 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: s}
+                  Variable: {subprogram: 93, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5429,7 +5464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 398
+      ID: 399
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5437,10 +5472,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 163 GoSliceHeaderType []main.structWithNoStrings
+            Type: 164 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5449,11 +5484,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 365
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5461,14 +5496,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 90 StructureType main.structWithMap
+            Type: 91 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: s}
+                  Variable: {subprogram: 56, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 414
+      ID: 415
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5476,14 +5511,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 173 StructureType main.aStruct
+            Type: 174 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 409
+      ID: 410
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5491,14 +5526,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.threeStringStruct
+            Type: 171 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 408
+      ID: 409
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5506,14 +5541,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 StructureType main.threeStringStruct
+            Type: 170 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 407
+      ID: 408
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5524,7 +5559,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5533,7 +5568,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: y}
+                  Variable: {subprogram: 99, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5542,7 +5577,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: z}
+                  Variable: {subprogram: 99, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5636,7 +5671,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 391
+      ID: 392
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5647,11 +5682,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 395
+      ID: 396
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5659,14 +5694,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType []uint
+            Type: 161 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 412
+      ID: 413
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5677,11 +5712,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 390
+      ID: 391
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5692,7 +5727,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5711,7 +5746,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 404
+      ID: 405
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5719,10 +5754,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType []uint
+            Type: 161 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5800,13 +5835,13 @@ Types:
       HasCount: true
       Element: 14 BaseType int8
     - __kind: ArrayType
-      ID: 116
+      ID: 117
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 101 GoMapType map[string]int
+      Element: 102 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -5859,7 +5894,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 214
+      ID: 215
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 622304
@@ -5868,7 +5903,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 199
+      ID: 200
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 622592
@@ -5885,7 +5920,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 184
+      ID: 185
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 619616
@@ -5909,14 +5944,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 182 GoSliceDataType []*main.deepSlice2.array
+      Data: 183 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 183
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 236
+      ID: 237
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446592
@@ -5924,21 +5959,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 237 PointerType **main.deepSlice3
+          Type: 238 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 240 GoSliceDataType []*main.deepSlice3.array
+      Data: 241 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 241
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 238 PointerType *main.deepSlice3
+      Element: 239 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 255
+      ID: 256
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446272
@@ -5946,21 +5981,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 256 PointerType **main.deepSlice8
+          Type: 257 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 259 GoSliceDataType []*main.deepSlice8.array
+      Data: 260 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 260
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 257 PointerType *main.deepSlice8
+      Element: 258 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 261
+      ID: 262
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446208
@@ -5968,19 +6003,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 262 PointerType **main.deepSlice9
+          Type: 263 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 265 GoSliceDataType []*main.deepSlice9.array
+      Data: 266 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 266
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 263 PointerType *main.deepSlice9
+      Element: 264 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -5997,35 +6032,35 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 179 GoSliceDataType []*string.array
+      Data: 180 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 180
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 162
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *[]uint
+          Type: 163 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 221 GoSliceDataType [][]uint.array
+      Data: 222 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 222
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 160 GoSliceHeaderType []uint
+      Element: 161 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 168
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 453952
@@ -6040,42 +6075,42 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 227 GoSliceDataType []bool.array
+      Data: 228 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 228
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 219
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 152 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 153 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 218
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 147 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 148 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 202
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 115 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 116 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 209
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 127 GoHMapBucketType bucket<bool,main.node>
+      Element: 128 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 190
       Name: '[]bucket<int,*main.deepMap2>.array'
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 246 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 247 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 279
       Name: '[]bucket<int,*main.deepMap8>.array'
@@ -6087,52 +6122,52 @@ Types:
       ByteSize: 2048
       Element: 284 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 95 GoHMapBucketType bucket<int,int>
+      Element: 96 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
       ID: 295
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
       Element: 293 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 211
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 132 GoHMapBucketType bucket<int,uint8>
+      Element: 133 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 206
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 198
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 110 GoHMapBucketType bucket<string,[]string>
+      Element: 111 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 196
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 105 GoHMapBucketType bucket<string,int>
+      Element: 106 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 195
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 100 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 101 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 142 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 143 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 213
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<uint8,uint8>
+      Element: 138 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 267
+      ID: 268
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454272
@@ -6140,7 +6175,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 268 PointerType *interface {}
+          Type: 90 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -6154,49 +6189,49 @@ Types:
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 216
+      ID: 217
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 214 ArrayType [4]int
+      Element: 215 ArrayType [4]int
     - __kind: ArrayType
-      ID: 198
+      ID: 199
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 199 ArrayType [4]string
+      Element: 200 ArrayType [4]string
     - __kind: ArrayType
-      ID: 206
+      ID: 207
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 185
+      ID: 186
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 192
+      ID: 193
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 211
+      ID: 212
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 203
+      ID: 204
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 446912
@@ -6204,7 +6239,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 204 PointerType *main.structWithMap
+          Type: 205 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -6216,30 +6251,30 @@ Types:
       ID: 308
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 90 StructureType main.structWithMap
+      Element: 91 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 164
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 164 PointerType *main.structWithNoStrings
+          Type: 165 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 223 GoSliceDataType []main.structWithNoStrings.array
+      Data: 224 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 165 StructureType main.structWithNoStrings
+      Element: 166 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 454080
@@ -6254,14 +6289,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 225 GoSliceDataType []string.array
+      Data: 226 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 226
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 161
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 453568
@@ -6276,14 +6311,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []uint.array
+      Data: 220 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 220
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 15 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 169
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 452928
@@ -6298,26 +6333,26 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []uint16.array
+      Data: 230 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 230
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 186
+      ID: 187
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 187 PointerType *main.deepMap2
+      Element: 188 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 247
+      ID: 248
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 248 PointerType *main.deepMap3
+      Element: 249 PointerType *main.deepMap3
     - __kind: ArrayType
       ID: 276
       Name: '[]val<*main.deepMap8>'
@@ -6333,35 +6368,35 @@ Types:
       HasCount: true
       Element: 286 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 200
+      ID: 201
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 213
+      ID: 214
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 214 ArrayType [4]int
+      Element: 215 ArrayType [4]int
     - __kind: ArrayType
-      ID: 202
+      ID: 203
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 203 GoSliceHeaderType []main.structWithMap
+      Element: 204 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 196
+      ID: 197
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 166 GoSliceHeaderType []string
+      Element: 167 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 190
+      ID: 191
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
@@ -6375,21 +6410,21 @@ Types:
       HasCount: true
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 193
+      ID: 194
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 174 StructureType main.nestedStruct
+      Element: 175 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 207
+      ID: 208
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 156 StructureType main.node
+      Element: 157 StructureType main.node
     - __kind: ArrayType
-      ID: 209
+      ID: 210
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -6402,81 +6437,81 @@ Types:
       GoRuntimeType: 532064
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 152
+      ID: 153
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 216 ArrayType []key<[4]int>
+          Type: 217 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 213 ArrayType []val<[4]int>
+          Type: 214 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 151 PointerType *bucket<[4]int,[4]int>
-      KeyType: 214 ArrayType [4]int
-      ValueType: 214 ArrayType [4]int
+          Type: 152 PointerType *bucket<[4]int,[4]int>
+      KeyType: 215 ArrayType [4]int
+      ValueType: 215 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 147
+      ID: 148
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 216 ArrayType []key<[4]int>
+          Type: 217 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 209 ArrayType []val<uint8>
+          Type: 210 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 146 PointerType *bucket<[4]int,uint8>
-      KeyType: 214 ArrayType [4]int
+          Type: 147 PointerType *bucket<[4]int,uint8>
+      KeyType: 215 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 115
+      ID: 116
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<[4]string>
+          Type: 199 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 200 ArrayType []val<[2]int>
+          Type: 201 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 114 PointerType *bucket<[4]string,[2]int>
-      KeyType: 199 ArrayType [4]string
+          Type: 115 PointerType *bucket<[4]string,[2]int>
+      KeyType: 200 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 127
+      ID: 128
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 206 ArrayType []key<bool>
+          Type: 207 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 207 ArrayType []val<main.node>
+          Type: 208 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 126 PointerType *bucket<bool,main.node>
+          Type: 127 PointerType *bucket<bool,main.node>
       KeyType: 4 BaseType bool
-      ValueType: 156 StructureType main.node
+      ValueType: 157 StructureType main.node
     - __kind: GoHMapBucketType
       ID: 72
       Name: bucket<int,*main.deepMap2>
@@ -6484,37 +6519,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 186 ArrayType []val<*main.deepMap2>
+          Type: 187 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 71 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 187 PointerType *main.deepMap2
+      ValueType: 188 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 246
+      ID: 247
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 247 ArrayType []val<*main.deepMap3>
+          Type: 248 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 245 PointerType *bucket<int,*main.deepMap3>
+          Type: 246 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 248 PointerType *main.deepMap3
+      ValueType: 249 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
       ID: 275
       Name: bucket<int,*main.deepMap8>
@@ -6522,10 +6557,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 276 ArrayType []val<*main.deepMap8>
@@ -6541,10 +6576,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 285 ArrayType []val<*main.deepMap9>
@@ -6554,22 +6589,22 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 286 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
-      ID: 95
+      ID: 96
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 190 ArrayType []val<int>
+          Type: 191 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 94 PointerType *bucket<int,int>
+          Type: 95 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
@@ -6579,10 +6614,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 294 ArrayType []val<interface {}>
@@ -6592,140 +6627,140 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 132
+      ID: 133
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 209 ArrayType []val<uint8>
+          Type: 210 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 131 PointerType *bucket<int,uint8>
+          Type: 132 PointerType *bucket<int,uint8>
       KeyType: 9 BaseType int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 122
+      ID: 123
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 193 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 202 ArrayType []val<[]main.structWithMap>
+          Type: 203 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 121 PointerType *bucket<string,[]main.structWithMap>
+          Type: 122 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 203 GoSliceHeaderType []main.structWithMap
+      ValueType: 204 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 110
+      ID: 111
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 193 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 196 ArrayType []val<[]string>
+          Type: 197 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 109 PointerType *bucket<string,[]string>
+          Type: 110 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 166 GoSliceHeaderType []string
+      ValueType: 167 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 105
+      ID: 106
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 193 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 190 ArrayType []val<int>
+          Type: 191 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 104 PointerType *bucket<string,int>
+          Type: 105 PointerType *bucket<string,int>
       KeyType: 11 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 100
+      ID: 101
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 193 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 193 ArrayType []val<main.nestedStruct>
+          Type: 194 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 99 PointerType *bucket<string,main.nestedStruct>
+          Type: 100 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 174 StructureType main.nestedStruct
+      ValueType: 175 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 142
+      ID: 143
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 211 ArrayType []key<uint8>
+          Type: 212 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 213 ArrayType []val<[4]int>
+          Type: 214 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 141 PointerType *bucket<uint8,[4]int>
+          Type: 142 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 214 ArrayType [4]int
+      ValueType: 215 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 137
+      ID: 138
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 211 ArrayType []key<uint8>
+          Type: 212 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 209 ArrayType []val<uint8>
+          Type: 210 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 136 PointerType *bucket<uint8,uint8>
+          Type: 137 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 153
+      ID: 154
       Name: chan bool
       GoRuntimeType: 543328
       GoKind: 18
@@ -6778,7 +6813,7 @@ Types:
       GoRuntimeType: 444992
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 150
+      ID: 151
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -6799,20 +6834,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 151 PointerType *bucket<[4]int,[4]int>
+          Type: 152 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 151 PointerType *bucket<[4]int,[4]int>
+          Type: 152 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 152 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 218 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketType: 153 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 219 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 145
+      ID: 146
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -6833,20 +6868,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 146 PointerType *bucket<[4]int,uint8>
+          Type: 147 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 146 PointerType *bucket<[4]int,uint8>
+          Type: 147 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 147 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 217 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketType: 148 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 218 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 113
+      ID: 114
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -6867,20 +6902,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 114 PointerType *bucket<[4]string,[2]int>
+          Type: 115 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 114 PointerType *bucket<[4]string,[2]int>
+          Type: 115 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 115 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 201 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketType: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 202 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 125
+      ID: 126
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -6901,18 +6936,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 126 PointerType *bucket<bool,main.node>
+          Type: 127 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 126 PointerType *bucket<bool,main.node>
+          Type: 127 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 127 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 208 GoSliceDataType []bucket<bool,main.node>.array
+      BucketType: 128 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 209 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 70
       Name: hash<int,*main.deepMap2>
@@ -6946,9 +6981,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 189 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 190 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 244
+      ID: 245
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -6969,18 +7004,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 245 PointerType *bucket<int,*main.deepMap3>
+          Type: 246 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 245 PointerType *bucket<int,*main.deepMap3>
+          Type: 246 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 246 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 250 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 247 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 251 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
       ID: 273
       Name: hash<int,*main.deepMap8>
@@ -7050,7 +7085,7 @@ Types:
       BucketType: 284 GoHMapBucketType bucket<int,*main.deepMap9>
       BucketsType: 288 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
-      ID: 93
+      ID: 94
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -7071,18 +7106,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 94 PointerType *bucket<int,int>
+          Type: 95 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 94 PointerType *bucket<int,int>
+          Type: 95 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 95 GoHMapBucketType bucket<int,int>
-      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
+      BucketType: 96 GoHMapBucketType bucket<int,int>
+      BucketsType: 192 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
       ID: 291
       Name: hash<int,interface {}>
@@ -7118,7 +7153,7 @@ Types:
       BucketType: 293 GoHMapBucketType bucket<int,interface {}>
       BucketsType: 295 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 130
+      ID: 131
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -7139,20 +7174,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 131 PointerType *bucket<int,uint8>
+          Type: 132 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 131 PointerType *bucket<int,uint8>
+          Type: 132 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 132 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 210 GoSliceDataType []bucket<int,uint8>.array
+      BucketType: 133 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 211 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 120
+      ID: 121
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -7173,20 +7208,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 121 PointerType *bucket<string,[]main.structWithMap>
+          Type: 122 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 121 PointerType *bucket<string,[]main.structWithMap>
+          Type: 122 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 205 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketType: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 206 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 108
+      ID: 109
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -7207,20 +7242,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 109 PointerType *bucket<string,[]string>
+          Type: 110 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 109 PointerType *bucket<string,[]string>
+          Type: 110 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 110 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 197 GoSliceDataType []bucket<string,[]string>.array
+      BucketType: 111 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 198 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 103
+      ID: 104
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -7241,20 +7276,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 104 PointerType *bucket<string,int>
+          Type: 105 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 104 PointerType *bucket<string,int>
+          Type: 105 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 105 GoHMapBucketType bucket<string,int>
-      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
+      BucketType: 106 GoHMapBucketType bucket<string,int>
+      BucketsType: 196 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 98
+      ID: 99
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -7275,20 +7310,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 99 PointerType *bucket<string,main.nestedStruct>
+          Type: 100 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 99 PointerType *bucket<string,main.nestedStruct>
+          Type: 100 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 100 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketType: 101 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 195 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 140
+      ID: 141
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -7309,20 +7344,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 141 PointerType *bucket<uint8,[4]int>
+          Type: 142 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 141 PointerType *bucket<uint8,[4]int>
+          Type: 142 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 142 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 215 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketType: 143 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 216 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 135
+      ID: 136
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -7343,18 +7378,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 136 PointerType *bucket<uint8,uint8>
+          Type: 137 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 136 PointerType *bucket<uint8,uint8>
+          Type: 137 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 212 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketType: 138 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 213 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -7412,7 +7447,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -7428,7 +7463,7 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 174 StructureType main.nestedStruct
+          Type: 175 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 89
       Name: main.behavior
@@ -7468,7 +7503,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 188
+      ID: 189
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.099296e+06
@@ -7476,9 +7511,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 242 GoMapType map[int]*main.deepMap3
+          Type: 243 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 249
+      ID: 250
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7530,9 +7565,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 231 PointerType *main.deepPtr3
+          Type: 232 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 232
+      ID: 233
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7544,9 +7579,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 251 PointerType *main.deepPtr8
+          Type: 252 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 252
+      ID: 253
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.09968e+06
@@ -7554,9 +7589,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 253 PointerType *main.deepPtr9
+          Type: 254 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 254
+      ID: 255
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.099552e+06
@@ -7576,7 +7611,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 181
+      ID: 182
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.1016e+06
@@ -7584,9 +7619,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 236 GoSliceHeaderType []*main.deepSlice3
+          Type: 237 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 239
+      ID: 240
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7598,9 +7633,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 255 GoSliceHeaderType []*main.deepSlice8
+          Type: 256 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 258
+      ID: 259
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.100832e+06
@@ -7608,9 +7643,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 261 GoSliceHeaderType []*main.deepSlice9
+          Type: 262 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 264
+      ID: 265
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.100704e+06
@@ -7618,9 +7653,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 267 GoSliceHeaderType []interface {}
+          Type: 268 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 175
+      ID: 176
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7675,7 +7710,7 @@ Types:
           Offset: 56
           Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 174
+      ID: 175
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.279296e+06
@@ -7688,7 +7723,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 156
+      ID: 157
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.279136e+06
@@ -7699,9 +7734,9 @@ Types:
           Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 157 PointerType *main.node
+          Type: 158 PointerType *main.node
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7730,21 +7765,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 234 PointerType *main.stringType1.str
+          Type: 235 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 233 GoStringDataType main.stringType1.str
+      Data: 234 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 233
+      ID: 234
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 235
+      ID: 236
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
-      ID: 90
+      ID: 91
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.098272e+06
@@ -7752,9 +7787,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 91 GoMapType map[int]int
+          Type: 92 GoMapType map[int]int
     - __kind: StructureType
-      ID: 165
+      ID: 166
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7766,7 +7801,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 155
+      ID: 156
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7778,7 +7813,7 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: main.t
       ByteSize: 24
       GoKind: 23
@@ -7797,9 +7832,9 @@ Types:
       ID: 306
       Name: main.t.array
       ByteSize: 2048
-      Element: 158 PointerType *main.t
+      Element: 159 PointerType *main.t
     - __kind: StructureType
-      ID: 169
+      ID: 170
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7819,33 +7854,33 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 148
+      ID: 149
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 879680
       GoKind: 21
-      HeaderType: 150 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 151 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 143
+      ID: 144
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 879776
       GoKind: 21
-      HeaderType: 145 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 146 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 111
+      ID: 112
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 879872
       GoKind: 21
-      HeaderType: 113 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 123
+      ID: 124
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 879968
       GoKind: 21
-      HeaderType: 125 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 126 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
@@ -7854,12 +7889,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 242
+      ID: 243
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879488
       GoKind: 21
-      HeaderType: 244 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 245 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 271
       Name: map[int]*main.deepMap8
@@ -7875,12 +7910,12 @@ Types:
       GoKind: 21
       HeaderType: 282 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 91
+      ID: 92
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 877856
       GoKind: 21
-      HeaderType: 93 GoHMapHeaderType hash<int,int>
+      HeaderType: 94 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
       ID: 289
       Name: map[int]interface {}
@@ -7889,54 +7924,54 @@ Types:
       GoKind: 21
       HeaderType: 291 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
-      ID: 128
+      ID: 129
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 880064
       GoKind: 21
-      HeaderType: 130 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 131 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 118
+      ID: 119
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 880160
       GoKind: 21
-      HeaderType: 120 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 121 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 106
+      ID: 107
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 880256
       GoKind: 21
-      HeaderType: 108 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 109 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 101
+      ID: 102
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 880352
       GoKind: 21
-      HeaderType: 103 GoHMapHeaderType hash<string,int>
+      HeaderType: 104 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 96
+      ID: 97
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 880448
       GoKind: 21
-      HeaderType: 98 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 99 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 138
+      ID: 139
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 880544
       GoKind: 21
-      HeaderType: 140 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 141 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 133
+      ID: 134
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 880640
       GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 136 GoHMapHeaderType hash<uint8,uint8>
     - __kind: UnresolvedPointeeType
       ID: 74
       Name: runtime.mapextra
@@ -7950,13 +7985,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 178 PointerType *string.str
+          Type: 179 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 177 GoStringDataType string.str
+      Data: 178 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 177
+      ID: 178
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -8103,6 +8138,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 532128
       GoKind: 26
-MaxTypeID: 422
+MaxTypeID: 423
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1755760", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -3383,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 238
+      ID: 250
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 239 PointerType *main.deepSlice3
+      Pointee: 251 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 257
+      ID: 271
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 258 PointerType *main.deepSlice8
+      Pointee: 272 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 263
+      ID: 277
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 264 PointerType *main.deepSlice9
+      Pointee: 278 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3404,7 +3404,7 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 305
+      ID: 246
       Name: '**main.t'
       ByteSize: 8
       Pointee: 159 PointerType *main.t
@@ -3421,20 +3421,20 @@ Types:
       ByteSize: 8
       Pointee: 183 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 242
+      ID: 254
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 253 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 261
+      ID: 275
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 274 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 267
+      ID: 281
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 280 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 181
       Name: '*[]*string.array'
@@ -3451,15 +3451,15 @@ Types:
       ByteSize: 8
       Pointee: 228 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 270
+      ID: 284
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 269 GoSliceDataType []interface {}.array
+      Pointee: 283 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 309
+      ID: 265
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 308 GoSliceDataType []main.structWithMap.array
+      Pointee: 264 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 225
       Name: '*[]main.structWithNoStrings.array'
@@ -3518,30 +3518,30 @@ Types:
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 246
+      ID: 258
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 247 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 259 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 274
+      ID: 288
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 275 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 289 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 283
+      ID: 297
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 284 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 298 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 96 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 292
+      ID: 306
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 293 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 307 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*bucket<int,uint8>'
@@ -3624,30 +3624,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 244
+      ID: 256
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 245 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 257 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 272
+      ID: 286
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 273 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 287 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 281
+      ID: 295
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 282 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 296 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 93
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 94 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 290
+      ID: 304
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 291 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 305 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 130
       Name: '*hash<int,uint8>'
@@ -3733,12 +3733,12 @@ Types:
       GoKind: 22
       Pointee: 189 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 249
+      ID: 261
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 355968
       GoKind: 22
-      Pointee: 250 UnresolvedPointeeType main.deepMap3
+      Pointee: 262 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -3747,19 +3747,19 @@ Types:
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 277
+      ID: 291
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 355648
       GoKind: 22
-      Pointee: 278 StructureType main.deepMap8
+      Pointee: 292 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 286
+      ID: 300
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355584
       GoKind: 22
-      Pointee: 287 StructureType main.deepMap9
+      Pointee: 301 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3782,19 +3782,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 252
+      ID: 266
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 253 StructureType main.deepPtr8
+      Pointee: 267 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 254
+      ID: 268
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356160
       GoKind: 22
-      Pointee: 255 StructureType main.deepPtr9
+      Pointee: 269 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3803,12 +3803,12 @@ Types:
       GoKind: 22
       Pointee: 182 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 239
+      ID: 251
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357120
       GoKind: 22
-      Pointee: 240 UnresolvedPointeeType main.deepSlice3
+      Pointee: 252 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3817,19 +3817,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 258
+      ID: 272
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 259 StructureType main.deepSlice8
+      Pointee: 273 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 264
+      ID: 278
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 356736
       GoKind: 22
-      Pointee: 265 StructureType main.deepSlice9
+      Pointee: 279 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 177
       Name: '*main.emptyStruct'
@@ -3898,10 +3898,10 @@ Types:
       GoKind: 22
       Pointee: 160 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 307
+      ID: 248
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 306 GoSliceDataType main.t.array
+      Pointee: 247 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 171
       Name: '*main.threeStringStruct'
@@ -5951,7 +5951,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 237
+      ID: 249
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446592
@@ -5959,21 +5959,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 238 PointerType **main.deepSlice3
+          Type: 250 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 241 GoSliceDataType []*main.deepSlice3.array
+      Data: 253 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 253
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 239 PointerType *main.deepSlice3
+      Element: 251 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 256
+      ID: 270
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446272
@@ -5981,21 +5981,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 257 PointerType **main.deepSlice8
+          Type: 271 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 260 GoSliceDataType []*main.deepSlice8.array
+      Data: 274 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 274
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 258 PointerType *main.deepSlice8
+      Element: 272 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 262
+      ID: 276
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446208
@@ -6003,19 +6003,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 263 PointerType **main.deepSlice9
+          Type: 277 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 266 GoSliceDataType []*main.deepSlice9.array
+      Data: 280 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 280
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 264 PointerType *main.deepSlice9
+      Element: 278 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6107,30 +6107,30 @@ Types:
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 263
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 247 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 259 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 293
       Name: '[]bucket<int,*main.deepMap8>.array'
       ByteSize: 2048
-      Element: 275 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 289 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 302
       Name: '[]bucket<int,*main.deepMap9>.array'
       ByteSize: 2048
-      Element: 284 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 298 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 192
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 96 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 309
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
-      Element: 293 GoHMapBucketType bucket<int,interface {}>
+      Element: 307 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
       ID: 211
       Name: '[]bucket<int,uint8>.array'
@@ -6167,7 +6167,7 @@ Types:
       ByteSize: 2048
       Element: 138 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 268
+      ID: 282
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454272
@@ -6182,9 +6182,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 269 GoSliceDataType []interface {}.array
+      Data: 283 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 283
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
@@ -6246,9 +6246,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 308 GoSliceDataType []main.structWithMap.array
+      Data: 264 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 308
+      ID: 264
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 91 StructureType main.structWithMap
@@ -6347,26 +6347,26 @@ Types:
       HasCount: true
       Element: 188 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 248
+      ID: 260
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 249 PointerType *main.deepMap3
+      Element: 261 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 276
+      ID: 290
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 277 PointerType *main.deepMap8
+      Element: 291 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 285
+      ID: 299
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 286 PointerType *main.deepMap9
+      Element: 300 PointerType *main.deepMap9
     - __kind: ArrayType
       ID: 201
       Name: '[]val<[2]int>'
@@ -6403,7 +6403,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 294
+      ID: 308
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
@@ -6532,7 +6532,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 188 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 247
+      ID: 259
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
@@ -6544,14 +6544,14 @@ Types:
           Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 248 ArrayType []val<*main.deepMap3>
+          Type: 260 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 246 PointerType *bucket<int,*main.deepMap3>
+          Type: 258 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 249 PointerType *main.deepMap3
+      ValueType: 261 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 275
+      ID: 289
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
@@ -6563,14 +6563,14 @@ Types:
           Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 276 ArrayType []val<*main.deepMap8>
+          Type: 290 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 274 PointerType *bucket<int,*main.deepMap8>
+          Type: 288 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 277 PointerType *main.deepMap8
+      ValueType: 291 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 284
+      ID: 298
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
@@ -6582,12 +6582,12 @@ Types:
           Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 285 ArrayType []val<*main.deepMap9>
+          Type: 299 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 283 PointerType *bucket<int,*main.deepMap9>
+          Type: 297 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 286 PointerType *main.deepMap9
+      ValueType: 300 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 96
       Name: bucket<int,int>
@@ -6608,7 +6608,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 293
+      ID: 307
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
@@ -6620,10 +6620,10 @@ Types:
           Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 294 ArrayType []val<interface {}>
+          Type: 308 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 292 PointerType *bucket<int,interface {}>
+          Type: 306 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -6983,7 +6983,7 @@ Types:
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
       BucketsType: 190 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 245
+      ID: 257
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -7004,20 +7004,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 246 PointerType *bucket<int,*main.deepMap3>
+          Type: 258 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 246 PointerType *bucket<int,*main.deepMap3>
+          Type: 258 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 247 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 251 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 259 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 263 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 273
+      ID: 287
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -7038,20 +7038,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 274 PointerType *bucket<int,*main.deepMap8>
+          Type: 288 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 274 PointerType *bucket<int,*main.deepMap8>
+          Type: 288 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 275 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 279 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 289 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 293 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 282
+      ID: 296
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -7072,18 +7072,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 283 PointerType *bucket<int,*main.deepMap9>
+          Type: 297 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 283 PointerType *bucket<int,*main.deepMap9>
+          Type: 297 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 284 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 288 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 298 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 302 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 94
       Name: hash<int,int>
@@ -7119,7 +7119,7 @@ Types:
       BucketType: 96 GoHMapBucketType bucket<int,int>
       BucketsType: 192 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 291
+      ID: 305
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -7140,18 +7140,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 292 PointerType *bucket<int,interface {}>
+          Type: 306 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 292 PointerType *bucket<int,interface {}>
+          Type: 306 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 293 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 295 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 307 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 309 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 131
       Name: hash<int,uint8>
@@ -7511,9 +7511,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 243 GoMapType map[int]*main.deepMap3
+          Type: 255 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 250
+      ID: 262
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7525,9 +7525,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 271 GoMapType map[int]*main.deepMap8
+          Type: 285 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 278
+      ID: 292
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.098528e+06
@@ -7535,9 +7535,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 280 GoMapType map[int]*main.deepMap9
+          Type: 294 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 287
+      ID: 301
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.0984e+06
@@ -7545,7 +7545,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 289 GoMapType map[int]interface {}
+          Type: 303 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7579,9 +7579,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 252 PointerType *main.deepPtr8
+          Type: 266 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 253
+      ID: 267
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.09968e+06
@@ -7589,9 +7589,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 254 PointerType *main.deepPtr9
+          Type: 268 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 255
+      ID: 269
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.099552e+06
@@ -7619,9 +7619,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 237 GoSliceHeaderType []*main.deepSlice3
+          Type: 249 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 240
+      ID: 252
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7633,9 +7633,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 256 GoSliceHeaderType []*main.deepSlice8
+          Type: 270 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 259
+      ID: 273
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.100832e+06
@@ -7643,9 +7643,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 262 GoSliceHeaderType []*main.deepSlice9
+          Type: 276 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 265
+      ID: 279
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.100704e+06
@@ -7653,7 +7653,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 268 GoSliceHeaderType []interface {}
+          Type: 282 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 176
       Name: main.emptyStruct
@@ -7671,16 +7671,16 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 296 StructureType sync.Mutex
+          Type: 237 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 297 StructureType sync.Once
+          Type: 238 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 300 StructureType sync.WaitGroup
+          Type: 241 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 304 StructureType sync/atomic.Int32
+          Type: 245 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
@@ -7820,16 +7820,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 305 PointerType **main.t
+          Type: 246 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 306 GoSliceDataType main.t.array
+      Data: 247 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 306
+      ID: 247
       Name: main.t.array
       ByteSize: 2048
       Element: 159 PointerType *main.t
@@ -7889,26 +7889,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 243
+      ID: 255
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879488
       GoKind: 21
-      HeaderType: 245 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 257 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 271
+      ID: 285
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879008
       GoKind: 21
-      HeaderType: 273 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 287 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 280
+      ID: 294
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 878912
       GoKind: 21
-      HeaderType: 282 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 296 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 92
       Name: map[int]int
@@ -7917,12 +7917,12 @@ Types:
       GoKind: 21
       HeaderType: 94 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 289
+      ID: 303
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 878816
       GoKind: 21
-      HeaderType: 291 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 305 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 129
       Name: map[int]uint8
@@ -7995,7 +7995,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 296
+      ID: 237
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.280576e+06
@@ -8008,7 +8008,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 297
+      ID: 238
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.281696e+06
@@ -8016,12 +8016,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 298 StructureType sync/atomic.Uint32
+          Type: 239 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 296 StructureType sync.Mutex
+          Type: 237 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 300
+      ID: 241
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.420384e+06
@@ -8029,21 +8029,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 301 StructureType sync.noCopy
+          Type: 242 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 302 StructureType sync/atomic.Uint64
+          Type: 243 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 301
+      ID: 242
       Name: sync.noCopy
       GoRuntimeType: 946336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 304
+      ID: 245
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282016e+06
@@ -8051,12 +8051,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 299 StructureType sync/atomic.noCopy
+          Type: 240 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 298
+      ID: 239
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.282176e+06
@@ -8064,12 +8064,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 299 StructureType sync/atomic.noCopy
+          Type: 240 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 302
+      ID: 243
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.420768e+06
@@ -8077,21 +8077,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 299 StructureType sync/atomic.noCopy
+          Type: 240 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 303 StructureType sync/atomic.align64
+          Type: 244 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 303
+      ID: 244
       Name: sync/atomic.align64
       GoRuntimeType: 946528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 299
+      ID: 240
       Name: sync/atomic.noCopy
       GoRuntimeType: 946432
       GoKind: 25

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 503 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd8e4a", Frameless: false}]
+        - ID: 97
+          Type: 504 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcd8fca", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -26,7 +26,21 @@ Probes:
       events:
         - ID: 53
           Type: 460 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xcd5eaa", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd5e6a", Frameless: false}]
+          Condition: null
+    - id: testAnyPtr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAnyPtr}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 55}
+      events:
+        - ID: 55
+          Type: 462 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xcd5f0a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -64,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 468 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcd6440", Frameless: true}]
+        - ID: 62
+          Type: 469 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcd65c0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 484 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd8100", Frameless: true}]
+        - ID: 78
+          Type: 485 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcd8280", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 482 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcd7d20", Frameless: true}]
+        - ID: 76
+          Type: 483 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcd7ea0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 492 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd84c0", Frameless: true}]
+        - ID: 86
+          Type: 493 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcd8640", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -278,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 494 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
+        - ID: 88
+          Type: 495 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 497 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
+        - ID: 91
+          Type: 498 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -306,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 511 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd8f80", Frameless: true}]
+        - ID: 105
+          Type: 512 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -320,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 513 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd9380", Frameless: true}]
+        - ID: 107
+          Type: 514 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcd9500", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -333,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 514 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcd93a0", Frameless: true}]
+        - ID: 108
+          Type: 515 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcd9520", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -351,7 +365,7 @@ Probes:
       events:
         - ID: 54
           Type: 461 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcd5f20", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5ee0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -459,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 516 EventRootType Probe[main.testInlinedBBB]
+        - ID: 110
+          Type: 517 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5926", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -487,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 517 EventRootType Probe[main.testInlinedBCA]
+        - ID: 111
+          Type: 518 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5a33", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -501,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 518 EventRootType Probe[main.testInlinedBCB]
+        - ID: 112
+          Type: 519 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5ae6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -516,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 515 EventRootType Probe[main.testInlinedPrint]
+        - ID: 109
+          Type: 516 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd568a"
               Frameless: false
@@ -540,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 519 EventRootType Probe[main.testInlinedSq]
+        - ID: 113
+          Type: 520 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5b41", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -555,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 520 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 114
+          Type: 521 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5b85"
               Frameless: false
@@ -647,7 +661,7 @@ Probes:
       events:
         - ID: 52
           Type: 459 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcd5e4a", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd5e40", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -657,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 486 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd82e0", Frameless: true}]
+        - ID: 80
+          Type: 487 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -671,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 466 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcd6400", Frameless: true}]
+        - ID: 60
+          Type: 467 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcd6580", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -685,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 472 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcd64c0", Frameless: true}]
+        - ID: 66
+          Type: 473 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcd6640", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -699,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 470 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcd6480", Frameless: true}]
+        - ID: 64
+          Type: 471 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcd6600", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -713,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 481 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd65e0", Frameless: true}]
+        - ID: 75
+          Type: 482 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd6760", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -727,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 480 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcd65c0", Frameless: true}]
+        - ID: 74
+          Type: 481 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcd6740", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -741,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 471 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd64a0", Frameless: true}]
+        - ID: 65
+          Type: 472 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd6620", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -755,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 479 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd65a0", Frameless: true}]
+        - ID: 73
+          Type: 480 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd6720", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -769,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 478 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcd6580", Frameless: true}]
+        - ID: 72
+          Type: 479 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcd6700", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -783,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 464 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcd63c0", Frameless: true}]
+        - ID: 58
+          Type: 465 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcd6540", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -797,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 465 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcd63e0", Frameless: true}]
+        - ID: 59
+          Type: 466 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcd6560", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -811,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 463 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcd63a0", Frameless: true}]
+        - ID: 57
+          Type: 464 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcd6520", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -825,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 473 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcd64e0", Frameless: true}]
+        - ID: 67
+          Type: 474 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcd6660", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -839,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 476 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcd6540", Frameless: true}]
+        - ID: 70
+          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcd66c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -853,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcd6560", Frameless: true}]
+        - ID: 71
+          Type: 478 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcd66e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -867,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 474 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcd6500", Frameless: true}]
+        - ID: 68
+          Type: 475 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcd6680", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -881,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 475 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcd6520", Frameless: true}]
+        - ID: 69
+          Type: 476 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcd66a0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -895,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 509 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd8f40", Frameless: true}]
+        - ID: 103
+          Type: 510 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -909,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 483 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcd7ee0", Frameless: true}]
+        - ID: 77
+          Type: 484 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -923,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 491 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
+        - ID: 85
+          Type: 492 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcd8600", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -937,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 501 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
+        - ID: 95
+          Type: 502 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -951,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 498 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
+        - ID: 92
+          Type: 499 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -965,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 500 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
+        - ID: 94
+          Type: 501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -979,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 508 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd8f20", Frameless: true}]
+        - ID: 102
+          Type: 509 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -993,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 487 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd8300", Frameless: true}]
+        - ID: 81
+          Type: 488 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1007,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 469 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcd6460", Frameless: true}]
+        - ID: 63
+          Type: 470 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcd65e0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1021,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 485 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd82c0", Frameless: true}]
+        - ID: 79
+          Type: 486 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1189,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 504 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd8ea0", Frameless: true}]
+        - ID: 98
+          Type: 505 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1273,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 495 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
+        - ID: 89
+          Type: 496 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1287,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 467 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcd6420", Frameless: true}]
+        - ID: 61
+          Type: 468 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcd65a0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1315,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 490 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
+        - ID: 84
+          Type: 491 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcd85c0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1329,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 499 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
+        - ID: 93
+          Type: 500 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1377,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 512 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd9200", Frameless: true}]
+        - ID: 106
+          Type: 513 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcd9380", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1391,11 +1405,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 496 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
+        - ID: 90
+          Type: 497 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1405,11 +1419,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 55
-          Type: 462 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcd6380", Frameless: true}]
+        - ID: 56
+          Type: 463 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcd6500", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1419,11 +1433,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 505 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd8ec0", Frameless: true}]
+        - ID: 99
+          Type: 506 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1433,11 +1447,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 506 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd8ee0", Frameless: true}]
+        - ID: 100
+          Type: 507 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1447,11 +1461,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 507 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd8f00", Frameless: true}]
+        - ID: 101
+          Type: 508 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1545,11 +1559,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 489 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd8360", Frameless: true}]
+        - ID: 83
+          Type: 490 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1559,11 +1573,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 493 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
+        - ID: 87
+          Type: 494 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1573,11 +1587,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 510 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd8f60", Frameless: true}]
+        - ID: 104
+          Type: 511 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1587,11 +1601,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 488 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd8320", Frameless: true}]
+        - ID: 82
+          Type: 489 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcd84a0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1615,11 +1629,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 502 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
+        - ID: 96
+          Type: 503 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcd8c80", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2353,46 +2367,35 @@ Subprograms:
           IsReturn: true
     - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd5e40..0xcd5e83]
+      OutOfLinePCRanges: [0xcd5e40..0xcd5e41]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 87 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd5e40..0xcd5e5f
+            - Range: 0xcd5e40..0xcd5e41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd5e5f..0xcd5e62
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd5e40..0xcd5e83, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
     - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0xcd5ea0..0xcd5f06]
+      OutOfLinePCRanges: [0xcd5e60..0xcd5ec6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 81 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd5ea0..0xcd5ec9
+            - Range: 0xcd5e60..0xcd5e89
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd5ec9..0xcd5ece
+            - Range: 0xcd5e89..0xcd5e8e
               Pieces:
                 - Size: 8
                   Op: null
@@ -2402,18 +2405,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd5ea0..0xcd5f06, Pieces: []}]
+          Locations: [{Range: 0xcd5e60..0xcd5ec6, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0xcd5f20..0xcd5f21]
+      OutOfLinePCRanges: [0xcd5ee0..0xcd5ee1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd5f20..0xcd5f21
+            - Range: 0xcd5ee0..0xcd5ee1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2422,308 +2425,325 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 55
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd6380..0xcd6381]
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xcd5f00..0xcd5f54]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 88 StructureType main.structWithMap
+        - Name: a
+          Type: 88 PointerType *interface {}
           Locations:
-            - Range: 0xcd6380..0xcd6381
+            - Range: 0xcd5f00..0xcd5f26
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations: [{Range: 0xcd5f00..0xcd5f54, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 56
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd63a0..0xcd63a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 94 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcd63a0..0xcd63a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 57
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd63c0..0xcd63c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 99 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd63c0..0xcd63c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd63e0..0xcd63e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcd63e0..0xcd63e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd6400..0xcd6401]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcd6400..0xcd6401
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcd6420..0xcd6421]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 99 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd6420..0xcd6421
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcd6440..0xcd6441]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 114 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcd6440..0xcd6441
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcd6460..0xcd6461]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 115 PointerType *map[string]int
-          Locations:
-            - Range: 0xcd6460..0xcd6461
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 63
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcd6480..0xcd6481]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 89 GoMapType map[int]int
-          Locations:
-            - Range: 0xcd6480..0xcd6481
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 64
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcd64a0..0xcd64a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 116 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcd64a0..0xcd64a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 65
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcd64c0..0xcd64c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcd64c0..0xcd64c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 66
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcd64e0..0xcd64e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 121 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0xcd64e0..0xcd64e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallValue
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0xcd6500..0xcd6501]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 126 GoMapType map[int]uint8
+        - Name: s
+          Type: 89 StructureType main.structWithMap
           Locations:
             - Range: 0xcd6500..0xcd6501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValueMassive
+    - ID: 57
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcd6520..0xcd6521]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 126 GoMapType map[int]uint8
+        - Name: m
+          Type: 95 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcd6520..0xcd6521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 58
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcd6540..0xcd6541]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 100 GoMapType map[string]int
           Locations:
             - Range: 0xcd6540..0xcd6541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 59
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcd6560..0xcd6561]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 105 GoMapType map[string][]string
           Locations:
             - Range: 0xcd6560..0xcd6561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapSmallKeySmallValue
+    - ID: 60
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcd6580..0xcd6581]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 110 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcd6580..0xcd6581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 61
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcd65a0..0xcd65a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 GoMapType map[uint8][4]int
+          Type: 100 GoMapType map[string]int
           Locations:
             - Range: 0xcd65a0..0xcd65a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapLargeKeySmallValue
+    - ID: 62
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcd65c0..0xcd65c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 141 GoMapType map[[4]int]uint8
+          Type: 115 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcd65c0..0xcd65c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 63
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcd65e0..0xcd65e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[[4]int][4]int
+          Type: 116 PointerType *map[string]int
           Locations:
             - Range: 0xcd65e0..0xcd65e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 64
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0xcd6600..0xcd6601]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 90 GoMapType map[int]int
+          Locations:
+            - Range: 0xcd6600..0xcd6601
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 65
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xcd6620..0xcd6621]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 117 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcd6620..0xcd6621
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 66
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xcd6640..0xcd6641]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 117 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcd6640..0xcd6641
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 67
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xcd6660..0xcd6661]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 122 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0xcd6660..0xcd6661
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xcd6680..0xcd6681]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 127 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcd6680..0xcd6681
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xcd66a0..0xcd66a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 127 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcd66a0..0xcd66a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcd66c0..0xcd66c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 132 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd66c0..0xcd66c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcd66e0..0xcd66e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 132 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd66e0..0xcd66e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcd6700..0xcd6701]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 132 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd6700..0xcd6701
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcd6720..0xcd6721]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 137 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcd6720..0xcd6721
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcd6740..0xcd6741]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 142 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcd6740..0xcd6741
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 75
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcd6760..0xcd6761]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 147 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcd6760..0xcd6761
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 76
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcd7d20..0xcd7d21]
+      OutOfLinePCRanges: [0xcd7ea0..0xcd7ea1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd7d20..0xcd7d21
+            - Range: 0xcd7ea0..0xcd7ea1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd7d20..0xcd7d21
+            - Range: 0xcd7ea0..0xcd7ea1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcd7d20..0xcd7d21
+            - Range: 0xcd7ea0..0xcd7ea1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcd7ee0..0xcd7ee1]
+      OutOfLinePCRanges: [0xcd8060..0xcd8061]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd7ee0..0xcd7ee1
+            - Range: 0xcd8060..0xcd8061
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd7ee0..0xcd7ee1
+            - Range: 0xcd8060..0xcd8061
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd7ee0..0xcd7ee1
+            - Range: 0xcd8060..0xcd8061
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd7ee0..0xcd7ee1
+            - Range: 0xcd8060..0xcd8061
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7ee0..0xcd7ee1
+            - Range: 0xcd8060..0xcd8061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2731,39 +2751,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcd8100..0xcd8101]
+      OutOfLinePCRanges: [0xcd8280..0xcd8281]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 151 GoChannelType chan bool
+          Type: 152 GoChannelType chan bool
           Locations:
-            - Range: 0xcd8100..0xcd8101
+            - Range: 0xcd8280..0xcd8281
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd82c0..0xcd82c1]
+      OutOfLinePCRanges: [0xcd8440..0xcd8441]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 152 PointerType *main.structWithTwoValues
+          Type: 153 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd82c0..0xcd82c1
+            - Range: 0xcd8440..0xcd8441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd82e0..0xcd82e1]
+      OutOfLinePCRanges: [0xcd8460..0xcd8461]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 154 StructureType main.node
+          Type: 155 StructureType main.node
           Locations:
-            - Range: 0xcd82e0..0xcd82e1
+            - Range: 0xcd8460..0xcd8461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2771,112 +2791,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd8300..0xcd8301]
+      OutOfLinePCRanges: [0xcd8480..0xcd8481]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 PointerType *main.node
+          Type: 156 PointerType *main.node
           Locations:
-            - Range: 0xcd8300..0xcd8301
+            - Range: 0xcd8480..0xcd8481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd8320..0xcd8321]
+      OutOfLinePCRanges: [0xcd84a0..0xcd84a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcd8320..0xcd8321
+            - Range: 0xcd84a0..0xcd84a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd8360..0xcd8361]
+      OutOfLinePCRanges: [0xcd84e0..0xcd84e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xcd8360..0xcd8361
+            - Range: 0xcd84e0..0xcd84e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd8440..0xcd8441]
+      OutOfLinePCRanges: [0xcd85c0..0xcd85c1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xcd8440..0xcd8441
+            - Range: 0xcd85c0..0xcd85c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd8480..0xcd8481]
+      OutOfLinePCRanges: [0xcd8600..0xcd8601]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcd8480..0xcd8481
+            - Range: 0xcd8600..0xcd8601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8480..0xcd8481
+            - Range: 0xcd8600..0xcd8601
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcd84c0..0xcd84c1]
+      OutOfLinePCRanges: [0xcd8640..0xcd8641]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 156 PointerType *main.t
+          Type: 157 PointerType *main.t
           Locations:
-            - Range: 0xcd84c0..0xcd84c1
+            - Range: 0xcd8640..0xcd8641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd89e0..0xcd89e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 158 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd89e0..0xcd89e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 87
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcd8b60..0xcd8b61]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 158 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd8a00..0xcd8a01
+            - Range: 0xcd8b60..0xcd8b61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2887,14 +2889,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType [][]uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd8a20..0xcd8a21
+            - Range: 0xcd8b80..0xcd8b81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2905,14 +2907,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd8a40..0xcd8a41]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcd8ba0..0xcd8ba1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 160 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcd8a40..0xcd8a41
+            - Range: 0xcd8ba0..0xcd8ba1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2920,24 +2922,17 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd8a40..0xcd8a41
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 90
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd8a60..0xcd8a61
+            - Range: 0xcd8bc0..0xcd8bc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2950,19 +2945,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd8a60..0xcd8a61
+            - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 91
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcd8a80..0xcd8a81]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcd8be0..0xcd8be1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd8a80..0xcd8a81
+            - Range: 0xcd8be0..0xcd8be1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2975,19 +2970,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd8a80..0xcd8a81
+            - Range: 0xcd8be0..0xcd8be1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcd8aa0..0xcd8aa1]
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 164 GoSliceHeaderType []string
+        - Name: xs
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd8aa0..0xcd8aa1
+            - Range: 0xcd8c00..0xcd8c01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2997,22 +2992,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8c00..0xcd8c01
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 93
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcd8c20..0xcd8c21]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 165 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcd8c20..0xcd8c21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcd8ac0..0xcd8ac1]
+      OutOfLinePCRanges: [0xcd8c40..0xcd8c41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd8ac0..0xcd8ac1
+            - Range: 0xcd8c40..0xcd8c41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 165 GoSliceHeaderType []bool
+          Type: 166 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcd8ac0..0xcd8ac1
+            - Range: 0xcd8c40..0xcd8c41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3025,37 +3045,19 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8ac0..0xcd8ac1
+            - Range: 0xcd8c40..0xcd8c41
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd8ae0..0xcd8ae1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 166 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcd8ae0..0xcd8ae1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 95
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd8b00..0xcd8b01]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 158 GoSliceHeaderType []uint
+          Type: 167 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcd8b00..0xcd8b01
+            - Range: 0xcd8c60..0xcd8c61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3066,24 +3068,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 96
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcd8c80..0xcd8c81]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 159 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcd8c80..0xcd8c81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 97
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd8e40..0xcd8e92]
+      OutOfLinePCRanges: [0xcd8fc0..0xcd9012]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd8e40..0xcd8e92, Pieces: []}]
+          Locations: [{Range: 0xcd8fc0..0xcd9012, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd8ea0..0xcd8ea1]
+      OutOfLinePCRanges: [0xcd9020..0xcd9021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8ea0..0xcd8ea1
+            - Range: 0xcd9020..0xcd9021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3091,15 +3111,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd8ec0..0xcd8ec1]
+      OutOfLinePCRanges: [0xcd9040..0xcd9041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8ec0..0xcd8ec1
+            - Range: 0xcd9040..0xcd9041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3110,7 +3130,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8ec0..0xcd8ec1
+            - Range: 0xcd9040..0xcd9041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3121,7 +3141,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8ec0..0xcd8ec1
+            - Range: 0xcd9040..0xcd9041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3129,15 +3149,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 100
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd8ee0..0xcd8eff]
+      OutOfLinePCRanges: [0xcd9060..0xcd907f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 167 StructureType main.threeStringStruct
+          Type: 168 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcd8ee0..0xcd8eff
+            - Range: 0xcd9060..0xcd907f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3153,55 +3173,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd8f00..0xcd8f01]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xcd8f00..0xcd8f01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 101
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd8f20..0xcd8f21]
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0xcd9080..0xcd9081]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 169 PointerType *main.oneStringStruct
+          Type: 169 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcd8f20..0xcd8f21
+            - Range: 0xcd9080..0xcd9081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcd8f40..0xcd8f41]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xcd90a0..0xcd90a1]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 170 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcd8f40..0xcd8f41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd90a0..0xcd90a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcd8f60..0xcd8f61]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcd90c0..0xcd90c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8f60..0xcd8f61
+            - Range: 0xcd90c0..0xcd90c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3210,14 +3214,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 104
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd8f80..0xcd8f81]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcd90e0..0xcd90e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8f80..0xcd8f81
+            - Range: 0xcd90e0..0xcd90e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3226,14 +3230,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testStruct
-      OutOfLinePCRanges: [0xcd9200..0xcd9223]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcd9100..0xcd9101]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 171 StructureType main.aStruct
+          Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9200..0xcd9223
+            - Range: 0xcd9100..0xcd9101
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 106
+      Name: main.testStruct
+      OutOfLinePCRanges: [0xcd9380..0xcd93a3]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 172 StructureType main.aStruct
+          Locations:
+            - Range: 0xcd9380..0xcd93a3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3251,29 +3271,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 106
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd9380..0xcd9381]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 173 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd9380..0xcd9381, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 107
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcd93a0..0xcd93a1]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0xcd9500..0xcd9501]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 174 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0xcd93a0..0xcd93a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 174 StructureType main.emptyStruct
+          Locations: [{Range: 0xcd9500..0xcd9501, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0xcd9520..0xcd9521]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 175 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0xcd9520..0xcd9521
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd5680..0xcd56e2]
       InlinePCRanges:
@@ -3303,28 +3323,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 110
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5926..0xcd595e]
           RootRanges: [0xcd58c0..0xcd5985]
       Variables: []
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5a33..0xcd5a71]
           RootRanges: [0xcd5a20..0xcd5b2e]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5ae6..0xcd5b1e]
           RootRanges: [0xcd5a20..0xcd5b2e]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3338,7 +3358,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3363,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 310
+      ID: 311
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 311 PointerType *main.deepSlice3
+      Pointee: 312 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 335
+      ID: 336
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 336 PointerType *main.deepSlice8
+      Pointee: 337 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 341
+      ID: 342
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 342 PointerType *main.deepSlice9
+      Pointee: 343 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3387,7 +3407,7 @@ Types:
       ID: 403
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 156 PointerType *main.t
+      Pointee: 157 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3396,35 +3416,35 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 149
+      ID: 150
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<[4]int,[4]int>
+      Pointee: 151 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 144
+      ID: 145
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 145 PointerType *table<[4]int,uint8>
+      Pointee: 146 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 112
+      ID: 113
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 113 PointerType *table<[4]string,[2]int>
+      Pointee: 114 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 124
+      ID: 125
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 125 PointerType *table<bool,main.node>
+      Pointee: 126 PointerType *table<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 318
+      ID: 319
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 319 PointerType *table<int,*main.deepMap3>
+      Pointee: 320 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 353
       Name: '**table<int,*main.deepMap8>'
@@ -3436,85 +3456,85 @@ Types:
       ByteSize: 8
       Pointee: 369 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 92
+      ID: 93
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 93 PointerType *table<int,int>
+      Pointee: 94 PointerType *table<int,int>
     - __kind: PointerType
       ID: 383
       Name: '**table<int,interface {}>'
       ByteSize: 8
       Pointee: 384 PointerType *table<int,interface {}>
     - __kind: PointerType
-      ID: 129
+      ID: 130
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 130 PointerType *table<int,uint8>
+      Pointee: 131 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 120
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 120 PointerType *table<string,[]main.structWithMap>
+      Pointee: 121 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 107
+      ID: 108
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 108 PointerType *table<string,[]string>
+      Pointee: 109 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 103
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 103 PointerType *table<string,int>
+      Pointee: 104 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 97
+      ID: 98
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 98 PointerType *table<string,main.nestedStruct>
+      Pointee: 99 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 139
+      ID: 140
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<uint8,[4]int>
+      Pointee: 141 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 134
+      ID: 135
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 135 PointerType *table<uint8,uint8>
+      Pointee: 136 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 314
+      ID: 315
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 313 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 314 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 339
+      ID: 340
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 338 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 339 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 345
+      ID: 346
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 344 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 345 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 178
+      ID: 179
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []*string.array
+      Pointee: 178 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 295
+      ID: 296
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType [][]uint.array
+      Pointee: 295 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 301
+      ID: 302
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []bool.array
+      Pointee: 301 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 349
       Name: '*[]interface {}.array'
@@ -3526,30 +3546,30 @@ Types:
       ByteSize: 8
       Pointee: 406 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 297
+      ID: 298
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 297 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 299
+      ID: 300
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []string.array
+      Pointee: 299 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 160
+      ID: 161
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 158 GoSliceHeaderType []uint
+      Pointee: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 293
+      ID: 294
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []uint.array
+      Pointee: 293 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 303
+      ID: 304
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []uint16.array
+      Pointee: 303 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3614,26 +3634,26 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 347
+      ID: 88
       Name: '*interface {}'
       ByteSize: 8
       GoRuntimeType: 390400
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 188
+      ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 382976
       GoKind: 22
-      Pointee: 189 StructureType main.deepMap2
+      Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 326
+      ID: 327
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 382912
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType main.deepMap3
+      Pointee: 328 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3663,12 +3683,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383488
       GoKind: 22
-      Pointee: 305 UnresolvedPointeeType main.deepPtr3
+      Pointee: 306 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3677,33 +3697,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 330
+      ID: 331
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383168
       GoKind: 22
-      Pointee: 331 StructureType main.deepPtr8
+      Pointee: 332 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 332
+      ID: 333
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383104
       GoKind: 22
-      Pointee: 333 StructureType main.deepPtr9
+      Pointee: 334 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 384128
       GoKind: 22
-      Pointee: 179 StructureType main.deepSlice2
+      Pointee: 180 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 311
+      ID: 312
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384064
       GoKind: 22
-      Pointee: 312 UnresolvedPointeeType main.deepSlice3
+      Pointee: 313 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3712,25 +3732,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 336
+      ID: 337
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 337 StructureType main.deepSlice8
+      Pointee: 338 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 342
+      ID: 343
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383680
       GoKind: 22
-      Pointee: 343 StructureType main.deepSlice9
+      Pointee: 344 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 174
+      ID: 175
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 173 StructureType main.emptyStruct
+      Pointee: 174 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
@@ -3739,18 +3759,18 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 155
+      ID: 156
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 384320
       GoKind: 22
-      Pointee: 154 StructureType main.node
+      Pointee: 155 StructureType main.node
     - __kind: PointerType
-      ID: 169
+      ID: 170
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 170 StructureType main.oneStringStruct
+      Pointee: 171 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -3758,81 +3778,81 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 307
+      ID: 308
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType main.stringType1.str
+      Pointee: 307 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 308 UnresolvedPointeeType main.stringType2
+      Pointee: 309 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 240
+      ID: 241
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382464
       GoKind: 22
-      Pointee: 88 StructureType main.structWithMap
+      Pointee: 89 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 162
+      ID: 163
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 163 StructureType main.structWithNoStrings
+      Pointee: 164 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 152
+      ID: 153
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 153 StructureType main.structWithTwoValues
+      Pointee: 154 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 156
+      ID: 157
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 GoSliceHeaderType main.t
+      Pointee: 158 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 405
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 404 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 168
+      ID: 169
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 167 StructureType main.threeStringStruct
+      Pointee: 168 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 147
+      ID: 148
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 149 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 142
+      ID: 143
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 143 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 144 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 110
+      ID: 111
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 111 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 112 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 122
+      ID: 123
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 123 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 124 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 316
+      ID: 317
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 317 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 351
       Name: '*map<int,*main.deepMap8>'
@@ -3844,86 +3864,86 @@ Types:
       ByteSize: 8
       Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 90
+      ID: 91
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 91 GoSwissMapHeaderType map<int,int>
+      Pointee: 92 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
       ID: 381
       Name: '*map<int,interface {}>'
       ByteSize: 8
       Pointee: 382 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
-      ID: 127
+      ID: 128
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 128 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 129 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 117
+      ID: 118
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 105
+      ID: 106
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 106 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 107 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 100
+      ID: 101
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 101 GoSwissMapHeaderType map<string,int>
+      Pointee: 102 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 95
+      ID: 96
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 137
+      ID: 138
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 139 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 132
+      ID: 133
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 133 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 134 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 115
+      ID: 116
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 GoMapType map[string]int
+      Pointee: 100 GoMapType map[string]int
     - __kind: PointerType
-      ID: 286
+      ID: 287
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 287 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 278
+      ID: 279
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 279 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 226
+      ID: 227
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 227 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 245
+      ID: 246
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 246 StructureType noalg.map.group[bool]main.node
+      Pointee: 247 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 184
+      ID: 185
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 322
+      ID: 323
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 323 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 357
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -3935,50 +3955,50 @@ Types:
       ByteSize: 8
       Pointee: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 194
+      ID: 195
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 195 StructureType noalg.map.group[int]int
+      Pointee: 196 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 387
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 388 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 253
+      ID: 254
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 254 StructureType noalg.map.group[int]uint8
+      Pointee: 255 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 235
+      ID: 236
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 236 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 218
+      ID: 219
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 219 StructureType noalg.map.group[string][]string
+      Pointee: 220 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 210
+      ID: 211
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 211 StructureType noalg.map.group[string]int
+      Pointee: 212 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 202
+      ID: 203
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 269
+      ID: 270
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 270 StructureType noalg.map.group[uint8][4]int
+      Pointee: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 261
+      ID: 262
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 262 StructureType noalg.map.group[uint8]uint8
+      Pointee: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3987,40 +4007,40 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 176
+      ID: 177
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 175 GoStringDataType string.str
+      Pointee: 176 GoStringDataType string.str
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 284 StructureType table<[4]int,[4]int>
+      Pointee: 285 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 276 StructureType table<[4]int,uint8>
+      Pointee: 277 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 224 StructureType table<[4]string,[2]int>
+      Pointee: 225 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 243 StructureType table<bool,main.node>
+      Pointee: 244 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 182 StructureType table<int,*main.deepMap2>
+      Pointee: 183 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 319
+      ID: 320
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 320 StructureType table<int,*main.deepMap3>
+      Pointee: 321 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 354
       Name: '*table<int,*main.deepMap8>'
@@ -4032,50 +4052,50 @@ Types:
       ByteSize: 8
       Pointee: 370 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 192 StructureType table<int,int>
+      Pointee: 193 StructureType table<int,int>
     - __kind: PointerType
       ID: 384
       Name: '*table<int,interface {}>'
       ByteSize: 8
       Pointee: 385 StructureType table<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 251 StructureType table<int,uint8>
+      Pointee: 252 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 233 StructureType table<string,[]main.structWithMap>
+      Pointee: 234 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 216 StructureType table<string,[]string>
+      Pointee: 217 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 208 StructureType table<string,int>
+      Pointee: 209 StructureType table<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 200 StructureType table<string,main.nestedStruct>
+      Pointee: 201 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 267 StructureType table<uint8,[4]int>
+      Pointee: 268 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 259 StructureType table<uint8,uint8>
+      Pointee: 260 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4119,8 +4139,23 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 503
+      ID: 504
       Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 462
+      Name: Probe[main.testAnyPtr]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 88 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 460
       Name: Probe[main.testAny]
@@ -4167,7 +4202,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 468
+      ID: 469
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4175,10 +4210,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 114 ArrayType [2]map[string]int
+            Type: 115 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4242,7 +4277,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 484
+      ID: 485
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4250,14 +4285,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 151 GoChannelType chan bool
+            Type: 152 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: c}
+                  Variable: {subprogram: 78, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 482
+      ID: 483
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4268,7 +4303,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: w}
+                  Variable: {subprogram: 76, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4277,7 +4312,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 1, name: x}
+                  Variable: {subprogram: 76, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4286,11 +4321,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 2, name: y}
+                  Variable: {subprogram: 76, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 492
+      ID: 493
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4298,10 +4333,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.t
+            Type: 157 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: t}
+                  Variable: {subprogram: 86, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4395,7 +4430,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 498
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4403,10 +4438,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4415,11 +4450,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 494
+      ID: 495
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4427,14 +4462,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 512
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4445,11 +4480,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 514
+      ID: 515
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4457,14 +4492,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 174 PointerType *main.emptyStruct
+            Type: 175 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 513
+      ID: 514
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4472,10 +4507,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 173 StructureType main.emptyStruct
+            Type: 174 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: e}
+                  Variable: {subprogram: 107, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -4584,7 +4619,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 516
+      ID: 517
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 454
@@ -4611,16 +4646,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 517
+      ID: 518
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 518
+      ID: 519
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 456
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 515
+      ID: 516
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4631,11 +4666,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 519
+      ID: 520
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4646,11 +4681,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: x}
+                  Variable: {subprogram: 113, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 521
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4661,7 +4696,7 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4755,7 +4790,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 486
+      ID: 487
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4763,14 +4798,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 154 StructureType main.node
+            Type: 155 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 466
+      ID: 467
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4778,14 +4813,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 109 GoMapType map[[4]string][2]int
+            Type: 110 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 473
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4793,14 +4828,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 GoMapType map[string][]main.structWithMap
+            Type: 117 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 470
+      ID: 471
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4808,14 +4843,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 89 GoMapType map[int]int
+            Type: 90 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 482
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4823,14 +4858,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[[4]int][4]int
+            Type: 147 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 481
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4838,14 +4873,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 141 GoMapType map[[4]int]uint8
+            Type: 142 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 471
+      ID: 472
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4853,14 +4888,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 116 GoMapType map[string][]main.structWithMap
+            Type: 117 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 480
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4868,14 +4903,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[uint8][4]int
+            Type: 137 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 479
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4883,14 +4918,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 465
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4898,14 +4933,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 465
+      ID: 466
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4913,14 +4948,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 104 GoMapType map[string][]string
+            Type: 105 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 463
+      ID: 464
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4928,14 +4963,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[string]main.nestedStruct
+            Type: 95 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 474
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4943,14 +4978,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[bool]main.node
+            Type: 122 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 478
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4958,14 +4993,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 477
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4973,14 +5008,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 476
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4988,14 +5023,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 126 GoMapType map[int]uint8
+            Type: 127 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 475
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5003,14 +5038,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 126 GoMapType map[int]uint8
+            Type: 127 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 509
+      ID: 510
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5021,11 +5056,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 483
+      ID: 484
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5036,7 +5071,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -5045,7 +5080,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: b}
+                  Variable: {subprogram: 77, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -5054,7 +5089,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: c}
+                  Variable: {subprogram: 77, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -5063,7 +5098,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 3, name: d}
+                  Variable: {subprogram: 77, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -5072,11 +5107,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 4, name: e}
+                  Variable: {subprogram: 77, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 491
+      ID: 492
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5087,7 +5122,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -5096,11 +5131,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: a}
+                  Variable: {subprogram: 85, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 499
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5108,10 +5143,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5120,11 +5155,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 501
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5135,16 +5170,16 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 94, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 165 GoSliceHeaderType []bool
+            Type: 166 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: s}
+                  Variable: {subprogram: 94, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5153,11 +5188,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 2, name: x}
+                  Variable: {subprogram: 94, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 502
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5165,14 +5200,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 166 GoSliceHeaderType []uint16
+            Type: 167 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 508
+      ID: 509
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5180,14 +5215,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.oneStringStruct
+            Type: 170 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 487
+      ID: 488
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5195,14 +5230,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 PointerType *main.node
+            Type: 156 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 469
+      ID: 470
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5210,14 +5245,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 PointerType *map[string]int
+            Type: 116 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 485
+      ID: 486
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5225,10 +5260,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 152 PointerType *main.structWithTwoValues
+            Type: 153 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5397,7 +5432,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 504
+      ID: 505
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5408,7 +5443,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5487,7 +5522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 495
+      ID: 496
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5495,14 +5530,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType [][]uint
+            Type: 160 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 467
+      ID: 468
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5510,10 +5545,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5532,7 +5567,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 490
+      ID: 491
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5543,11 +5578,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 500
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5555,10 +5590,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []string
+            Type: 165 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: s}
+                  Variable: {subprogram: 93, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5592,7 +5627,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 497
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5600,10 +5635,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5612,11 +5647,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 462
+      ID: 463
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5624,14 +5659,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 88 StructureType main.structWithMap
+            Type: 89 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: s}
+                  Variable: {subprogram: 56, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 512
+      ID: 513
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5639,14 +5674,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 171 StructureType main.aStruct
+            Type: 172 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 507
+      ID: 508
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5654,14 +5689,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 PointerType *main.threeStringStruct
+            Type: 169 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 506
+      ID: 507
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5669,14 +5704,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 167 StructureType main.threeStringStruct
+            Type: 168 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 505
+      ID: 506
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5687,7 +5722,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5696,7 +5731,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: y}
+                  Variable: {subprogram: 99, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5705,7 +5740,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: z}
+                  Variable: {subprogram: 99, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5799,7 +5834,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 490
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5810,11 +5845,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 493
+      ID: 494
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5822,14 +5857,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 510
+      ID: 511
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5840,11 +5875,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 488
+      ID: 489
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5855,7 +5890,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5874,7 +5909,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 502
+      ID: 503
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5882,10 +5917,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5963,13 +5998,13 @@ Types:
       HasCount: true
       Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 114
+      ID: 115
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 99 GoMapType map[string]int
+      Element: 100 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -6022,7 +6057,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 273
+      ID: 274
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 678880
@@ -6031,7 +6066,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 230
+      ID: 231
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 679168
@@ -6063,14 +6098,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 180 GoSliceDataType []*main.deepSlice2.array
+      Data: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 181
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 309
+      ID: 310
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474688
@@ -6078,21 +6113,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 310 PointerType **main.deepSlice3
+          Type: 311 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 313 GoSliceDataType []*main.deepSlice3.array
+      Data: 314 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 313
+      ID: 314
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 311 PointerType *main.deepSlice3
+      Element: 312 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 334
+      ID: 335
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474368
@@ -6100,21 +6135,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 335 PointerType **main.deepSlice8
+          Type: 336 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 338 GoSliceDataType []*main.deepSlice8.array
+      Data: 339 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 338
+      ID: 339
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 336 PointerType *main.deepSlice8
+      Element: 337 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 340
+      ID: 341
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474304
@@ -6122,19 +6157,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 341 PointerType **main.deepSlice9
+          Type: 342 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 344 GoSliceDataType []*main.deepSlice9.array
+      Data: 345 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 345
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 342 PointerType *main.deepSlice9
+      Element: 343 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6151,42 +6186,42 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 177 GoSliceDataType []*string.array
+      Data: 178 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 178
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 291
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<[4]int,[4]int>
+      Element: 151 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 283
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 145 PointerType *table<[4]int,uint8>
+      Element: 146 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 232
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 113 PointerType *table<[4]string,[2]int>
+      Element: 114 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 250
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 125 PointerType *table<bool,main.node>
+      Element: 126 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 329
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 319 PointerType *table<int,*main.deepMap3>
+      Element: 320 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 363
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -6198,73 +6233,73 @@ Types:
       ByteSize: 8192
       Element: 369 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 199
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 93 PointerType *table<int,int>
+      Element: 94 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 391
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
       Element: 384 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 258
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 130 PointerType *table<int,uint8>
+      Element: 131 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 242
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 120 PointerType *table<string,[]main.structWithMap>
+      Element: 121 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 223
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 108 PointerType *table<string,[]string>
+      Element: 109 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 215
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 103 PointerType *table<string,int>
+      Element: 104 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 207
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 98 PointerType *table<string,main.nestedStruct>
+      Element: 99 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 275
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 140 PointerType *table<uint8,[4]int>
+      Element: 141 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 266
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 135 PointerType *table<uint8,uint8>
+      Element: 136 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 160 PointerType *[]uint
+          Type: 161 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 294 GoSliceDataType [][]uint.array
+      Data: 295 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 295
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 158 GoSliceHeaderType []uint
+      Element: 159 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 166
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 483648
@@ -6279,14 +6314,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 300 GoSliceDataType []bool.array
+      Data: 301 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 301
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 346
+      ID: 347
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 483968
@@ -6294,7 +6329,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 347 PointerType *interface {}
+          Type: 88 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -6308,7 +6343,7 @@ Types:
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 239
+      ID: 240
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 475008
@@ -6316,7 +6351,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 240 PointerType *main.structWithMap
+          Type: 241 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -6328,58 +6363,58 @@ Types:
       ID: 406
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 88 StructureType main.structWithMap
+      Element: 89 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 162
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *main.structWithNoStrings
+          Type: 163 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 296 GoSliceDataType []main.structWithNoStrings.array
+      Data: 297 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 297
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 163 StructureType main.structWithNoStrings
+      Element: 164 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 292
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 287 StructureType noalg.map.group[[4]int][4]int
+      Element: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 279 StructureType noalg.map.group[[4]int]uint8
+      Element: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 233
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 227 StructureType noalg.map.group[[4]string][2]int
+      Element: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 246 StructureType noalg.map.group[bool]main.node
+      Element: 247 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 330
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 323 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 364
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -6391,52 +6426,52 @@ Types:
       ByteSize: 2048
       Element: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 195 StructureType noalg.map.group[int]int
+      Element: 196 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 392
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
       Element: 388 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 259
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 254 StructureType noalg.map.group[int]uint8
+      Element: 255 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 243
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 236 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 219 StructureType noalg.map.group[string][]string
+      Element: 220 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 211 StructureType noalg.map.group[string]int
+      Element: 212 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 208
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 203 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 276
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 270 StructureType noalg.map.group[uint8][4]int
+      Element: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 267
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 262 StructureType noalg.map.group[uint8]uint8
+      Element: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 165
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 483776
@@ -6451,14 +6486,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 298 GoSliceDataType []string.array
+      Data: 299 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 299
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 159
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 483264
@@ -6473,14 +6508,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType []uint.array
+      Data: 293 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 293
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 16 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 482624
@@ -6495,9 +6530,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 302 GoSliceDataType []uint16.array
+      Data: 303 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 303
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -6508,7 +6543,7 @@ Types:
       GoRuntimeType: 581152
       GoKind: 1
     - __kind: GoChannelType
-      ID: 151
+      ID: 152
       Name: chan bool
       GoRuntimeType: 592480
       GoKind: 18
@@ -6561,89 +6596,89 @@ Types:
       GoRuntimeType: 472960
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 285
+      ID: 286
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 286 PointerType *noalg.map.group[[4]int][4]int
+          Type: 287 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 287 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 291 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 292 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 277
+      ID: 278
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 278 PointerType *noalg.map.group[[4]int]uint8
+          Type: 279 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 279 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 283 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 284 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 225
+      ID: 226
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 226 PointerType *noalg.map.group[[4]string][2]int
+          Type: 227 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 227 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 233 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 244
+      ID: 245
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 245 PointerType *noalg.map.group[bool]main.node
+          Type: 246 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 246 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 250 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 247 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 184
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 185 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 191 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 321
+      ID: 322
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 322 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 323 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 323 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 329 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 356
       Name: groupReference<int,*main.deepMap8>
@@ -6673,19 +6708,19 @@ Types:
       GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 193
+      ID: 194
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 194 PointerType *noalg.map.group[int]int
+          Type: 195 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 195 StructureType noalg.map.group[int]int
-      GroupSliceType: 199 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 196 StructureType noalg.map.group[int]int
+      GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 386
       Name: groupReference<int,interface {}>
@@ -6701,103 +6736,103 @@ Types:
       GroupType: 388 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 392 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 252
+      ID: 253
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 253 PointerType *noalg.map.group[int]uint8
+          Type: 254 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 254 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 255 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 234
+      ID: 235
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 235 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 236 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 236 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 217
+      ID: 218
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 218 PointerType *noalg.map.group[string][]string
+          Type: 219 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 219 StructureType noalg.map.group[string][]string
-      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 220 StructureType noalg.map.group[string][]string
+      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 209
+      ID: 210
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 210 PointerType *noalg.map.group[string]int
+          Type: 211 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 211 StructureType noalg.map.group[string]int
-      GroupSliceType: 215 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 212 StructureType noalg.map.group[string]int
+      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 202
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 203 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 207 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 268
+      ID: 269
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 269 PointerType *noalg.map.group[uint8][4]int
+          Type: 270 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 270 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 275 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 271 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 276 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 260
+      ID: 261
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 261 PointerType *noalg.map.group[uint8]uint8
+          Type: 262 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 262 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 266 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 263 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6868,7 +6903,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6884,7 +6919,7 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 172 StructureType main.nestedStruct
+          Type: 173 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
@@ -6924,7 +6959,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 189
+      ID: 190
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.181664e+06
@@ -6932,9 +6967,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 315 GoMapType map[int]*main.deepMap3
+          Type: 316 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 328
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -6986,9 +7021,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 304 PointerType *main.deepPtr3
+          Type: 305 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 305
+      ID: 306
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7000,9 +7035,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 330 PointerType *main.deepPtr8
+          Type: 331 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 331
+      ID: 332
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.182048e+06
@@ -7010,9 +7045,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 332 PointerType *main.deepPtr9
+          Type: 333 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 333
+      ID: 334
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18192e+06
@@ -7032,7 +7067,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 179
+      ID: 180
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.183968e+06
@@ -7040,9 +7075,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 309 GoSliceHeaderType []*main.deepSlice3
+          Type: 310 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 312
+      ID: 313
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7054,9 +7089,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 334 GoSliceHeaderType []*main.deepSlice8
+          Type: 335 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 337
+      ID: 338
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.1832e+06
@@ -7064,9 +7099,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 340 GoSliceHeaderType []*main.deepSlice9
+          Type: 341 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 343
+      ID: 344
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.183072e+06
@@ -7074,9 +7109,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 346 GoSliceHeaderType []interface {}
+          Type: 347 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7131,7 +7166,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.45696e+06
@@ -7144,7 +7179,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 154
+      ID: 155
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.4568e+06
@@ -7155,9 +7190,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 155 PointerType *main.node
+          Type: 156 PointerType *main.node
     - __kind: StructureType
-      ID: 170
+      ID: 171
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7186,21 +7221,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *main.stringType1.str
+          Type: 308 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 306 GoStringDataType main.stringType1.str
+      Data: 307 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 307
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 308
+      ID: 309
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
-      ID: 88
+      ID: 89
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.18064e+06
@@ -7208,9 +7243,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 89 GoMapType map[int]int
+          Type: 90 GoMapType map[int]int
     - __kind: StructureType
-      ID: 163
+      ID: 164
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7222,7 +7257,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 153
+      ID: 154
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7234,7 +7269,7 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 157
+      ID: 158
       Name: main.t
       ByteSize: 24
       GoKind: 23
@@ -7253,9 +7288,9 @@ Types:
       ID: 404
       Name: main.t.array
       ByteSize: 2048
-      Element: 156 PointerType *main.t
+      Element: 157 PointerType *main.t
     - __kind: StructureType
-      ID: 167
+      ID: 168
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7275,7 +7310,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 149
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7288,7 +7323,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<[4]int,[4]int>
+          Type: 150 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7304,10 +7339,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 290 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 287 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 291 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 143
+      ID: 144
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7320,7 +7355,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 144 PointerType **table<[4]int,uint8>
+          Type: 145 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7336,10 +7371,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 282 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 279 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 283 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 111
+      ID: 112
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -7352,7 +7387,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 112 PointerType **table<[4]string,[2]int>
+          Type: 113 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7368,10 +7403,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 227 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 232 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 123
+      ID: 124
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -7384,7 +7419,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 124 PointerType **table<bool,main.node>
+          Type: 125 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7400,8 +7435,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 249 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 246 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 250 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 247 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -7432,10 +7467,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 190 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 185 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 317
+      ID: 318
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7448,7 +7483,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 318 PointerType **table<int,*main.deepMap3>
+          Type: 319 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7464,8 +7499,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 328 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 323 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 352
       Name: map<int,*main.deepMap8>
@@ -7531,7 +7566,7 @@ Types:
       TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap9>.array
       GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
-      ID: 91
+      ID: 92
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -7544,7 +7579,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 92 PointerType **table<int,int>
+          Type: 93 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7560,8 +7595,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 198 GoSliceDataType []*table<int,int>.array
-      GroupType: 195 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
+      GroupType: 196 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 382
       Name: map<int,interface {}>
@@ -7595,7 +7630,7 @@ Types:
       TablePtrSliceType: 391 GoSliceDataType []*table<int,interface {}>.array
       GroupType: 388 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 128
+      ID: 129
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7608,7 +7643,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 129 PointerType **table<int,uint8>
+          Type: 130 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7624,10 +7659,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 254 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 258 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 255 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 118
+      ID: 119
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -7640,7 +7675,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 119 PointerType **table<string,[]main.structWithMap>
+          Type: 120 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7656,10 +7691,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 241 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 236 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 106
+      ID: 107
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -7672,7 +7707,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 107 PointerType **table<string,[]string>
+          Type: 108 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7688,10 +7723,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 222 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 219 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 223 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 220 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 101
+      ID: 102
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -7704,7 +7739,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 102 PointerType **table<string,int>
+          Type: 103 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7720,10 +7755,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 214 GoSliceDataType []*table<string,int>.array
-      GroupType: 211 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 215 GoSliceDataType []*table<string,int>.array
+      GroupType: 212 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 96
+      ID: 97
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -7736,7 +7771,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 97 PointerType **table<string,main.nestedStruct>
+          Type: 98 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7752,10 +7787,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 206 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 203 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 207 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 139
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7768,7 +7803,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<uint8,[4]int>
+          Type: 140 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7784,10 +7819,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 274 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 270 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 275 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 133
+      ID: 134
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7800,7 +7835,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 134 PointerType **table<uint8,uint8>
+          Type: 135 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7816,36 +7851,36 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 265 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 262 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 266 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 146
+      ID: 147
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.124704e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 149 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 141
+      ID: 142
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.124832e+06
       GoKind: 21
-      HeaderType: 143 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 144 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 109
+      ID: 110
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.12496e+06
       GoKind: 21
-      HeaderType: 111 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 112 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 121
+      ID: 122
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.125088e+06
       GoKind: 21
-      HeaderType: 123 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 124 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
@@ -7854,12 +7889,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 315
+      ID: 316
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124448e+06
       GoKind: 21
-      HeaderType: 317 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 350
       Name: map[int]*main.deepMap8
@@ -7875,12 +7910,12 @@ Types:
       GoKind: 21
       HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 89
+      ID: 90
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.123168e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<int,int>
+      HeaderType: 92 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 380
       Name: map[int]interface {}
@@ -7889,108 +7924,108 @@ Types:
       GoKind: 21
       HeaderType: 382 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
-      ID: 126
+      ID: 127
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.125216e+06
       GoKind: 21
-      HeaderType: 128 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 129 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 116
+      ID: 117
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.125344e+06
       GoKind: 21
-      HeaderType: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 104
+      ID: 105
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.125472e+06
       GoKind: 21
-      HeaderType: 106 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 107 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 99
+      ID: 100
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.1256e+06
       GoKind: 21
-      HeaderType: 101 GoSwissMapHeaderType map<string,int>
+      HeaderType: 102 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 94
+      ID: 95
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.125728e+06
       GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 136
+      ID: 137
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.125856e+06
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 139 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 131
+      ID: 132
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.125984e+06
       GoKind: 21
-      HeaderType: 133 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 134 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 288
+      ID: 289
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 678976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 289 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 290 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 280
+      ID: 281
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 679072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 281 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 282 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 228
+      ID: 229
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 679360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 229 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 230 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 247
+      ID: 248
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 679456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 248 StructureType noalg.struct { key bool; elem main.node }
+      Element: 249 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 186
+      ID: 187
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 678304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 187 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 324
+      ID: 325
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 325 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 359
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -8010,14 +8045,14 @@ Types:
       HasCount: true
       Element: 375 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 196
+      ID: 197
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 676384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 197 StructureType noalg.struct { key int; elem int }
+      Element: 198 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 389
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -8028,70 +8063,70 @@ Types:
       HasCount: true
       Element: 390 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 255
+      ID: 256
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 679552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 256 StructureType noalg.struct { key int; elem uint8 }
+      Element: 257 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 237
+      ID: 238
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 679648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 238 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 239 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 220
+      ID: 221
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 679744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 221 StructureType noalg.struct { key string; elem []string }
+      Element: 222 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 212
+      ID: 213
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 679840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem int }
+      Element: 214 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 204
+      ID: 205
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 679936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 205 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 206 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 271
+      ID: 272
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 680032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 272 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 273 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 263
+      ID: 264
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 680128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 264 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 265 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 287
+      ID: 288
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.290144e+06
@@ -8102,9 +8137,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 288 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 289 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 279
+      ID: 280
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.2904e+06
@@ -8115,9 +8150,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 280 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 281 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 227
+      ID: 228
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.290656e+06
@@ -8128,9 +8163,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 228 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 229 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 246
+      ID: 247
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.290912e+06
@@ -8141,9 +8176,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 247 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 248 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 185
+      ID: 186
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.289888e+06
@@ -8154,9 +8189,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 186 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 323
+      ID: 324
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.289632e+06
@@ -8167,7 +8202,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 324 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 358
       Name: noalg.map.group[int]*main.deepMap8
@@ -8195,7 +8230,7 @@ Types:
           Offset: 8
           Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 195
+      ID: 196
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.287072e+06
@@ -8206,7 +8241,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 196 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 197 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 388
       Name: noalg.map.group[int]interface {}
@@ -8221,7 +8256,7 @@ Types:
           Offset: 8
           Type: 389 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 254
+      ID: 255
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.291168e+06
@@ -8232,9 +8267,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 255 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 256 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 236
+      ID: 237
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.291424e+06
@@ -8245,9 +8280,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 237 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 238 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 219
+      ID: 220
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.29168e+06
@@ -8258,9 +8293,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 220 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 211
+      ID: 212
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.291936e+06
@@ -8271,9 +8306,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 213 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 203
+      ID: 204
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.292192e+06
@@ -8284,9 +8319,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 204 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 205 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 270
+      ID: 271
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.292448e+06
@@ -8297,9 +8332,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 271 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 272 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 262
+      ID: 263
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.292704e+06
@@ -8310,9 +8345,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 263 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 264 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 289
+      ID: 290
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.290016e+06
@@ -8320,12 +8355,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
     - __kind: StructureType
-      ID: 281
+      ID: 282
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.290272e+06
@@ -8333,12 +8368,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 229
+      ID: 230
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.290528e+06
@@ -8346,12 +8381,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 230 ArrayType [4]string
+          Type: 231 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 248
+      ID: 249
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.290784e+06
@@ -8362,9 +8397,9 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 154 StructureType main.node
+          Type: 155 StructureType main.node
     - __kind: StructureType
-      ID: 187
+      ID: 188
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.28976e+06
@@ -8375,9 +8410,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 188 PointerType *main.deepMap2
+          Type: 189 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 325
+      ID: 326
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.289504e+06
@@ -8388,7 +8423,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 326 PointerType *main.deepMap3
+          Type: 327 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 360
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -8416,7 +8451,7 @@ Types:
           Offset: 8
           Type: 376 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 197
+      ID: 198
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.286944e+06
@@ -8442,7 +8477,7 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 256
+      ID: 257
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.29104e+06
@@ -8455,7 +8490,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 238
+      ID: 239
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.291296e+06
@@ -8466,9 +8501,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 239 GoSliceHeaderType []main.structWithMap
+          Type: 240 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 221
+      ID: 222
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.291552e+06
@@ -8479,9 +8514,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 164 GoSliceHeaderType []string
+          Type: 165 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 213
+      ID: 214
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.291808e+06
@@ -8494,7 +8529,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 205
+      ID: 206
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.292064e+06
@@ -8505,9 +8540,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 172 StructureType main.nestedStruct
+          Type: 173 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 272
+      ID: 273
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.29232e+06
@@ -8518,9 +8553,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
     - __kind: StructureType
-      ID: 264
+      ID: 265
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.292576e+06
@@ -8541,13 +8576,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 176 PointerType *string.str
+          Type: 177 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 175 GoStringDataType string.str
+      Data: 176 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 175
+      ID: 176
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -8656,7 +8691,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 284
+      ID: 285
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -8678,9 +8713,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 285 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 286 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 276
+      ID: 277
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8702,9 +8737,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 277 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 278 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 224
+      ID: 225
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -8726,9 +8761,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 225 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 226 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 243
+      ID: 244
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -8750,9 +8785,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 244 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 245 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 182
+      ID: 183
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -8774,9 +8809,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 320
+      ID: 321
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8798,7 +8833,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 321 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 355
       Name: table<int,*main.deepMap8>
@@ -8848,7 +8883,7 @@ Types:
           Offset: 16
           Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 192
+      ID: 193
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -8870,7 +8905,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 193 GoSwissMapGroupsType groupReference<int,int>
+          Type: 194 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 385
       Name: table<int,interface {}>
@@ -8896,7 +8931,7 @@ Types:
           Offset: 16
           Type: 386 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 251
+      ID: 252
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8918,9 +8953,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 252 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 253 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 233
+      ID: 234
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -8942,9 +8977,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 234 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 235 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 216
+      ID: 217
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -8966,9 +9001,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 217 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 218 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 208
+      ID: 209
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -8990,9 +9025,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 209 GoSwissMapGroupsType groupReference<string,int>
+          Type: 210 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 200
+      ID: 201
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -9014,9 +9049,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 202 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 267
+      ID: 268
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -9038,9 +9073,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 268 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 269 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 259
+      ID: 260
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9062,7 +9097,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 260 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 261 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -9105,6 +9140,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 581216
       GoKind: 26
-MaxTypeID: 520
+MaxTypeID: 521
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17f93a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -3445,7 +3445,7 @@ Types:
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 526240
+      GoRuntimeType: 526432
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
@@ -3607,175 +3607,175 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 390336
+      GoRuntimeType: 390528
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 389248
+      GoRuntimeType: 389440
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 390208
+      GoRuntimeType: 390400
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 390272
+      GoRuntimeType: 390464
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 389888
+      GoRuntimeType: 390080
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 389504
+      GoRuntimeType: 389696
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 389632
+      GoRuntimeType: 389824
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 26
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 389760
+      GoRuntimeType: 389952
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 389376
+      GoRuntimeType: 389568
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
       ID: 88
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 390464
+      GoRuntimeType: 390656
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 383040
+      GoRuntimeType: 383232
       GoKind: 22
       Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
       ID: 341
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 382976
+      GoRuntimeType: 383168
       GoKind: 22
       Pointee: 342 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 382720
+      GoRuntimeType: 382912
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
       ID: 377
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 382656
+      GoRuntimeType: 382848
       GoKind: 22
       Pointee: 378 StructureType main.deepMap8
     - __kind: PointerType
       ID: 392
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 382592
+      GoRuntimeType: 382784
       GoKind: 22
       Pointee: 393 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 383616
+      GoRuntimeType: 383808
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 306
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 383552
+      GoRuntimeType: 383744
       GoKind: 22
       Pointee: 307 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 383296
+      GoRuntimeType: 383488
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 347
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 383232
+      GoRuntimeType: 383424
       GoKind: 22
       Pointee: 348 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 349
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 383168
+      GoRuntimeType: 383360
       GoKind: 22
       Pointee: 350 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 384192
+      GoRuntimeType: 384384
       GoKind: 22
       Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 326
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 384128
+      GoRuntimeType: 384320
       GoKind: 22
       Pointee: 327 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 383872
+      GoRuntimeType: 384064
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 353
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 383808
+      GoRuntimeType: 384000
       GoKind: 22
       Pointee: 354 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 359
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 383744
+      GoRuntimeType: 383936
       GoKind: 22
       Pointee: 360 StructureType main.deepSlice9
     - __kind: PointerType
@@ -3788,14 +3788,14 @@ Types:
       ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 384320
+      GoRuntimeType: 384512
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 384384
+      GoRuntimeType: 384576
       GoKind: 22
       Pointee: 156 StructureType main.node
     - __kind: PointerType
@@ -3825,7 +3825,7 @@ Types:
       ID: 242
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 382528
+      GoRuntimeType: 382720
       GoKind: 22
       Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
@@ -4036,7 +4036,7 @@ Types:
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 389312
+      GoRuntimeType: 389504
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -4133,42 +4133,42 @@ Types:
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 389952
+      GoRuntimeType: 390144
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 389568
+      GoRuntimeType: 389760
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 389696
+      GoRuntimeType: 389888
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 389824
+      GoRuntimeType: 390016
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 389440
+      GoRuntimeType: 389632
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 390016
+      GoRuntimeType: 390208
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -6007,7 +6007,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 679328
+      GoRuntimeType: 679520
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6024,7 +6024,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 680672
+      GoRuntimeType: 680864
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6057,7 +6057,7 @@ Types:
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 680768
+      GoRuntimeType: 680960
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6090,7 +6090,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 680864
+      GoRuntimeType: 681056
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6099,7 +6099,7 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 680576
+      GoRuntimeType: 680768
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6108,7 +6108,7 @@ Types:
       ID: 275
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 678944
+      GoRuntimeType: 679136
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6117,7 +6117,7 @@ Types:
       ID: 232
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 679232
+      GoRuntimeType: 679424
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6134,7 +6134,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 474816
+      GoRuntimeType: 475008
       GoKind: 23
       RawFields:
         - Name: array
@@ -6156,7 +6156,7 @@ Types:
       ID: 324
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 474752
+      GoRuntimeType: 474944
       GoKind: 23
       RawFields:
         - Name: array
@@ -6178,7 +6178,7 @@ Types:
       ID: 351
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 474432
+      GoRuntimeType: 474624
       GoKind: 23
       RawFields:
         - Name: array
@@ -6200,7 +6200,7 @@ Types:
       ID: 357
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 474368
+      GoRuntimeType: 474560
       GoKind: 23
       RawFields:
         - Name: array
@@ -6222,7 +6222,7 @@ Types:
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 475840
+      GoRuntimeType: 476032
       GoKind: 23
       RawFields:
         - Name: array
@@ -6350,7 +6350,7 @@ Types:
       ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 483712
+      GoRuntimeType: 483904
       GoKind: 23
       RawFields:
         - Name: array
@@ -6372,7 +6372,7 @@ Types:
       ID: 363
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 484032
+      GoRuntimeType: 484224
       GoKind: 23
       RawFields:
         - Name: array
@@ -6394,7 +6394,7 @@ Types:
       ID: 241
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 475072
+      GoRuntimeType: 475264
       GoKind: 23
       RawFields:
         - Name: array
@@ -6522,7 +6522,7 @@ Types:
       ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 483840
+      GoRuntimeType: 484032
       GoKind: 23
       RawFields:
         - Name: array
@@ -6544,7 +6544,7 @@ Types:
       ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 483328
+      GoRuntimeType: 483520
       GoKind: 23
       RawFields:
         - Name: array
@@ -6566,7 +6566,7 @@ Types:
       ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 482688
+      GoRuntimeType: 482880
       GoKind: 23
       RawFields:
         - Name: array
@@ -6588,35 +6588,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 581216
+      GoRuntimeType: 581408
       GoKind: 1
     - __kind: GoChannelType
       ID: 153
       Name: chan bool
-      GoRuntimeType: 592544
+      GoRuntimeType: 592736
       GoKind: 18
     - __kind: GoChannelType
       ID: 80
       Name: chan struct {}
-      GoRuntimeType: 591456
+      GoRuntimeType: 591648
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 581024
+      GoRuntimeType: 581216
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 580960
+      GoRuntimeType: 581152
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.022464e+06
+      GoRuntimeType: 1.022656e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6629,19 +6629,19 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 581088
+      GoRuntimeType: 581280
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 581152
+      GoRuntimeType: 581344
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 473024
+      GoRuntimeType: 473216
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 287
@@ -6885,37 +6885,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 580768
+      GoRuntimeType: 580960
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 580384
+      GoRuntimeType: 580576
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 580512
+      GoRuntimeType: 580704
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 580640
+      GoRuntimeType: 580832
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 580256
+      GoRuntimeType: 580448
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 844384
+      GoRuntimeType: 844576
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6928,7 +6928,7 @@ Types:
       ID: 313
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.467712e+06
+      GoRuntimeType: 1.46816e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6941,7 +6941,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.018496e+06
+      GoRuntimeType: 1.018688e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6972,7 +6972,7 @@ Types:
       ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.018112e+06
+      GoRuntimeType: 1.018304e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7000,7 +7000,7 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.181984e+06
+      GoRuntimeType: 1.182432e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7010,7 +7010,7 @@ Types:
       ID: 191
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.181856e+06
+      GoRuntimeType: 1.182304e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7024,7 +7024,7 @@ Types:
       ID: 74
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.181216e+06
+      GoRuntimeType: 1.181664e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7034,7 +7034,7 @@ Types:
       ID: 378
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.181088e+06
+      GoRuntimeType: 1.181536e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7044,7 +7044,7 @@ Types:
       ID: 393
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.18096e+06
+      GoRuntimeType: 1.181408e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7054,7 +7054,7 @@ Types:
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.183136e+06
+      GoRuntimeType: 1.183584e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7064,7 +7064,7 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.183008e+06
+      GoRuntimeType: 1.183456e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7078,7 +7078,7 @@ Types:
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.182368e+06
+      GoRuntimeType: 1.182816e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7088,7 +7088,7 @@ Types:
       ID: 348
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.18224e+06
+      GoRuntimeType: 1.182688e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7098,7 +7098,7 @@ Types:
       ID: 350
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.182112e+06
+      GoRuntimeType: 1.18256e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7108,7 +7108,7 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.184288e+06
+      GoRuntimeType: 1.184736e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7118,7 +7118,7 @@ Types:
       ID: 181
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.18416e+06
+      GoRuntimeType: 1.184608e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7132,7 +7132,7 @@ Types:
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.18352e+06
+      GoRuntimeType: 1.183968e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7142,7 +7142,7 @@ Types:
       ID: 354
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.183392e+06
+      GoRuntimeType: 1.18384e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7152,7 +7152,7 @@ Types:
       ID: 360
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.183264e+06
+      GoRuntimeType: 1.183712e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7167,7 +7167,7 @@ Types:
       ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.824768e+06
+      GoRuntimeType: 1.825216e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7189,7 +7189,7 @@ Types:
       ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.958592e+06
+      GoRuntimeType: 1.95904e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7217,7 +7217,7 @@ Types:
       ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.457152e+06
+      GoRuntimeType: 1.4576e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7230,7 +7230,7 @@ Types:
       ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.456992e+06
+      GoRuntimeType: 1.45744e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7252,7 +7252,7 @@ Types:
       ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.01824e+06
+      GoRuntimeType: 1.018432e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7286,7 +7286,7 @@ Types:
       ID: 89
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.180704e+06
+      GoRuntimeType: 1.181152e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7296,7 +7296,7 @@ Types:
       ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.180832e+06
+      GoRuntimeType: 1.18128e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -7915,126 +7915,126 @@ Types:
       ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.124768e+06
+      GoRuntimeType: 1.12496e+06
       GoKind: 21
       HeaderType: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.124896e+06
+      GoRuntimeType: 1.125088e+06
       GoKind: 21
       HeaderType: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.125024e+06
+      GoRuntimeType: 1.125216e+06
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.125152e+06
+      GoRuntimeType: 1.125344e+06
       GoKind: 21
       HeaderType: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.12464e+06
+      GoRuntimeType: 1.124832e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 330
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.124512e+06
+      GoRuntimeType: 1.124704e+06
       GoKind: 21
       HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 366
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.123872e+06
+      GoRuntimeType: 1.124064e+06
       GoKind: 21
       HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 381
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.123744e+06
+      GoRuntimeType: 1.123936e+06
       GoKind: 21
       HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.123232e+06
+      GoRuntimeType: 1.123424e+06
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 396
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.123616e+06
+      GoRuntimeType: 1.123808e+06
       GoKind: 21
       HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.12528e+06
+      GoRuntimeType: 1.125472e+06
       GoKind: 21
       HeaderType: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.125408e+06
+      GoRuntimeType: 1.1256e+06
       GoKind: 21
       HeaderType: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.125536e+06
+      GoRuntimeType: 1.125728e+06
       GoKind: 21
       HeaderType: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.125664e+06
+      GoRuntimeType: 1.125856e+06
       GoKind: 21
       HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.125792e+06
+      GoRuntimeType: 1.125984e+06
       GoKind: 21
       HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.12592e+06
+      GoRuntimeType: 1.126112e+06
       GoKind: 21
       HeaderType: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.126048e+06
+      GoRuntimeType: 1.12624e+06
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
       ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 679040
+      GoRuntimeType: 679232
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8043,7 +8043,7 @@ Types:
       ID: 282
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 679136
+      GoRuntimeType: 679328
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8052,7 +8052,7 @@ Types:
       ID: 230
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 679424
+      GoRuntimeType: 679616
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8061,7 +8061,7 @@ Types:
       ID: 249
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 679520
+      GoRuntimeType: 679712
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8070,7 +8070,7 @@ Types:
       ID: 188
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 678368
+      GoRuntimeType: 678560
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8079,7 +8079,7 @@ Types:
       ID: 339
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 678272
+      GoRuntimeType: 678464
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8088,7 +8088,7 @@ Types:
       ID: 375
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 677792
+      GoRuntimeType: 677984
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8097,7 +8097,7 @@ Types:
       ID: 390
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 677696
+      GoRuntimeType: 677888
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8106,7 +8106,7 @@ Types:
       ID: 198
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 676448
+      GoRuntimeType: 676640
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8115,7 +8115,7 @@ Types:
       ID: 405
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 677600
+      GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8124,7 +8124,7 @@ Types:
       ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 679616
+      GoRuntimeType: 679808
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8133,7 +8133,7 @@ Types:
       ID: 239
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 679712
+      GoRuntimeType: 679904
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8142,7 +8142,7 @@ Types:
       ID: 222
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 679808
+      GoRuntimeType: 680000
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8151,7 +8151,7 @@ Types:
       ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 679904
+      GoRuntimeType: 680096
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8160,7 +8160,7 @@ Types:
       ID: 206
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 680000
+      GoRuntimeType: 680192
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8169,7 +8169,7 @@ Types:
       ID: 273
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 680096
+      GoRuntimeType: 680288
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8178,7 +8178,7 @@ Types:
       ID: 265
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 680192
+      GoRuntimeType: 680384
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8187,7 +8187,7 @@ Types:
       ID: 289
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.290336e+06
+      GoRuntimeType: 1.290784e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8200,7 +8200,7 @@ Types:
       ID: 281
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.290592e+06
+      GoRuntimeType: 1.29104e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8213,7 +8213,7 @@ Types:
       ID: 229
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.290848e+06
+      GoRuntimeType: 1.291296e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8226,7 +8226,7 @@ Types:
       ID: 248
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.291104e+06
+      GoRuntimeType: 1.291552e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8239,7 +8239,7 @@ Types:
       ID: 187
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.29008e+06
+      GoRuntimeType: 1.290528e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8252,7 +8252,7 @@ Types:
       ID: 338
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.289824e+06
+      GoRuntimeType: 1.290272e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8265,7 +8265,7 @@ Types:
       ID: 374
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.288544e+06
+      GoRuntimeType: 1.288992e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8278,7 +8278,7 @@ Types:
       ID: 389
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.288288e+06
+      GoRuntimeType: 1.288736e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8291,7 +8291,7 @@ Types:
       ID: 197
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.287264e+06
+      GoRuntimeType: 1.287712e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8304,7 +8304,7 @@ Types:
       ID: 404
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.288032e+06
+      GoRuntimeType: 1.28848e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8317,7 +8317,7 @@ Types:
       ID: 256
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.29136e+06
+      GoRuntimeType: 1.291808e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8330,7 +8330,7 @@ Types:
       ID: 238
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.291616e+06
+      GoRuntimeType: 1.292064e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8343,7 +8343,7 @@ Types:
       ID: 221
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.291872e+06
+      GoRuntimeType: 1.29232e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8356,7 +8356,7 @@ Types:
       ID: 213
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.292128e+06
+      GoRuntimeType: 1.292576e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8369,7 +8369,7 @@ Types:
       ID: 205
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.292384e+06
+      GoRuntimeType: 1.292832e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8382,7 +8382,7 @@ Types:
       ID: 272
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.29264e+06
+      GoRuntimeType: 1.293088e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8395,7 +8395,7 @@ Types:
       ID: 264
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.292896e+06
+      GoRuntimeType: 1.293344e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8408,7 +8408,7 @@ Types:
       ID: 291
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.290208e+06
+      GoRuntimeType: 1.290656e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8421,7 +8421,7 @@ Types:
       ID: 283
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.290464e+06
+      GoRuntimeType: 1.290912e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8434,7 +8434,7 @@ Types:
       ID: 231
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.29072e+06
+      GoRuntimeType: 1.291168e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8447,7 +8447,7 @@ Types:
       ID: 250
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.290976e+06
+      GoRuntimeType: 1.291424e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8460,7 +8460,7 @@ Types:
       ID: 189
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.289952e+06
+      GoRuntimeType: 1.2904e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8473,7 +8473,7 @@ Types:
       ID: 340
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.289696e+06
+      GoRuntimeType: 1.290144e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8486,7 +8486,7 @@ Types:
       ID: 376
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.288416e+06
+      GoRuntimeType: 1.288864e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8499,7 +8499,7 @@ Types:
       ID: 391
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.28816e+06
+      GoRuntimeType: 1.288608e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8512,7 +8512,7 @@ Types:
       ID: 199
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.287136e+06
+      GoRuntimeType: 1.287584e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8525,7 +8525,7 @@ Types:
       ID: 406
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.287904e+06
+      GoRuntimeType: 1.288352e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8538,7 +8538,7 @@ Types:
       ID: 258
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.291232e+06
+      GoRuntimeType: 1.29168e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8551,7 +8551,7 @@ Types:
       ID: 240
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.291488e+06
+      GoRuntimeType: 1.291936e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8564,7 +8564,7 @@ Types:
       ID: 223
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.291744e+06
+      GoRuntimeType: 1.292192e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8577,7 +8577,7 @@ Types:
       ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.292e+06
+      GoRuntimeType: 1.292448e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8590,7 +8590,7 @@ Types:
       ID: 207
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.292256e+06
+      GoRuntimeType: 1.292704e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8603,7 +8603,7 @@ Types:
       ID: 274
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.292512e+06
+      GoRuntimeType: 1.29296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8616,7 +8616,7 @@ Types:
       ID: 266
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.292768e+06
+      GoRuntimeType: 1.293216e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8629,7 +8629,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 580192
+      GoRuntimeType: 580384
       GoKind: 24
       RawFields:
         - Name: str
@@ -8647,7 +8647,7 @@ Types:
       ID: 311
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.458432e+06
+      GoRuntimeType: 1.45888e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8660,7 +8660,7 @@ Types:
       ID: 314
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.606784e+06
+      GoRuntimeType: 1.607232e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8676,7 +8676,7 @@ Types:
       ID: 317
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.606976e+06
+      GoRuntimeType: 1.607424e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -8691,14 +8691,14 @@ Types:
     - __kind: StructureType
       ID: 312
       Name: sync.noCopy
-      GoRuntimeType: 983776
+      GoRuntimeType: 983968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 320
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.459712e+06
+      GoRuntimeType: 1.46016e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8711,7 +8711,7 @@ Types:
       ID: 315
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.459872e+06
+      GoRuntimeType: 1.46032e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8724,7 +8724,7 @@ Types:
       ID: 318
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.60736e+06
+      GoRuntimeType: 1.607808e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8739,13 +8739,13 @@ Types:
     - __kind: StructureType
       ID: 319
       Name: sync/atomic.align64
-      GoRuntimeType: 983968
+      GoRuntimeType: 984160
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 316
       Name: sync/atomic.noCopy
-      GoRuntimeType: 983872
+      GoRuntimeType: 984064
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -9160,43 +9160,43 @@ Types:
       ID: 16
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 580832
+      GoRuntimeType: 581024
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 580448
+      GoRuntimeType: 580640
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 580576
+      GoRuntimeType: 580768
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 580704
+      GoRuntimeType: 580896
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 580320
+      GoRuntimeType: 580512
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 580896
+      GoRuntimeType: 581088
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 581280
+      GoRuntimeType: 581472
       GoKind: 26
 MaxTypeID: 523
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -3383,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 311
+      ID: 324
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 312 PointerType *main.deepSlice3
+      Pointee: 325 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 336
+      ID: 351
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 337 PointerType *main.deepSlice8
+      Pointee: 352 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 342
+      ID: 357
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 343 PointerType *main.deepSlice9
+      Pointee: 358 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3404,7 +3404,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 403
+      ID: 320
       Name: '**main.t'
       ByteSize: 8
       Pointee: 157 PointerType *main.t
@@ -3441,30 +3441,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 319
+      ID: 332
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 320 PointerType *table<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 353
-      Name: '**table<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 354 PointerType *table<int,*main.deepMap8>
+      Pointee: 333 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 368
+      Name: '**table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 369 PointerType *table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 383
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 369 PointerType *table<int,*main.deepMap9>
+      Pointee: 384 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 93
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 94 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 383
+      ID: 398
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 384 PointerType *table<int,interface {}>
+      Pointee: 399 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 130
       Name: '**table<int,uint8>'
@@ -3506,20 +3506,20 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 315
+      ID: 328
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 314 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 327 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 340
+      ID: 355
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 339 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 354 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 346
+      ID: 361
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 345 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 360 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 179
       Name: '*[]*string.array'
@@ -3536,15 +3536,15 @@ Types:
       ByteSize: 8
       Pointee: 301 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 349
+      ID: 364
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 348 GoSliceDataType []interface {}.array
+      Pointee: 363 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 407
+      ID: 345
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 406 GoSliceDataType []main.structWithMap.array
+      Pointee: 344 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 298
       Name: '*[]main.structWithNoStrings.array'
@@ -3648,12 +3648,12 @@ Types:
       GoKind: 22
       Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 327
+      ID: 340
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 382912
       GoKind: 22
-      Pointee: 328 UnresolvedPointeeType main.deepMap3
+      Pointee: 341 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3662,19 +3662,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 361
+      ID: 376
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 382592
       GoKind: 22
-      Pointee: 362 StructureType main.deepMap8
+      Pointee: 377 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 376
+      ID: 391
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382528
       GoKind: 22
-      Pointee: 377 StructureType main.deepMap9
+      Pointee: 392 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3697,19 +3697,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 331
+      ID: 346
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383168
       GoKind: 22
-      Pointee: 332 StructureType main.deepPtr8
+      Pointee: 347 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 333
+      ID: 348
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383104
       GoKind: 22
-      Pointee: 334 StructureType main.deepPtr9
+      Pointee: 349 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3718,12 +3718,12 @@ Types:
       GoKind: 22
       Pointee: 180 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 312
+      ID: 325
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384064
       GoKind: 22
-      Pointee: 313 UnresolvedPointeeType main.deepSlice3
+      Pointee: 326 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3732,19 +3732,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 337
+      ID: 352
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 338 StructureType main.deepSlice8
+      Pointee: 353 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 343
+      ID: 358
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383680
       GoKind: 22
-      Pointee: 344 StructureType main.deepSlice9
+      Pointee: 359 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 175
       Name: '*main.emptyStruct'
@@ -3813,10 +3813,10 @@ Types:
       GoKind: 22
       Pointee: 158 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 405
+      ID: 322
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 404 GoSliceDataType main.t.array
+      Pointee: 321 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 169
       Name: '*main.threeStringStruct'
@@ -3849,30 +3849,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 317
+      ID: 330
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 351
-      Name: '*map<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 352 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 366
+      Name: '*map<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 381
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 91
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 92 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 381
+      ID: 396
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 382 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 397 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 128
       Name: '*map<int,uint8>'
@@ -3940,30 +3940,30 @@ Types:
       ByteSize: 8
       Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 323
+      ID: 336
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 357
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 358 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 372
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 387
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 195
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 196 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 387
+      ID: 402
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 388 StructureType noalg.map.group[int]interface {}
+      Pointee: 403 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 254
       Name: '*noalg.map.group[int]uint8'
@@ -4037,30 +4037,30 @@ Types:
       ByteSize: 8
       Pointee: 183 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 320
+      ID: 333
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 321 StructureType table<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 354
-      Name: '*table<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 355 StructureType table<int,*main.deepMap8>
+      Pointee: 334 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 369
+      Name: '*table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 370 StructureType table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 384
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 370 StructureType table<int,*main.deepMap9>
+      Pointee: 385 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 193 StructureType table<int,int>
     - __kind: PointerType
-      ID: 384
+      ID: 399
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 385 StructureType table<int,interface {}>
+      Pointee: 400 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '*table<int,uint8>'
@@ -6105,7 +6105,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 310
+      ID: 323
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474688
@@ -6113,21 +6113,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 311 PointerType **main.deepSlice3
+          Type: 324 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 314 GoSliceDataType []*main.deepSlice3.array
+      Data: 327 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 314
+      ID: 327
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 312 PointerType *main.deepSlice3
+      Element: 325 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 335
+      ID: 350
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474368
@@ -6135,21 +6135,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 336 PointerType **main.deepSlice8
+          Type: 351 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 339 GoSliceDataType []*main.deepSlice8.array
+      Data: 354 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 354
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 337 PointerType *main.deepSlice8
+      Element: 352 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 341
+      ID: 356
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474304
@@ -6157,19 +6157,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 342 PointerType **main.deepSlice9
+          Type: 357 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 345 GoSliceDataType []*main.deepSlice9.array
+      Data: 360 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 360
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 343 PointerType *main.deepSlice9
+      Element: 358 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6218,30 +6218,30 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 342
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 320 PointerType *table<int,*main.deepMap3>
-    - __kind: GoSliceDataType
-      ID: 363
-      Name: '[]*table<int,*main.deepMap8>.array'
-      ByteSize: 8192
-      Element: 354 PointerType *table<int,*main.deepMap8>
+      Element: 333 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 378
+      Name: '[]*table<int,*main.deepMap8>.array'
+      ByteSize: 8192
+      Element: 369 PointerType *table<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 393
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 369 PointerType *table<int,*main.deepMap9>
+      Element: 384 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 199
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 94 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 406
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 384 PointerType *table<int,interface {}>
+      Element: 399 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]*table<int,uint8>.array'
@@ -6321,7 +6321,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 347
+      ID: 362
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 483968
@@ -6336,9 +6336,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 348 GoSliceDataType []interface {}.array
+      Data: 363 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 348
+      ID: 363
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
@@ -6358,9 +6358,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 406 GoSliceDataType []main.structWithMap.array
+      Data: 344 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 344
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 89 StructureType main.structWithMap
@@ -6411,30 +6411,30 @@ Types:
       ByteSize: 2048
       Element: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 330
+      ID: 343
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 324 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: GoSliceDataType
-      ID: 364
-      Name: '[]noalg.map.group[int]*main.deepMap8.array'
-      ByteSize: 2048
-      Element: 358 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 379
+      Name: '[]noalg.map.group[int]*main.deepMap8.array'
+      ByteSize: 2048
+      Element: 373 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSliceDataType
+      ID: 394
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 373 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 196 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 392
+      ID: 407
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 388 StructureType noalg.map.group[int]interface {}
+      Element: 403 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]noalg.map.group[int]uint8.array'
@@ -6666,47 +6666,47 @@ Types:
       GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 322
+      ID: 335
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 323 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 336 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 356
+      ID: 371
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 357 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 372 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 358 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 364 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 386
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 387 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 394 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 194
       Name: groupReference<int,int>
@@ -6722,19 +6722,19 @@ Types:
       GroupType: 196 StructureType noalg.map.group[int]int
       GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 386
+      ID: 401
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 387 PointerType *noalg.map.group[int]interface {}
+          Type: 402 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 388 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 392 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 403 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 253
       Name: groupReference<int,uint8>
@@ -6877,7 +6877,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 395
+      ID: 312
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.46752e+06
@@ -6967,9 +6967,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 316 GoMapType map[int]*main.deepMap3
+          Type: 329 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 328
+      ID: 341
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -6981,9 +6981,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 350 GoMapType map[int]*main.deepMap8
+          Type: 365 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 362
+      ID: 377
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.180896e+06
@@ -6991,9 +6991,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 365 GoMapType map[int]*main.deepMap9
+          Type: 380 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 377
+      ID: 392
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.180768e+06
@@ -7001,7 +7001,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 380 GoMapType map[int]interface {}
+          Type: 395 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7035,9 +7035,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 331 PointerType *main.deepPtr8
+          Type: 346 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 332
+      ID: 347
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.182048e+06
@@ -7045,9 +7045,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 333 PointerType *main.deepPtr9
+          Type: 348 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 334
+      ID: 349
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18192e+06
@@ -7075,9 +7075,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 310 GoSliceHeaderType []*main.deepSlice3
+          Type: 323 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 313
+      ID: 326
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7089,9 +7089,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 335 GoSliceHeaderType []*main.deepSlice8
+          Type: 350 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 338
+      ID: 353
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.1832e+06
@@ -7099,9 +7099,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 341 GoSliceHeaderType []*main.deepSlice9
+          Type: 356 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 344
+      ID: 359
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.183072e+06
@@ -7109,7 +7109,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 347 GoSliceHeaderType []interface {}
+          Type: 362 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 174
       Name: main.emptyStruct
@@ -7127,16 +7127,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 393 StructureType sync.Mutex
+          Type: 310 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 396 StructureType sync.Once
+          Type: 313 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 399 StructureType sync.WaitGroup
+          Type: 316 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 402 StructureType sync/atomic.Int32
+          Type: 319 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -7276,16 +7276,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 403 PointerType **main.t
+          Type: 320 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 404 GoSliceDataType main.t.array
+      Data: 321 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 404
+      ID: 321
       Name: main.t.array
       ByteSize: 2048
       Element: 157 PointerType *main.t
@@ -7470,7 +7470,7 @@ Types:
       TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 318
+      ID: 331
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7483,7 +7483,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 319 PointerType **table<int,*main.deepMap3>
+          Type: 332 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7499,10 +7499,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 342 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 352
+      ID: 367
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7515,7 +7515,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 353 PointerType **table<int,*main.deepMap8>
+          Type: 368 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7531,10 +7531,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 363 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 358 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 367
+      ID: 382
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7547,7 +7547,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 368 PointerType **table<int,*main.deepMap9>
+          Type: 383 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7563,8 +7563,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 393 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 92
       Name: map<int,int>
@@ -7598,7 +7598,7 @@ Types:
       TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
       GroupType: 196 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 382
+      ID: 397
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7611,7 +7611,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 383 PointerType **table<int,interface {}>
+          Type: 398 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7627,8 +7627,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 391 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 388 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 406 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 403 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 129
       Name: map<int,uint8>
@@ -7889,26 +7889,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 316
+      ID: 329
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124448e+06
       GoKind: 21
-      HeaderType: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 350
+      ID: 365
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.123808e+06
       GoKind: 21
-      HeaderType: 352 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 365
+      ID: 380
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.12368e+06
       GoKind: 21
-      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 90
       Name: map[int]int
@@ -7917,12 +7917,12 @@ Types:
       GoKind: 21
       HeaderType: 92 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 380
+      ID: 395
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.123552e+06
       GoKind: 21
-      HeaderType: 382 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 397 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 127
       Name: map[int]uint8
@@ -8018,32 +8018,32 @@ Types:
       HasCount: true
       Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 325
+      ID: 338
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 339 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 359
+      ID: 374
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 677728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 360 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 374
+      ID: 389
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677632
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 390 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 197
       Name: noalg.[8]struct { key int; elem int }
@@ -8054,14 +8054,14 @@ Types:
       HasCount: true
       Element: 198 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 389
+      ID: 404
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 677536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 390 StructureType noalg.struct { key int; elem interface {} }
+      Element: 405 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 256
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -8191,7 +8191,7 @@ Types:
           Offset: 8
           Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 324
+      ID: 337
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.289632e+06
@@ -8202,9 +8202,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 338 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 358
+      ID: 373
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.288352e+06
@@ -8215,9 +8215,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 359 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 373
+      ID: 388
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.288096e+06
@@ -8228,7 +8228,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 389 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 196
       Name: noalg.map.group[int]int
@@ -8243,7 +8243,7 @@ Types:
           Offset: 8
           Type: 197 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 388
+      ID: 403
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.28784e+06
@@ -8254,7 +8254,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 389 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 404 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 255
       Name: noalg.map.group[int]uint8
@@ -8412,7 +8412,7 @@ Types:
           Offset: 8
           Type: 189 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 326
+      ID: 339
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.289504e+06
@@ -8423,9 +8423,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 327 PointerType *main.deepMap3
+          Type: 340 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 360
+      ID: 375
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.288224e+06
@@ -8436,9 +8436,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 361 PointerType *main.deepMap8
+          Type: 376 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 375
+      ID: 390
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.287968e+06
@@ -8449,7 +8449,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 376 PointerType *main.deepMap9
+          Type: 391 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 198
       Name: noalg.struct { key int; elem int }
@@ -8464,7 +8464,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 390
+      ID: 405
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.287712e+06
@@ -8586,7 +8586,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 393
+      ID: 310
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.45824e+06
@@ -8594,12 +8594,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 395 StructureType internal/sync.Mutex
+          Type: 312 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 396
+      ID: 313
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.606592e+06
@@ -8607,15 +8607,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 397 StructureType sync/atomic.Uint32
+          Type: 314 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 393 StructureType sync.Mutex
+          Type: 310 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 399
+      ID: 316
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.606784e+06
@@ -8623,21 +8623,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 400 StructureType sync/atomic.Uint64
+          Type: 317 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 394
+      ID: 311
       Name: sync.noCopy
       GoRuntimeType: 983712
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 402
+      ID: 319
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.45952e+06
@@ -8645,12 +8645,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 397
+      ID: 314
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.45968e+06
@@ -8658,12 +8658,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 400
+      ID: 317
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607168e+06
@@ -8671,21 +8671,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 401 StructureType sync/atomic.align64
+          Type: 318 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 401
+      ID: 318
       Name: sync/atomic.align64
       GoRuntimeType: 983904
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 398
+      ID: 315
       Name: sync/atomic.noCopy
       GoRuntimeType: 983808
       GoKind: 25
@@ -8811,7 +8811,7 @@ Types:
           Offset: 16
           Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 321
+      ID: 334
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8833,9 +8833,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 335 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 355
+      ID: 370
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8857,9 +8857,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 356 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 370
+      ID: 385
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8881,7 +8881,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 386 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 193
       Name: table<int,int>
@@ -8907,7 +8907,7 @@ Types:
           Offset: 16
           Type: 194 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 385
+      ID: 400
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8929,7 +8929,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 386 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 401 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 252
       Name: table<int,uint8>

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 504 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd8fca", Frameless: false}]
+        - ID: 98
+          Type: 506 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcd906a", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 460 EventRootType Probe[main.testAny]
+          Type: 461 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd5e6a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 462 EventRootType Probe[main.testAnyPtr]
+          Type: 463 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd5f0a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 422 EventRootType Probe[main.testArrayOfArrays]
+          Type: 423 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 424 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 425 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -78,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 469 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcd65c0", Frameless: true}]
+        - ID: 63
+          Type: 471 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcd6660", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 423 EventRootType Probe[main.testArrayOfStrings]
+          Type: 424 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 442 EventRootType Probe[main.testBigStruct]
+          Type: 443 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a20", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 411 EventRootType Probe[main.testBoolArray]
+          Type: 412 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 408 EventRootType Probe[main.testByteArray]
+          Type: 409 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4100", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 485 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd8280", Frameless: true}]
+        - ID: 79
+          Type: 487 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcd8320", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -162,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 483 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcd7ea0", Frameless: true}]
+        - ID: 77
+          Type: 485 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcd7f40", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -176,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 493 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd8640", Frameless: true}]
+        - ID: 87
+          Type: 495 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcd86e0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 447 EventRootType Probe[main.testDeepMap1]
+          Type: 448 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e00", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 448 EventRootType Probe[main.testDeepMap7]
+          Type: 449 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e20", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 443 EventRootType Probe[main.testDeepPtr1]
+          Type: 444 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4ae0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 444 EventRootType Probe[main.testDeepPtr7]
+          Type: 445 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b00", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 445 EventRootType Probe[main.testDeepSlice1]
+          Type: 446 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4c80", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 446 EventRootType Probe[main.testDeepSlice7]
+          Type: 447 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ca0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -292,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 495 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
+        - ID: 89
+          Type: 497 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -306,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 498 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
+        - ID: 92
+          Type: 500 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcd8c80", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -320,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 512 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
+        - ID: 106
+          Type: 514 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 514 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd9500", Frameless: true}]
+        - ID: 108
+          Type: 516 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 515 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcd9520", Frameless: true}]
+        - ID: 109
+          Type: 517 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 461 EventRootType Probe[main.testError]
+          Type: 462 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd5ee0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 452 EventRootType Probe[main.testEsotericHeap]
+          Type: 453 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd53ea", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 451 EventRootType Probe[main.testEsotericStack]
+          Type: 452 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd52ce", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 457 EventRootType Probe[main.testFrameless]
+          Type: 458 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 458 EventRootType Probe[main.testFramelessArray]
+          Type: 459 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5b64", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 453 EventRootType Probe[main.testInlinedBA]
+          Type: 454 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd582a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 454 EventRootType Probe[main.testInlinedBB]
+          Type: 455 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd58ce", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 455 EventRootType Probe[main.testInlinedBBA]
+          Type: 456 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd59aa", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 517 EventRootType Probe[main.testInlinedBBB]
+        - ID: 111
+          Type: 519 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5926", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 456 EventRootType Probe[main.testInlinedBC]
+          Type: 457 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5a2e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 518 EventRootType Probe[main.testInlinedBCA]
+        - ID: 112
+          Type: 520 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5a33", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 519 EventRootType Probe[main.testInlinedBCB]
+        - ID: 113
+          Type: 521 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5ae6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 516 EventRootType Probe[main.testInlinedPrint]
+        - ID: 110
+          Type: 518 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd568a"
               Frameless: false
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 520 EventRootType Probe[main.testInlinedSq]
+        - ID: 114
+          Type: 522 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5b41", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 114
-          Type: 521 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 115
+          Type: 523 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5b85"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 414 EventRootType Probe[main.testInt16Array]
+          Type: 415 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 415 EventRootType Probe[main.testInt32Array]
+          Type: 416 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 416 EventRootType Probe[main.testInt64Array]
+          Type: 417 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 413 EventRootType Probe[main.testInt8Array]
+          Type: 414 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 412 EventRootType Probe[main.testIntArray]
+          Type: 413 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 459 EventRootType Probe[main.testInterface]
+          Type: 460 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd5e40", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -671,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 487 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
+        - ID: 81
+          Type: 489 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcd8500", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -685,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 467 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcd6580", Frameless: true}]
+        - ID: 61
+          Type: 469 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcd6620", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -699,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 473 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcd6640", Frameless: true}]
+        - ID: 67
+          Type: 475 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcd66e0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -713,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 471 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcd6600", Frameless: true}]
+        - ID: 65
+          Type: 473 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcd66a0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -727,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 482 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd6760", Frameless: true}]
+        - ID: 76
+          Type: 484 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd6800", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -741,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 481 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcd6740", Frameless: true}]
+        - ID: 75
+          Type: 483 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcd67e0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -755,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 472 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd6620", Frameless: true}]
+        - ID: 66
+          Type: 474 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd66c0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -769,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 480 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd6720", Frameless: true}]
+        - ID: 74
+          Type: 482 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd67c0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -783,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 479 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcd6700", Frameless: true}]
+        - ID: 73
+          Type: 481 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcd67a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -797,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 465 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcd6540", Frameless: true}]
+        - ID: 59
+          Type: 467 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcd65e0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -811,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 466 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcd6560", Frameless: true}]
+        - ID: 60
+          Type: 468 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcd6600", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -825,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 464 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcd6520", Frameless: true}]
+        - ID: 58
+          Type: 466 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcd65c0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -839,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 474 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcd6660", Frameless: true}]
+        - ID: 68
+          Type: 476 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcd6700", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -853,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcd66c0", Frameless: true}]
+        - ID: 71
+          Type: 479 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcd6760", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -867,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 478 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcd66e0", Frameless: true}]
+        - ID: 72
+          Type: 480 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcd6780", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -881,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 475 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcd6680", Frameless: true}]
+        - ID: 69
+          Type: 477 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcd6720", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -895,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 476 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcd66a0", Frameless: true}]
+        - ID: 70
+          Type: 478 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcd6740", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -909,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 510 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
+        - ID: 104
+          Type: 512 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -923,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 484 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
+        - ID: 78
+          Type: 486 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcd8100", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -937,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 492 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd8600", Frameless: true}]
+        - ID: 86
+          Type: 494 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcd86a0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -951,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 502 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
+        - ID: 96
+          Type: 504 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcd8d00", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -965,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 499 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
+        - ID: 93
+          Type: 501 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -979,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 501 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
+        - ID: 95
+          Type: 503 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcd8ce0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -993,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 509 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
+        - ID: 103
+          Type: 511 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1007,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 488 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
+        - ID: 82
+          Type: 490 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcd8520", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1021,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 470 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcd65e0", Frameless: true}]
+        - ID: 64
+          Type: 472 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcd6680", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1035,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 486 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
+        - ID: 80
+          Type: 488 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 409 EventRootType Probe[main.testRuneArray]
+          Type: 410 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 428 EventRootType Probe[main.testSingleBool]
+          Type: 429 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 426 EventRootType Probe[main.testSingleByte]
+          Type: 427 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd46e0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 439 EventRootType Probe[main.testSingleFloat32]
+          Type: 440 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 440 EventRootType Probe[main.testSingleFloat64]
+          Type: 441 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 429 EventRootType Probe[main.testSingleInt]
+          Type: 430 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 431 EventRootType Probe[main.testSingleInt16]
+          Type: 432 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 432 EventRootType Probe[main.testSingleInt32]
+          Type: 433 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 433 EventRootType Probe[main.testSingleInt64]
+          Type: 434 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 430 EventRootType Probe[main.testSingleInt8]
+          Type: 431 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 427 EventRootType Probe[main.testSingleRune]
+          Type: 428 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4700", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1203,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 505 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
+        - ID: 99
+          Type: 507 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 434 EventRootType Probe[main.testSingleUint]
+          Type: 435 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 436 EventRootType Probe[main.testSingleUint16]
+          Type: 437 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 437 EventRootType Probe[main.testSingleUint32]
+          Type: 438 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 438 EventRootType Probe[main.testSingleUint64]
+          Type: 439 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 435 EventRootType Probe[main.testSingleUint8]
+          Type: 436 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1287,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 496 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
+        - ID: 90
+          Type: 498 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1301,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 468 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcd65a0", Frameless: true}]
+        - ID: 62
+          Type: 470 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcd6640", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 410 EventRootType Probe[main.testStringArray]
+          Type: 411 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1329,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 491 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd85c0", Frameless: true}]
+        - ID: 85
+          Type: 493 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcd8660", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1343,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 500 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
+        - ID: 94
+          Type: 502 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcd8cc0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 449 EventRootType Probe[main.testStringType1]
+          Type: 450 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 450 EventRootType Probe[main.testStringType2]
+          Type: 451 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 513 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd9380", Frameless: true}]
+        - ID: 107
+          Type: 515 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcd9420", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1405,11 +1405,28 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 497 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
+        - ID: 91
+          Type: 499 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
+          Condition: null
+    - id: testStructWithAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithAny}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 56}
+      events:
+        - ID: 56
+          Type: 464 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xcd5f60", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1419,11 +1436,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 463 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcd6500", Frameless: true}]
+        - ID: 57
+          Type: 465 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcd65a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1433,11 +1450,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 506 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
+        - ID: 100
+          Type: 508 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1447,11 +1464,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 507 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
+        - ID: 101
+          Type: 509 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1461,11 +1478,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 508 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
+        - ID: 102
+          Type: 510 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1478,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 441 EventRootType Probe[main.testTypeAlias]
+          Type: 442 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1492,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 419 EventRootType Probe[main.testUint16Array]
+          Type: 420 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1506,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 420 EventRootType Probe[main.testUint32Array]
+          Type: 421 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1520,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 421 EventRootType Probe[main.testUint64Array]
+          Type: 422 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1534,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 418 EventRootType Probe[main.testUint8Array]
+          Type: 419 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1548,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 417 EventRootType Probe[main.testUintArray]
+          Type: 418 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1559,11 +1576,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 490 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
+        - ID: 84
+          Type: 492 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcd8580", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1573,11 +1590,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 494 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
+        - ID: 88
+          Type: 496 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1587,11 +1604,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 511 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
+        - ID: 105
+          Type: 513 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1601,11 +1618,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 489 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd84a0", Frameless: true}]
+        - ID: 83
+          Type: 491 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcd8540", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1618,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 425 EventRootType Probe[main.testVeryLargeArray]
+          Type: 426 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1629,11 +1646,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 503 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd8c80", Frameless: true}]
+        - ID: 97
+          Type: 505 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcd8d20", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2442,308 +2459,324 @@ Subprograms:
           IsParameter: true
           IsReturn: true
     - ID: 56
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd6500..0xcd6501]
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xcd5f60..0xcd5f61]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 89 StructureType main.structWithMap
+          Type: 89 StructureType main.structWithAny
           Locations:
-            - Range: 0xcd6500..0xcd6501
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5f60..0xcd5f61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd6520..0xcd6521]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 95 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcd6520..0xcd6521
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd6540..0xcd6541]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd6540..0xcd6541
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd6560..0xcd6561]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 105 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcd6560..0xcd6561
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd6580..0xcd6581]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 110 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcd6580..0xcd6581
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testSmallMap
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0xcd65a0..0xcd65a1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
+        - Name: s
+          Type: 90 StructureType main.structWithMap
           Locations:
             - Range: 0xcd65a0..0xcd65a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testArrayOfMaps
+    - ID: 58
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcd65c0..0xcd65c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 115 ArrayType [2]map[string]int
+          Type: 96 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcd65c0..0xcd65c1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testPointerToMap
+    - ID: 59
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcd65e0..0xcd65e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 116 PointerType *map[string]int
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0xcd65e0..0xcd65e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapIntToInt
+    - ID: 60
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcd6600..0xcd6601]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 90 GoMapType map[int]int
+          Type: 106 GoMapType map[string][]string
           Locations:
             - Range: 0xcd6600..0xcd6601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapMassive
+    - ID: 61
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcd6620..0xcd6621]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 117 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 111 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcd6620..0xcd6621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapEmbeddedMaps
+    - ID: 62
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcd6640..0xcd6641]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 117 GoMapType map[string][]main.structWithMap
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0xcd6640..0xcd6641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithLinkedList
+    - ID: 63
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcd6660..0xcd6661]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[bool]main.node
+          Type: 116 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcd6660..0xcd6661
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValue
+    - ID: 64
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcd6680..0xcd6681]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[int]uint8
+          Type: 117 PointerType *map[string]int
           Locations:
             - Range: 0xcd6680..0xcd6681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallValueMassive
+    - ID: 65
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcd66a0..0xcd66a1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 127 GoMapType map[int]uint8
+        - Name: m
+          Type: 91 GoMapType map[int]int
           Locations:
             - Range: 0xcd66a0..0xcd66a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 66
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xcd66c0..0xcd66c1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd66c0..0xcd66c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 67
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcd66e0..0xcd66e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd66e0..0xcd66e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeySmallValue
+    - ID: 68
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcd6700..0xcd6701]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 123 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcd6700..0xcd6701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 69
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcd6720..0xcd6721]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 GoMapType map[uint8][4]int
+          Type: 128 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd6720..0xcd6721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeySmallValue
+    - ID: 70
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcd6740..0xcd6741]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 142 GoMapType map[[4]int]uint8
+        - Name: redactMyEntries
+          Type: 128 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd6740..0xcd6741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcd6760..0xcd6761]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 147 GoMapType map[[4]int][4]int
+          Type: 133 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd6760..0xcd6761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 72
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcd6780..0xcd6781]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd6780..0xcd6781
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcd67a0..0xcd67a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd67a0..0xcd67a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcd67c0..0xcd67c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 138 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcd67c0..0xcd67c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcd67e0..0xcd67e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 143 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcd67e0..0xcd67e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 76
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcd6800..0xcd6801]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 148 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcd6800..0xcd6801
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 77
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcd7ea0..0xcd7ea1]
+      OutOfLinePCRanges: [0xcd7f40..0xcd7f41]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd7ea0..0xcd7ea1
+            - Range: 0xcd7f40..0xcd7f41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd7ea0..0xcd7ea1
+            - Range: 0xcd7f40..0xcd7f41
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcd7ea0..0xcd7ea1
+            - Range: 0xcd7f40..0xcd7f41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcd8060..0xcd8061]
+      OutOfLinePCRanges: [0xcd8100..0xcd8101]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd8060..0xcd8061
+            - Range: 0xcd8100..0xcd8101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd8060..0xcd8061
+            - Range: 0xcd8100..0xcd8101
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd8060..0xcd8061
+            - Range: 0xcd8100..0xcd8101
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8060..0xcd8061
+            - Range: 0xcd8100..0xcd8101
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8060..0xcd8061
+            - Range: 0xcd8100..0xcd8101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2751,39 +2784,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcd8280..0xcd8281]
+      OutOfLinePCRanges: [0xcd8320..0xcd8321]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 152 GoChannelType chan bool
+          Type: 153 GoChannelType chan bool
           Locations:
-            - Range: 0xcd8280..0xcd8281
+            - Range: 0xcd8320..0xcd8321
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd8440..0xcd8441]
+      OutOfLinePCRanges: [0xcd84e0..0xcd84e1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 153 PointerType *main.structWithTwoValues
+          Type: 154 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd8440..0xcd8441
+            - Range: 0xcd84e0..0xcd84e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd8460..0xcd8461]
+      OutOfLinePCRanges: [0xcd8500..0xcd8501]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 StructureType main.node
+          Type: 156 StructureType main.node
           Locations:
-            - Range: 0xcd8460..0xcd8461
+            - Range: 0xcd8500..0xcd8501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2791,112 +2824,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd8480..0xcd8481]
+      OutOfLinePCRanges: [0xcd8520..0xcd8521]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 156 PointerType *main.node
+          Type: 157 PointerType *main.node
           Locations:
-            - Range: 0xcd8480..0xcd8481
+            - Range: 0xcd8520..0xcd8521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd84a0..0xcd84a1]
+      OutOfLinePCRanges: [0xcd8540..0xcd8541]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcd84a0..0xcd84a1
+            - Range: 0xcd8540..0xcd8541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd84e0..0xcd84e1]
+      OutOfLinePCRanges: [0xcd8580..0xcd8581]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xcd84e0..0xcd84e1
+            - Range: 0xcd8580..0xcd8581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd85c0..0xcd85c1]
+      OutOfLinePCRanges: [0xcd8660..0xcd8661]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xcd85c0..0xcd85c1
+            - Range: 0xcd8660..0xcd8661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd8600..0xcd8601]
+      OutOfLinePCRanges: [0xcd86a0..0xcd86a1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcd8600..0xcd8601
+            - Range: 0xcd86a0..0xcd86a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8600..0xcd8601
+            - Range: 0xcd86a0..0xcd86a1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcd8640..0xcd8641]
+      OutOfLinePCRanges: [0xcd86e0..0xcd86e1]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 157 PointerType *main.t
+          Type: 158 PointerType *main.t
           Locations:
-            - Range: 0xcd8640..0xcd8641
+            - Range: 0xcd86e0..0xcd86e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd8b60..0xcd8b61]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 159 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd8b60..0xcd8b61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 88
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType []uint
+          Type: 160 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd8b80..0xcd8b81
+            - Range: 0xcd8c00..0xcd8c01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2907,105 +2922,12 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd8ba0..0xcd8ba1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 160 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcd8ba0..0xcd8ba1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 90
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd8bc0..0xcd8bc1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd8bc0..0xcd8bc1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 91
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd8be0..0xcd8be1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd8be0..0xcd8be1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd8be0..0xcd8be1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd8c00..0xcd8c01
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd8c00..0xcd8c01
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 93
-      Name: main.testStringSlice
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcd8c20..0xcd8c21]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 165 GoSliceHeaderType []string
+        - Name: u
+          Type: 160 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd8c20..0xcd8c21
               Pieces:
@@ -3017,22 +2939,133 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSliceWithOtherParams
+    - ID: 90
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcd8c40..0xcd8c41]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 161 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcd8c40..0xcd8c41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8c60..0xcd8c61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8c60..0xcd8c61
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcd8c80..0xcd8c81]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8c80..0xcd8c81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8c80..0xcd8c81
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcd8ca0..0xcd8ca1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8ca0..0xcd8ca1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8ca0..0xcd8ca1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcd8cc0..0xcd8cc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 166 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcd8cc0..0xcd8cc1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcd8ce0..0xcd8ce1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd8c40..0xcd8c41
+            - Range: 0xcd8ce0..0xcd8ce1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 166 GoSliceHeaderType []bool
+          Type: 167 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcd8c40..0xcd8c41
+            - Range: 0xcd8ce0..0xcd8ce1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3045,37 +3078,19 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8c40..0xcd8c41
+            - Range: 0xcd8ce0..0xcd8ce1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 95
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 167 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcd8c60..0xcd8c61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 96
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd8c80..0xcd8c81]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcd8d00..0xcd8d01]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 159 GoSliceHeaderType []uint
+          Type: 168 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcd8c80..0xcd8c81
+            - Range: 0xcd8d00..0xcd8d01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3086,119 +3101,35 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 97
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcd8d20..0xcd8d21]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 160 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcd8d20..0xcd8d21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd8fc0..0xcd9012]
+      OutOfLinePCRanges: [0xcd9060..0xcd90b2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd8fc0..0xcd9012, Pieces: []}]
+          Locations: [{Range: 0xcd9060..0xcd90b2, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd9020..0xcd9021]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd9020..0xcd9021
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd9040..0xcd9041]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd9040..0xcd9041
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: y
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd9040..0xcd9041
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: z
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd9040..0xcd9041
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd9060..0xcd907f]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0xcd9060..0xcd907f
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 101
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd9080..0xcd9081]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 169 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xcd9080..0xcd9081
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 102
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd90a0..0xcd90a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 170 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0xcd90a0..0xcd90a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 103
-      Name: main.testMassiveString
+      Name: main.testSingleString
       OutOfLinePCRanges: [0xcd90c0..0xcd90c1]
       InlinePCRanges: []
       Variables:
@@ -3213,8 +3144,8 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
-      Name: main.testUnitializedString
+    - ID: 100
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0xcd90e0..0xcd90e1]
       InlinePCRanges: []
       Variables:
@@ -3229,15 +3160,101 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd9100..0xcd9101]
+        - Name: y
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd90e0..0xcd90e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd90e0..0xcd90e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 101
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0xcd9100..0xcd911f]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 169 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0xcd9100..0xcd911f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 102
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0xcd9120..0xcd9121]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 170 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0xcd9120..0xcd9121
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xcd9140..0xcd9141]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 171 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0xcd9140..0xcd9141
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 104
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcd9160..0xcd9161]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9100..0xcd9101
+            - Range: 0xcd9160..0xcd9161
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcd9180..0xcd9181]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd9180..0xcd9181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3246,14 +3263,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 106
-      Name: main.testStruct
-      OutOfLinePCRanges: [0xcd9380..0xcd93a3]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcd91a0..0xcd91a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 172 StructureType main.aStruct
+          Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9380..0xcd93a3
+            - Range: 0xcd91a0..0xcd91a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 107
+      Name: main.testStruct
+      OutOfLinePCRanges: [0xcd9420..0xcd9443]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 173 StructureType main.aStruct
+          Locations:
+            - Range: 0xcd9420..0xcd9443
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3271,29 +3304,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd9500..0xcd9501]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 174 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd9500..0xcd9501, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 108
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcd9520..0xcd9521]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0xcd95a0..0xcd95a1]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 175 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0xcd9520..0xcd9521
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 175 StructureType main.emptyStruct
+          Locations: [{Range: 0xcd95a0..0xcd95a1, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 109
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0xcd95c0..0xcd95c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 176 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0xcd95c0..0xcd95c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 110
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd5680..0xcd56e2]
       InlinePCRanges:
@@ -3323,28 +3356,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5926..0xcd595e]
           RootRanges: [0xcd58c0..0xcd5985]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5a33..0xcd5a71]
           RootRanges: [0xcd5a20..0xcd5b2e]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5ae6..0xcd5b1e]
           RootRanges: [0xcd5a20..0xcd5b2e]
       Variables: []
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3358,7 +3391,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 115
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3383,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 324
+      ID: 325
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 325 PointerType *main.deepSlice3
+      Pointee: 326 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 351
+      ID: 352
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 352 PointerType *main.deepSlice8
+      Pointee: 353 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 357
+      ID: 358
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 358 PointerType *main.deepSlice9
+      Pointee: 359 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3404,373 +3437,373 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 320
+      ID: 321
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 157 PointerType *main.t
+      Pointee: 158 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 526176
+      GoRuntimeType: 526240
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 151 PointerType *table<[4]int,[4]int>
+      Pointee: 152 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 146 PointerType *table<[4]int,uint8>
+      Pointee: 147 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 114 PointerType *table<[4]string,[2]int>
+      Pointee: 115 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<bool,main.node>
+      Pointee: 127 PointerType *table<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 332
+      ID: 333
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 333 PointerType *table<int,*main.deepMap3>
+      Pointee: 334 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 368
+      ID: 369
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 369 PointerType *table<int,*main.deepMap8>
+      Pointee: 370 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 383
+      ID: 384
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 384 PointerType *table<int,*main.deepMap9>
+      Pointee: 385 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 94 PointerType *table<int,int>
+      Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 399 PointerType *table<int,interface {}>
+      Pointee: 400 PointerType *table<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 131 PointerType *table<int,uint8>
+      Pointee: 132 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 121 PointerType *table<string,[]main.structWithMap>
+      Pointee: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 109 PointerType *table<string,[]string>
+      Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 104 PointerType *table<string,int>
+      Pointee: 105 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 99 PointerType *table<string,main.nestedStruct>
+      Pointee: 100 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 141 PointerType *table<uint8,[4]int>
+      Pointee: 142 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 136 PointerType *table<uint8,uint8>
+      Pointee: 137 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 182
+      ID: 183
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 328
+      ID: 329
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 327 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 328 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 355
+      ID: 356
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 354 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 355 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 361
+      ID: 362
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 360 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 361 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 179
+      ID: 180
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []*string.array
+      Pointee: 179 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 296
+      ID: 297
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 295 GoSliceDataType [][]uint.array
+      Pointee: 296 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 302
+      ID: 303
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 301 GoSliceDataType []bool.array
+      Pointee: 302 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 364
+      ID: 365
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 363 GoSliceDataType []interface {}.array
+      Pointee: 364 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 345
+      ID: 346
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 344 GoSliceDataType []main.structWithMap.array
+      Pointee: 345 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 298
+      ID: 299
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 297 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 298 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 300
+      ID: 301
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 299 GoSliceDataType []string.array
+      Pointee: 300 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 161
+      ID: 162
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 159 GoSliceHeaderType []uint
+      Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 294
+      ID: 295
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType []uint.array
+      Pointee: 294 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 303 GoSliceDataType []uint16.array
+      Pointee: 304 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 390272
+      GoRuntimeType: 390336
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 389184
+      GoRuntimeType: 389248
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 390144
+      GoRuntimeType: 390208
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 390208
+      GoRuntimeType: 390272
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 389824
+      GoRuntimeType: 389888
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 389440
+      GoRuntimeType: 389504
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 389568
+      GoRuntimeType: 389632
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 26
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 389696
+      GoRuntimeType: 389760
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 389312
+      GoRuntimeType: 389376
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
       ID: 88
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 390400
+      GoRuntimeType: 390464
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 189
+      ID: 190
       Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 383040
+      GoKind: 22
+      Pointee: 191 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 341
+      Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 382976
       GoKind: 22
-      Pointee: 190 StructureType main.deepMap2
-    - __kind: PointerType
-      ID: 340
-      Name: '*main.deepMap3'
-      ByteSize: 8
-      GoRuntimeType: 382912
-      GoKind: 22
-      Pointee: 341 UnresolvedPointeeType main.deepMap3
+      Pointee: 342 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 382656
+      GoRuntimeType: 382720
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 376
+      ID: 377
       Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 382656
+      GoKind: 22
+      Pointee: 378 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 392
+      Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382592
       GoKind: 22
-      Pointee: 377 StructureType main.deepMap8
-    - __kind: PointerType
-      ID: 391
-      Name: '*main.deepMap9'
-      ByteSize: 8
-      GoRuntimeType: 382528
-      GoKind: 22
-      Pointee: 392 StructureType main.deepMap9
+      Pointee: 393 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 383552
+      GoRuntimeType: 383616
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 305
+      ID: 306
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 383488
+      GoRuntimeType: 383552
       GoKind: 22
-      Pointee: 306 UnresolvedPointeeType main.deepPtr3
+      Pointee: 307 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 383232
+      GoRuntimeType: 383296
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 346
+      ID: 347
       Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 383232
+      GoKind: 22
+      Pointee: 348 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 349
+      Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383168
       GoKind: 22
-      Pointee: 347 StructureType main.deepPtr8
-    - __kind: PointerType
-      ID: 348
-      Name: '*main.deepPtr9'
-      ByteSize: 8
-      GoRuntimeType: 383104
-      GoKind: 22
-      Pointee: 349 StructureType main.deepPtr9
+      Pointee: 350 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 384128
+      GoRuntimeType: 384192
       GoKind: 22
-      Pointee: 180 StructureType main.deepSlice2
+      Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 325
+      ID: 326
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 384064
+      GoRuntimeType: 384128
       GoKind: 22
-      Pointee: 326 UnresolvedPointeeType main.deepSlice3
+      Pointee: 327 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 383808
+      GoRuntimeType: 383872
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 352
+      ID: 353
       Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 383808
+      GoKind: 22
+      Pointee: 354 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 359
+      Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 353 StructureType main.deepSlice8
+      Pointee: 360 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 358
-      Name: '*main.deepSlice9'
-      ByteSize: 8
-      GoRuntimeType: 383680
-      GoKind: 22
-      Pointee: 359 StructureType main.deepSlice9
-    - __kind: PointerType
-      ID: 175
+      ID: 176
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 174 StructureType main.emptyStruct
+      Pointee: 175 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 384256
+      GoRuntimeType: 384320
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 156
+      ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 384320
+      GoRuntimeType: 384384
       GoKind: 22
-      Pointee: 155 StructureType main.node
+      Pointee: 156 StructureType main.node
     - __kind: PointerType
-      ID: 170
+      ID: 171
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 StructureType main.oneStringStruct
+      Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -3778,371 +3811,371 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 308
+      ID: 309
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType main.stringType1.str
+      Pointee: 308 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 309 UnresolvedPointeeType main.stringType2
+      Pointee: 310 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 241
+      ID: 242
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 382464
+      GoRuntimeType: 382528
       GoKind: 22
-      Pointee: 89 StructureType main.structWithMap
+      Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 163
+      ID: 164
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 164 StructureType main.structWithNoStrings
+      Pointee: 165 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 153
+      ID: 154
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 154 StructureType main.structWithTwoValues
+      Pointee: 155 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 157
+      ID: 158
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 158 GoSliceHeaderType main.t
+      Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 322
+      ID: 323
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 321 GoSliceDataType main.t.array
+      Pointee: 322 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 169
+      ID: 170
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 168 StructureType main.threeStringStruct
+      Pointee: 169 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 148
+      ID: 149
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 149 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 143
+      ID: 144
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 144 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 111
+      ID: 112
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 112 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 123
+      ID: 124
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 330
+      ID: 331
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 366
+      ID: 367
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 381
+      ID: 382
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 91
+      ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 92 GoSwissMapHeaderType map<int,int>
+      Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 396
+      ID: 397
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 397 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
-      ID: 128
+      ID: 129
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 129 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 106
+      ID: 107
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 107 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 101
+      ID: 102
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 102 GoSwissMapHeaderType map<string,int>
+      Pointee: 103 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 96
+      ID: 97
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 138
+      ID: 139
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 139 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 133
+      ID: 134
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 134 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 116
+      ID: 117
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 GoMapType map[string]int
+      Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 287
+      ID: 288
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 288 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 279
+      ID: 280
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 280 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 227
+      ID: 228
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 228 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 246
+      ID: 247
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 247 StructureType noalg.map.group[bool]main.node
+      Pointee: 248 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 185
+      ID: 186
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 336
+      ID: 337
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 337 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 372
+      ID: 373
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 387
+      ID: 388
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 388 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 195
+      ID: 196
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[int]int
+      Pointee: 197 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 402
+      ID: 403
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 403 StructureType noalg.map.group[int]interface {}
+      Pointee: 404 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 254
+      ID: 255
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 255 StructureType noalg.map.group[int]uint8
+      Pointee: 256 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 236
+      ID: 237
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 237 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 219
+      ID: 220
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 220 StructureType noalg.map.group[string][]string
+      Pointee: 221 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 211
+      ID: 212
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 212 StructureType noalg.map.group[string]int
+      Pointee: 213 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 203
+      ID: 204
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 270
+      ID: 271
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 271 StructureType noalg.map.group[uint8][4]int
+      Pointee: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 262
+      ID: 263
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 263 StructureType noalg.map.group[uint8]uint8
+      Pointee: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 389248
+      GoRuntimeType: 389312
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 177
+      ID: 178
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 176 GoStringDataType string.str
+      Pointee: 177 GoStringDataType string.str
     - __kind: PointerType
-      ID: 151
+      ID: 152
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 285 StructureType table<[4]int,[4]int>
+      Pointee: 286 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 146
+      ID: 147
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 277 StructureType table<[4]int,uint8>
+      Pointee: 278 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 114
+      ID: 115
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 225 StructureType table<[4]string,[2]int>
+      Pointee: 226 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 126
+      ID: 127
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 244 StructureType table<bool,main.node>
+      Pointee: 245 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 183 StructureType table<int,*main.deepMap2>
+      Pointee: 184 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 333
+      ID: 334
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 334 StructureType table<int,*main.deepMap3>
+      Pointee: 335 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 369
+      ID: 370
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 370 StructureType table<int,*main.deepMap8>
+      Pointee: 371 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 384
+      ID: 385
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 385 StructureType table<int,*main.deepMap9>
+      Pointee: 386 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 94
+      ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 193 StructureType table<int,int>
+      Pointee: 194 StructureType table<int,int>
     - __kind: PointerType
-      ID: 399
+      ID: 400
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 400 StructureType table<int,interface {}>
+      Pointee: 401 StructureType table<int,interface {}>
     - __kind: PointerType
-      ID: 131
+      ID: 132
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 252 StructureType table<int,uint8>
+      Pointee: 253 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 122
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 234 StructureType table<string,[]main.structWithMap>
+      Pointee: 235 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 109
+      ID: 110
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 217 StructureType table<string,[]string>
+      Pointee: 218 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 104
+      ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 209 StructureType table<string,int>
+      Pointee: 210 StructureType table<string,int>
     - __kind: PointerType
-      ID: 99
+      ID: 100
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 201 StructureType table<string,main.nestedStruct>
+      Pointee: 202 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 141
+      ID: 142
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 268 StructureType table<uint8,[4]int>
+      Pointee: 269 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 136
+      ID: 137
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 260 StructureType table<uint8,uint8>
+      Pointee: 261 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 389888
+      GoRuntimeType: 389952
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 389504
+      GoRuntimeType: 389568
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 389632
+      GoRuntimeType: 389696
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 389760
+      GoRuntimeType: 389824
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 389376
+      GoRuntimeType: 389440
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 389952
+      GoRuntimeType: 390016
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 504
+      ID: 506
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 462
+      ID: 463
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4157,7 +4190,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 460
+      ID: 461
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4172,7 +4205,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 424
+      ID: 425
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4187,7 +4220,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 422
+      ID: 423
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4202,7 +4235,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 469
+      ID: 471
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4210,14 +4243,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 ArrayType [2]map[string]int
+            Type: 116 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 423
+      ID: 424
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4232,7 +4265,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 442
+      ID: 443
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4247,7 +4280,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 411
+      ID: 412
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4262,7 +4295,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 408
+      ID: 409
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4277,7 +4310,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 485
+      ID: 487
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4285,14 +4318,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 152 GoChannelType chan bool
+            Type: 153 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: c}
+                  Variable: {subprogram: 79, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 483
+      ID: 485
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4303,7 +4336,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: w}
+                  Variable: {subprogram: 77, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4312,7 +4345,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: x}
+                  Variable: {subprogram: 77, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4321,11 +4354,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: y}
+                  Variable: {subprogram: 77, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 493
+      ID: 495
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4333,14 +4366,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 157 PointerType *main.t
+            Type: 158 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: t}
+                  Variable: {subprogram: 87, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 447
+      ID: 448
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4355,7 +4388,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 448
+      ID: 449
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4370,7 +4403,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 443
+      ID: 444
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4385,7 +4418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 444
+      ID: 445
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4400,7 +4433,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 445
+      ID: 446
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4415,7 +4448,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 446
+      ID: 447
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4430,7 +4463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4438,10 +4471,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4450,11 +4483,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 495
+      ID: 497
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4462,14 +4495,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 512
+      ID: 514
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4480,11 +4513,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 515
+      ID: 517
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4492,14 +4525,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 PointerType *main.emptyStruct
+            Type: 176 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 109, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 514
+      ID: 516
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4507,14 +4540,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 174 StructureType main.emptyStruct
+            Type: 175 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 461
+      ID: 462
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4529,7 +4562,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 452
+      ID: 453
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4544,7 +4577,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 451
+      ID: 452
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4559,7 +4592,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 458
+      ID: 459
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4574,7 +4607,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 457
+      ID: 458
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4589,7 +4622,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 453
+      ID: 454
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4604,7 +4637,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 455
+      ID: 456
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4619,10 +4652,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 517
+      ID: 519
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 454
+      ID: 455
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4646,16 +4679,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 518
+      ID: 520
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 519
+      ID: 521
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 456
+      ID: 457
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 516
+      ID: 518
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4666,11 +4699,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 522
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4681,11 +4714,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: x}
+                  Variable: {subprogram: 114, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 521
+      ID: 523
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4696,11 +4729,11 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: a}
+                  Variable: {subprogram: 115, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 414
+      ID: 415
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4715,7 +4748,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 415
+      ID: 416
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4730,7 +4763,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 416
+      ID: 417
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4745,7 +4778,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 413
+      ID: 414
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4760,7 +4793,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 412
+      ID: 413
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4775,7 +4808,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 459
+      ID: 460
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4790,7 +4823,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 487
+      ID: 489
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4798,14 +4831,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 StructureType main.node
+            Type: 156 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 467
+      ID: 469
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4813,14 +4846,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[[4]string][2]int
+            Type: 111 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 475
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4828,14 +4861,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 117 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 471
+      ID: 473
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4843,14 +4876,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 90 GoMapType map[int]int
+            Type: 91 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 482
+      ID: 484
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4858,14 +4891,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 147 GoMapType map[[4]int][4]int
+            Type: 148 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 483
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4873,14 +4906,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 142 GoMapType map[[4]int]uint8
+            Type: 143 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 474
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4888,14 +4921,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 117 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 482
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4903,14 +4936,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[uint8][4]int
+            Type: 138 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 481
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4918,14 +4951,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 465
+      ID: 467
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4933,14 +4966,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 466
+      ID: 468
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4948,14 +4981,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[string][]string
+            Type: 106 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 466
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4963,14 +4996,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 95 GoMapType map[string]main.nestedStruct
+            Type: 96 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 476
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4978,14 +5011,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[bool]main.node
+            Type: 123 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 480
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4993,14 +5026,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 479
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5008,14 +5041,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 478
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5023,14 +5056,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 477
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5038,14 +5071,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 510
+      ID: 512
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5056,11 +5089,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 484
+      ID: 486
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5071,7 +5104,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -5080,7 +5113,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: b}
+                  Variable: {subprogram: 78, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -5089,7 +5122,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: c}
+                  Variable: {subprogram: 78, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -5098,7 +5131,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 3, name: d}
+                  Variable: {subprogram: 78, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -5107,11 +5140,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 4, name: e}
+                  Variable: {subprogram: 78, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 492
+      ID: 494
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5122,7 +5155,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -5131,11 +5164,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: a}
+                  Variable: {subprogram: 86, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5143,10 +5176,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5155,11 +5188,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5170,16 +5203,16 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: a}
+                  Variable: {subprogram: 95, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 166 GoSliceHeaderType []bool
+            Type: 167 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: s}
+                  Variable: {subprogram: 95, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5188,11 +5221,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 2, name: x}
+                  Variable: {subprogram: 95, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 502
+      ID: 504
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5200,14 +5233,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 167 GoSliceHeaderType []uint16
+            Type: 168 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 509
+      ID: 511
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5215,14 +5248,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.oneStringStruct
+            Type: 171 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: a}
+                  Variable: {subprogram: 103, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 488
+      ID: 490
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5230,14 +5263,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.node
+            Type: 157 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 470
+      ID: 472
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5245,14 +5278,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 PointerType *map[string]int
+            Type: 117 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 486
+      ID: 488
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5260,14 +5293,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 153 PointerType *main.structWithTwoValues
+            Type: 154 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 409
+      ID: 410
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5282,7 +5315,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 428
+      ID: 429
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5297,7 +5330,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 426
+      ID: 427
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5312,7 +5345,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 439
+      ID: 440
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5327,7 +5360,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 440
+      ID: 441
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5342,7 +5375,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 431
+      ID: 432
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5357,7 +5390,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 432
+      ID: 433
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5372,7 +5405,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 433
+      ID: 434
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5387,7 +5420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 430
+      ID: 431
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5402,7 +5435,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 429
+      ID: 430
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5417,7 +5450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 427
+      ID: 428
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5432,7 +5465,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 505
+      ID: 507
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5443,11 +5476,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 436
+      ID: 437
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5462,7 +5495,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 437
+      ID: 438
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5477,7 +5510,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 438
+      ID: 439
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5492,7 +5525,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 435
+      ID: 436
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5507,7 +5540,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 434
+      ID: 435
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5522,7 +5555,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5530,14 +5563,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType [][]uint
+            Type: 161 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: u}
+                  Variable: {subprogram: 90, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 468
+      ID: 470
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5545,14 +5578,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 410
+      ID: 411
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5567,7 +5600,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 491
+      ID: 493
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5578,11 +5611,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 502
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5590,14 +5623,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 165 GoSliceHeaderType []string
+            Type: 166 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: s}
+                  Variable: {subprogram: 94, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 449
+      ID: 450
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5612,7 +5645,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 450
+      ID: 451
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5627,7 +5660,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 499
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5635,10 +5668,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5647,11 +5680,26 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 463
+      ID: 464
+      Name: Probe[main.testStructWithAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 89 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 465
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5659,14 +5707,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 89 StructureType main.structWithMap
+            Type: 90 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 513
+      ID: 515
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5674,14 +5722,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 172 StructureType main.aStruct
+            Type: 173 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 508
+      ID: 510
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5689,14 +5737,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.threeStringStruct
+            Type: 170 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 507
+      ID: 509
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5704,14 +5752,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 StructureType main.threeStringStruct
+            Type: 169 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 506
+      ID: 508
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5722,7 +5770,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5731,7 +5779,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: y}
+                  Variable: {subprogram: 100, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5740,11 +5788,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: z}
+                  Variable: {subprogram: 100, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 441
+      ID: 442
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5759,7 +5807,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 419
+      ID: 420
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5774,7 +5822,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 420
+      ID: 421
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5789,7 +5837,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 421
+      ID: 422
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5804,7 +5852,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 418
+      ID: 419
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5819,7 +5867,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 417
+      ID: 418
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5834,7 +5882,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 490
+      ID: 492
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5845,11 +5893,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 494
+      ID: 496
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5857,14 +5905,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 513
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5875,11 +5923,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 491
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5890,11 +5938,11 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 425
+      ID: 426
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5909,7 +5957,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 503
+      ID: 505
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5917,10 +5965,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: xs}
+                  Variable: {subprogram: 97, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5959,7 +6007,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 679264
+      GoRuntimeType: 679328
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5976,7 +6024,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 680608
+      GoRuntimeType: 680672
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5998,18 +6046,18 @@ Types:
       HasCount: true
       Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 115
+      ID: 116
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 100 GoMapType map[string]int
+      Element: 101 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 680704
+      GoRuntimeType: 680768
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6042,7 +6090,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 680800
+      GoRuntimeType: 680864
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6051,25 +6099,25 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 680512
+      GoRuntimeType: 680576
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 274
+      ID: 275
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 678880
+      GoRuntimeType: 678944
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 231
+      ID: 232
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 679168
+      GoRuntimeType: 679232
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6086,7 +6134,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 474752
+      GoRuntimeType: 474816
       GoKind: 23
       RawFields:
         - Name: array
@@ -6098,83 +6146,83 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 181 GoSliceDataType []*main.deepSlice2.array
+      Data: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 182
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 323
+      ID: 324
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 474688
+      GoRuntimeType: 474752
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 324 PointerType **main.deepSlice3
+          Type: 325 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 327 GoSliceDataType []*main.deepSlice3.array
+      Data: 328 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 327
+      ID: 328
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 325 PointerType *main.deepSlice3
+      Element: 326 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 350
+      ID: 351
       Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 474432
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 352 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 355 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 355
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 353 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 357
+      Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474368
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 351 PointerType **main.deepSlice8
+          Type: 358 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 354 GoSliceDataType []*main.deepSlice8.array
+      Data: 361 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 354
-      Name: '[]*main.deepSlice8.array'
-      ByteSize: 2048
-      Element: 352 PointerType *main.deepSlice8
-    - __kind: GoSliceHeaderType
-      ID: 356
-      Name: '[]*main.deepSlice9'
-      ByteSize: 24
-      GoRuntimeType: 474304
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 357 PointerType **main.deepSlice9
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 360 GoSliceDataType []*main.deepSlice9.array
-    - __kind: GoSliceDataType
-      ID: 360
+      ID: 361
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 358 PointerType *main.deepSlice9
+      Element: 359 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 475776
+      GoRuntimeType: 475840
       GoKind: 23
       RawFields:
         - Name: array
@@ -6186,123 +6234,123 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 178 GoSliceDataType []*string.array
+      Data: 179 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 179
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 292
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 151 PointerType *table<[4]int,[4]int>
+      Element: 152 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 146 PointerType *table<[4]int,uint8>
+      Element: 147 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 233
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 114 PointerType *table<[4]string,[2]int>
+      Element: 115 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<bool,main.node>
+      Element: 127 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 342
+      ID: 343
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 333 PointerType *table<int,*main.deepMap3>
+      Element: 334 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 378
+      ID: 379
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 369 PointerType *table<int,*main.deepMap8>
+      Element: 370 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 393
+      ID: 394
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 384 PointerType *table<int,*main.deepMap9>
+      Element: 385 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 94 PointerType *table<int,int>
+      Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 407
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 399 PointerType *table<int,interface {}>
+      Element: 400 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 259
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 131 PointerType *table<int,uint8>
+      Element: 132 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 243
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 121 PointerType *table<string,[]main.structWithMap>
+      Element: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 109 PointerType *table<string,[]string>
+      Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 104 PointerType *table<string,int>
+      Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 208
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 99 PointerType *table<string,main.nestedStruct>
+      Element: 100 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 276
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 141 PointerType *table<uint8,[4]int>
+      Element: 142 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 267
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 136 PointerType *table<uint8,uint8>
+      Element: 137 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 161
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType *[]uint
+          Type: 162 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 295 GoSliceDataType [][]uint.array
+      Data: 296 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 296
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 159 GoSliceHeaderType []uint
+      Element: 160 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 483648
+      GoRuntimeType: 483712
       GoKind: 23
       RawFields:
         - Name: array
@@ -6314,17 +6362,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 301 GoSliceDataType []bool.array
+      Data: 302 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 301
+      ID: 302
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 362
+      ID: 363
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 483968
+      GoRuntimeType: 484032
       GoKind: 23
       RawFields:
         - Name: array
@@ -6336,145 +6384,145 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 363 GoSliceDataType []interface {}.array
+      Data: 364 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 363
+      ID: 364
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 240
+      ID: 241
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 475008
+      GoRuntimeType: 475072
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 241 PointerType *main.structWithMap
+          Type: 242 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 344 GoSliceDataType []main.structWithMap.array
+      Data: 345 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 345
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 89 StructureType main.structWithMap
+      Element: 90 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 163
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *main.structWithNoStrings
+          Type: 164 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 297 GoSliceDataType []main.structWithNoStrings.array
+      Data: 298 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 297
+      ID: 298
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 164 StructureType main.structWithNoStrings
+      Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 293
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 288 StructureType noalg.map.group[[4]int][4]int
+      Element: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 285
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 280 StructureType noalg.map.group[[4]int]uint8
+      Element: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 234
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 228 StructureType noalg.map.group[[4]string][2]int
+      Element: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 252
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 247 StructureType noalg.map.group[bool]main.node
+      Element: 248 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 193
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 186 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 344
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 337 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 379
+      ID: 380
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 373 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 395
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 388 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 201
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 196 StructureType noalg.map.group[int]int
+      Element: 197 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 408
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 403 StructureType noalg.map.group[int]interface {}
+      Element: 404 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 260
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 255 StructureType noalg.map.group[int]uint8
+      Element: 256 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 244
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 237 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 225
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 220 StructureType noalg.map.group[string][]string
+      Element: 221 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 217
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 212 StructureType noalg.map.group[string]int
+      Element: 213 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 209
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 204 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 277
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 271 StructureType noalg.map.group[uint8][4]int
+      Element: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 268
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 263 StructureType noalg.map.group[uint8]uint8
+      Element: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 483776
+      GoRuntimeType: 483840
       GoKind: 23
       RawFields:
         - Name: array
@@ -6486,17 +6534,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 299 GoSliceDataType []string.array
+      Data: 300 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 299
+      ID: 300
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 483264
+      GoRuntimeType: 483328
       GoKind: 23
       RawFields:
         - Name: array
@@ -6508,17 +6556,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType []uint.array
+      Data: 294 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 294
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 16 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 482624
+      GoRuntimeType: 482688
       GoKind: 23
       RawFields:
         - Name: array
@@ -6530,9 +6578,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 303 GoSliceDataType []uint16.array
+      Data: 304 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 303
+      ID: 304
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -6540,35 +6588,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 581152
+      GoRuntimeType: 581216
       GoKind: 1
     - __kind: GoChannelType
-      ID: 152
+      ID: 153
       Name: chan bool
-      GoRuntimeType: 592480
+      GoRuntimeType: 592544
       GoKind: 18
     - __kind: GoChannelType
       ID: 80
       Name: chan struct {}
-      GoRuntimeType: 591392
+      GoRuntimeType: 591456
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 580960
+      GoRuntimeType: 581024
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 580896
+      GoRuntimeType: 580960
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.0224e+06
+      GoRuntimeType: 1.022464e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6581,293 +6629,293 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 581024
+      GoRuntimeType: 581088
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 581088
+      GoRuntimeType: 581152
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 472960
+      GoRuntimeType: 473024
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 286
+      ID: 287
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 287 PointerType *noalg.map.group[[4]int][4]int
+          Type: 288 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 292 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 293 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 278
+      ID: 279
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 279 PointerType *noalg.map.group[[4]int]uint8
+          Type: 280 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 284 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 285 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 226
+      ID: 227
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 227 PointerType *noalg.map.group[[4]string][2]int
+          Type: 228 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 233 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 245
+      ID: 246
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 246 PointerType *noalg.map.group[bool]main.node
+          Type: 247 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 247 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 248 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 252 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 184
+      ID: 185
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 185 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 186 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 335
+      ID: 336
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 336 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 337 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 344 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 372
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 373 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 380 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 386
+      ID: 387
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 387 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 388 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 394 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 395 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 195
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[int]int
+          Type: 196 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[int]int
-      GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 197 StructureType noalg.map.group[int]int
+      GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 401
+      ID: 402
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 402 PointerType *noalg.map.group[int]interface {}
+          Type: 403 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 403 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 404 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 408 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 253
+      ID: 254
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 254 PointerType *noalg.map.group[int]uint8
+          Type: 255 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 255 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 256 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 260 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 235
+      ID: 236
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 236 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 237 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 218
+      ID: 219
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 219 PointerType *noalg.map.group[string][]string
+          Type: 220 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 220 StructureType noalg.map.group[string][]string
-      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 221 StructureType noalg.map.group[string][]string
+      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 210
+      ID: 211
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 211 PointerType *noalg.map.group[string]int
+          Type: 212 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 212 StructureType noalg.map.group[string]int
-      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 213 StructureType noalg.map.group[string]int
+      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 203
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 204 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 269
+      ID: 270
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 270 PointerType *noalg.map.group[uint8][4]int
+          Type: 271 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 271 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 276 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 272 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 277 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 261
+      ID: 262
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 262 PointerType *noalg.map.group[uint8]uint8
+          Type: 263 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 263 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 264 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 580704
+      GoRuntimeType: 580768
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 580320
+      GoRuntimeType: 580384
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 580448
+      GoRuntimeType: 580512
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 580576
+      GoRuntimeType: 580640
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 580192
+      GoRuntimeType: 580256
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 844320
+      GoRuntimeType: 844384
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6877,10 +6925,10 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 312
+      ID: 313
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.46752e+06
+      GoRuntimeType: 1.467712e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6893,7 +6941,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.018432e+06
+      GoRuntimeType: 1.018496e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6903,7 +6951,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6919,12 +6967,12 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 173 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.018048e+06
+      GoRuntimeType: 1.018112e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6952,61 +7000,61 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.181792e+06
+      GoRuntimeType: 1.181984e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 190
+      ID: 191
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.181664e+06
+      GoRuntimeType: 1.181856e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 329 GoMapType map[int]*main.deepMap3
+          Type: 330 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 342
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
       ID: 74
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.181024e+06
+      GoRuntimeType: 1.181216e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 365 GoMapType map[int]*main.deepMap8
+          Type: 366 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 377
+      ID: 378
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.180896e+06
+      GoRuntimeType: 1.181088e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 380 GoMapType map[int]*main.deepMap9
+          Type: 381 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 392
+      ID: 393
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.180768e+06
+      GoRuntimeType: 1.18096e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 395 GoMapType map[int]interface {}
+          Type: 396 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.182944e+06
+      GoRuntimeType: 1.183136e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7016,41 +7064,41 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.182816e+06
+      GoRuntimeType: 1.183008e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 305 PointerType *main.deepPtr3
+          Type: 306 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 306
+      ID: 307
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.182176e+06
+      GoRuntimeType: 1.182368e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 346 PointerType *main.deepPtr8
+          Type: 347 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 347
+      ID: 348
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.182048e+06
+      GoRuntimeType: 1.18224e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 348 PointerType *main.deepPtr9
+          Type: 349 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 349
+      ID: 350
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.18192e+06
+      GoRuntimeType: 1.182112e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7060,58 +7108,58 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.184096e+06
+      GoRuntimeType: 1.184288e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 180
+      ID: 181
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.183968e+06
+      GoRuntimeType: 1.18416e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 323 GoSliceHeaderType []*main.deepSlice3
+          Type: 324 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 326
+      ID: 327
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.183328e+06
+      GoRuntimeType: 1.18352e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 350 GoSliceHeaderType []*main.deepSlice8
+          Type: 351 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 353
+      ID: 354
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.1832e+06
+      GoRuntimeType: 1.183392e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 356 GoSliceHeaderType []*main.deepSlice9
+          Type: 357 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 359
+      ID: 360
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.183072e+06
+      GoRuntimeType: 1.183264e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 362 GoSliceHeaderType []interface {}
+          Type: 363 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 174
+      ID: 175
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7119,7 +7167,7 @@ Types:
       ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.824576e+06
+      GoRuntimeType: 1.824768e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7127,21 +7175,21 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 310 StructureType sync.Mutex
+          Type: 311 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 313 StructureType sync.Once
+          Type: 314 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 316 StructureType sync.WaitGroup
+          Type: 317 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 319 StructureType sync/atomic.Int32
+          Type: 320 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.9584e+06
+      GoRuntimeType: 1.958592e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7166,10 +7214,10 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.45696e+06
+      GoRuntimeType: 1.457152e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7179,10 +7227,10 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 155
+      ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.4568e+06
+      GoRuntimeType: 1.456992e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7190,9 +7238,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 156 PointerType *main.node
+          Type: 157 PointerType *main.node
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7204,7 +7252,7 @@ Types:
       ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.018176e+06
+      GoRuntimeType: 1.01824e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7221,31 +7269,41 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *main.stringType1.str
+          Type: 309 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 307 GoStringDataType main.stringType1.str
+      Data: 308 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 308
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 309
+      ID: 310
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
       ID: 89
+      Name: main.structWithAny
+      ByteSize: 16
+      GoRuntimeType: 1.180704e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.18064e+06
+      GoRuntimeType: 1.180832e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 90 GoMapType map[int]int
+          Type: 91 GoMapType map[int]int
     - __kind: StructureType
-      ID: 164
+      ID: 165
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7257,7 +7315,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 154
+      ID: 155
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7269,28 +7327,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 159
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 320 PointerType **main.t
+          Type: 321 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 321 GoSliceDataType main.t.array
+      Data: 322 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 321
+      ID: 322
       Name: main.t.array
       ByteSize: 2048
-      Element: 157 PointerType *main.t
+      Element: 158 PointerType *main.t
     - __kind: StructureType
-      ID: 168
+      ID: 169
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7310,7 +7368,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 149
+      ID: 150
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7323,7 +7381,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 150 PointerType **table<[4]int,[4]int>
+          Type: 151 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7339,10 +7397,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 291 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 292 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 144
+      ID: 145
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7355,7 +7413,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 145 PointerType **table<[4]int,uint8>
+          Type: 146 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7371,10 +7429,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 283 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 284 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 112
+      ID: 113
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -7387,7 +7445,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 113 PointerType **table<[4]string,[2]int>
+          Type: 114 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7403,10 +7461,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 232 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 233 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 125
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -7419,7 +7477,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<bool,main.node>
+          Type: 126 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7435,8 +7493,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 247 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 251 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 248 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -7467,10 +7525,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 331
+      ID: 332
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7483,7 +7541,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 332 PointerType **table<int,*main.deepMap3>
+          Type: 333 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7499,10 +7557,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 342 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 343 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 367
+      ID: 368
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7515,7 +7573,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 368 PointerType **table<int,*main.deepMap8>
+          Type: 369 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7531,10 +7589,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 379 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 382
+      ID: 383
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7547,7 +7605,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 383 PointerType **table<int,*main.deepMap9>
+          Type: 384 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7563,10 +7621,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 393 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 394 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
-      ID: 92
+      ID: 93
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -7579,7 +7637,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 93 PointerType **table<int,int>
+          Type: 94 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7595,10 +7653,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
-      GroupType: 196 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
+      GroupType: 197 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 397
+      ID: 398
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7611,7 +7669,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 398 PointerType **table<int,interface {}>
+          Type: 399 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7627,10 +7685,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 406 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 403 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 407 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 404 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 129
+      ID: 130
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7643,7 +7701,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 130 PointerType **table<int,uint8>
+          Type: 131 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7659,10 +7717,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 255 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 259 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 256 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 119
+      ID: 120
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -7675,7 +7733,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 120 PointerType **table<string,[]main.structWithMap>
+          Type: 121 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7691,10 +7749,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 107
+      ID: 108
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -7707,7 +7765,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 108 PointerType **table<string,[]string>
+          Type: 109 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7723,10 +7781,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 223 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 220 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 221 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 102
+      ID: 103
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -7739,7 +7797,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 103 PointerType **table<string,int>
+          Type: 104 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7755,10 +7813,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 215 GoSliceDataType []*table<string,int>.array
-      GroupType: 212 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 216 GoSliceDataType []*table<string,int>.array
+      GroupType: 213 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 97
+      ID: 98
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -7771,7 +7829,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 98 PointerType **table<string,main.nestedStruct>
+          Type: 99 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7787,10 +7845,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 207 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 208 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 139
+      ID: 140
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7803,7 +7861,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 140 PointerType **table<uint8,[4]int>
+          Type: 141 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7819,10 +7877,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 275 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 271 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 276 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 134
+      ID: 135
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7835,7 +7893,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 135 PointerType **table<uint8,uint8>
+          Type: 136 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7851,285 +7909,285 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 263 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 267 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 147
+      ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.124704e+06
+      GoRuntimeType: 1.124768e+06
       GoKind: 21
-      HeaderType: 149 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 142
+      ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.124832e+06
+      GoRuntimeType: 1.124896e+06
       GoKind: 21
-      HeaderType: 144 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 110
+      ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.12496e+06
+      GoRuntimeType: 1.125024e+06
       GoKind: 21
-      HeaderType: 112 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 122
+      ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.125088e+06
+      GoRuntimeType: 1.125152e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.124576e+06
+      GoRuntimeType: 1.12464e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 329
+      ID: 330
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.124448e+06
+      GoRuntimeType: 1.124512e+06
       GoKind: 21
-      HeaderType: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 365
+      ID: 366
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.123808e+06
+      GoRuntimeType: 1.123872e+06
       GoKind: 21
-      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 380
+      ID: 381
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.12368e+06
+      GoRuntimeType: 1.123744e+06
       GoKind: 21
-      HeaderType: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 90
+      ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.123168e+06
+      GoRuntimeType: 1.123232e+06
       GoKind: 21
-      HeaderType: 92 GoSwissMapHeaderType map<int,int>
+      HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 395
+      ID: 396
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.123552e+06
+      GoRuntimeType: 1.123616e+06
       GoKind: 21
-      HeaderType: 397 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
-      ID: 127
+      ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.125216e+06
+      GoRuntimeType: 1.12528e+06
       GoKind: 21
-      HeaderType: 129 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 117
+      ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.125344e+06
+      GoRuntimeType: 1.125408e+06
       GoKind: 21
-      HeaderType: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 105
+      ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.125472e+06
+      GoRuntimeType: 1.125536e+06
       GoKind: 21
-      HeaderType: 107 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 100
+      ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.1256e+06
+      GoRuntimeType: 1.125664e+06
       GoKind: 21
-      HeaderType: 102 GoSwissMapHeaderType map<string,int>
+      HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 95
+      ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.125728e+06
+      GoRuntimeType: 1.125792e+06
       GoKind: 21
-      HeaderType: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 137
+      ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.125856e+06
+      GoRuntimeType: 1.12592e+06
       GoKind: 21
-      HeaderType: 139 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 132
+      ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.125984e+06
+      GoRuntimeType: 1.126048e+06
       GoKind: 21
-      HeaderType: 134 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 289
+      ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 678976
+      GoRuntimeType: 679040
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 290 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 291 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 281
+      ID: 282
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 679072
+      GoRuntimeType: 679136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 282 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 283 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 229
+      ID: 230
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 679360
+      GoRuntimeType: 679424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 230 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 231 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 248
+      ID: 249
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 679456
+      GoRuntimeType: 679520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 249 StructureType noalg.struct { key bool; elem main.node }
+      Element: 250 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 187
+      ID: 188
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 678304
+      GoRuntimeType: 678368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 338
+      ID: 339
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 678208
+      GoRuntimeType: 678272
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 339 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 340 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 374
+      ID: 375
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 677728
+      GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 376 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 389
+      ID: 390
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 677632
+      GoRuntimeType: 677696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 390 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 391 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 197
+      ID: 198
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 676384
+      GoRuntimeType: 676448
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key int; elem int }
+      Element: 199 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 404
+      ID: 405
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 677536
+      GoRuntimeType: 677600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 405 StructureType noalg.struct { key int; elem interface {} }
+      Element: 406 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 256
+      ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 679552
+      GoRuntimeType: 679616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 257 StructureType noalg.struct { key int; elem uint8 }
+      Element: 258 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 238
+      ID: 239
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 679648
+      GoRuntimeType: 679712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 239 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 240 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 221
+      ID: 222
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 679744
+      GoRuntimeType: 679808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem []string }
+      Element: 223 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 213
+      ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 679840
+      GoRuntimeType: 679904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 214 StructureType noalg.struct { key string; elem int }
+      Element: 215 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 205
+      ID: 206
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 679936
+      GoRuntimeType: 680000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 207 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 272
+      ID: 273
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 680032
+      GoRuntimeType: 680096
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 273 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 274 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 264
+      ID: 265
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 680128
+      GoRuntimeType: 680192
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 265 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 266 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 288
+      ID: 289
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.290144e+06
+      GoRuntimeType: 1.290336e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8137,12 +8195,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 289 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 290 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 280
+      ID: 281
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.2904e+06
+      GoRuntimeType: 1.290592e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8150,12 +8208,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 281 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 282 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 228
+      ID: 229
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.290656e+06
+      GoRuntimeType: 1.290848e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8163,12 +8221,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 229 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 230 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 247
+      ID: 248
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.290912e+06
+      GoRuntimeType: 1.291104e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8176,12 +8234,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 248 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 249 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 186
+      ID: 187
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.289888e+06
+      GoRuntimeType: 1.29008e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8189,12 +8247,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 337
+      ID: 338
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.289632e+06
+      GoRuntimeType: 1.289824e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8202,12 +8260,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 338 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 339 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 373
+      ID: 374
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.288352e+06
+      GoRuntimeType: 1.288544e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8215,12 +8273,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 375 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 388
+      ID: 389
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.288096e+06
+      GoRuntimeType: 1.288288e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8228,12 +8286,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 389 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 390 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 196
+      ID: 197
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.287072e+06
+      GoRuntimeType: 1.287264e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8241,12 +8299,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 198 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 403
+      ID: 404
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.28784e+06
+      GoRuntimeType: 1.288032e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8254,12 +8312,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 404 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 405 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 255
+      ID: 256
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.291168e+06
+      GoRuntimeType: 1.29136e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8267,12 +8325,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 256 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 257 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 237
+      ID: 238
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.291424e+06
+      GoRuntimeType: 1.291616e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8280,12 +8338,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 238 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 239 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 220
+      ID: 221
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.29168e+06
+      GoRuntimeType: 1.291872e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8293,12 +8351,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 212
+      ID: 213
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.291936e+06
+      GoRuntimeType: 1.292128e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8306,12 +8364,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 213 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 204
+      ID: 205
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.292192e+06
+      GoRuntimeType: 1.292384e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8319,12 +8377,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 206 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 271
+      ID: 272
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.292448e+06
+      GoRuntimeType: 1.29264e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8332,12 +8390,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 272 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 273 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 263
+      ID: 264
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.292704e+06
+      GoRuntimeType: 1.292896e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8345,51 +8403,51 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 264 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 265 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 290
+      ID: 291
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.290016e+06
+      GoRuntimeType: 1.290208e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
     - __kind: StructureType
-      ID: 282
+      ID: 283
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.290272e+06
+      GoRuntimeType: 1.290464e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 230
+      ID: 231
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.290528e+06
+      GoRuntimeType: 1.29072e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 231 ArrayType [4]string
+          Type: 232 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 249
+      ID: 250
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.290784e+06
+      GoRuntimeType: 1.290976e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8397,12 +8455,12 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 155 StructureType main.node
+          Type: 156 StructureType main.node
     - __kind: StructureType
-      ID: 188
+      ID: 189
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.28976e+06
+      GoRuntimeType: 1.289952e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8410,12 +8468,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 189 PointerType *main.deepMap2
+          Type: 190 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 339
+      ID: 340
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.289504e+06
+      GoRuntimeType: 1.289696e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8423,12 +8481,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 340 PointerType *main.deepMap3
+          Type: 341 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 375
+      ID: 376
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.288224e+06
+      GoRuntimeType: 1.288416e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8436,12 +8494,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 376 PointerType *main.deepMap8
+          Type: 377 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 390
+      ID: 391
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.287968e+06
+      GoRuntimeType: 1.28816e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8449,12 +8507,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 391 PointerType *main.deepMap9
+          Type: 392 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 198
+      ID: 199
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.286944e+06
+      GoRuntimeType: 1.287136e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8464,10 +8522,10 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 405
+      ID: 406
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.287712e+06
+      GoRuntimeType: 1.287904e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8477,10 +8535,10 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 257
+      ID: 258
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.29104e+06
+      GoRuntimeType: 1.291232e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8490,10 +8548,10 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 239
+      ID: 240
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.291296e+06
+      GoRuntimeType: 1.291488e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8501,12 +8559,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 240 GoSliceHeaderType []main.structWithMap
+          Type: 241 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 222
+      ID: 223
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.291552e+06
+      GoRuntimeType: 1.291744e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8514,12 +8572,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 165 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 214
+      ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.291808e+06
+      GoRuntimeType: 1.292e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8529,10 +8587,10 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 206
+      ID: 207
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.292064e+06
+      GoRuntimeType: 1.292256e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8540,12 +8598,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 173 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 273
+      ID: 274
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.29232e+06
+      GoRuntimeType: 1.292512e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8553,12 +8611,12 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
     - __kind: StructureType
-      ID: 265
+      ID: 266
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.292576e+06
+      GoRuntimeType: 1.292768e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8571,127 +8629,127 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 580128
+      GoRuntimeType: 580192
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 177 PointerType *string.str
+          Type: 178 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 176 GoStringDataType string.str
+      Data: 177 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 176
+      ID: 177
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 310
+      ID: 311
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.45824e+06
+      GoRuntimeType: 1.458432e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 312 StructureType internal/sync.Mutex
+          Type: 313 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 313
+      ID: 314
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.606592e+06
+      GoRuntimeType: 1.606784e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 314 StructureType sync/atomic.Uint32
+          Type: 315 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 310 StructureType sync.Mutex
+          Type: 311 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 316
+      ID: 317
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.606784e+06
+      GoRuntimeType: 1.606976e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 317 StructureType sync/atomic.Uint64
+          Type: 318 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 311
+      ID: 312
       Name: sync.noCopy
-      GoRuntimeType: 983712
+      GoRuntimeType: 983776
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 319
+      ID: 320
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.45952e+06
+      GoRuntimeType: 1.459712e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
+          Type: 316 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 314
+      ID: 315
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.45968e+06
+      GoRuntimeType: 1.459872e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
+          Type: 316 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 317
+      ID: 318
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.607168e+06
+      GoRuntimeType: 1.60736e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
+          Type: 316 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 318 StructureType sync/atomic.align64
+          Type: 319 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 318
+      ID: 319
       Name: sync/atomic.align64
-      GoRuntimeType: 983904
+      GoRuntimeType: 983968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 315
+      ID: 316
       Name: sync/atomic.noCopy
-      GoRuntimeType: 983808
+      GoRuntimeType: 983872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 285
+      ID: 286
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -8713,9 +8771,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 286 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 287 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 277
+      ID: 278
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8737,9 +8795,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 278 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 279 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 225
+      ID: 226
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -8761,9 +8819,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 226 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 227 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 244
+      ID: 245
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -8785,9 +8843,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 245 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 246 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 183
+      ID: 184
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -8809,9 +8867,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 334
+      ID: 335
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8833,9 +8891,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 335 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 336 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 370
+      ID: 371
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8857,9 +8915,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 372 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 385
+      ID: 386
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8881,9 +8939,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 386 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 387 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 193
+      ID: 194
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -8905,9 +8963,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<int,int>
+          Type: 195 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 400
+      ID: 401
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8929,9 +8987,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 401 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 402 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 252
+      ID: 253
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8953,9 +9011,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 253 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 254 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 234
+      ID: 235
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -8977,9 +9035,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 235 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 236 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 217
+      ID: 218
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9001,9 +9059,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 218 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 209
+      ID: 210
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -9025,9 +9083,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 210 GoSwissMapGroupsType groupReference<string,int>
+          Type: 211 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 201
+      ID: 202
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -9049,9 +9107,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 203 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 268
+      ID: 269
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -9073,9 +9131,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 269 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 270 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 260
+      ID: 261
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9097,49 +9155,49 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 261 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 16
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 580768
+      GoRuntimeType: 580832
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 580384
+      GoRuntimeType: 580448
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 580512
+      GoRuntimeType: 580576
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 580640
+      GoRuntimeType: 580704
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 580256
+      GoRuntimeType: 580320
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 580832
+      GoRuntimeType: 580896
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 581216
+      GoRuntimeType: 581280
       GoKind: 26
-MaxTypeID: 521
+MaxTypeID: 523
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x17f93a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x17fa3a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 506 EventRootType Probe[main.stackC]
+          Type: 1169 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcd906a", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 461 EventRootType Probe[main.testAny]
+          Type: 1124 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd5e6a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 463 EventRootType Probe[main.testAnyPtr]
+          Type: 1126 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd5f0a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 423 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1086 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 425 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1088 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 471 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1134 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd6660", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 424 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1087 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 443 EventRootType Probe[main.testBigStruct]
+          Type: 1106 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a20", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 412 EventRootType Probe[main.testBoolArray]
+          Type: 1075 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 409 EventRootType Probe[main.testByteArray]
+          Type: 1072 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4100", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 487 EventRootType Probe[main.testChannel]
+          Type: 1150 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd8320", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 485 EventRootType Probe[main.testCombinedByte]
+          Type: 1148 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd7f40", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 495 EventRootType Probe[main.testCycle]
+          Type: 1158 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd86e0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 448 EventRootType Probe[main.testDeepMap1]
+          Type: 1111 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e00", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 449 EventRootType Probe[main.testDeepMap7]
+          Type: 1112 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e20", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 444 EventRootType Probe[main.testDeepPtr1]
+          Type: 1107 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4ae0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 445 EventRootType Probe[main.testDeepPtr7]
+          Type: 1108 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b00", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 446 EventRootType Probe[main.testDeepSlice1]
+          Type: 1109 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4c80", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 447 EventRootType Probe[main.testDeepSlice7]
+          Type: 1110 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ca0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 497 EventRootType Probe[main.testEmptySlice]
+          Type: 1160 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 500 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1163 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcd8c80", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 514 EventRootType Probe[main.testEmptyString]
+          Type: 1177 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -337,7 +337,7 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - ID: 108
-          Type: 516 EventRootType Probe[main.testEmptyStruct]
+          Type: 1179 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -350,7 +350,7 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - ID: 109
-          Type: 517 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1180 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
           Condition: null
     - id: testError
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 462 EventRootType Probe[main.testError]
+          Type: 1125 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd5ee0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 453 EventRootType Probe[main.testEsotericHeap]
+          Type: 1116 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd53ea", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 452 EventRootType Probe[main.testEsotericStack]
+          Type: 1115 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd52ce", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 458 EventRootType Probe[main.testFrameless]
+          Type: 1121 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 459 EventRootType Probe[main.testFramelessArray]
+          Type: 1122 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5b64", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 454 EventRootType Probe[main.testInlinedBA]
+          Type: 1117 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd582a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 455 EventRootType Probe[main.testInlinedBB]
+          Type: 1118 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd58ce", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 456 EventRootType Probe[main.testInlinedBBA]
+          Type: 1119 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd59aa", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -476,7 +476,7 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - ID: 111
-          Type: 519 EventRootType Probe[main.testInlinedBBB]
+          Type: 1182 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5926", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 457 EventRootType Probe[main.testInlinedBC]
+          Type: 1120 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5a2e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -504,7 +504,7 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - ID: 112
-          Type: 520 EventRootType Probe[main.testInlinedBCA]
+          Type: 1183 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5a33", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -518,7 +518,7 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - ID: 113
-          Type: 521 EventRootType Probe[main.testInlinedBCB]
+          Type: 1184 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5ae6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - ID: 110
-          Type: 518 EventRootType Probe[main.testInlinedPrint]
+          Type: 1181 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd568a"
               Frameless: false
@@ -557,7 +557,7 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - ID: 114
-          Type: 522 EventRootType Probe[main.testInlinedSq]
+          Type: 1185 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5b41", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -572,7 +572,7 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - ID: 115
-          Type: 523 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1186 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5b85"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 415 EventRootType Probe[main.testInt16Array]
+          Type: 1078 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 416 EventRootType Probe[main.testInt32Array]
+          Type: 1079 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 417 EventRootType Probe[main.testInt64Array]
+          Type: 1080 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 414 EventRootType Probe[main.testInt8Array]
+          Type: 1077 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 413 EventRootType Probe[main.testIntArray]
+          Type: 1076 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 460 EventRootType Probe[main.testInterface]
+          Type: 1123 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd5e40", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 489 EventRootType Probe[main.testLinkedList]
+          Type: 1152 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd8500", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 469 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1132 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd6620", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 475 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1138 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd66e0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 473 EventRootType Probe[main.testMapIntToInt]
+          Type: 1136 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd66a0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 484 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1147 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6800", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 483 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1146 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd67e0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 474 EventRootType Probe[main.testMapMassive]
+          Type: 1137 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd66c0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 482 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1145 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd67c0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 481 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1144 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd67a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 467 EventRootType Probe[main.testMapStringToInt]
+          Type: 1130 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd65e0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 468 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1131 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd6600", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 466 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1129 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd65c0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 476 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1139 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd6700", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 479 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1142 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd6760", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 480 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1143 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd6780", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 477 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1140 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd6720", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 478 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1141 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd6740", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 512 EventRootType Probe[main.testMassiveString]
+          Type: 1175 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 486 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1149 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd8100", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 494 EventRootType Probe[main.testNilPointer]
+          Type: 1157 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd86a0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 504 EventRootType Probe[main.testNilSlice]
+          Type: 1167 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcd8d00", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 501 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1164 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 503 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1166 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcd8ce0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 511 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1174 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 490 EventRootType Probe[main.testPointerLoop]
+          Type: 1153 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd8520", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 472 EventRootType Probe[main.testPointerToMap]
+          Type: 1135 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd6680", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 488 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1151 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 410 EventRootType Probe[main.testRuneArray]
+          Type: 1073 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 429 EventRootType Probe[main.testSingleBool]
+          Type: 1092 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 427 EventRootType Probe[main.testSingleByte]
+          Type: 1090 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd46e0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 440 EventRootType Probe[main.testSingleFloat32]
+          Type: 1103 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 441 EventRootType Probe[main.testSingleFloat64]
+          Type: 1104 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 430 EventRootType Probe[main.testSingleInt]
+          Type: 1093 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 432 EventRootType Probe[main.testSingleInt16]
+          Type: 1095 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 433 EventRootType Probe[main.testSingleInt32]
+          Type: 1096 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 434 EventRootType Probe[main.testSingleInt64]
+          Type: 1097 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 431 EventRootType Probe[main.testSingleInt8]
+          Type: 1094 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 428 EventRootType Probe[main.testSingleRune]
+          Type: 1091 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4700", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 507 EventRootType Probe[main.testSingleString]
+          Type: 1170 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 435 EventRootType Probe[main.testSingleUint]
+          Type: 1098 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 437 EventRootType Probe[main.testSingleUint16]
+          Type: 1100 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 438 EventRootType Probe[main.testSingleUint32]
+          Type: 1101 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 439 EventRootType Probe[main.testSingleUint64]
+          Type: 1102 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 436 EventRootType Probe[main.testSingleUint8]
+          Type: 1099 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 498 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1161 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 470 EventRootType Probe[main.testSmallMap]
+          Type: 1133 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd6640", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 411 EventRootType Probe[main.testStringArray]
+          Type: 1074 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 493 EventRootType Probe[main.testStringPointer]
+          Type: 1156 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd8660", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 502 EventRootType Probe[main.testStringSlice]
+          Type: 1165 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcd8cc0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 450 EventRootType Probe[main.testStringType1]
+          Type: 1113 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 451 EventRootType Probe[main.testStringType2]
+          Type: 1114 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1394,7 +1394,7 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - ID: 107
-          Type: 515 EventRootType Probe[main.testStruct]
+          Type: 1178 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcd9420", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 499 EventRootType Probe[main.testStructSlice]
+          Type: 1162 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,7 +1425,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 464 EventRootType Probe[main.testStructWithAny]
+          Type: 1127 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcd5f60", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1439,7 +1439,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 465 EventRootType Probe[main.testStructWithMap]
+          Type: 1128 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd65a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1453,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 508 EventRootType Probe[main.testThreeStrings]
+          Type: 1171 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1467,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 509 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1172 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1481,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 510 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1173 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 442 EventRootType Probe[main.testTypeAlias]
+          Type: 1105 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 420 EventRootType Probe[main.testUint16Array]
+          Type: 1083 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 421 EventRootType Probe[main.testUint32Array]
+          Type: 1084 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 422 EventRootType Probe[main.testUint64Array]
+          Type: 1085 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 419 EventRootType Probe[main.testUint8Array]
+          Type: 1082 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 418 EventRootType Probe[main.testUintArray]
+          Type: 1081 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1579,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 492 EventRootType Probe[main.testUintPointer]
+          Type: 1155 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8580", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1593,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 496 EventRootType Probe[main.testUintSlice]
+          Type: 1159 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1607,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 513 EventRootType Probe[main.testUnitializedString]
+          Type: 1176 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1621,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 491 EventRootType Probe[main.testUnsafePointer]
+          Type: 1154 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd8540", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 426 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1089 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1649,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 505 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1168 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd8d20", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3416,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 325
+      ID: 988
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 326 PointerType *main.deepSlice3
+      Pointee: 989 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 352
+      ID: 1015
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 353 PointerType *main.deepSlice8
+      Pointee: 1016 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 358
+      ID: 1021
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 359 PointerType *main.deepSlice9
+      Pointee: 1022 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3437,7 +3437,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 321
+      ID: 984
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3474,30 +3474,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 333
+      ID: 996
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 334 PointerType *table<int,*main.deepMap3>
+      Pointee: 997 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 369
+      ID: 1032
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 370 PointerType *table<int,*main.deepMap8>
+      Pointee: 1033 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 384
+      ID: 1047
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 385 PointerType *table<int,*main.deepMap9>
+      Pointee: 1048 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 399
+      ID: 1062
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 400 PointerType *table<int,interface {}>
+      Pointee: 1063 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '**table<int,uint8>'
@@ -3513,6 +3513,11 @@ Types:
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
+    - __kind: PointerType
+      ID: 727
+      Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 728 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3539,20 +3544,20 @@ Types:
       ByteSize: 8
       Pointee: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 329
+      ID: 992
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 328 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 991 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 356
+      ID: 1019
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 355 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1018 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 362
+      ID: 1025
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 361 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1024 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 180
       Name: '*[]*string.array'
@@ -3569,15 +3574,20 @@ Types:
       ByteSize: 8
       Pointee: 302 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 365
+      ID: 767
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 766 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 1028
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 364 GoSliceDataType []interface {}.array
+      Pointee: 1027 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 346
+      ID: 1009
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 345 GoSliceDataType []main.structWithMap.array
+      Pointee: 1008 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 299
       Name: '*[]main.structWithNoStrings.array'
@@ -3604,6 +3614,72 @@ Types:
       ByteSize: 8
       Pointee: 304 GoSliceDataType []uint16.array
     - __kind: PointerType
+      ID: 765
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 764 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 897
+      Name: '*archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.976896e+06
+      GoKind: 22
+      Pointee: 898 UnresolvedPointeeType archive/tar.Writer
+    - __kind: PointerType
+      ID: 535
+      Name: '*archive/tar.headerError'
+      ByteSize: 8
+      GoRuntimeType: 926624
+      GoKind: 22
+      Pointee: 536 GoSliceHeaderType archive/tar.headerError
+    - __kind: PointerType
+      ID: 538
+      Name: '*archive/tar.headerError.array'
+      ByteSize: 8
+      Pointee: 537 GoSliceDataType archive/tar.headerError.array
+    - __kind: PointerType
+      ID: 832
+      Name: '*archive/tar.regFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.43072e+06
+      GoKind: 22
+      Pointee: 833 UnresolvedPointeeType archive/tar.regFileWriter
+    - __kind: PointerType
+      ID: 780
+      Name: '*archive/zip.countWriter'
+      ByteSize: 8
+      GoRuntimeType: 926816
+      GoKind: 22
+      Pointee: 781 UnresolvedPointeeType archive/zip.countWriter
+    - __kind: PointerType
+      ID: 782
+      Name: '*archive/zip.dirWriter'
+      ByteSize: 8
+      GoRuntimeType: 926912
+      GoKind: 22
+      Pointee: 783 StructureType archive/zip.dirWriter
+    - __kind: PointerType
+      ID: 880
+      Name: '*archive/zip.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.896576e+06
+      GoKind: 22
+      Pointee: 881 UnresolvedPointeeType archive/zip.fileWriter
+    - __kind: PointerType
+      ID: 808
+      Name: '*archive/zip.nopCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.053248e+06
+      GoKind: 22
+      Pointee: 809 StructureType archive/zip.nopCloser
+    - __kind: PointerType
+      ID: 810
+      Name: '*archive/zip.pooledFlateWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.053504e+06
+      GoKind: 22
+      Pointee: 811 UnresolvedPointeeType archive/zip.pooledFlateWriter
+    - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
@@ -3611,12 +3687,442 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
+      ID: 855
+      Name: '*bufio.Reader'
+      ByteSize: 8
+      GoRuntimeType: 2.165024e+06
+      GoKind: 22
+      Pointee: 856 UnresolvedPointeeType bufio.Reader
+    - __kind: PointerType
+      ID: 884
+      Name: '*bufio.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.941088e+06
+      GoKind: 22
+      Pointee: 885 UnresolvedPointeeType bufio.Writer
+    - __kind: PointerType
+      ID: 935
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.262304e+06
+      GoKind: 22
+      Pointee: 936 UnresolvedPointeeType bytes.Buffer
+    - __kind: PointerType
+      ID: 447
+      Name: '*compress/flate.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 909152
+      GoKind: 22
+      Pointee: 339 BaseType compress/flate.CorruptInputError
+    - __kind: PointerType
+      ID: 448
+      Name: '*compress/flate.InternalError'
+      ByteSize: 8
+      GoRuntimeType: 909248
+      GoKind: 22
+      Pointee: 340 GoStringHeaderType compress/flate.InternalError
+    - __kind: PointerType
+      ID: 342
+      Name: '*compress/flate.InternalError.str'
+      ByteSize: 8
+      Pointee: 341 GoStringDataType compress/flate.InternalError.str
+    - __kind: PointerType
+      ID: 830
+      Name: '*compress/flate.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.42016e+06
+      GoKind: 22
+      Pointee: 831 UnresolvedPointeeType compress/flate.Writer
+    - __kind: PointerType
+      ID: 776
+      Name: '*compress/flate.dictWriter'
+      ByteSize: 8
+      GoRuntimeType: 909344
+      GoKind: 22
+      Pointee: 777 UnresolvedPointeeType compress/flate.dictWriter
+    - __kind: PointerType
+      ID: 852
+      Name: '*compress/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.718336e+06
+      GoKind: 22
+      Pointee: 853 UnresolvedPointeeType compress/gzip.Writer
+    - __kind: PointerType
+      ID: 679
+      Name: '*context.deadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.199456e+06
+      GoKind: 22
+      Pointee: 680 StructureType context.deadlineExceededError
+    - __kind: PointerType
+      ID: 527
+      Name: '*crypto/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 921248
+      GoKind: 22
+      Pointee: 353 BaseType crypto/aes.KeySizeError
+    - __kind: PointerType
+      ID: 528
+      Name: '*crypto/des.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 921440
+      GoKind: 22
+      Pointee: 354 BaseType crypto/des.KeySizeError
+    - __kind: PointerType
+      ID: 529
+      Name: '*crypto/internal/fips140/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 921728
+      GoKind: 22
+      Pointee: 355 BaseType crypto/internal/fips140/aes.KeySizeError
+    - __kind: PointerType
+      ID: 842
+      Name: '*crypto/internal/fips140/hmac.HMAC'
+      ByteSize: 8
+      GoRuntimeType: 1.56064e+06
+      GoKind: 22
+      Pointee: 843 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+    - __kind: PointerType
+      ID: 876
+      Name: '*crypto/internal/fips140/sha256.Digest'
+      ByteSize: 8
+      GoRuntimeType: 1.855008e+06
+      GoKind: 22
+      Pointee: 877 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+    - __kind: PointerType
+      ID: 908
+      Name: '*crypto/internal/fips140/sha3.Digest'
+      ByteSize: 8
+      GoRuntimeType: 2.112352e+06
+      GoKind: 22
+      Pointee: 909 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+    - __kind: PointerType
+      ID: 882
+      Name: '*crypto/internal/fips140/sha3.SHAKE'
+      ByteSize: 8
+      GoRuntimeType: 1.897088e+06
+      GoKind: 22
+      Pointee: 883 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+    - __kind: PointerType
+      ID: 878
+      Name: '*crypto/internal/fips140/sha512.Digest'
+      ByteSize: 8
+      GoRuntimeType: 1.85568e+06
+      GoKind: 22
+      Pointee: 879 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+    - __kind: PointerType
+      ID: 874
+      Name: '*crypto/md5.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.84784e+06
+      GoKind: 22
+      Pointee: 875 UnresolvedPointeeType crypto/md5.digest
+    - __kind: PointerType
+      ID: 530
+      Name: '*crypto/rc4.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 922016
+      GoKind: 22
+      Pointee: 356 BaseType crypto/rc4.KeySizeError
+    - __kind: PointerType
+      ID: 892
+      Name: '*crypto/sha1.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.946464e+06
+      GoKind: 22
+      Pointee: 893 UnresolvedPointeeType crypto/sha1.digest
+    - __kind: PointerType
+      ID: 864
+      Name: '*crypto/sha3.SHA3'
+      ByteSize: 8
+      GoRuntimeType: 1.801824e+06
+      GoKind: 22
+      Pointee: 865 UnresolvedPointeeType crypto/sha3.SHA3
+    - __kind: PointerType
+      ID: 453
+      Name: '*crypto/tls.AlertError'
+      ByteSize: 8
+      GoRuntimeType: 910880
+      GoKind: 22
+      Pointee: 343 BaseType crypto/tls.AlertError
+    - __kind: PointerType
+      ID: 619
+      Name: '*crypto/tls.CertificateVerificationError'
+      ByteSize: 8
+      GoRuntimeType: 1.041856e+06
+      GoKind: 22
+      Pointee: 620 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+    - __kind: PointerType
+      ID: 961
+      Name: '*crypto/tls.Conn'
+      ByteSize: 8
+      GoRuntimeType: 2.374176e+06
+      GoKind: 22
+      Pointee: 962 UnresolvedPointeeType crypto/tls.Conn
+    - __kind: PointerType
+      ID: 451
+      Name: '*crypto/tls.ECHRejectionError'
+      ByteSize: 8
+      GoRuntimeType: 910688
+      GoKind: 22
+      Pointee: 452 UnresolvedPointeeType crypto/tls.ECHRejectionError
+    - __kind: PointerType
+      ID: 449
+      Name: '*crypto/tls.RecordHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 910592
+      GoKind: 22
+      Pointee: 450 StructureType crypto/tls.RecordHeaderError
+    - __kind: PointerType
+      ID: 618
+      Name: '*crypto/tls.alert'
+      ByteSize: 8
+      GoRuntimeType: 1.040192e+06
+      GoKind: 22
+      Pointee: 575 BaseType crypto/tls.alert
+    - __kind: PointerType
+      ID: 840
+      Name: '*crypto/tls.cthWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.5536e+06
+      GoKind: 22
+      Pointee: 841 UnresolvedPointeeType crypto/tls.cthWrapper
+    - __kind: PointerType
+      ID: 847
+      Name: '*crypto/tls.finishedHash'
+      ByteSize: 8
+      GoRuntimeType: 1.636032e+06
+      GoKind: 22
+      Pointee: 848 UnresolvedPointeeType crypto/tls.finishedHash
+    - __kind: PointerType
+      ID: 714
+      Name: '*crypto/tls.permanentError'
+      ByteSize: 8
+      GoRuntimeType: 1.42048e+06
+      GoKind: 22
+      Pointee: 715 UnresolvedPointeeType crypto/tls.permanentError
+    - __kind: PointerType
+      ID: 729
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.034944e+06
+      GoKind: 22
+      Pointee: 730 UnresolvedPointeeType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 523
+      Name: '*crypto/x509.CertificateInvalidError'
+      ByteSize: 8
+      GoRuntimeType: 920288
+      GoKind: 22
+      Pointee: 524 StructureType crypto/x509.CertificateInvalidError
+    - __kind: PointerType
+      ID: 517
+      Name: '*crypto/x509.ConstraintViolationError'
+      ByteSize: 8
+      GoRuntimeType: 919808
+      GoKind: 22
+      Pointee: 518 StructureType crypto/x509.ConstraintViolationError
+    - __kind: PointerType
+      ID: 519
+      Name: '*crypto/x509.HostnameError'
+      ByteSize: 8
+      GoRuntimeType: 919904
+      GoKind: 22
+      Pointee: 520 StructureType crypto/x509.HostnameError
+    - __kind: PointerType
+      ID: 516
+      Name: '*crypto/x509.InsecureAlgorithmError'
+      ByteSize: 8
+      GoRuntimeType: 919712
+      GoKind: 22
+      Pointee: 352 BaseType crypto/x509.InsecureAlgorithmError
+    - __kind: PointerType
+      ID: 624
+      Name: '*crypto/x509.SystemRootsError'
+      ByteSize: 8
+      GoRuntimeType: 1.047616e+06
+      GoKind: 22
+      Pointee: 625 StructureType crypto/x509.SystemRootsError
+    - __kind: PointerType
+      ID: 525
+      Name: '*crypto/x509.UnhandledCriticalExtension'
+      ByteSize: 8
+      GoRuntimeType: 920384
+      GoKind: 22
+      Pointee: 526 StructureType crypto/x509.UnhandledCriticalExtension
+    - __kind: PointerType
+      ID: 521
+      Name: '*crypto/x509.UnknownAuthorityError'
+      ByteSize: 8
+      GoRuntimeType: 920192
+      GoKind: 22
+      Pointee: 522 StructureType crypto/x509.UnknownAuthorityError
+    - __kind: PointerType
+      ID: 539
+      Name: '*encoding/asn1.StructuralError'
+      ByteSize: 8
+      GoRuntimeType: 927104
+      GoKind: 22
+      Pointee: 540 StructureType encoding/asn1.StructuralError
+    - __kind: PointerType
+      ID: 543
+      Name: '*encoding/asn1.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 927296
+      GoKind: 22
+      Pointee: 544 StructureType encoding/asn1.SyntaxError
+    - __kind: PointerType
+      ID: 541
+      Name: '*encoding/asn1.invalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 927200
+      GoKind: 22
+      Pointee: 542 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+    - __kind: PointerType
+      ID: 437
+      Name: '*encoding/base64.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 907232
+      GoKind: 22
+      Pointee: 337 BaseType encoding/base64.CorruptInputError
+    - __kind: PointerType
+      ID: 798
+      Name: '*encoding/base64.encoder'
+      ByteSize: 8
+      GoRuntimeType: 1.037376e+06
+      GoKind: 22
+      Pointee: 799 UnresolvedPointeeType encoding/base64.encoder
+    - __kind: PointerType
+      ID: 440
+      Name: '*encoding/hex.InvalidByteError'
+      ByteSize: 8
+      GoRuntimeType: 908096
+      GoKind: 22
+      Pointee: 338 BaseType encoding/hex.InvalidByteError
+    - __kind: PointerType
+      ID: 408
+      Name: '*encoding/json.InvalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 901952
+      GoKind: 22
+      Pointee: 409 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+    - __kind: PointerType
+      ID: 610
+      Name: '*encoding/json.MarshalerError'
+      ByteSize: 8
+      GoRuntimeType: 1.033664e+06
+      GoKind: 22
+      Pointee: 611 UnresolvedPointeeType encoding/json.MarshalerError
+    - __kind: PointerType
+      ID: 400
+      Name: '*encoding/json.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 901568
+      GoKind: 22
+      Pointee: 401 UnresolvedPointeeType encoding/json.SyntaxError
+    - __kind: PointerType
+      ID: 406
+      Name: '*encoding/json.UnmarshalTypeError'
+      ByteSize: 8
+      GoRuntimeType: 901856
+      GoKind: 22
+      Pointee: 407 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+    - __kind: PointerType
+      ID: 404
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 901760
+      GoKind: 22
+      Pointee: 405 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 402
+      Name: '*encoding/json.UnsupportedValueError'
+      ByteSize: 8
+      GoRuntimeType: 901664
+      GoKind: 22
+      Pointee: 403 UnresolvedPointeeType encoding/json.UnsupportedValueError
+    - __kind: PointerType
+      ID: 941
+      Name: '*encoding/json.encodeState'
+      ByteSize: 8
+      GoRuntimeType: 2.287328e+06
+      GoKind: 22
+      Pointee: 942 UnresolvedPointeeType encoding/json.encodeState
+    - __kind: PointerType
+      ID: 410
+      Name: '*encoding/json.jsonError'
+      ByteSize: 8
+      GoRuntimeType: 902336
+      GoKind: 22
+      Pointee: 411 StructureType encoding/json.jsonError
+    - __kind: PointerType
+      ID: 806
+      Name: '*encoding/pem.lineBreaker'
+      ByteSize: 8
+      GoRuntimeType: 1.050176e+06
+      GoKind: 22
+      Pointee: 807 UnresolvedPointeeType encoding/pem.lineBreaker
+    - __kind: PointerType
+      ID: 511
+      Name: '*encoding/xml.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 918752
+      GoKind: 22
+      Pointee: 512 UnresolvedPointeeType encoding/xml.SyntaxError
+    - __kind: PointerType
+      ID: 509
+      Name: '*encoding/xml.TagPathError'
+      ByteSize: 8
+      GoRuntimeType: 918656
+      GoKind: 22
+      Pointee: 510 UnresolvedPointeeType encoding/xml.TagPathError
+    - __kind: PointerType
+      ID: 513
+      Name: '*encoding/xml.UnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 918848
+      GoKind: 22
+      Pointee: 349 GoStringHeaderType encoding/xml.UnmarshalError
+    - __kind: PointerType
+      ID: 351
+      Name: '*encoding/xml.UnmarshalError.str'
+      ByteSize: 8
+      Pointee: 350 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: PointerType
+      ID: 514
+      Name: '*encoding/xml.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 918944
+      GoKind: 22
+      Pointee: 515 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 919
+      Name: '*encoding/xml.printer'
+      ByteSize: 8
+      GoRuntimeType: 2.150784e+06
+      GoKind: 22
+      Pointee: 920 UnresolvedPointeeType encoding/xml.printer
+    - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 389440
       GoKind: 22
       Pointee: 13 GoInterfaceType error
+    - __kind: PointerType
+      ID: 378
+      Name: '*errors.errorString'
+      ByteSize: 8
+      GoRuntimeType: 892256
+      GoKind: 22
+      Pointee: 379 UnresolvedPointeeType errors.errorString
+    - __kind: PointerType
+      ID: 577
+      Name: '*errors.joinError'
+      ByteSize: 8
+      GoRuntimeType: 1.01856e+06
+      GoKind: 22
+      Pointee: 578 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -3631,6 +4137,814 @@ Types:
       GoRuntimeType: 390464
       GoKind: 22
       Pointee: 18 BaseType float64
+    - __kind: PointerType
+      ID: 929
+      Name: '*fmt.pp'
+      ByteSize: 8
+      GoRuntimeType: 2.254624e+06
+      GoKind: 22
+      Pointee: 930 UnresolvedPointeeType fmt.pp
+    - __kind: PointerType
+      ID: 579
+      Name: '*fmt.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.020352e+06
+      GoKind: 22
+      Pointee: 580 UnresolvedPointeeType fmt.wrapError
+    - __kind: PointerType
+      ID: 581
+      Name: '*fmt.wrapErrors'
+      ByteSize: 8
+      GoRuntimeType: 1.02048e+06
+      GoKind: 22
+      Pointee: 582 UnresolvedPointeeType fmt.wrapErrors
+    - __kind: PointerType
+      ID: 438
+      Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 907616
+      GoKind: 22
+      Pointee: 439 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+    - __kind: PointerType
+      ID: 419
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 904736
+      GoKind: 22
+      Pointee: 420 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+    - __kind: PointerType
+      ID: 421
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 904832
+      GoKind: 22
+      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+    - __kind: PointerType
+      ID: 742
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
+      ByteSize: 8
+      GoRuntimeType: 904544
+      GoKind: 22
+      Pointee: 743 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+    - __kind: PointerType
+      ID: 425
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
+      ByteSize: 8
+      GoRuntimeType: 905120
+      GoKind: 22
+      Pointee: 426 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+    - __kind: PointerType
+      ID: 744
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
+      ByteSize: 8
+      GoRuntimeType: 904640
+      GoKind: 22
+      Pointee: 745 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+    - __kind: PointerType
+      ID: 423
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
+      ByteSize: 8
+      GoRuntimeType: 904928
+      GoKind: 22
+      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+    - __kind: PointerType
+      ID: 333
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
+      ByteSize: 8
+      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: PointerType
+      ID: 418
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
+      ByteSize: 8
+      GoRuntimeType: 904448
+      GoKind: 22
+      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+    - __kind: PointerType
+      ID: 330
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
+      ByteSize: 8
+      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: PointerType
+      ID: 424
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
+      ByteSize: 8
+      GoRuntimeType: 905024
+      GoKind: 22
+      Pointee: 334 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+    - __kind: PointerType
+      ID: 336
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
+      ByteSize: 8
+      Pointee: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: PointerType
+      ID: 820
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.20496e+06
+      GoKind: 22
+      Pointee: 821 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+    - __kind: PointerType
+      ID: 905
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.049952e+06
+      GoKind: 22
+      Pointee: 906 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+    - __kind: PointerType
+      ID: 533
+      Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
+      ByteSize: 8
+      GoRuntimeType: 925568
+      GoKind: 22
+      Pointee: 534 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+    - __kind: PointerType
+      ID: 688
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
+      ByteSize: 8
+      GoRuntimeType: 1.208544e+06
+      GoKind: 22
+      Pointee: 689 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+    - __kind: PointerType
+      ID: 937
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
+      ByteSize: 8
+      GoRuntimeType: 2.264352e+06
+      GoKind: 22
+      Pointee: 938 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+    - __kind: PointerType
+      ID: 460
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
+      ByteSize: 8
+      GoRuntimeType: 914240
+      GoKind: 22
+      Pointee: 461 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+    - __kind: PointerType
+      ID: 467
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
+      ByteSize: 8
+      GoRuntimeType: 915296
+      GoKind: 22
+      Pointee: 468 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+    - __kind: PointerType
+      ID: 462
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
+      ByteSize: 8
+      GoRuntimeType: 915008
+      GoKind: 22
+      Pointee: 348 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+    - __kind: PointerType
+      ID: 465
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
+      ByteSize: 8
+      GoRuntimeType: 915200
+      GoKind: 22
+      Pointee: 466 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+    - __kind: PointerType
+      ID: 463
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
+      ByteSize: 8
+      GoRuntimeType: 915104
+      GoKind: 22
+      Pointee: 464 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+    - __kind: PointerType
+      ID: 483
+      Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
+      ByteSize: 8
+      GoRuntimeType: 917216
+      GoKind: 22
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+    - __kind: PointerType
+      ID: 487
+      Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
+      ByteSize: 8
+      GoRuntimeType: 917408
+      GoKind: 22
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+    - __kind: PointerType
+      ID: 485
+      Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
+      ByteSize: 8
+      GoRuntimeType: 917312
+      GoKind: 22
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+    - __kind: PointerType
+      ID: 481
+      Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
+      ByteSize: 8
+      GoRuntimeType: 917120
+      GoKind: 22
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+    - __kind: PointerType
+      ID: 769
+      Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 8
+      Pointee: 768 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: PointerType
+      ID: 495
+      Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
+      ByteSize: 8
+      GoRuntimeType: 917792
+      GoKind: 22
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+    - __kind: PointerType
+      ID: 489
+      Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
+      ByteSize: 8
+      GoRuntimeType: 917504
+      GoKind: 22
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+    - __kind: PointerType
+      ID: 493
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
+      ByteSize: 8
+      GoRuntimeType: 917696
+      GoKind: 22
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+    - __kind: PointerType
+      ID: 491
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
+      ByteSize: 8
+      GoRuntimeType: 917600
+      GoKind: 22
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+    - __kind: PointerType
+      ID: 497
+      Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
+      ByteSize: 8
+      GoRuntimeType: 917888
+      GoKind: 22
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+    - __kind: PointerType
+      ID: 503
+      Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
+      ByteSize: 8
+      GoRuntimeType: 918176
+      GoKind: 22
+      Pointee: 504 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+    - __kind: PointerType
+      ID: 505
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
+      ByteSize: 8
+      GoRuntimeType: 918272
+      GoKind: 22
+      Pointee: 506 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+    - __kind: PointerType
+      ID: 501
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
+      ByteSize: 8
+      GoRuntimeType: 918080
+      GoKind: 22
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+    - __kind: PointerType
+      ID: 499
+      Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
+      ByteSize: 8
+      GoRuntimeType: 917984
+      GoKind: 22
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+    - __kind: PointerType
+      ID: 507
+      Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
+      ByteSize: 8
+      GoRuntimeType: 918464
+      GoKind: 22
+      Pointee: 508 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+    - __kind: PointerType
+      ID: 427
+      Name: '*github.com/cihub/seelog.baseError'
+      ByteSize: 8
+      GoRuntimeType: 906272
+      GoKind: 22
+      Pointee: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: PointerType
+      ID: 858
+      Name: '*github.com/cihub/seelog.bufferedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.794432e+06
+      GoKind: 22
+      Pointee: 859 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+    - __kind: PointerType
+      ID: 429
+      Name: '*github.com/cihub/seelog.cannotOpenFileError'
+      ByteSize: 8
+      GoRuntimeType: 906368
+      GoKind: 22
+      Pointee: 430 StructureType github.com/cihub/seelog.cannotOpenFileError
+    - __kind: PointerType
+      ID: 838
+      Name: '*github.com/cihub/seelog.connWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.55248e+06
+      GoKind: 22
+      Pointee: 839 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+    - __kind: PointerType
+      ID: 794
+      Name: '*github.com/cihub/seelog.consoleWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.036352e+06
+      GoKind: 22
+      Pointee: 795 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+    - __kind: PointerType
+      ID: 828
+      Name: '*github.com/cihub/seelog.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.41824e+06
+      GoKind: 22
+      Pointee: 829 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+    - __kind: PointerType
+      ID: 433
+      Name: '*github.com/cihub/seelog.missingArgumentError'
+      ByteSize: 8
+      GoRuntimeType: 906560
+      GoKind: 22
+      Pointee: 434 StructureType github.com/cihub/seelog.missingArgumentError
+    - __kind: PointerType
+      ID: 895
+      Name: '*github.com/cihub/seelog.rollingFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.966816e+06
+      GoKind: 22
+      Pointee: 896 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+    - __kind: PointerType
+      ID: 912
+      Name: '*github.com/cihub/seelog.rollingFileWriterSize'
+      ByteSize: 8
+      GoRuntimeType: 2.123936e+06
+      GoKind: 22
+      Pointee: 907 StructureType github.com/cihub/seelog.rollingFileWriterSize
+    - __kind: PointerType
+      ID: 911
+      Name: '*github.com/cihub/seelog.rollingFileWriterTime'
+      ByteSize: 8
+      GoRuntimeType: 2.123552e+06
+      GoKind: 22
+      Pointee: 910 StructureType github.com/cihub/seelog.rollingFileWriterTime
+    - __kind: PointerType
+      ID: 796
+      Name: '*github.com/cihub/seelog.smtpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.03648e+06
+      GoKind: 22
+      Pointee: 797 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+    - __kind: PointerType
+      ID: 431
+      Name: '*github.com/cihub/seelog.unexpectedAttributeError'
+      ByteSize: 8
+      GoRuntimeType: 906464
+      GoKind: 22
+      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedAttributeError
+    - __kind: PointerType
+      ID: 435
+      Name: '*github.com/cihub/seelog.unexpectedChildElementError'
+      ByteSize: 8
+      GoRuntimeType: 906656
+      GoKind: 22
+      Pointee: 436 StructureType github.com/cihub/seelog.unexpectedChildElementError
+    - __kind: PointerType
+      ID: 860
+      Name: '*github.com/cihub/seelog/archive/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.796224e+06
+      GoKind: 22
+      Pointee: 861 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+    - __kind: PointerType
+      ID: 901
+      Name: '*github.com/cihub/seelog/archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.003552e+06
+      GoKind: 22
+      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+    - __kind: PointerType
+      ID: 903
+      Name: '*github.com/cihub/seelog/archive/zip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.034624e+06
+      GoKind: 22
+      Pointee: 904 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+    - __kind: PointerType
+      ID: 719
+      Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
+      ByteSize: 8
+      GoRuntimeType: 1.43312e+06
+      GoKind: 22
+      Pointee: 720 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+    - __kind: PointerType
+      ID: 632
+      Name: '*github.com/go-viper/mapstructure/v2.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.061696e+06
+      GoKind: 22
+      Pointee: 633 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+    - __kind: PointerType
+      ID: 630
+      Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.061568e+06
+      GoKind: 22
+      Pointee: 631 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+    - __kind: PointerType
+      ID: 634
+      Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.065664e+06
+      GoKind: 22
+      Pointee: 635 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 636
+      Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
+      ByteSize: 8
+      GoRuntimeType: 1.065792e+06
+      GoKind: 22
+      Pointee: 637 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+    - __kind: PointerType
+      ID: 849
+      Name: '*github.com/gogo/protobuf/proto.textWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.663104e+06
+      GoKind: 22
+      Pointee: 850 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+    - __kind: PointerType
+      ID: 626
+      Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.048256e+06
+      GoKind: 22
+      Pointee: 627 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 441
+      Name: '*github.com/google/uuid.invalidLengthError'
+      ByteSize: 8
+      GoRuntimeType: 908288
+      GoKind: 22
+      Pointee: 442 StructureType github.com/google/uuid.invalidLengthError
+    - __kind: PointerType
+      ID: 953
+      Name: '*github.com/json-iterator/go.Stream'
+      ByteSize: 8
+      GoRuntimeType: 2.3504e+06
+      GoKind: 22
+      Pointee: 954 UnresolvedPointeeType github.com/json-iterator/go.Stream
+    - __kind: PointerType
+      ID: 690
+      Name: '*github.com/pkg/errors.fundamental'
+      ByteSize: 8
+      GoRuntimeType: 1.216992e+06
+      GoKind: 22
+      Pointee: 691 UnresolvedPointeeType github.com/pkg/errors.fundamental
+    - __kind: PointerType
+      ID: 663
+      Name: '*github.com/tinylib/msgp/msgp.ArrayError'
+      ByteSize: 8
+      GoRuntimeType: 1.195744e+06
+      GoKind: 22
+      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.ArrayError
+    - __kind: PointerType
+      ID: 657
+      Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
+      ByteSize: 8
+      GoRuntimeType: 1.19536e+06
+      GoKind: 22
+      Pointee: 658 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+    - __kind: PointerType
+      ID: 596
+      Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.027648e+06
+      GoKind: 22
+      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+    - __kind: PointerType
+      ID: 669
+      Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.196128e+06
+      GoKind: 22
+      Pointee: 670 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+    - __kind: PointerType
+      ID: 595
+      Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.02752e+06
+      GoKind: 22
+      Pointee: 574 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+    - __kind: PointerType
+      ID: 661
+      Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
+      ByteSize: 8
+      GoRuntimeType: 1.195616e+06
+      GoKind: 22
+      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+    - __kind: PointerType
+      ID: 659
+      Name: '*github.com/tinylib/msgp/msgp.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.195488e+06
+      GoKind: 22
+      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.TypeError
+    - __kind: PointerType
+      ID: 667
+      Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
+      ByteSize: 8
+      GoRuntimeType: 1.196e+06
+      GoKind: 22
+      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+    - __kind: PointerType
+      ID: 665
+      Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.195872e+06
+      GoKind: 22
+      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+    - __kind: PointerType
+      ID: 957
+      Name: '*github.com/tinylib/msgp/msgp.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.362208e+06
+      GoKind: 22
+      Pointee: 958 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+    - __kind: PointerType
+      ID: 673
+      Name: '*github.com/tinylib/msgp/msgp.errFatal'
+      ByteSize: 8
+      GoRuntimeType: 1.196512e+06
+      GoKind: 22
+      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.errFatal
+    - __kind: PointerType
+      ID: 600
+      Name: '*github.com/tinylib/msgp/msgp.errRecursion'
+      ByteSize: 8
+      GoRuntimeType: 1.027904e+06
+      GoKind: 22
+      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.errRecursion
+    - __kind: PointerType
+      ID: 598
+      Name: '*github.com/tinylib/msgp/msgp.errShort'
+      ByteSize: 8
+      GoRuntimeType: 1.027776e+06
+      GoKind: 22
+      Pointee: 599 StructureType github.com/tinylib/msgp/msgp.errShort
+    - __kind: PointerType
+      ID: 671
+      Name: '*github.com/tinylib/msgp/msgp.errWrapped'
+      ByteSize: 8
+      GoRuntimeType: 1.196384e+06
+      GoKind: 22
+      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.errWrapped
+    - __kind: PointerType
+      ID: 555
+      Name: '*go.opentelemetry.io/otel/trace.errorConst'
+      ByteSize: 8
+      GoRuntimeType: 940064
+      GoKind: 22
+      Pointee: 361 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+    - __kind: PointerType
+      ID: 363
+      Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
+      ByteSize: 8
+      Pointee: 362 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: PointerType
+      ID: 732
+      Name: '*go.uber.org/multierr.multiError'
+      ByteSize: 8
+      GoRuntimeType: 1.661568e+06
+      GoKind: 22
+      Pointee: 733 UnresolvedPointeeType go.uber.org/multierr.multiError
+    - __kind: PointerType
+      ID: 640
+      Name: '*go.uber.org/zap.errArrayElem'
+      ByteSize: 8
+      GoRuntimeType: 1.080512e+06
+      GoKind: 22
+      Pointee: 641 StructureType go.uber.org/zap.errArrayElem
+    - __kind: PointerType
+      ID: 826
+      Name: '*go.uber.org/zap.nopCloserSink'
+      ByteSize: 8
+      GoRuntimeType: 1.256544e+06
+      GoKind: 22
+      Pointee: 827 StructureType go.uber.org/zap.nopCloserSink
+    - __kind: PointerType
+      ID: 917
+      Name: '*go.uber.org/zap/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.138912e+06
+      GoKind: 22
+      Pointee: 918 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+    - __kind: PointerType
+      ID: 812
+      Name: '*go.uber.org/zap/zapcore.writerWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.082816e+06
+      GoKind: 22
+      Pointee: 813 StructureType go.uber.org/zap/zapcore.writerWrapper
+    - __kind: PointerType
+      ID: 556
+      Name: '*golang.org/x/net/http2.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 941312
+      GoKind: 22
+      Pointee: 364 BaseType golang.org/x/net/http2.ConnectionError
+    - __kind: PointerType
+      ID: 698
+      Name: '*golang.org/x/net/http2.StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.258208e+06
+      GoKind: 22
+      Pointee: 699 StructureType golang.org/x/net/http2.StreamError
+    - __kind: PointerType
+      ID: 559
+      Name: '*golang.org/x/net/http2.connError'
+      ByteSize: 8
+      GoRuntimeType: 941600
+      GoKind: 22
+      Pointee: 560 StructureType golang.org/x/net/http2.connError
+    - __kind: PointerType
+      ID: 558
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 941504
+      GoKind: 22
+      Pointee: 368 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 370
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 369 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 562
+      Name: '*golang.org/x/net/http2.headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 941792
+      GoKind: 22
+      Pointee: 374 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+    - __kind: PointerType
+      ID: 376
+      Name: '*golang.org/x/net/http2.headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 375 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: PointerType
+      ID: 561
+      Name: '*golang.org/x/net/http2.headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 941696
+      GoKind: 22
+      Pointee: 371 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+    - __kind: PointerType
+      ID: 373
+      Name: '*golang.org/x/net/http2.headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 372 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: PointerType
+      ID: 557
+      Name: '*golang.org/x/net/http2.pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 941408
+      GoKind: 22
+      Pointee: 365 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+    - __kind: PointerType
+      ID: 367
+      Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 366 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 915
+      Name: '*golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.136992e+06
+      GoKind: 22
+      Pointee: 916 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 563
+      Name: '*golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 941888
+      GoKind: 22
+      Pointee: 564 StructureType golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 565
+      Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 941984
+      GoKind: 22
+      Pointee: 377 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 551
+      Name: '*google.golang.org/grpc.dropError'
+      ByteSize: 8
+      GoRuntimeType: 935264
+      GoKind: 22
+      Pointee: 552 StructureType google.golang.org/grpc.dropError
+    - __kind: PointerType
+      ID: 696
+      Name: '*google.golang.org/grpc/internal/status.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.255264e+06
+      GoKind: 22
+      Pointee: 697 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+    - __kind: PointerType
+      ID: 721
+      Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 1.44048e+06
+      GoKind: 22
+      Pointee: 722 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+    - __kind: PointerType
+      ID: 553
+      Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
+      ByteSize: 8
+      GoRuntimeType: 938336
+      GoKind: 22
+      Pointee: 554 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+    - __kind: PointerType
+      ID: 866
+      Name: '*google.golang.org/grpc/internal/transport.bufConn'
+      ByteSize: 8
+      GoRuntimeType: 1.802272e+06
+      GoKind: 22
+      Pointee: 867 StructureType google.golang.org/grpc/internal/transport.bufConn
+    - __kind: PointerType
+      ID: 824
+      Name: '*google.golang.org/grpc/internal/transport.bufWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.251808e+06
+      GoKind: 22
+      Pointee: 825 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+    - __kind: PointerType
+      ID: 638
+      Name: '*google.golang.org/grpc/internal/transport.ioError'
+      ByteSize: 8
+      GoRuntimeType: 1.074752e+06
+      GoKind: 22
+      Pointee: 639 StructureType google.golang.org/grpc/internal/transport.ioError
+    - __kind: PointerType
+      ID: 784
+      Name: '*google.golang.org/grpc/mem.writer'
+      ByteSize: 8
+      GoRuntimeType: 938432
+      GoKind: 22
+      Pointee: 785 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+    - __kind: PointerType
+      ID: 531
+      Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
+      ByteSize: 8
+      GoRuntimeType: 923456
+      GoKind: 22
+      Pointee: 532 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+    - __kind: PointerType
+      ID: 628
+      Name: '*google.golang.org/protobuf/internal/errors.prefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.051584e+06
+      GoKind: 22
+      Pointee: 629 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+    - __kind: PointerType
+      ID: 694
+      Name: '*google.golang.org/protobuf/internal/errors.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.223264e+06
+      GoKind: 22
+      Pointee: 695 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+    - __kind: PointerType
+      ID: 692
+      Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
+      ByteSize: 8
+      GoRuntimeType: 1.223008e+06
+      GoKind: 22
+      Pointee: 693 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+    - __kind: PointerType
+      ID: 545
+      Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
+      ByteSize: 8
+      GoRuntimeType: 928160
+      GoKind: 22
+      Pointee: 546 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+    - __kind: PointerType
+      ID: 547
+      Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
+      ByteSize: 8
+      GoRuntimeType: 928256
+      GoKind: 22
+      Pointee: 548 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+    - __kind: PointerType
+      ID: 475
+      Name: '*gopkg.in/yaml%2ev3.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 915680
+      GoKind: 22
+      Pointee: 476 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+    - __kind: PointerType
+      ID: 872
+      Name: '*hash/crc32.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.842912e+06
+      GoKind: 22
+      Pointee: 873 UnresolvedPointeeType hash/crc32.digest
+    - __kind: PointerType
+      ID: 566
+      Name: '*html/template.Error'
+      ByteSize: 8
+      GoRuntimeType: 942752
+      GoKind: 22
+      Pointee: 567 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -3674,6 +4988,90 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
+      ID: 445
+      Name: '*internal/bisect.parseError'
+      ByteSize: 8
+      GoRuntimeType: 908864
+      GoKind: 22
+      Pointee: 446 UnresolvedPointeeType internal/bisect.parseError
+    - __kind: PointerType
+      ID: 443
+      Name: '*internal/chacha8rand.errUnmarshalChaCha8'
+      ByteSize: 8
+      GoRuntimeType: 908768
+      GoKind: 22
+      Pointee: 444 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+    - __kind: PointerType
+      ID: 770
+      Name: '*internal/godebug.runtimeStderr'
+      ByteSize: 8
+      GoRuntimeType: 896768
+      GoKind: 22
+      Pointee: 771 UnresolvedPointeeType internal/godebug.runtimeStderr
+    - __kind: PointerType
+      ID: 655
+      Name: '*internal/poll.DeadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.194592e+06
+      GoKind: 22
+      Pointee: 656 UnresolvedPointeeType internal/poll.DeadlineExceededError
+    - __kind: PointerType
+      ID: 959
+      Name: '*internal/poll.FD'
+      ByteSize: 8
+      GoRuntimeType: 2.36784e+06
+      GoKind: 22
+      Pointee: 960 UnresolvedPointeeType internal/poll.FD
+    - __kind: PointerType
+      ID: 653
+      Name: '*internal/poll.errNetClosing'
+      ByteSize: 8
+      GoRuntimeType: 1.194464e+06
+      GoKind: 22
+      Pointee: 654 StructureType internal/poll.errNetClosing
+    - __kind: PointerType
+      ID: 380
+      Name: '*internal/reflectlite.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 896000
+      GoKind: 22
+      Pointee: 381 UnresolvedPointeeType internal/reflectlite.ValueError
+    - __kind: PointerType
+      ID: 816
+      Name: '*io.PipeWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.186016e+06
+      GoKind: 22
+      Pointee: 817 UnresolvedPointeeType io.PipeWriter
+    - __kind: PointerType
+      ID: 814
+      Name: '*io.discard'
+      ByteSize: 8
+      GoRuntimeType: 1.185632e+06
+      GoKind: 22
+      Pointee: 815 StructureType io.discard
+    - __kind: PointerType
+      ID: 788
+      Name: '*io.multiWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.018816e+06
+      GoKind: 22
+      Pointee: 789 UnresolvedPointeeType io.multiWriter
+    - __kind: PointerType
+      ID: 651
+      Name: '*io/fs.PathError'
+      ByteSize: 8
+      GoRuntimeType: 1.194208e+06
+      GoKind: 22
+      Pointee: 652 UnresolvedPointeeType io/fs.PathError
+    - __kind: PointerType
+      ID: 862
+      Name: '*log/slog/internal/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 1.796448e+06
+      GoKind: 22
+      Pointee: 863 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+    - __kind: PointerType
       ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
@@ -3681,12 +5079,12 @@ Types:
       GoKind: 22
       Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 341
+      ID: 1004
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383168
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType main.deepMap3
+      Pointee: 1005 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3695,19 +5093,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 377
+      ID: 1040
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 382848
       GoKind: 22
-      Pointee: 378 StructureType main.deepMap8
+      Pointee: 1041 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 392
+      ID: 1055
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382784
       GoKind: 22
-      Pointee: 393 StructureType main.deepMap9
+      Pointee: 1056 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3716,12 +5114,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 306
+      ID: 963
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 307 UnresolvedPointeeType main.deepPtr3
+      Pointee: 964 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3730,19 +5128,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 347
+      ID: 1010
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383424
       GoKind: 22
-      Pointee: 348 StructureType main.deepPtr8
+      Pointee: 1011 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 349
+      ID: 1012
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383360
       GoKind: 22
-      Pointee: 350 StructureType main.deepPtr9
+      Pointee: 1013 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3751,12 +5149,12 @@ Types:
       GoKind: 22
       Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 326
+      ID: 989
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384320
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType main.deepSlice3
+      Pointee: 990 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3765,19 +5163,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 353
+      ID: 1016
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 384000
       GoKind: 22
-      Pointee: 354 StructureType main.deepSlice8
+      Pointee: 1017 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 359
+      ID: 1022
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383936
       GoKind: 22
-      Pointee: 360 StructureType main.deepSlice9
+      Pointee: 1023 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 176
       Name: '*main.emptyStruct'
@@ -3792,6 +5190,13 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
+      ID: 980
+      Name: '*main.firstBehavior'
+      ByteSize: 8
+      GoRuntimeType: 891968
+      GoKind: 22
+      Pointee: 981 StructureType main.firstBehavior
+    - __kind: PointerType
       ID: 157
       Name: '*main.node'
       ByteSize: 8
@@ -3805,22 +5210,36 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
+      ID: 982
+      Name: '*main.secondBehavior'
+      ByteSize: 8
+      GoRuntimeType: 892064
+      GoKind: 22
+      Pointee: 983 StructureType main.secondBehavior
+    - __kind: PointerType
+      ID: 968
+      Name: '*main.somethingImpl'
+      ByteSize: 8
+      GoRuntimeType: 892160
+      GoKind: 22
+      Pointee: 969 UnresolvedPointeeType main.somethingImpl
+    - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
       ByteSize: 8
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 309
+      ID: 966
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType main.stringType1.str
+      Pointee: 965 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 310 UnresolvedPointeeType main.stringType2
+      Pointee: 967 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 242
       Name: '*main.structWithMap'
@@ -3846,10 +5265,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 323
+      ID: 986
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 322 GoSliceDataType main.t.array
+      Pointee: 985 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -3882,30 +5301,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 331
+      ID: 994
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 995 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 367
+      ID: 1030
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1031 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 382
+      ID: 1045
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1046 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 397
+      ID: 1060
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 398 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1061 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 129
       Name: '*map<int,uint8>'
@@ -3921,6 +5340,11 @@ Types:
       Name: '*map<string,[]string>'
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 725
+      Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 726 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -3948,6 +5372,452 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
+      ID: 479
+      Name: '*math/big.ErrNaN'
+      ByteSize: 8
+      GoRuntimeType: 916544
+      GoKind: 22
+      Pointee: 480 StructureType math/big.ErrNaN
+    - __kind: PointerType
+      ID: 778
+      Name: '*mime/multipart.writerOnly·1'
+      ByteSize: 8
+      GoRuntimeType: 911360
+      GoKind: 22
+      Pointee: 779 StructureType mime/multipart.writerOnly·1
+    - __kind: PointerType
+      ID: 682
+      Name: '*net.AddrError'
+      ByteSize: 8
+      GoRuntimeType: 1.202784e+06
+      GoKind: 22
+      Pointee: 683 UnresolvedPointeeType net.AddrError
+    - __kind: PointerType
+      ID: 708
+      Name: '*net.DNSError'
+      ByteSize: 8
+      GoRuntimeType: 1.41648e+06
+      GoKind: 22
+      Pointee: 709 UnresolvedPointeeType net.DNSError
+    - __kind: PointerType
+      ID: 923
+      Name: '*net.IPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.22544e+06
+      GoKind: 22
+      Pointee: 924 UnresolvedPointeeType net.IPConn
+    - __kind: PointerType
+      ID: 706
+      Name: '*net.OpError'
+      ByteSize: 8
+      GoRuntimeType: 1.41616e+06
+      GoKind: 22
+      Pointee: 707 UnresolvedPointeeType net.OpError
+    - __kind: PointerType
+      ID: 684
+      Name: '*net.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.202912e+06
+      GoKind: 22
+      Pointee: 685 UnresolvedPointeeType net.ParseError
+    - __kind: PointerType
+      ID: 933
+      Name: '*net.TCPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.255648e+06
+      GoKind: 22
+      Pointee: 934 UnresolvedPointeeType net.TCPConn
+    - __kind: PointerType
+      ID: 943
+      Name: '*net.UDPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.30064e+06
+      GoKind: 22
+      Pointee: 944 UnresolvedPointeeType net.UDPConn
+    - __kind: PointerType
+      ID: 931
+      Name: '*net.UnixConn'
+      ByteSize: 8
+      GoRuntimeType: 2.255136e+06
+      GoKind: 22
+      Pointee: 932 UnresolvedPointeeType net.UnixConn
+    - __kind: PointerType
+      ID: 681
+      Name: '*net.UnknownNetworkError'
+      ByteSize: 8
+      GoRuntimeType: 1.202016e+06
+      GoKind: 22
+      Pointee: 644 GoStringHeaderType net.UnknownNetworkError
+    - __kind: PointerType
+      ID: 646
+      Name: '*net.UnknownNetworkError.str'
+      ByteSize: 8
+      Pointee: 645 GoStringDataType net.UnknownNetworkError.str
+    - __kind: PointerType
+      ID: 612
+      Name: '*net.canceledError'
+      ByteSize: 8
+      GoRuntimeType: 1.03456e+06
+      GoKind: 22
+      Pointee: 613 StructureType net.canceledError
+    - __kind: PointerType
+      ID: 899
+      Name: '*net.conn'
+      ByteSize: 8
+      GoRuntimeType: 2.000672e+06
+      GoKind: 22
+      Pointee: 900 UnresolvedPointeeType net.conn
+    - __kind: PointerType
+      ID: 751
+      Name: '*net.dialResult·1'
+      ByteSize: 8
+      GoRuntimeType: 1.838208e+06
+      GoKind: 22
+      Pointee: 752 StructureType net.dialResult·1
+    - __kind: PointerType
+      ID: 945
+      Name: '*net.netFD'
+      ByteSize: 8
+      GoRuntimeType: 2.304896e+06
+      GoKind: 22
+      Pointee: 946 UnresolvedPointeeType net.netFD
+    - __kind: PointerType
+      ID: 412
+      Name: '*net.notFoundError'
+      ByteSize: 8
+      GoRuntimeType: 903296
+      GoKind: 22
+      Pointee: 413 UnresolvedPointeeType net.notFoundError
+    - __kind: PointerType
+      ID: 414
+      Name: '*net.result·2'
+      ByteSize: 8
+      GoRuntimeType: 903968
+      GoKind: 22
+      Pointee: 415 StructureType net.result·2
+    - __kind: PointerType
+      ID: 927
+      Name: '*net.tcpConnWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.241664e+06
+      GoKind: 22
+      Pointee: 928 StructureType net.tcpConnWithoutReadFrom
+    - __kind: PointerType
+      ID: 925
+      Name: '*net.tcpConnWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.241184e+06
+      GoKind: 22
+      Pointee: 926 StructureType net.tcpConnWithoutWriteTo
+    - __kind: PointerType
+      ID: 686
+      Name: '*net.temporaryError'
+      ByteSize: 8
+      GoRuntimeType: 1.203552e+06
+      GoKind: 22
+      Pointee: 687 UnresolvedPointeeType net.temporaryError
+    - __kind: PointerType
+      ID: 710
+      Name: '*net.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.41664e+06
+      GoKind: 22
+      Pointee: 711 UnresolvedPointeeType net.timeoutError
+    - __kind: PointerType
+      ID: 602
+      Name: '*net/http.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 1.030336e+06
+      GoKind: 22
+      Pointee: 603 UnresolvedPointeeType net/http.ProtocolError
+    - __kind: PointerType
+      ID: 772
+      Name: '*net/http.bufioFlushWriter'
+      ByteSize: 8
+      GoRuntimeType: 899072
+      GoKind: 22
+      Pointee: 773 StructureType net/http.bufioFlushWriter
+    - __kind: PointerType
+      ID: 389
+      Name: '*net/http.http2ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 899744
+      GoKind: 22
+      Pointee: 309 BaseType net/http.http2ConnectionError
+    - __kind: PointerType
+      ID: 390
+      Name: '*net/http.http2GoAwayError'
+      ByteSize: 8
+      GoRuntimeType: 899840
+      GoKind: 22
+      Pointee: 391 StructureType net/http.http2GoAwayError
+    - __kind: PointerType
+      ID: 702
+      Name: '*net/http.http2StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.41232e+06
+      GoKind: 22
+      Pointee: 703 StructureType net/http.http2StreamError
+    - __kind: PointerType
+      ID: 394
+      Name: '*net/http.http2connError'
+      ByteSize: 8
+      GoRuntimeType: 900416
+      GoKind: 22
+      Pointee: 395 StructureType net/http.http2connError
+    - __kind: PointerType
+      ID: 834
+      Name: '*net/http.http2dataBuffer'
+      ByteSize: 8
+      GoRuntimeType: 1.54896e+06
+      GoKind: 22
+      Pointee: 835 UnresolvedPointeeType net/http.http2dataBuffer
+    - __kind: PointerType
+      ID: 393
+      Name: '*net/http.http2duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 900320
+      GoKind: 22
+      Pointee: 313 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 315
+      Name: '*net/http.http2duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 397
+      Name: '*net/http.http2headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 900608
+      GoKind: 22
+      Pointee: 319 GoStringHeaderType net/http.http2headerFieldNameError
+    - __kind: PointerType
+      ID: 321
+      Name: '*net/http.http2headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 320 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: PointerType
+      ID: 396
+      Name: '*net/http.http2headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 900512
+      GoKind: 22
+      Pointee: 316 GoStringHeaderType net/http.http2headerFieldValueError
+    - __kind: PointerType
+      ID: 318
+      Name: '*net/http.http2headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 317 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: PointerType
+      ID: 677
+      Name: '*net/http.http2httpError'
+      ByteSize: 8
+      GoRuntimeType: 1.19856e+06
+      GoKind: 22
+      Pointee: 678 UnresolvedPointeeType net/http.http2httpError
+    - __kind: PointerType
+      ID: 608
+      Name: '*net/http.http2noCachedConnError'
+      ByteSize: 8
+      GoRuntimeType: 1.030976e+06
+      GoKind: 22
+      Pointee: 609 StructureType net/http.http2noCachedConnError
+    - __kind: PointerType
+      ID: 888
+      Name: '*net/http.http2pipe'
+      ByteSize: 8
+      GoRuntimeType: 1.943136e+06
+      GoKind: 22
+      Pointee: 889 UnresolvedPointeeType net/http.http2pipe
+    - __kind: PointerType
+      ID: 392
+      Name: '*net/http.http2pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 900224
+      GoKind: 22
+      Pointee: 310 GoStringHeaderType net/http.http2pseudoHeaderError
+    - __kind: PointerType
+      ID: 312
+      Name: '*net/http.http2pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 774
+      Name: '*net/http.http2stickyErrWriter'
+      ByteSize: 8
+      GoRuntimeType: 900704
+      GoKind: 22
+      Pointee: 775 StructureType net/http.http2stickyErrWriter
+    - __kind: PointerType
+      ID: 604
+      Name: '*net/http.nothingWrittenError'
+      ByteSize: 8
+      GoRuntimeType: 1.030592e+06
+      GoKind: 22
+      Pointee: 605 StructureType net/http.nothingWrittenError
+    - __kind: PointerType
+      ID: 836
+      Name: '*net/http.persistConn'
+      ByteSize: 8
+      GoRuntimeType: 2.166272e+06
+      GoKind: 22
+      Pointee: 837 UnresolvedPointeeType net/http.persistConn
+    - __kind: PointerType
+      ID: 792
+      Name: '*net/http.persistConnWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.030464e+06
+      GoKind: 22
+      Pointee: 793 StructureType net/http.persistConnWriter
+    - __kind: PointerType
+      ID: 818
+      Name: '*net/http.readWriteCloserBody'
+      ByteSize: 8
+      GoRuntimeType: 1.197664e+06
+      GoKind: 22
+      Pointee: 819 StructureType net/http.readWriteCloserBody
+    - __kind: PointerType
+      ID: 398
+      Name: '*net/http.requestBodyReadError'
+      ByteSize: 8
+      GoRuntimeType: 900800
+      GoKind: 22
+      Pointee: 399 StructureType net/http.requestBodyReadError
+    - __kind: PointerType
+      ID: 704
+      Name: '*net/http.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.41344e+06
+      GoKind: 22
+      Pointee: 705 UnresolvedPointeeType net/http.timeoutError
+    - __kind: PointerType
+      ID: 675
+      Name: '*net/http.tlsHandshakeTimeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.198432e+06
+      GoKind: 22
+      Pointee: 676 StructureType net/http.tlsHandshakeTimeoutError
+    - __kind: PointerType
+      ID: 606
+      Name: '*net/http.transportReadFromServerError'
+      ByteSize: 8
+      GoRuntimeType: 1.03072e+06
+      GoKind: 22
+      Pointee: 607 StructureType net/http.transportReadFromServerError
+    - __kind: PointerType
+      ID: 870
+      Name: '*net/http.unencryptedNetConnInTLSConn'
+      ByteSize: 8
+      GoRuntimeType: 1.834848e+06
+      GoKind: 22
+      Pointee: 871 StructureType net/http.unencryptedNetConnInTLSConn
+    - __kind: PointerType
+      ID: 387
+      Name: '*net/http.unsupportedTEError'
+      ByteSize: 8
+      GoRuntimeType: 898976
+      GoKind: 22
+      Pointee: 388 UnresolvedPointeeType net/http.unsupportedTEError
+    - __kind: PointerType
+      ID: 890
+      Name: '*net/http/internal.FlushAfterChunkWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.944672e+06
+      GoKind: 22
+      Pointee: 891 StructureType net/http/internal.FlushAfterChunkWriter
+    - __kind: PointerType
+      ID: 802
+      Name: '*net/http/internal.chunkedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.043008e+06
+      GoKind: 22
+      Pointee: 803 UnresolvedPointeeType net/http/internal.chunkedWriter
+    - __kind: PointerType
+      ID: 471
+      Name: '*net/netip.parseAddrError'
+      ByteSize: 8
+      GoRuntimeType: 915488
+      GoKind: 22
+      Pointee: 472 StructureType net/netip.parseAddrError
+    - __kind: PointerType
+      ID: 469
+      Name: '*net/netip.parsePrefixError'
+      ByteSize: 8
+      GoRuntimeType: 915392
+      GoKind: 22
+      Pointee: 470 StructureType net/netip.parsePrefixError
+    - __kind: PointerType
+      ID: 844
+      Name: '*net/smtp.Client'
+      ByteSize: 8
+      GoRuntimeType: 2.110944e+06
+      GoKind: 22
+      Pointee: 845 UnresolvedPointeeType net/smtp.Client
+    - __kind: PointerType
+      ID: 804
+      Name: '*net/smtp.dataCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.047872e+06
+      GoKind: 22
+      Pointee: 805 StructureType net/smtp.dataCloser
+    - __kind: PointerType
+      ID: 455
+      Name: '*net/textproto.Error'
+      ByteSize: 8
+      GoRuntimeType: 911552
+      GoKind: 22
+      Pointee: 456 UnresolvedPointeeType net/textproto.Error
+    - __kind: PointerType
+      ID: 454
+      Name: '*net/textproto.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 911456
+      GoKind: 22
+      Pointee: 344 GoStringHeaderType net/textproto.ProtocolError
+    - __kind: PointerType
+      ID: 346
+      Name: '*net/textproto.ProtocolError.str'
+      ByteSize: 8
+      Pointee: 345 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: PointerType
+      ID: 800
+      Name: '*net/textproto.dotWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.04224e+06
+      GoKind: 22
+      Pointee: 801 UnresolvedPointeeType net/textproto.dotWriter
+    - __kind: PointerType
+      ID: 712
+      Name: '*net/url.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.41696e+06
+      GoKind: 22
+      Pointee: 713 UnresolvedPointeeType net/url.Error
+    - __kind: PointerType
+      ID: 416
+      Name: '*net/url.EscapeError'
+      ByteSize: 8
+      GoRuntimeType: 904064
+      GoKind: 22
+      Pointee: 322 GoStringHeaderType net/url.EscapeError
+    - __kind: PointerType
+      ID: 324
+      Name: '*net/url.EscapeError.str'
+      ByteSize: 8
+      Pointee: 323 GoStringDataType net/url.EscapeError.str
+    - __kind: PointerType
+      ID: 417
+      Name: '*net/url.InvalidHostError'
+      ByteSize: 8
+      GoRuntimeType: 904160
+      GoKind: 22
+      Pointee: 325 GoStringHeaderType net/url.InvalidHostError
+    - __kind: PointerType
+      ID: 327
+      Name: '*net/url.InvalidHostError.str'
+      ByteSize: 8
+      Pointee: 326 GoStringDataType net/url.InvalidHostError.str
+    - __kind: PointerType
       ID: 288
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
@@ -3973,30 +5843,30 @@ Types:
       ByteSize: 8
       Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 337
+      ID: 1000
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 338 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1001 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 373
+      ID: 1036
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 374 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1037 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 388
+      ID: 1051
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 389 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1052 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 196
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 197 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 403
+      ID: 1066
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 404 StructureType noalg.map.group[int]interface {}
+      Pointee: 1067 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 255
       Name: '*noalg.map.group[int]uint8'
@@ -4012,6 +5882,11 @@ Types:
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
       Pointee: 221 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 758
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 212
       Name: '*noalg.map.group[string]int'
@@ -4033,6 +5908,161 @@ Types:
       ByteSize: 8
       Pointee: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
+      ID: 951
+      Name: '*os.File'
+      ByteSize: 8
+      GoRuntimeType: 2.343552e+06
+      GoKind: 22
+      Pointee: 952 UnresolvedPointeeType os.File
+    - __kind: PointerType
+      ID: 583
+      Name: '*os.LinkError'
+      ByteSize: 8
+      GoRuntimeType: 1.021632e+06
+      GoKind: 22
+      Pointee: 584 UnresolvedPointeeType os.LinkError
+    - __kind: PointerType
+      ID: 647
+      Name: '*os.SyscallError'
+      ByteSize: 8
+      GoRuntimeType: 1.187552e+06
+      GoKind: 22
+      Pointee: 648 UnresolvedPointeeType os.SyscallError
+    - __kind: PointerType
+      ID: 949
+      Name: '*os.fileWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.339872e+06
+      GoKind: 22
+      Pointee: 950 StructureType os.fileWithoutReadFrom
+    - __kind: PointerType
+      ID: 947
+      Name: '*os.fileWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.339136e+06
+      GoKind: 22
+      Pointee: 948 StructureType os.fileWithoutWriteTo
+    - __kind: PointerType
+      ID: 614
+      Name: '*os/exec.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.038912e+06
+      GoKind: 22
+      Pointee: 615 UnresolvedPointeeType os/exec.Error
+    - __kind: PointerType
+      ID: 754
+      Name: '*os/exec.ExitError'
+      ByteSize: 8
+      GoRuntimeType: 2.0808e+06
+      GoKind: 22
+      Pointee: 755 UnresolvedPointeeType os/exec.ExitError
+    - __kind: PointerType
+      ID: 822
+      Name: '*os/exec.prefixSuffixSaver'
+      ByteSize: 8
+      GoRuntimeType: 1.209824e+06
+      GoKind: 22
+      Pointee: 823 UnresolvedPointeeType os/exec.prefixSuffixSaver
+    - __kind: PointerType
+      ID: 616
+      Name: '*os/exec.wrappedError'
+      ByteSize: 8
+      GoRuntimeType: 1.03904e+06
+      GoKind: 22
+      Pointee: 617 StructureType os/exec.wrappedError
+    - __kind: PointerType
+      ID: 550
+      Name: '*os/user.UnknownGroupIdError'
+      ByteSize: 8
+      GoRuntimeType: 933344
+      GoKind: 22
+      Pointee: 358 GoStringHeaderType os/user.UnknownGroupIdError
+    - __kind: PointerType
+      ID: 360
+      Name: '*os/user.UnknownGroupIdError.str'
+      ByteSize: 8
+      Pointee: 359 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: PointerType
+      ID: 549
+      Name: '*os/user.UnknownUserIdError'
+      ByteSize: 8
+      GoRuntimeType: 933248
+      GoKind: 22
+      Pointee: 357 BaseType os/user.UnknownUserIdError
+    - __kind: PointerType
+      ID: 382
+      Name: '*reflect.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 896672
+      GoKind: 22
+      Pointee: 383 UnresolvedPointeeType reflect.ValueError
+    - __kind: PointerType
+      ID: 477
+      Name: '*regexp/syntax.Error'
+      ByteSize: 8
+      GoRuntimeType: 916160
+      GoKind: 22
+      Pointee: 478 UnresolvedPointeeType regexp/syntax.Error
+    - __kind: PointerType
+      ID: 587
+      Name: '*runtime.PanicNilError'
+      ByteSize: 8
+      GoRuntimeType: 1.023168e+06
+      GoKind: 22
+      Pointee: 588 UnresolvedPointeeType runtime.PanicNilError
+    - __kind: PointerType
+      ID: 591
+      Name: '*runtime.TypeAssertionError'
+      ByteSize: 8
+      GoRuntimeType: 1.02496e+06
+      GoKind: 22
+      Pointee: 592 UnresolvedPointeeType runtime.TypeAssertionError
+    - __kind: PointerType
+      ID: 589
+      Name: '*runtime.boundsError'
+      ByteSize: 8
+      GoRuntimeType: 1.023296e+06
+      GoKind: 22
+      Pointee: 590 StructureType runtime.boundsError
+    - __kind: PointerType
+      ID: 649
+      Name: '*runtime.errorAddressString'
+      ByteSize: 8
+      GoRuntimeType: 1.192928e+06
+      GoKind: 22
+      Pointee: 650 StructureType runtime.errorAddressString
+    - __kind: PointerType
+      ID: 585
+      Name: '*runtime.errorString'
+      ByteSize: 8
+      GoRuntimeType: 1.022784e+06
+      GoKind: 22
+      Pointee: 568 GoStringHeaderType runtime.errorString
+    - __kind: PointerType
+      ID: 570
+      Name: '*runtime.errorString.str'
+      ByteSize: 8
+      Pointee: 569 GoStringDataType runtime.errorString.str
+    - __kind: PointerType
+      ID: 586
+      Name: '*runtime.plainError'
+      ByteSize: 8
+      GoRuntimeType: 1.022912e+06
+      GoKind: 22
+      Pointee: 571 GoStringHeaderType runtime.plainError
+    - __kind: PointerType
+      ID: 573
+      Name: '*runtime.plainError.str'
+      ByteSize: 8
+      Pointee: 572 GoStringDataType runtime.plainError.str
+    - __kind: PointerType
+      ID: 593
+      Name: '*strconv.NumError'
+      ByteSize: 8
+      GoRuntimeType: 1.025216e+06
+      GoKind: 22
+      Pointee: 594 UnresolvedPointeeType strconv.NumError
+    - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
@@ -4044,6 +6074,34 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 177 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 886
+      Name: '*strings.Builder'
+      ByteSize: 8
+      GoRuntimeType: 1.941856e+06
+      GoKind: 22
+      Pointee: 887 UnresolvedPointeeType strings.Builder
+    - __kind: PointerType
+      ID: 790
+      Name: '*strings.appendSliceWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.025344e+06
+      GoKind: 22
+      Pointee: 791 UnresolvedPointeeType strings.appendSliceWriter
+    - __kind: PointerType
+      ID: 786
+      Name: '*struct { io.Writer }'
+      ByteSize: 8
+      GoRuntimeType: 966144
+      GoKind: 22
+      Pointee: 787 StructureType struct { io.Writer }
+    - __kind: PointerType
+      ID: 701
+      Name: '*syscall.Errno'
+      ByteSize: 8
+      GoRuntimeType: 1.41168e+06
+      GoKind: 22
+      Pointee: 700 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
@@ -4070,30 +6128,30 @@ Types:
       ByteSize: 8
       Pointee: 184 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 334
+      ID: 997
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 335 StructureType table<int,*main.deepMap3>
+      Pointee: 998 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 370
+      ID: 1033
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 371 StructureType table<int,*main.deepMap8>
+      Pointee: 1034 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 385
+      ID: 1048
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 386 StructureType table<int,*main.deepMap9>
+      Pointee: 1049 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 194 StructureType table<int,int>
     - __kind: PointerType
-      ID: 400
+      ID: 1063
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 401 StructureType table<int,interface {}>
+      Pointee: 1064 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*table<int,uint8>'
@@ -4109,6 +6167,11 @@ Types:
       Name: '*table<string,[]string>'
       ByteSize: 8
       Pointee: 218 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 728
+      Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 756 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
@@ -4129,6 +6192,46 @@ Types:
       Name: '*table<uint8,uint8>'
       ByteSize: 8
       Pointee: 261 StructureType table<uint8,uint8>
+    - __kind: PointerType
+      ID: 921
+      Name: '*text/tabwriter.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.151168e+06
+      GoKind: 22
+      Pointee: 922 UnresolvedPointeeType text/tabwriter.Writer
+    - __kind: PointerType
+      ID: 642
+      Name: '*text/template.ExecError'
+      ByteSize: 8
+      GoRuntimeType: 1.084352e+06
+      GoKind: 22
+      Pointee: 643 StructureType text/template.ExecError
+    - __kind: PointerType
+      ID: 717
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.617024e+06
+      GoKind: 22
+      Pointee: 718 UnresolvedPointeeType time.Location
+    - __kind: PointerType
+      ID: 385
+      Name: '*time.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 897536
+      GoKind: 22
+      Pointee: 386 UnresolvedPointeeType time.ParseError
+    - __kind: PointerType
+      ID: 384
+      Name: '*time.fileSizeError'
+      ByteSize: 8
+      GoRuntimeType: 897440
+      GoKind: 22
+      Pointee: 306 GoStringHeaderType time.fileSizeError
+    - __kind: PointerType
+      ID: 308
+      Name: '*time.fileSizeError.str'
+      ByteSize: 8
+      Pointee: 307 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4171,11 +6274,53 @@ Types:
       GoRuntimeType: 390208
       GoKind: 22
       Pointee: 1 BaseType uintptr
+    - __kind: PointerType
+      ID: 473
+      Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
+      ByteSize: 8
+      GoRuntimeType: 915584
+      GoKind: 22
+      Pointee: 474 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+    - __kind: PointerType
+      ID: 913
+      Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.126624e+06
+      GoKind: 22
+      Pointee: 914 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 457
+      Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 911744
+      GoKind: 22
+      Pointee: 458 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 459
+      Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 911840
+      GoKind: 22
+      Pointee: 347 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 621
+      Name: '*vendor/golang.org/x/net/idna.labelError'
+      ByteSize: 8
+      GoRuntimeType: 1.042752e+06
+      GoKind: 22
+      Pointee: 622 StructureType vendor/golang.org/x/net/idna.labelError
+    - __kind: PointerType
+      ID: 623
+      Name: '*vendor/golang.org/x/net/idna.runeError'
+      ByteSize: 8
+      GoRuntimeType: 1.04288e+06
+      GoKind: 22
+      Pointee: 576 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 506
+      ID: 1169
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 463
+      ID: 1126
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4190,7 +6335,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 461
+      ID: 1124
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4205,7 +6350,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 425
+      ID: 1088
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4220,7 +6365,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 423
+      ID: 1086
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4235,7 +6380,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 471
+      ID: 1134
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4250,7 +6395,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 424
+      ID: 1087
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4265,7 +6410,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 443
+      ID: 1106
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4280,7 +6425,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 412
+      ID: 1075
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4295,7 +6440,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 409
+      ID: 1072
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4310,7 +6455,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 487
+      ID: 1150
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4325,7 +6470,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 485
+      ID: 1148
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4358,7 +6503,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 495
+      ID: 1158
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4373,7 +6518,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 448
+      ID: 1111
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4388,7 +6533,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 449
+      ID: 1112
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4403,7 +6548,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 444
+      ID: 1107
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4418,7 +6563,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 445
+      ID: 1108
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4433,7 +6578,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 446
+      ID: 1109
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4448,7 +6593,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 447
+      ID: 1110
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4463,7 +6608,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 1163
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4487,7 +6632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 1160
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4502,7 +6647,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 514
+      ID: 1177
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4517,7 +6662,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 517
+      ID: 1180
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4532,7 +6677,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 516
+      ID: 1179
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4547,7 +6692,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 462
+      ID: 1125
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4562,7 +6707,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 453
+      ID: 1116
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4577,7 +6722,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 452
+      ID: 1115
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4592,7 +6737,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 459
+      ID: 1122
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4607,7 +6752,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 458
+      ID: 1121
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4622,7 +6767,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 454
+      ID: 1117
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4637,7 +6782,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 456
+      ID: 1119
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4652,10 +6797,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 519
+      ID: 1182
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 455
+      ID: 1118
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4679,16 +6824,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 1183
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 521
+      ID: 1184
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 457
+      ID: 1120
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 518
+      ID: 1181
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4703,7 +6848,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 522
+      ID: 1185
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4718,7 +6863,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 523
+      ID: 1186
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4733,7 +6878,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 415
+      ID: 1078
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4748,7 +6893,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 416
+      ID: 1079
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4763,7 +6908,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 417
+      ID: 1080
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4778,7 +6923,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 414
+      ID: 1077
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4793,7 +6938,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 413
+      ID: 1076
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4808,7 +6953,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 460
+      ID: 1123
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4823,7 +6968,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 1152
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4838,7 +6983,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 469
+      ID: 1132
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4853,7 +6998,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 1138
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4868,7 +7013,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 1136
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4883,7 +7028,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 484
+      ID: 1147
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4898,7 +7043,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 483
+      ID: 1146
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4913,7 +7058,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 1137
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4928,7 +7073,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 482
+      ID: 1145
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4943,7 +7088,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 1144
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4958,7 +7103,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 467
+      ID: 1130
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4973,7 +7118,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 468
+      ID: 1131
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4988,7 +7133,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 466
+      ID: 1129
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5003,7 +7148,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 1139
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5018,7 +7163,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 1143
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5033,7 +7178,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 1142
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5048,7 +7193,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 1141
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5063,7 +7208,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 1140
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5078,7 +7223,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 512
+      ID: 1175
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5093,7 +7238,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 486
+      ID: 1149
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5144,7 +7289,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 494
+      ID: 1157
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5168,7 +7313,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 1164
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5192,7 +7337,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 503
+      ID: 1166
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5225,7 +7370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 504
+      ID: 1167
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5240,7 +7385,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 1174
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5255,7 +7400,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 490
+      ID: 1153
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5270,7 +7415,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 1135
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5285,7 +7430,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 488
+      ID: 1151
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5300,7 +7445,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 410
+      ID: 1073
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5315,7 +7460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 429
+      ID: 1092
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5330,7 +7475,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 427
+      ID: 1090
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5345,7 +7490,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 440
+      ID: 1103
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5360,7 +7505,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 441
+      ID: 1104
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5375,7 +7520,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 432
+      ID: 1095
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5390,7 +7535,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 433
+      ID: 1096
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5405,7 +7550,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 434
+      ID: 1097
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5420,7 +7565,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 431
+      ID: 1094
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5435,7 +7580,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 430
+      ID: 1093
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5450,7 +7595,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 428
+      ID: 1091
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5465,7 +7610,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 507
+      ID: 1170
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5480,7 +7625,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 437
+      ID: 1100
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5495,7 +7640,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 438
+      ID: 1101
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5510,7 +7655,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 439
+      ID: 1102
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5525,7 +7670,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 436
+      ID: 1099
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5540,7 +7685,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 435
+      ID: 1098
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5555,7 +7700,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 1161
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5570,7 +7715,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 470
+      ID: 1133
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5585,7 +7730,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 411
+      ID: 1074
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5600,7 +7745,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 493
+      ID: 1156
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5615,7 +7760,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 502
+      ID: 1165
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5630,7 +7775,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 450
+      ID: 1113
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5645,7 +7790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 451
+      ID: 1114
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5660,7 +7805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 1162
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5684,7 +7829,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 1127
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5699,7 +7844,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 465
+      ID: 1128
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5714,7 +7859,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 515
+      ID: 1178
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5729,7 +7874,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 510
+      ID: 1173
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5744,7 +7889,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 509
+      ID: 1172
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5759,7 +7904,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 508
+      ID: 1171
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5792,7 +7937,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 442
+      ID: 1105
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5807,7 +7952,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 420
+      ID: 1083
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5822,7 +7967,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 421
+      ID: 1084
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5837,7 +7982,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 1085
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5852,7 +7997,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 419
+      ID: 1082
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5867,7 +8012,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 418
+      ID: 1081
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5882,7 +8027,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 492
+      ID: 1155
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5897,7 +8042,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 1159
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5912,7 +8057,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 513
+      ID: 1176
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5927,7 +8072,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 491
+      ID: 1154
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5942,7 +8087,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 426
+      ID: 1089
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5957,7 +8102,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 505
+      ID: 1168
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6130,6 +8275,15 @@ Types:
       Count: 5
       HasCount: true
       Element: 7 BaseType int
+    - __kind: ArrayType
+      ID: 746
+      Name: '[5]uint8'
+      ByteSize: 5
+      GoRuntimeType: 680672
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*main.deepSlice2'
@@ -6153,7 +8307,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 324
+      ID: 987
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474944
@@ -6161,21 +8315,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 325 PointerType **main.deepSlice3
+          Type: 988 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 328 GoSliceDataType []*main.deepSlice3.array
+      Data: 991 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 991
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 326 PointerType *main.deepSlice3
+      Element: 989 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 351
+      ID: 1014
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474624
@@ -6183,21 +8337,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 352 PointerType **main.deepSlice8
+          Type: 1015 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 355 GoSliceDataType []*main.deepSlice8.array
+      Data: 1018 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 355
+      ID: 1018
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 353 PointerType *main.deepSlice8
+      Element: 1016 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 357
+      ID: 1020
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474560
@@ -6205,19 +8359,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 358 PointerType **main.deepSlice9
+          Type: 1021 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 361 GoSliceDataType []*main.deepSlice9.array
+      Data: 1024 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 1024
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 359 PointerType *main.deepSlice9
+      Element: 1022 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6266,30 +8420,30 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 1006
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 334 PointerType *table<int,*main.deepMap3>
+      Element: 997 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 379
+      ID: 1042
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 370 PointerType *table<int,*main.deepMap8>
+      Element: 1033 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 1057
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 385 PointerType *table<int,*main.deepMap9>
+      Element: 1048 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 1070
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 400 PointerType *table<int,interface {}>
+      Element: 1063 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]*table<int,uint8>.array'
@@ -6305,6 +8459,11 @@ Types:
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 762
+      Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
+      ByteSize: 8192
+      Element: 728 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 216
       Name: '[]*table<string,int>.array'
@@ -6369,7 +8528,29 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 363
+      ID: 741
+      Name: '[]float64'
+      ByteSize: 24
+      GoRuntimeType: 483776
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 25 PointerType *float64
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 766 GoSliceDataType []float64.array
+    - __kind: GoSliceDataType
+      ID: 766
+      Name: '[]float64.array'
+      ByteSize: 2048
+      Element: 18 BaseType float64
+    - __kind: GoSliceHeaderType
+      ID: 1026
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484224
@@ -6384,9 +8565,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 364 GoSliceDataType []interface {}.array
+      Data: 1027 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 1027
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
@@ -6406,9 +8587,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 345 GoSliceDataType []main.structWithMap.array
+      Data: 1008 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 1008
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -6459,30 +8640,30 @@ Types:
       ByteSize: 2048
       Element: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 1007
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 338 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1001 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 1043
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 374 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1037 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 1058
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 389 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1052 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 201
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 197 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 408
+      ID: 1071
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 404 StructureType noalg.map.group[int]interface {}
+      Element: 1067 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]noalg.map.group[int]uint8.array'
@@ -6498,6 +8679,11 @@ Types:
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 221 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 763
+      Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 2048
+      Element: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 217
       Name: '[]noalg.map.group[string]int.array'
@@ -6584,12 +8770,104 @@ Types:
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
+    - __kind: GoSliceHeaderType
+      ID: 735
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 482752
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 5 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 764 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 764
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 898
+      Name: archive/tar.Writer
+      ByteSize: 8
+    - __kind: GoSliceHeaderType
+      ID: 536
+      Name: archive/tar.headerError
+      ByteSize: 24
+      GoRuntimeType: 926720
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 22 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 537 GoSliceDataType archive/tar.headerError.array
+    - __kind: GoSliceDataType
+      ID: 537
+      Name: archive/tar.headerError.array
+      ByteSize: 2048
+      Element: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 833
+      Name: archive/tar.regFileWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 781
+      Name: archive/zip.countWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 783
+      Name: archive/zip.dirWriter
+      GoRuntimeType: 1.115488e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 881
+      Name: archive/zip.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 809
+      Name: archive/zip.nopCloser
+      ByteSize: 16
+      GoRuntimeType: 1.55952e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 811
+      Name: archive/zip.pooledFlateWriter
+      ByteSize: 8
     - __kind: BaseType
       ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 581408
       GoKind: 1
+    - __kind: UnresolvedPointeeType
+      ID: 856
+      Name: bufio.Reader
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 885
+      Name: bufio.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 936
+      Name: bytes.Buffer
+      ByteSize: 8
     - __kind: GoChannelType
       ID: 153
       Name: chan bool
@@ -6612,6 +8890,355 @@ Types:
       ByteSize: 8
       GoRuntimeType: 581152
       GoKind: 15
+    - __kind: BaseType
+      ID: 339
+      Name: compress/flate.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 831136
+      GoKind: 6
+    - __kind: GoStringHeaderType
+      ID: 340
+      Name: compress/flate.InternalError
+      ByteSize: 16
+      GoRuntimeType: 831232
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 342 PointerType *compress/flate.InternalError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 341 GoStringDataType compress/flate.InternalError.str
+    - __kind: GoStringDataType
+      ID: 341
+      Name: compress/flate.InternalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 831
+      Name: compress/flate.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 777
+      Name: compress/flate.dictWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 853
+      Name: compress/gzip.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 680
+      Name: context.deadlineExceededError
+      GoRuntimeType: 1.47392e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 353
+      Name: crypto/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 833728
+      GoKind: 2
+    - __kind: BaseType
+      ID: 354
+      Name: crypto/des.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 833824
+      GoKind: 2
+    - __kind: BaseType
+      ID: 355
+      Name: crypto/internal/fips140/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 833920
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 843
+      Name: crypto/internal/fips140/hmac.HMAC
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 877
+      Name: crypto/internal/fips140/sha256.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 909
+      Name: crypto/internal/fips140/sha3.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 883
+      Name: crypto/internal/fips140/sha3.SHAKE
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 879
+      Name: crypto/internal/fips140/sha512.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 875
+      Name: crypto/md5.digest
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 356
+      Name: crypto/rc4.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 834016
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 893
+      Name: crypto/sha1.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 865
+      Name: crypto/sha3.SHA3
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 343
+      Name: crypto/tls.AlertError
+      ByteSize: 1
+      GoRuntimeType: 831712
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 620
+      Name: crypto/tls.CertificateVerificationError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 962
+      Name: crypto/tls.Conn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 452
+      Name: crypto/tls.ECHRejectionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 450
+      Name: crypto/tls.RecordHeaderError
+      ByteSize: 40
+      GoRuntimeType: 1.722944e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: RecordHeader
+          Offset: 16
+          Type: 746 ArrayType [5]uint8
+        - Name: Conn
+          Offset: 24
+          Type: 747 GoInterfaceType net.Conn
+    - __kind: BaseType
+      ID: 575
+      Name: crypto/tls.alert
+      ByteSize: 1
+      GoRuntimeType: 988960
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 841
+      Name: crypto/tls.cthWrapper
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 848
+      Name: crypto/tls.finishedHash
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 715
+      Name: crypto/tls.permanentError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 730
+      Name: crypto/x509.Certificate
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 524
+      Name: crypto/x509.CertificateInvalidError
+      ByteSize: 32
+      GoRuntimeType: 1.725824e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 729 PointerType *crypto/x509.Certificate
+        - Name: Reason
+          Offset: 8
+          Type: 749 BaseType crypto/x509.InvalidReason
+        - Name: Detail
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 518
+      Name: crypto/x509.ConstraintViolationError
+      GoRuntimeType: 1.113056e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 520
+      Name: crypto/x509.HostnameError
+      ByteSize: 24
+      GoRuntimeType: 1.59424e+06
+      GoKind: 25
+      RawFields:
+        - Name: Certificate
+          Offset: 0
+          Type: 729 PointerType *crypto/x509.Certificate
+        - Name: Host
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 352
+      Name: crypto/x509.InsecureAlgorithmError
+      ByteSize: 8
+      GoRuntimeType: 833344
+      GoKind: 2
+    - __kind: BaseType
+      ID: 749
+      Name: crypto/x509.InvalidReason
+      ByteSize: 8
+      GoRuntimeType: 586592
+      GoKind: 2
+    - __kind: StructureType
+      ID: 625
+      Name: crypto/x509.SystemRootsError
+      ByteSize: 16
+      GoRuntimeType: 1.55552e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 526
+      Name: crypto/x509.UnhandledCriticalExtension
+      GoRuntimeType: 1.113312e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 522
+      Name: crypto/x509.UnknownAuthorityError
+      ByteSize: 32
+      GoRuntimeType: 1.725632e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 729 PointerType *crypto/x509.Certificate
+        - Name: hintErr
+          Offset: 8
+          Type: 13 GoInterfaceType error
+        - Name: hintCert
+          Offset: 24
+          Type: 729 PointerType *crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 540
+      Name: encoding/asn1.StructuralError
+      ByteSize: 16
+      GoRuntimeType: 1.43136e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 544
+      Name: encoding/asn1.SyntaxError
+      ByteSize: 16
+      GoRuntimeType: 1.43152e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 542
+      Name: encoding/asn1.invalidUnmarshalError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 337
+      Name: encoding/base64.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 830752
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 799
+      Name: encoding/base64.encoder
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 338
+      Name: encoding/hex.InvalidByteError
+      ByteSize: 1
+      GoRuntimeType: 830944
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 409
+      Name: encoding/json.InvalidUnmarshalError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 611
+      Name: encoding/json.MarshalerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 401
+      Name: encoding/json.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 407
+      Name: encoding/json.UnmarshalTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 405
+      Name: encoding/json.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 403
+      Name: encoding/json.UnsupportedValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 942
+      Name: encoding/json.encodeState
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 411
+      Name: encoding/json.jsonError
+      ByteSize: 16
+      GoRuntimeType: 1.4152e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 807
+      Name: encoding/pem.lineBreaker
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 512
+      Name: encoding/xml.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 510
+      Name: encoding/xml.TagPathError
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 349
+      Name: encoding/xml.UnmarshalError
+      ByteSize: 16
+      GoRuntimeType: 833248
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 351 PointerType *encoding/xml.UnmarshalError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 350 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: GoStringDataType
+      ID: 350
+      Name: encoding/xml.UnmarshalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 515
+      Name: encoding/xml.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 920
+      Name: encoding/xml.printer
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 13
       Name: error
@@ -6625,6 +9252,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 379
+      Name: errors.errorString
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 578
+      Name: errors.joinError
+      ByteSize: 8
     - __kind: BaseType
       ID: 17
       Name: float32
@@ -6637,12 +9272,1062 @@ Types:
       ByteSize: 8
       GoRuntimeType: 581344
       GoKind: 14
+    - __kind: UnresolvedPointeeType
+      ID: 930
+      Name: fmt.pp
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 580
+      Name: fmt.wrapError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 582
+      Name: fmt.wrapErrors
+      ByteSize: 8
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
       GoRuntimeType: 473216
       GoKind: 19
+    - __kind: UnresolvedPointeeType
+      ID: 439
+      Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 420
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      ByteSize: 216
+      GoRuntimeType: 1.721792e+06
+      GoKind: 25
+      RawFields:
+        - Name: Metric
+          Offset: 0
+          Type: 739 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+        - Name: ChannelSize
+          Offset: 192
+          Type: 7 BaseType int
+        - Name: Msg
+          Offset: 200
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 422
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 743
+      Name: github.com/DataDog/datadog-go/v5/statsd.Event
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 426
+      Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      GoRuntimeType: 1.109344e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 745
+      Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 331
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      ByteSize: 16
+      GoRuntimeType: 830176
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: GoStringDataType
+      ID: 332
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 739
+      Name: github.com/DataDog/datadog-go/v5/statsd.metric
+      ByteSize: 192
+      GoRuntimeType: 2.210976e+06
+      GoKind: 25
+      RawFields:
+        - Name: metricType
+          Offset: 0
+          Type: 740 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+        - Name: namespace
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+        - Name: globalTags
+          Offset: 24
+          Type: 166 GoSliceHeaderType []string
+        - Name: name
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fvalue
+          Offset: 64
+          Type: 18 BaseType float64
+        - Name: fvalues
+          Offset: 72
+          Type: 741 GoSliceHeaderType []float64
+        - Name: ivalue
+          Offset: 96
+          Type: 12 BaseType int64
+        - Name: svalue
+          Offset: 104
+          Type: 9 GoStringHeaderType string
+        - Name: evalue
+          Offset: 120
+          Type: 742 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+        - Name: scvalue
+          Offset: 128
+          Type: 744 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+        - Name: tags
+          Offset: 136
+          Type: 166 GoSliceHeaderType []string
+        - Name: stags
+          Offset: 160
+          Type: 9 GoStringHeaderType string
+        - Name: rate
+          Offset: 176
+          Type: 18 BaseType float64
+        - Name: timestamp
+          Offset: 184
+          Type: 12 BaseType int64
+    - __kind: BaseType
+      ID: 740
+      Name: github.com/DataDog/datadog-go/v5/statsd.metricType
+      ByteSize: 8
+      GoRuntimeType: 583200
+      GoKind: 2
+    - __kind: GoStringHeaderType
+      ID: 328
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      ByteSize: 16
+      GoRuntimeType: 830080
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: GoStringDataType
+      ID: 329
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 334
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      ByteSize: 16
+      GoRuntimeType: 830272
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 336 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: GoStringDataType
+      ID: 335
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 821
+      Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 906
+      Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 534
+      Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 689
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 938
+      Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 461
+      Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 468
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      GoRuntimeType: 1.112288e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 348
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      ByteSize: 8
+      GoRuntimeType: 832384
+      GoKind: 2
+    - __kind: StructureType
+      ID: 466
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      GoRuntimeType: 1.11216e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 464
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      ByteSize: 32
+      GoRuntimeType: 1.59232e+06
+      GoKind: 25
+      RawFields:
+        - Name: OS
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Arch
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 484
+      Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      ByteSize: 32
+      GoRuntimeType: 1.59312e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 488
+      Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      ByteSize: 32
+      GoRuntimeType: 1.725056e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Size
+          Offset: 16
+          Type: 12 BaseType int64
+        - Name: MaxSize
+          Offset: 24
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 486
+      Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      ByteSize: 16
+      GoRuntimeType: 1.42496e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 482
+      Name: github.com/DataDog/go-tuf/client.ErrNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.42464e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 724
+      Name: github.com/DataDog/go-tuf/data.Hashes
+      ByteSize: 8
+      GoRuntimeType: 1.49488e+06
+      GoKind: 21
+      HeaderType: 726 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+    - __kind: GoSliceHeaderType
+      ID: 748
+      Name: github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 24
+      GoRuntimeType: 1.046336e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 5 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 768 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: GoSliceDataType
+      ID: 768
+      Name: github.com/DataDog/go-tuf/data.HexBytes.array
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: StructureType
+      ID: 496
+      Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      ByteSize: 16
+      GoRuntimeType: 1.59344e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 724 GoMapType github.com/DataDog/go-tuf/data.Hashes
+        - Name: Actual
+          Offset: 8
+          Type: 724 GoMapType github.com/DataDog/go-tuf/data.Hashes
+    - __kind: StructureType
+      ID: 490
+      Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      ByteSize: 16
+      GoRuntimeType: 1.42512e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 494
+      Name: github.com/DataDog/go-tuf/util.ErrWrongHash
+      ByteSize: 64
+      GoRuntimeType: 1.725248e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Expected
+          Offset: 16
+          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+        - Name: Actual
+          Offset: 40
+          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: StructureType
+      ID: 492
+      Name: github.com/DataDog/go-tuf/util.ErrWrongLength
+      ByteSize: 16
+      GoRuntimeType: 1.59328e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: Actual
+          Offset: 8
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 498
+      Name: github.com/DataDog/go-tuf/verify.ErrExpired
+      ByteSize: 24
+      GoRuntimeType: 1.42528e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expired
+          Offset: 0
+          Type: 716 StructureType time.Time
+    - __kind: StructureType
+      ID: 504
+      Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
+      ByteSize: 16
+      GoRuntimeType: 1.59376e+06
+      GoKind: 25
+      RawFields:
+        - Name: Actual
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: Current
+          Offset: 8
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 506
+      Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
+      ByteSize: 16
+      GoRuntimeType: 1.4256e+06
+      GoKind: 25
+      RawFields:
+        - Name: KeyID
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 502
+      Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      ByteSize: 16
+      GoRuntimeType: 1.5936e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: Actual
+          Offset: 8
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 500
+      Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      ByteSize: 16
+      GoRuntimeType: 1.42544e+06
+      GoKind: 25
+      RawFields:
+        - Name: Role
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 508
+      Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      ByteSize: 16
+      GoRuntimeType: 1.59392e+06
+      GoKind: 25
+      RawFields:
+        - Name: Given
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: Expected
+          Offset: 8
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 428
+      Name: github.com/cihub/seelog.baseError
+      ByteSize: 16
+      GoRuntimeType: 1.41744e+06
+      GoKind: 25
+      RawFields:
+        - Name: message
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 859
+      Name: github.com/cihub/seelog.bufferedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 430
+      Name: github.com/cihub/seelog.cannotOpenFileError
+      ByteSize: 16
+      GoRuntimeType: 1.4176e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 839
+      Name: github.com/cihub/seelog.connWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 795
+      Name: github.com/cihub/seelog.consoleWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 829
+      Name: github.com/cihub/seelog.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 434
+      Name: github.com/cihub/seelog.missingArgumentError
+      ByteSize: 16
+      GoRuntimeType: 1.41792e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 896
+      Name: github.com/cihub/seelog.rollingFileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 907
+      Name: github.com/cihub/seelog.rollingFileWriterSize
+      ByteSize: 16
+      GoRuntimeType: 2.09936e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 895 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: maxFileSize
+          Offset: 8
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 910
+      Name: github.com/cihub/seelog.rollingFileWriterTime
+      ByteSize: 40
+      GoRuntimeType: 2.123168e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 895 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: timePattern
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+        - Name: currentTimeFileName
+          Offset: 24
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 797
+      Name: github.com/cihub/seelog.smtpWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 432
+      Name: github.com/cihub/seelog.unexpectedAttributeError
+      ByteSize: 16
+      GoRuntimeType: 1.41776e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: StructureType
+      ID: 436
+      Name: github.com/cihub/seelog.unexpectedChildElementError
+      ByteSize: 16
+      GoRuntimeType: 1.41808e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 861
+      Name: github.com/cihub/seelog/archive/gzip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 902
+      Name: github.com/cihub/seelog/archive/tar.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 904
+      Name: github.com/cihub/seelog/archive/zip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 720
+      Name: github.com/go-viper/mapstructure/v2.DecodeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 633
+      Name: github.com/go-viper/mapstructure/v2.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 631
+      Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 635
+      Name: github.com/gogo/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 637
+      Name: github.com/gogo/protobuf/proto.invalidUTF8Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 850
+      Name: github.com/gogo/protobuf/proto.textWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 627
+      Name: github.com/golang/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 442
+      Name: github.com/google/uuid.invalidLengthError
+      ByteSize: 8
+      GoRuntimeType: 1.41904e+06
+      GoKind: 25
+      RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
+    - __kind: UnresolvedPointeeType
+      ID: 954
+      Name: github.com/json-iterator/go.Stream
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 691
+      Name: github.com/pkg/errors.fundamental
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 664
+      Name: github.com/tinylib/msgp/msgp.ArrayError
+      ByteSize: 24
+      GoRuntimeType: 1.833056e+06
+      GoKind: 25
+      RawFields:
+        - Name: Wanted
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Got
+          Offset: 4
+          Type: 2 BaseType uint32
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 658
+      Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 597
+      Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
+      ByteSize: 2
+      GoRuntimeType: 1.69584e+06
+      GoKind: 25
+      RawFields:
+        - Name: Got
+          Offset: 0
+          Type: 15 BaseType int8
+        - Name: Want
+          Offset: 1
+          Type: 15 BaseType int8
+    - __kind: StructureType
+      ID: 670
+      Name: github.com/tinylib/msgp/msgp.IntOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.833504e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 574
+      Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
+      ByteSize: 1
+      GoRuntimeType: 986272
+      GoKind: 8
+    - __kind: StructureType
+      ID: 662
+      Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
+      ByteSize: 32
+      GoRuntimeType: 1.832832e+06
+      GoKind: 25
+      RawFields:
+        - Name: Nanos
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: FieldLength
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 750
+      Name: github.com/tinylib/msgp/msgp.Type
+      ByteSize: 1
+      GoRuntimeType: 828352
+      GoKind: 8
+    - __kind: StructureType
+      ID: 660
+      Name: github.com/tinylib/msgp/msgp.TypeError
+      ByteSize: 24
+      GoRuntimeType: 1.832608e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 750 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: Encoded
+          Offset: 1
+          Type: 750 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 668
+      Name: github.com/tinylib/msgp/msgp.UintBelowZero
+      ByteSize: 24
+      GoRuntimeType: 1.747296e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 666
+      Name: github.com/tinylib/msgp/msgp.UintOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.83328e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 958
+      Name: github.com/tinylib/msgp/msgp.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 674
+      Name: github.com/tinylib/msgp/msgp.errFatal
+      ByteSize: 16
+      GoRuntimeType: 1.617984e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctx
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 601
+      Name: github.com/tinylib/msgp/msgp.errRecursion
+      GoRuntimeType: 1.278752e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 599
+      Name: github.com/tinylib/msgp/msgp.errShort
+      GoRuntimeType: 1.278624e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 672
+      Name: github.com/tinylib/msgp/msgp.errWrapped
+      ByteSize: 32
+      GoRuntimeType: 1.747488e+06
+      GoKind: 25
+      RawFields:
+        - Name: cause
+          Offset: 0
+          Type: 13 GoInterfaceType error
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 361
+      Name: go.opentelemetry.io/otel/trace.errorConst
+      ByteSize: 16
+      GoRuntimeType: 835840
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 363 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 362 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: GoStringDataType
+      ID: 362
+      Name: go.opentelemetry.io/otel/trace.errorConst.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 733
+      Name: go.uber.org/multierr.multiError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 641
+      Name: go.uber.org/zap.errArrayElem
+      ByteSize: 16
+      GoRuntimeType: 1.4432e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 827
+      Name: go.uber.org/zap.nopCloserSink
+      ByteSize: 16
+      GoRuntimeType: 1.671936e+06
+      GoKind: 25
+      RawFields:
+        - Name: WriteSyncer
+          Offset: 0
+          Type: 851 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+    - __kind: UnresolvedPointeeType
+      ID: 918
+      Name: go.uber.org/zap/buffer.Buffer
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 851
+      Name: go.uber.org/zap/zapcore.WriteSyncer
+      ByteSize: 16
+      GoRuntimeType: 1.12304e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 813
+      Name: go.uber.org/zap/zapcore.writerWrapper
+      ByteSize: 16
+      GoRuntimeType: 1.56448e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 364
+      Name: golang.org/x/net/http2.ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 836416
+      GoKind: 10
+    - __kind: BaseType
+      ID: 731
+      Name: golang.org/x/net/http2.ErrCode
+      ByteSize: 4
+      GoRuntimeType: 999424
+      GoKind: 10
+    - __kind: StructureType
+      ID: 699
+      Name: golang.org/x/net/http2.StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.872256e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 731 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 560
+      Name: golang.org/x/net/http2.connError
+      ByteSize: 24
+      GoRuntimeType: 1.60096e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 731 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 368
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 836608
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 370 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 369 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 369
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 374
+      Name: golang.org/x/net/http2.headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 836800
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 376 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 375 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 375
+      Name: golang.org/x/net/http2.headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 371
+      Name: golang.org/x/net/http2.headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 836704
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 373 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 372 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 372
+      Name: golang.org/x/net/http2.headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 365
+      Name: golang.org/x/net/http2.pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 836512
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 367 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 366 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 366
+      Name: golang.org/x/net/http2.pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 916
+      Name: golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 564
+      Name: golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.44384e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: BaseType
+      ID: 377
+      Name: golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 836896
+      GoKind: 2
+    - __kind: StructureType
+      ID: 552
+      Name: google.golang.org/grpc.dropError
+      ByteSize: 16
+      GoRuntimeType: 1.43888e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 697
+      Name: google.golang.org/grpc/internal/status.Error
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 722
+      Name: google.golang.org/grpc/internal/transport.ConnectionError
+      ByteSize: 40
+      GoRuntimeType: 1.90016e+06
+      GoKind: 25
+      RawFields:
+        - Name: Desc
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: temp
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: err
+          Offset: 24
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 554
+      Name: google.golang.org/grpc/internal/transport.NewStreamError
+      ByteSize: 24
+      GoRuntimeType: 1.60048e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+        - Name: AllowTransparentRetry
+          Offset: 16
+          Type: 4 BaseType bool
+    - __kind: StructureType
+      ID: 867
+      Name: google.golang.org/grpc/internal/transport.bufConn
+      ByteSize: 32
+      GoRuntimeType: 1.957728e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 747 GoInterfaceType net.Conn
+        - Name: r
+          Offset: 16
+          Type: 894 GoInterfaceType io.Reader
+    - __kind: UnresolvedPointeeType
+      ID: 825
+      Name: google.golang.org/grpc/internal/transport.bufWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 639
+      Name: google.golang.org/grpc/internal/transport.ioError
+      ByteSize: 16
+      GoRuntimeType: 1.56208e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 785
+      Name: google.golang.org/grpc/mem.writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 532
+      Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 629
+      Name: google.golang.org/protobuf/internal/errors.prefixError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 695
+      Name: google.golang.org/protobuf/internal/errors.wrapError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 693
+      Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      GoRuntimeType: 1.50544e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 546
+      Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.43216e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 548
+      Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
+      ByteSize: 16
+      GoRuntimeType: 1.43232e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 476
+      Name: gopkg.in/yaml%2ev3.TypeError
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
       ID: 287
       Name: groupReference<[4]int,[4]int>
@@ -6714,47 +10399,47 @@ Types:
       GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 336
+      ID: 999
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 337 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1000 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 344 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1001 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1007 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 372
+      ID: 1035
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 373 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1036 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 380 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1037 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1043 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 387
+      ID: 1050
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 388 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1051 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 395 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1052 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1058 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 195
       Name: groupReference<int,int>
@@ -6770,19 +10455,19 @@ Types:
       GroupType: 197 StructureType noalg.map.group[int]int
       GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 402
+      ID: 1065
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 403 PointerType *noalg.map.group[int]interface {}
+          Type: 1066 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 404 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 408 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1067 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1071 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 254
       Name: groupReference<int,uint8>
@@ -6825,6 +10510,20 @@ Types:
           Type: 8 BaseType uint64
       GroupType: 221 StructureType noalg.map.group[string][]string
       GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 757
+      Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 758 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 763 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 211
       Name: groupReference<string,int>
@@ -6881,6 +10580,14 @@ Types:
           Type: 8 BaseType uint64
       GroupType: 264 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
+    - __kind: UnresolvedPointeeType
+      ID: 873
+      Name: hash/crc32.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 567
+      Name: html/template.Error
+      ByteSize: 8
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6924,8 +10631,38 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 446
+      Name: internal/bisect.parseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 444
+      Name: internal/chacha8rand.errUnmarshalChaCha8
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 771
+      Name: internal/godebug.runtimeStderr
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 656
+      Name: internal/poll.DeadlineExceededError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 960
+      Name: internal/poll.FD
+      ByteSize: 8
     - __kind: StructureType
-      ID: 313
+      ID: 654
+      Name: internal/poll.errNetClosing
+      GoRuntimeType: 1.47072e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 381
+      Name: internal/reflectlite.ValueError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 972
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.46816e+06
@@ -6937,6 +10674,49 @@ Types:
         - Name: sema
           Offset: 4
           Type: 2 BaseType uint32
+    - __kind: UnresolvedPointeeType
+      ID: 817
+      Name: io.PipeWriter
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 857
+      Name: io.ReadWriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.18576e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 894
+      Name: io.Reader
+      ByteSize: 16
+      GoRuntimeType: 1.018944e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 846
+      Name: io.WriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.105632e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 55
       Name: io.Writer
@@ -6950,6 +10730,24 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 815
+      Name: io.discard
+      GoRuntimeType: 1.45808e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 789
+      Name: io.multiWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 652
+      Name: io/fs.PathError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 863
+      Name: log/slog/internal/buffer.Buffer
+      ByteSize: 8
     - __kind: StructureType
       ID: 173
       Name: main.aStruct
@@ -7015,9 +10813,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 330 GoMapType map[int]*main.deepMap3
+          Type: 993 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 1005
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7029,9 +10827,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 366 GoMapType map[int]*main.deepMap8
+          Type: 1029 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 378
+      ID: 1041
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.181536e+06
@@ -7039,9 +10837,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 381 GoMapType map[int]*main.deepMap9
+          Type: 1044 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 393
+      ID: 1056
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.181408e+06
@@ -7049,7 +10847,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 396 GoMapType map[int]interface {}
+          Type: 1059 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7069,9 +10867,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 306 PointerType *main.deepPtr3
+          Type: 963 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 307
+      ID: 964
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7083,9 +10881,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 347 PointerType *main.deepPtr8
+          Type: 1010 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 348
+      ID: 1011
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.182688e+06
@@ -7093,9 +10891,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 349 PointerType *main.deepPtr9
+          Type: 1012 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 350
+      ID: 1013
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18256e+06
@@ -7123,9 +10921,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 324 GoSliceHeaderType []*main.deepSlice3
+          Type: 987 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 990
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7137,9 +10935,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 351 GoSliceHeaderType []*main.deepSlice8
+          Type: 1014 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 354
+      ID: 1017
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.18384e+06
@@ -7147,9 +10945,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 357 GoSliceHeaderType []*main.deepSlice9
+          Type: 1020 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 360
+      ID: 1023
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.183712e+06
@@ -7157,7 +10955,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 363 GoSliceHeaderType []interface {}
+          Type: 1026 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 175
       Name: main.emptyStruct
@@ -7175,16 +10973,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 311 StructureType sync.Mutex
+          Type: 970 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 314 StructureType sync.Once
+          Type: 973 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 317 StructureType sync.WaitGroup
+          Type: 976 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 320 StructureType sync/atomic.Int32
+          Type: 979 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -7213,6 +11011,16 @@ Types:
         - Name: foo
           Offset: 56
           Type: 83 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 981
+      Name: main.firstBehavior
+      ByteSize: 16
+      GoRuntimeType: 1.40832e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
       ID: 174
       Name: main.nestedStruct
@@ -7248,6 +11056,13 @@ Types:
         - Name: a
           Offset: 0
           Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 983
+      Name: main.secondBehavior
+      ByteSize: 8
+      GoRuntimeType: 1.40848e+06
+      GoKind: 25
+      RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 82
       Name: main.something
@@ -7261,6 +11076,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 969
+      Name: main.somethingImpl
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 76
       Name: main.stringType1
@@ -7269,17 +11088,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *main.stringType1.str
+          Type: 966 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 308 GoStringDataType main.stringType1.str
+      Data: 965 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 965
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 310
+      ID: 967
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -7334,16 +11153,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 321 PointerType **main.t
+          Type: 984 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 322 GoSliceDataType main.t.array
+      Data: 985 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 322
+      ID: 985
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -7528,7 +11347,7 @@ Types:
       TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 332
+      ID: 995
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7541,7 +11360,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 333 PointerType **table<int,*main.deepMap3>
+          Type: 996 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7557,10 +11376,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 343 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1006 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1001 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 368
+      ID: 1031
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7573,7 +11392,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 369 PointerType **table<int,*main.deepMap8>
+          Type: 1032 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7589,10 +11408,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 379 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1042 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1037 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 383
+      ID: 1046
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7605,7 +11424,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 384 PointerType **table<int,*main.deepMap9>
+          Type: 1047 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7621,8 +11440,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 394 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1057 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1052 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 93
       Name: map<int,int>
@@ -7656,7 +11475,7 @@ Types:
       TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
       GroupType: 197 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 398
+      ID: 1061
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7669,7 +11488,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 399 PointerType **table<int,interface {}>
+          Type: 1062 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7685,8 +11504,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 407 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 404 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1070 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1067 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 130
       Name: map<int,uint8>
@@ -7783,6 +11602,38 @@ Types:
           Type: 8 BaseType uint64
       TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
       GroupType: 221 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 726
+      Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 727 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 762 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -7947,26 +11798,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 330
+      ID: 993
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124704e+06
       GoKind: 21
-      HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 995 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 366
+      ID: 1029
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.124064e+06
       GoKind: 21
-      HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1031 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 381
+      ID: 1044
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.123936e+06
       GoKind: 21
-      HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1046 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
@@ -7975,12 +11826,12 @@ Types:
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 396
+      ID: 1059
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.123808e+06
       GoKind: 21
-      HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1061 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
@@ -8030,6 +11881,601 @@ Types:
       GoRuntimeType: 1.12624e+06
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: StructureType
+      ID: 480
+      Name: math/big.ErrNaN
+      ByteSize: 16
+      GoRuntimeType: 1.42432e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 779
+      Name: mime/multipart.writerOnly·1
+      ByteSize: 16
+      GoRuntimeType: 1.42112e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 683
+      Name: net.AddrError
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 747
+      Name: net.Conn
+      ByteSize: 16
+      GoRuntimeType: 1.59104e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 709
+      Name: net.DNSError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 924
+      Name: net.IPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 707
+      Name: net.OpError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 685
+      Name: net.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 934
+      Name: net.TCPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 944
+      Name: net.UDPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 932
+      Name: net.UnixConn
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 644
+      Name: net.UnknownNetworkError
+      ByteSize: 16
+      GoRuntimeType: 1.10896e+06
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 646 PointerType *net.UnknownNetworkError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 645 GoStringDataType net.UnknownNetworkError.str
+    - __kind: GoStringDataType
+      ID: 645
+      Name: net.UnknownNetworkError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 613
+      Name: net.canceledError
+      GoRuntimeType: 1.279776e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 900
+      Name: net.conn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 752
+      Name: net.dialResult·1
+      ByteSize: 40
+      GoRuntimeType: 2.098656e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 747 GoInterfaceType net.Conn
+        - Name: error
+          Offset: 16
+          Type: 13 GoInterfaceType error
+        - Name: primary
+          Offset: 32
+          Type: 4 BaseType bool
+        - Name: done
+          Offset: 33
+          Type: 4 BaseType bool
+    - __kind: UnresolvedPointeeType
+      ID: 946
+      Name: net.netFD
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 940
+      Name: net.noReadFrom
+      GoRuntimeType: 1.109216e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 939
+      Name: net.noWriteTo
+      GoRuntimeType: 1.109088e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 413
+      Name: net.notFoundError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 415
+      Name: net.result·2
+      ByteSize: 112
+      GoRuntimeType: 1.7216e+06
+      GoKind: 25
+      RawFields:
+        - Name: p
+          Offset: 0
+          Type: 734 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+        - Name: server
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: error
+          Offset: 96
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 928
+      Name: net.tcpConnWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.283392e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 940 StructureType net.noReadFrom
+        - Name: TCPConn
+          Offset: 0
+          Type: 933 PointerType *net.TCPConn
+    - __kind: StructureType
+      ID: 926
+      Name: net.tcpConnWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.282848e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 939 StructureType net.noWriteTo
+        - Name: TCPConn
+          Offset: 0
+          Type: 933 PointerType *net.TCPConn
+    - __kind: UnresolvedPointeeType
+      ID: 687
+      Name: net.temporaryError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 711
+      Name: net.timeoutError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 603
+      Name: net/http.ProtocolError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 773
+      Name: net/http.bufioFlushWriter
+      ByteSize: 16
+      GoRuntimeType: 1.41264e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 309
+      Name: net/http.http2ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 828832
+      GoKind: 10
+    - __kind: BaseType
+      ID: 723
+      Name: net/http.http2ErrCode
+      ByteSize: 4
+      GoRuntimeType: 986368
+      GoKind: 10
+    - __kind: StructureType
+      ID: 391
+      Name: net/http.http2GoAwayError
+      ByteSize: 24
+      GoRuntimeType: 1.719872e+06
+      GoKind: 25
+      RawFields:
+        - Name: LastStreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: ErrCode
+          Offset: 4
+          Type: 723 BaseType net/http.http2ErrCode
+        - Name: DebugData
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 703
+      Name: net/http.http2StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.891456e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 723 BaseType net/http.http2ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 395
+      Name: net/http.http2connError
+      ByteSize: 24
+      GoRuntimeType: 1.59056e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 723 BaseType net/http.http2ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 835
+      Name: net/http.http2dataBuffer
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 313
+      Name: net/http.http2duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 829024
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 315 PointerType *net/http.http2duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 314
+      Name: net/http.http2duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 319
+      Name: net/http.http2headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 829216
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 321 PointerType *net/http.http2headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 320 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 320
+      Name: net/http.http2headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 316
+      Name: net/http.http2headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 829120
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 318 PointerType *net/http.http2headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 317 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 317
+      Name: net/http.http2headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 678
+      Name: net/http.http2httpError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 609
+      Name: net/http.http2noCachedConnError
+      GoRuntimeType: 1.279008e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 889
+      Name: net/http.http2pipe
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 310
+      Name: net/http.http2pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 828928
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 312 PointerType *net/http.http2pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 311
+      Name: net/http.http2pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 775
+      Name: net/http.http2stickyErrWriter
+      ByteSize: 48
+      GoRuntimeType: 1.815744e+06
+      GoKind: 25
+      RawFields:
+        - Name: group
+          Offset: 0
+          Type: 868 GoInterfaceType net/http.http2synctestGroupInterface
+        - Name: conn
+          Offset: 16
+          Type: 747 GoInterfaceType net.Conn
+        - Name: timeout
+          Offset: 32
+          Type: 869 BaseType time.Duration
+        - Name: err
+          Offset: 40
+          Type: 33 PointerType *error
+    - __kind: GoInterfaceType
+      ID: 868
+      Name: net/http.http2synctestGroupInterface
+      ByteSize: 16
+      GoRuntimeType: 1.412e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: ArrayType
+      ID: 854
+      Name: net/http.incomparable
+      GoRuntimeType: 898784
+      GoKind: 17
+      HasCount: true
+      Element: 83 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 605
+      Name: net/http.nothingWrittenError
+      ByteSize: 16
+      GoRuntimeType: 1.5496e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 837
+      Name: net/http.persistConn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 793
+      Name: net/http.persistConnWriter
+      ByteSize: 8
+      GoRuntimeType: 1.54944e+06
+      GoKind: 25
+      RawFields:
+        - Name: pc
+          Offset: 0
+          Type: 836 PointerType *net/http.persistConn
+    - __kind: StructureType
+      ID: 819
+      Name: net/http.readWriteCloserBody
+      ByteSize: 24
+      GoRuntimeType: 1.791744e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 854 ArrayType net/http.incomparable
+        - Name: br
+          Offset: 0
+          Type: 855 PointerType *bufio.Reader
+        - Name: ReadWriteCloser
+          Offset: 8
+          Type: 857 GoInterfaceType io.ReadWriteCloser
+    - __kind: StructureType
+      ID: 399
+      Name: net/http.requestBodyReadError
+      ByteSize: 16
+      GoRuntimeType: 1.4136e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 705
+      Name: net/http.timeoutError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 676
+      Name: net/http.tlsHandshakeTimeoutError
+      GoRuntimeType: 1.4736e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 607
+      Name: net/http.transportReadFromServerError
+      ByteSize: 16
+      GoRuntimeType: 1.54976e+06
+      GoKind: 25
+      RawFields:
+        - Name: err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 871
+      Name: net/http.unencryptedNetConnInTLSConn
+      ByteSize: 32
+      GoRuntimeType: 2.017632e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 747 GoInterfaceType net.Conn
+        - Name: conn
+          Offset: 16
+          Type: 747 GoInterfaceType net.Conn
+    - __kind: UnresolvedPointeeType
+      ID: 388
+      Name: net/http.unsupportedTEError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 891
+      Name: net/http/internal.FlushAfterChunkWriter
+      ByteSize: 8
+      GoRuntimeType: 2.033664e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 884 PointerType *bufio.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 803
+      Name: net/http/internal.chunkedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 472
+      Name: net/netip.parseAddrError
+      ByteSize: 48
+      GoRuntimeType: 1.724672e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: at
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 470
+      Name: net/netip.parsePrefixError
+      ByteSize: 32
+      GoRuntimeType: 1.59248e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 845
+      Name: net/smtp.Client
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 805
+      Name: net/smtp.dataCloser
+      ByteSize: 24
+      GoRuntimeType: 1.5944e+06
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 844 PointerType *net/smtp.Client
+        - Name: WriteCloser
+          Offset: 8
+          Type: 846 GoInterfaceType io.WriteCloser
+    - __kind: UnresolvedPointeeType
+      ID: 456
+      Name: net/textproto.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 344
+      Name: net/textproto.ProtocolError
+      ByteSize: 16
+      GoRuntimeType: 831808
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 346 PointerType *net/textproto.ProtocolError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 345 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: GoStringDataType
+      ID: 345
+      Name: net/textproto.ProtocolError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 801
+      Name: net/textproto.dotWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 713
+      Name: net/url.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 322
+      Name: net/url.EscapeError
+      ByteSize: 16
+      GoRuntimeType: 829792
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 324 PointerType *net/url.EscapeError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 323 GoStringDataType net/url.EscapeError.str
+    - __kind: GoStringDataType
+      ID: 323
+      Name: net/url.EscapeError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 325
+      Name: net/url.InvalidHostError
+      ByteSize: 16
+      GoRuntimeType: 829888
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 327 PointerType *net/url.InvalidHostError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 326 GoStringDataType net/url.InvalidHostError.str
+    - __kind: GoStringDataType
+      ID: 326
+      Name: net/url.InvalidHostError.str
+      ByteSize: 2048
     - __kind: ArrayType
       ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
@@ -8076,32 +12522,32 @@ Types:
       HasCount: true
       Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 339
+      ID: 1002
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678464
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 340 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1003 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 375
+      ID: 1038
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 677984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 376 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1039 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 390
+      ID: 1053
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 391 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1054 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 198
       Name: noalg.[8]struct { key int; elem int }
@@ -8112,14 +12558,14 @@ Types:
       HasCount: true
       Element: 199 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 405
+      ID: 1068
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 406 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1069 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -8147,6 +12593,15 @@ Types:
       Count: 8
       HasCount: true
       Element: 223 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 760
+      Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      ByteSize: 320
+      GoRuntimeType: 755104
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 761 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 214
       Name: noalg.[8]struct { key string; elem int }
@@ -8249,7 +12704,7 @@ Types:
           Offset: 8
           Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 338
+      ID: 1001
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.290272e+06
@@ -8260,9 +12715,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 339 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1002 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 374
+      ID: 1037
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.288992e+06
@@ -8273,9 +12728,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 375 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1038 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 389
+      ID: 1052
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.288736e+06
@@ -8286,7 +12741,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 390 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1053 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 197
       Name: noalg.map.group[int]int
@@ -8301,7 +12756,7 @@ Types:
           Offset: 8
           Type: 198 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 404
+      ID: 1067
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.28848e+06
@@ -8312,7 +12767,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 405 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1068 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 256
       Name: noalg.map.group[int]uint8
@@ -8352,6 +12807,19 @@ Types:
         - Name: slots
           Offset: 8
           Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 759
+      Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 328
+      GoRuntimeType: 1.353504e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 760 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 213
       Name: noalg.map.group[string]int
@@ -8470,7 +12938,7 @@ Types:
           Offset: 8
           Type: 190 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 340
+      ID: 1003
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.290144e+06
@@ -8481,9 +12949,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 341 PointerType *main.deepMap3
+          Type: 1004 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 376
+      ID: 1039
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.288864e+06
@@ -8494,9 +12962,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 377 PointerType *main.deepMap8
+          Type: 1040 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 391
+      ID: 1054
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.288608e+06
@@ -8507,7 +12975,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 392 PointerType *main.deepMap9
+          Type: 1055 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 199
       Name: noalg.struct { key int; elem int }
@@ -8522,7 +12990,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 406
+      ID: 1069
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.288352e+06
@@ -8573,6 +13041,19 @@ Types:
         - Name: elem
           Offset: 16
           Type: 166 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 761
+      Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      ByteSize: 40
+      GoRuntimeType: 1.353376e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 215
       Name: noalg.struct { key string; elem int }
@@ -8625,6 +13106,199 @@ Types:
         - Name: elem
           Offset: 1
           Type: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 952
+      Name: os.File
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 584
+      Name: os.LinkError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 648
+      Name: os.SyscallError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 950
+      Name: os.fileWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.352e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 956 StructureType os.noReadFrom
+        - Name: File
+          Offset: 0
+          Type: 951 PointerType *os.File
+    - __kind: StructureType
+      ID: 948
+      Name: os.fileWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.3512e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 955 StructureType os.noWriteTo
+        - Name: File
+          Offset: 0
+          Type: 951 PointerType *os.File
+    - __kind: StructureType
+      ID: 956
+      Name: os.noReadFrom
+      GoRuntimeType: 1.106528e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 955
+      Name: os.noWriteTo
+      GoRuntimeType: 1.1064e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 615
+      Name: os/exec.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 755
+      Name: os/exec.ExitError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 823
+      Name: os/exec.prefixSuffixSaver
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 617
+      Name: os/exec.wrappedError
+      ByteSize: 32
+      GoRuntimeType: 1.696416e+06
+      GoKind: 25
+      RawFields:
+        - Name: prefix
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: err
+          Offset: 16
+          Type: 13 GoInterfaceType error
+    - __kind: GoStringHeaderType
+      ID: 358
+      Name: os/user.UnknownGroupIdError
+      ByteSize: 16
+      GoRuntimeType: 835072
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 360 PointerType *os/user.UnknownGroupIdError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 359 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: GoStringDataType
+      ID: 359
+      Name: os/user.UnknownGroupIdError.str
+      ByteSize: 2048
+    - __kind: BaseType
+      ID: 357
+      Name: os/user.UnknownUserIdError
+      ByteSize: 8
+      GoRuntimeType: 834976
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 383
+      Name: reflect.ValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 478
+      Name: regexp/syntax.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 588
+      Name: runtime.PanicNilError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 592
+      Name: runtime.TypeAssertionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 590
+      Name: runtime.boundsError
+      ByteSize: 24
+      GoRuntimeType: 1.879872e+06
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: y
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: signed
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: code
+          Offset: 17
+          Type: 753 BaseType runtime.boundsErrorCode
+    - __kind: BaseType
+      ID: 753
+      Name: runtime.boundsErrorCode
+      ByteSize: 1
+      GoRuntimeType: 581536
+      GoKind: 8
+    - __kind: StructureType
+      ID: 650
+      Name: runtime.errorAddressString
+      ByteSize: 24
+      GoRuntimeType: 1.744224e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: addr
+          Offset: 16
+          Type: 1 BaseType uintptr
+    - __kind: GoStringHeaderType
+      ID: 568
+      Name: runtime.errorString
+      ByteSize: 16
+      GoRuntimeType: 985024
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 570 PointerType *runtime.errorString.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 569 GoStringDataType runtime.errorString.str
+    - __kind: GoStringDataType
+      ID: 569
+      Name: runtime.errorString.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 571
+      Name: runtime.plainError
+      ByteSize: 16
+      GoRuntimeType: 985120
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 573 PointerType *runtime.plainError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 572 GoStringDataType runtime.plainError.str
+    - __kind: GoStringDataType
+      ID: 572
+      Name: runtime.plainError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 594
+      Name: strconv.NumError
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
@@ -8643,8 +13317,26 @@ Types:
       ID: 177
       Name: string.str
       ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 887
+      Name: strings.Builder
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 791
+      Name: strings.appendSliceWriter
+      ByteSize: 8
     - __kind: StructureType
-      ID: 311
+      ID: 787
+      Name: struct { io.Writer }
+      ByteSize: 16
+      GoRuntimeType: 1.4504e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 970
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.45888e+06
@@ -8652,12 +13344,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 971 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 313 StructureType internal/sync.Mutex
+          Type: 972 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 314
+      ID: 973
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.607232e+06
@@ -8665,15 +13357,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 971 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 315 StructureType sync/atomic.Uint32
+          Type: 974 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 311 StructureType sync.Mutex
+          Type: 970 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 317
+      ID: 976
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.607424e+06
@@ -8681,21 +13373,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 971 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 318 StructureType sync/atomic.Uint64
+          Type: 977 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 312
+      ID: 971
       Name: sync.noCopy
       GoRuntimeType: 983968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 320
+      ID: 979
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.46016e+06
@@ -8703,12 +13395,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 975 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 315
+      ID: 974
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.46032e+06
@@ -8716,12 +13408,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 975 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 318
+      ID: 977
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607808e+06
@@ -8729,25 +13421,31 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 975 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 319 StructureType sync/atomic.align64
+          Type: 978 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 319
+      ID: 978
       Name: sync/atomic.align64
       GoRuntimeType: 984160
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 316
+      ID: 975
       Name: sync/atomic.noCopy
       GoRuntimeType: 984064
       GoKind: 25
       RawFields: []
+    - __kind: BaseType
+      ID: 700
+      Name: syscall.Errno
+      ByteSize: 8
+      GoRuntimeType: 1.278368e+06
+      GoKind: 12
     - __kind: StructureType
       ID: 286
       Name: table<[4]int,[4]int>
@@ -8869,7 +13567,7 @@ Types:
           Offset: 16
           Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 335
+      ID: 998
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8891,9 +13589,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 336 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 999 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 371
+      ID: 1034
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8915,9 +13613,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 372 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1035 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 386
+      ID: 1049
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8939,7 +13637,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 387 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1050 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 194
       Name: table<int,int>
@@ -8965,7 +13663,7 @@ Types:
           Offset: 16
           Type: 195 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 401
+      ID: 1064
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8987,7 +13685,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 402 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1065 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 253
       Name: table<int,uint8>
@@ -9060,6 +13758,30 @@ Types:
         - Name: groups
           Offset: 16
           Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 756
+      Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 757 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 210
       Name: table<string,int>
@@ -9156,6 +13878,71 @@ Types:
         - Name: groups
           Offset: 16
           Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
+    - __kind: UnresolvedPointeeType
+      ID: 922
+      Name: text/tabwriter.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 643
+      Name: text/template.ExecError
+      ByteSize: 32
+      GoRuntimeType: 1.700832e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 13 GoInterfaceType error
+    - __kind: BaseType
+      ID: 869
+      Name: time.Duration
+      ByteSize: 8
+      GoRuntimeType: 1.906016e+06
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 718
+      Name: time.Location
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 386
+      Name: time.ParseError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 716
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.36688e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 12 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 717 PointerType *time.Location
+    - __kind: GoStringHeaderType
+      ID: 306
+      Name: time.fileSizeError
+      ByteSize: 16
+      GoRuntimeType: 827968
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 308 PointerType *time.fileSizeError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 307 GoStringDataType time.fileSizeError.str
+    - __kind: GoStringDataType
+      ID: 307
+      Name: time.fileSizeError.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -9198,6 +13985,120 @@ Types:
       ByteSize: 8
       GoRuntimeType: 581472
       GoKind: 26
-MaxTypeID: 523
+    - __kind: StructureType
+      ID: 734
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
+      ByteSize: 80
+      GoRuntimeType: 2.055072e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 735 GoSliceHeaderType []uint8
+        - Name: header
+          Offset: 24
+          Type: 736 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+        - Name: section
+          Offset: 36
+          Type: 737 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+        - Name: off
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: index
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: resHeaderValid
+          Offset: 56
+          Type: 4 BaseType bool
+        - Name: resHeaderOffset
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: resHeaderType
+          Offset: 72
+          Type: 738 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+        - Name: resHeaderLength
+          Offset: 74
+          Type: 6 BaseType uint16
+    - __kind: BaseType
+      ID: 738
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Type
+      ByteSize: 2
+      GoRuntimeType: 990592
+      GoKind: 9
+    - __kind: StructureType
+      ID: 736
+      Name: vendor/golang.org/x/net/dns/dnsmessage.header
+      ByteSize: 12
+      GoRuntimeType: 1.916768e+06
+      GoKind: 25
+      RawFields:
+        - Name: id
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: bits
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: questions
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: answers
+          Offset: 6
+          Type: 6 BaseType uint16
+        - Name: authorities
+          Offset: 8
+          Type: 6 BaseType uint16
+        - Name: additionals
+          Offset: 10
+          Type: 6 BaseType uint16
+    - __kind: UnresolvedPointeeType
+      ID: 474
+      Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 737
+      Name: vendor/golang.org/x/net/dns/dnsmessage.section
+      ByteSize: 1
+      GoRuntimeType: 585120
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 914
+      Name: vendor/golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 458
+      Name: vendor/golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.42144e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: BaseType
+      ID: 347
+      Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 831904
+      GoKind: 2
+    - __kind: StructureType
+      ID: 622
+      Name: vendor/golang.org/x/net/idna.labelError
+      ByteSize: 32
+      GoRuntimeType: 1.696608e+06
+      GoKind: 25
+      RawFields:
+        - Name: label
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: code_
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 576
+      Name: vendor/golang.org/x/net/idna.runeError
+      ByteSize: 4
+      GoRuntimeType: 989440
+      GoKind: 5
+MaxTypeID: 1186
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17fa3a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 504 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcdd80a", Frameless: false}]
+        - ID: 98
+          Type: 506 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcdd8ca", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 460 EventRootType Probe[main.testAny]
+          Type: 461 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda74a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 462 EventRootType Probe[main.testAnyPtr]
+          Type: 463 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcda7ea", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 422 EventRootType Probe[main.testArrayOfArrays]
+          Type: 423 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 424 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 425 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -78,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 469 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcdae20", Frameless: true}]
+        - ID: 63
+          Type: 471 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcdaee0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 423 EventRootType Probe[main.testArrayOfStrings]
+          Type: 424 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 442 EventRootType Probe[main.testBigStruct]
+          Type: 443 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 411 EventRootType Probe[main.testBoolArray]
+          Type: 412 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 408 EventRootType Probe[main.testByteArray]
+          Type: 409 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 485 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcdcae0", Frameless: true}]
+        - ID: 79
+          Type: 487 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcdcba0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -162,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 483 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcdc700", Frameless: true}]
+        - ID: 77
+          Type: 485 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcdc7c0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -176,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 493 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcdce80", Frameless: true}]
+        - ID: 87
+          Type: 495 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcdcf40", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 447 EventRootType Probe[main.testDeepMap1]
+          Type: 448 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9700", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 448 EventRootType Probe[main.testDeepMap7]
+          Type: 449 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9720", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 443 EventRootType Probe[main.testDeepPtr1]
+          Type: 444 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd93e0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 444 EventRootType Probe[main.testDeepPtr7]
+          Type: 445 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9400", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 445 EventRootType Probe[main.testDeepSlice1]
+          Type: 446 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd9580", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 446 EventRootType Probe[main.testDeepSlice7]
+          Type: 447 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -292,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 495 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcdd3c0", Frameless: true}]
+        - ID: 89
+          Type: 497 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdd480", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -306,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 498 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
+        - ID: 92
+          Type: 500 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdd4e0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -320,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 512 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
+        - ID: 106
+          Type: 514 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 514 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcddd40", Frameless: true}]
+        - ID: 108
+          Type: 516 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcdde00", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 515 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcddd60", Frameless: true}]
+        - ID: 109
+          Type: 517 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcdde20", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 461 EventRootType Probe[main.testError]
+          Type: 462 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcda7c0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 452 EventRootType Probe[main.testEsotericHeap]
+          Type: 453 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9cca", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 451 EventRootType Probe[main.testEsotericStack]
+          Type: 452 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 457 EventRootType Probe[main.testFrameless]
+          Type: 458 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda420", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 458 EventRootType Probe[main.testFramelessArray]
+          Type: 459 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda444", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 453 EventRootType Probe[main.testInlinedBA]
+          Type: 454 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda10a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 454 EventRootType Probe[main.testInlinedBB]
+          Type: 455 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda1ae", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 455 EventRootType Probe[main.testInlinedBBA]
+          Type: 456 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda28a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 517 EventRootType Probe[main.testInlinedBBB]
+        - ID: 111
+          Type: 519 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda206", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 456 EventRootType Probe[main.testInlinedBC]
+          Type: 457 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda30e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 518 EventRootType Probe[main.testInlinedBCA]
+        - ID: 112
+          Type: 520 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda313", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 519 EventRootType Probe[main.testInlinedBCB]
+        - ID: 113
+          Type: 521 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda3bb", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 516 EventRootType Probe[main.testInlinedPrint]
+        - ID: 110
+          Type: 518 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd9f6a"
               Frameless: false
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 520 EventRootType Probe[main.testInlinedSq]
+        - ID: 114
+          Type: 522 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda421", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 114
-          Type: 521 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 115
+          Type: 523 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda465"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 414 EventRootType Probe[main.testInt16Array]
+          Type: 415 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 415 EventRootType Probe[main.testInt32Array]
+          Type: 416 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 416 EventRootType Probe[main.testInt64Array]
+          Type: 417 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 413 EventRootType Probe[main.testInt8Array]
+          Type: 414 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 412 EventRootType Probe[main.testIntArray]
+          Type: 413 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 459 EventRootType Probe[main.testInterface]
+          Type: 460 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda720", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -671,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 487 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
+        - ID: 81
+          Type: 489 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcdcd60", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -685,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 467 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcdade0", Frameless: true}]
+        - ID: 61
+          Type: 469 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcdaea0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -699,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 473 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcdaea0", Frameless: true}]
+        - ID: 67
+          Type: 475 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcdaf60", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -713,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 471 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcdae60", Frameless: true}]
+        - ID: 65
+          Type: 473 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcdaf20", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -727,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 482 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcdafc0", Frameless: true}]
+        - ID: 76
+          Type: 484 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdb080", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -741,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 481 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcdafa0", Frameless: true}]
+        - ID: 75
+          Type: 483 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcdb060", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -755,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 472 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcdae80", Frameless: true}]
+        - ID: 66
+          Type: 474 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcdaf40", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -769,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 480 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcdaf80", Frameless: true}]
+        - ID: 74
+          Type: 482 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdb040", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -783,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 479 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcdaf60", Frameless: true}]
+        - ID: 73
+          Type: 481 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcdb020", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -797,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 465 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcdada0", Frameless: true}]
+        - ID: 59
+          Type: 467 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcdae60", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -811,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 466 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcdadc0", Frameless: true}]
+        - ID: 60
+          Type: 468 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcdae80", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -825,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 464 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcdad80", Frameless: true}]
+        - ID: 58
+          Type: 466 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -839,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 474 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcdaec0", Frameless: true}]
+        - ID: 68
+          Type: 476 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcdaf80", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -853,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcdaf20", Frameless: true}]
+        - ID: 71
+          Type: 479 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcdafe0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -867,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 478 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcdaf40", Frameless: true}]
+        - ID: 72
+          Type: 480 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcdb000", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -881,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 475 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcdaee0", Frameless: true}]
+        - ID: 69
+          Type: 477 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcdafa0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -895,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 476 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcdaf00", Frameless: true}]
+        - ID: 70
+          Type: 478 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcdafc0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -909,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 510 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdd900", Frameless: true}]
+        - ID: 104
+          Type: 512 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -923,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 484 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcdc8c0", Frameless: true}]
+        - ID: 78
+          Type: 486 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcdc980", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -937,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 492 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcdce40", Frameless: true}]
+        - ID: 86
+          Type: 494 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcdcf00", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -951,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 502 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdd4a0", Frameless: true}]
+        - ID: 96
+          Type: 504 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdd560", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -965,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 499 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcdd440", Frameless: true}]
+        - ID: 93
+          Type: 501 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdd500", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -979,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 501 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdd480", Frameless: true}]
+        - ID: 95
+          Type: 503 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdd540", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -993,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 509 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcdd8e0", Frameless: true}]
+        - ID: 103
+          Type: 511 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcdd9a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1007,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 488 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcdccc0", Frameless: true}]
+        - ID: 82
+          Type: 490 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcdcd80", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1021,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 470 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
+        - ID: 64
+          Type: 472 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcdaf00", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1035,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 486 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcdcc80", Frameless: true}]
+        - ID: 80
+          Type: 488 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcdcd40", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 409 EventRootType Probe[main.testRuneArray]
+          Type: 410 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 428 EventRootType Probe[main.testSingleBool]
+          Type: 429 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 426 EventRootType Probe[main.testSingleByte]
+          Type: 427 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd8fe0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 439 EventRootType Probe[main.testSingleFloat32]
+          Type: 440 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 440 EventRootType Probe[main.testSingleFloat64]
+          Type: 441 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 429 EventRootType Probe[main.testSingleInt]
+          Type: 430 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 431 EventRootType Probe[main.testSingleInt16]
+          Type: 432 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 432 EventRootType Probe[main.testSingleInt32]
+          Type: 433 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 433 EventRootType Probe[main.testSingleInt64]
+          Type: 434 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 430 EventRootType Probe[main.testSingleInt8]
+          Type: 431 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 427 EventRootType Probe[main.testSingleRune]
+          Type: 428 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9000", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1203,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 505 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcdd860", Frameless: true}]
+        - ID: 99
+          Type: 507 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 434 EventRootType Probe[main.testSingleUint]
+          Type: 435 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 436 EventRootType Probe[main.testSingleUint16]
+          Type: 437 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 437 EventRootType Probe[main.testSingleUint32]
+          Type: 438 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 438 EventRootType Probe[main.testSingleUint64]
+          Type: 439 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 435 EventRootType Probe[main.testSingleUint8]
+          Type: 436 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1287,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 496 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
+        - ID: 90
+          Type: 498 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdd4a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1301,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 468 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcdae00", Frameless: true}]
+        - ID: 62
+          Type: 470 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcdaec0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 410 EventRootType Probe[main.testStringArray]
+          Type: 411 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1329,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 491 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcdce00", Frameless: true}]
+        - ID: 85
+          Type: 493 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcdcec0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1343,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 500 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
+        - ID: 94
+          Type: 502 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdd520", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 449 EventRootType Probe[main.testStringType1]
+          Type: 450 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 450 EventRootType Probe[main.testStringType2]
+          Type: 451 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 513 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcddbc0", Frameless: true}]
+        - ID: 107
+          Type: 515 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcddc80", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1405,11 +1405,28 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 497 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcdd400", Frameless: true}]
+        - ID: 91
+          Type: 499 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdd4c0", Frameless: true}]
+          Condition: null
+    - id: testStructWithAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithAny}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 56}
+      events:
+        - ID: 56
+          Type: 464 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xcda840", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1419,11 +1436,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 463 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcdad60", Frameless: true}]
+        - ID: 57
+          Type: 465 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcdae20", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1433,11 +1450,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 506 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcdd880", Frameless: true}]
+        - ID: 100
+          Type: 508 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1447,11 +1464,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 507 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcdd8a0", Frameless: true}]
+        - ID: 101
+          Type: 509 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcdd960", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1461,11 +1478,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 508 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcdd8c0", Frameless: true}]
+        - ID: 102
+          Type: 510 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcdd980", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1478,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 441 EventRootType Probe[main.testTypeAlias]
+          Type: 442 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1492,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 419 EventRootType Probe[main.testUint16Array]
+          Type: 420 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1506,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 420 EventRootType Probe[main.testUint32Array]
+          Type: 421 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1520,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 421 EventRootType Probe[main.testUint64Array]
+          Type: 422 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1534,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 418 EventRootType Probe[main.testUint8Array]
+          Type: 419 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1548,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 417 EventRootType Probe[main.testUintArray]
+          Type: 418 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1559,11 +1576,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 490 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcdcd20", Frameless: true}]
+        - ID: 84
+          Type: 492 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcdcde0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1573,11 +1590,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 494 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
+        - ID: 88
+          Type: 496 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1587,11 +1604,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 511 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
+        - ID: 105
+          Type: 513 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcdd9e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1601,11 +1618,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 489 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
+        - ID: 83
+          Type: 491 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcdcda0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1618,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 425 EventRootType Probe[main.testVeryLargeArray]
+          Type: 426 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1629,11 +1646,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 503 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdd4c0", Frameless: true}]
+        - ID: 97
+          Type: 505 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2442,308 +2459,324 @@ Subprograms:
           IsParameter: true
           IsReturn: true
     - ID: 56
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcdad60..0xcdad61]
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0xcda840..0xcda841]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 89 StructureType main.structWithMap
+          Type: 89 StructureType main.structWithAny
           Locations:
-            - Range: 0xcdad60..0xcdad61
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda840..0xcda841
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcdad80..0xcdad81]
+      Name: main.testStructWithMap
+      OutOfLinePCRanges: [0xcdae20..0xcdae21]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 95 GoMapType map[string]main.nestedStruct
+        - Name: s
+          Type: 90 StructureType main.structWithMap
           Locations:
-            - Range: 0xcdad80..0xcdad81
+            - Range: 0xcdae20..0xcdae21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcdada0..0xcdada1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0xcdada0..0xcdada1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcdadc0..0xcdadc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 105 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcdadc0..0xcdadc1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcdade0..0xcdade1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 110 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcdade0..0xcdade1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcdae00..0xcdae01]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0xcdae00..0xcdae01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcdae20..0xcdae21]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 115 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcdae20..0xcdae21
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 63
-      Name: main.testPointerToMap
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcdae40..0xcdae41]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 116 PointerType *map[string]int
+          Type: 96 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcdae40..0xcdae41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapIntToInt
+    - ID: 59
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcdae60..0xcdae61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 90 GoMapType map[int]int
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0xcdae60..0xcdae61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapMassive
+    - ID: 60
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcdae80..0xcdae81]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 117 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 106 GoMapType map[string][]string
           Locations:
             - Range: 0xcdae80..0xcdae81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapEmbeddedMaps
+    - ID: 61
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcdaea0..0xcdaea1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 117 GoMapType map[string][]main.structWithMap
+          Type: 111 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcdaea0..0xcdaea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithLinkedList
+    - ID: 62
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcdaec0..0xcdaec1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[bool]main.node
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0xcdaec0..0xcdaec1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValue
+    - ID: 63
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcdaee0..0xcdaee1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[int]uint8
+          Type: 116 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcdaee0..0xcdaee1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallValueMassive
+    - ID: 64
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcdaf00..0xcdaf01]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 127 GoMapType map[int]uint8
+        - Name: m
+          Type: 117 PointerType *map[string]int
           Locations:
             - Range: 0xcdaf00..0xcdaf01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 65
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcdaf20..0xcdaf21]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 91 GoMapType map[int]int
           Locations:
             - Range: 0xcdaf20..0xcdaf21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 66
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xcdaf40..0xcdaf41]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcdaf40..0xcdaf41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeySmallValue
+    - ID: 67
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcdaf60..0xcdaf61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcdaf60..0xcdaf61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 68
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcdaf80..0xcdaf81]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 GoMapType map[uint8][4]int
+          Type: 123 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcdaf80..0xcdaf81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeySmallValue
+    - ID: 69
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcdafa0..0xcdafa1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 142 GoMapType map[[4]int]uint8
+          Type: 128 GoMapType map[int]uint8
           Locations:
             - Range: 0xcdafa0..0xcdafa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 70
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcdafc0..0xcdafc1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 147 GoMapType map[[4]int][4]int
+        - Name: redactMyEntries
+          Type: 128 GoMapType map[int]uint8
           Locations:
             - Range: 0xcdafc0..0xcdafc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcdafe0..0xcdafe1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdafe0..0xcdafe1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcdb000..0xcdb001]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdb000..0xcdb001
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcdb020..0xcdb021]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdb020..0xcdb021
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcdb040..0xcdb041]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 138 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcdb040..0xcdb041
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcdb060..0xcdb061]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 143 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcdb060..0xcdb061
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 76
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcdb080..0xcdb081]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 148 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcdb080..0xcdb081
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 77
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdc700..0xcdc701]
+      OutOfLinePCRanges: [0xcdc7c0..0xcdc7c1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc700..0xcdc701
+            - Range: 0xcdc7c0..0xcdc7c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc700..0xcdc701
+            - Range: 0xcdc7c0..0xcdc7c1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdc700..0xcdc701
+            - Range: 0xcdc7c0..0xcdc7c1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdc8c0..0xcdc8c1]
+      OutOfLinePCRanges: [0xcdc980..0xcdc981]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdc8c0..0xcdc8c1
+            - Range: 0xcdc980..0xcdc981
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc8c0..0xcdc8c1
+            - Range: 0xcdc980..0xcdc981
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcdc8c0..0xcdc8c1
+            - Range: 0xcdc980..0xcdc981
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdc8c0..0xcdc8c1
+            - Range: 0xcdc980..0xcdc981
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc8c0..0xcdc8c1
+            - Range: 0xcdc980..0xcdc981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2751,39 +2784,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdcae0..0xcdcae1]
+      OutOfLinePCRanges: [0xcdcba0..0xcdcba1]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 152 GoChannelType chan bool
+          Type: 153 GoChannelType chan bool
           Locations:
-            - Range: 0xcdcae0..0xcdcae1
+            - Range: 0xcdcba0..0xcdcba1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdcc80..0xcdcc81]
+      OutOfLinePCRanges: [0xcdcd40..0xcdcd41]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 153 PointerType *main.structWithTwoValues
+          Type: 154 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdcc80..0xcdcc81
+            - Range: 0xcdcd40..0xcdcd41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdcca0..0xcdcca1]
+      OutOfLinePCRanges: [0xcdcd60..0xcdcd61]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 StructureType main.node
+          Type: 156 StructureType main.node
           Locations:
-            - Range: 0xcdcca0..0xcdcca1
+            - Range: 0xcdcd60..0xcdcd61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2791,221 +2824,92 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdccc0..0xcdccc1]
+      OutOfLinePCRanges: [0xcdcd80..0xcdcd81]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 156 PointerType *main.node
+          Type: 157 PointerType *main.node
           Locations:
-            - Range: 0xcdccc0..0xcdccc1
+            - Range: 0xcdcd80..0xcdcd81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdcce0..0xcdcce1]
+      OutOfLinePCRanges: [0xcdcda0..0xcdcda1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdcda0..0xcdcda1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdcd20..0xcdcd21]
+      OutOfLinePCRanges: [0xcdcde0..0xcdcde1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xcdcd20..0xcdcd21
+            - Range: 0xcdcde0..0xcdcde1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdce00..0xcdce01]
+      OutOfLinePCRanges: [0xcdcec0..0xcdcec1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xcdce00..0xcdce01
+            - Range: 0xcdcec0..0xcdcec1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdce40..0xcdce41]
+      OutOfLinePCRanges: [0xcdcf00..0xcdcf01]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcdce40..0xcdce41
+            - Range: 0xcdcf00..0xcdcf01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdce40..0xcdce41
+            - Range: 0xcdcf00..0xcdcf01
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdce80..0xcdce81]
+      OutOfLinePCRanges: [0xcdcf40..0xcdcf41]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 157 PointerType *main.t
+          Type: 158 PointerType *main.t
           Locations:
-            - Range: 0xcdce80..0xcdce81
+            - Range: 0xcdcf40..0xcdcf41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdd3a0..0xcdd3a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 159 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdd3a0..0xcdd3a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 88
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdd3c0..0xcdd3c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 159 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdd3c0..0xcdd3c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 89
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 160 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcdd3e0..0xcdd3e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 90
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdd400..0xcdd401]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd400..0xcdd401
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd400..0xcdd401
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 91
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdd420..0xcdd421]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd420..0xcdd421
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd420..0xcdd421
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdd440..0xcdd441]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd440..0xcdd441
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd440..0xcdd441
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 93
-      Name: main.testStringSlice
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdd460..0xcdd461]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 165 GoSliceHeaderType []string
+        - Name: u
+          Type: 160 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdd460..0xcdd461
               Pieces:
@@ -3017,22 +2921,151 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSliceWithOtherParams
+    - ID: 89
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdd480..0xcdd481]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 160 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdd480..0xcdd481
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcdd4a0..0xcdd4a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 161 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcdd4a0..0xcdd4a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcdd4c0..0xcdd4c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd4c0..0xcdd4c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd4c0..0xcdd4c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcdd4e0..0xcdd4e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd4e0..0xcdd4e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd4e0..0xcdd4e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcdd500..0xcdd501]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd500..0xcdd501
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd500..0xcdd501
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcdd520..0xcdd521]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 166 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcdd520..0xcdd521
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcdd540..0xcdd541]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcdd480..0xcdd481
+            - Range: 0xcdd540..0xcdd541
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 166 GoSliceHeaderType []bool
+          Type: 167 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdd480..0xcdd481
+            - Range: 0xcdd540..0xcdd541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3045,37 +3078,19 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdd480..0xcdd481
+            - Range: 0xcdd540..0xcdd541
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 95
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdd4a0..0xcdd4a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 167 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcdd4a0..0xcdd4a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 96
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdd4c0..0xcdd4c1]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcdd560..0xcdd561]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 159 GoSliceHeaderType []uint
+          Type: 168 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcdd4c0..0xcdd4c1
+            - Range: 0xcdd560..0xcdd561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3086,135 +3101,35 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 97
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcdd580..0xcdd581]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 160 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdd580..0xcdd581
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0xcdd800..0xcdd852]
+      OutOfLinePCRanges: [0xcdd8c0..0xcdd912]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcdd800..0xcdd852, Pieces: []}]
+          Locations: [{Range: 0xcdd8c0..0xcdd912, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0xcdd860..0xcdd861]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdd860..0xcdd861
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcdd880..0xcdd881]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdd880..0xcdd881
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: y
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdd880..0xcdd881
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: z
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdd880..0xcdd881
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcdd8a0..0xcdd8bf]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0xcdd8a0..0xcdd8bf
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 101
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcdd8c0..0xcdd8c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 169 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xcdd8c0..0xcdd8c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 102
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcdd8e0..0xcdd8e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 170 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0xcdd8e0..0xcdd8e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 103
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcdd900..0xcdd901]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdd900..0xcdd901
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 104
-      Name: main.testUnitializedString
+      Name: main.testSingleString
       OutOfLinePCRanges: [0xcdd920..0xcdd921]
       InlinePCRanges: []
       Variables:
@@ -3229,8 +3144,8 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
-      Name: main.testEmptyString
+    - ID: 100
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0xcdd940..0xcdd941]
       InlinePCRanges: []
       Variables:
@@ -3245,15 +3160,133 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 106
-      Name: main.testStruct
-      OutOfLinePCRanges: [0xcddbc0..0xcddbe3]
+        - Name: y
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdd940..0xcdd941
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdd940..0xcdd941
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 101
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0xcdd960..0xcdd97f]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 169 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0xcdd960..0xcdd97f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 102
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0xcdd980..0xcdd981]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 170 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0xcdd980..0xcdd981
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xcdd9a0..0xcdd9a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 171 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0xcdd9a0..0xcdd9a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 104
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcdd9c0..0xcdd9c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 172 StructureType main.aStruct
+          Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddbc0..0xcddbe3
+            - Range: 0xcdd9c0..0xcdd9c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcdd9e0..0xcdd9e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdd9e0..0xcdd9e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 106
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcdda00..0xcdda01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdda00..0xcdda01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 107
+      Name: main.testStruct
+      OutOfLinePCRanges: [0xcddc80..0xcddca3]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 173 StructureType main.aStruct
+          Locations:
+            - Range: 0xcddc80..0xcddca3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3271,29 +3304,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcddd40..0xcddd41]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 174 StructureType main.emptyStruct
-          Locations: [{Range: 0xcddd40..0xcddd41, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 108
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcddd60..0xcddd61]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0xcdde00..0xcdde01]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 175 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0xcddd60..0xcddd61
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 175 StructureType main.emptyStruct
+          Locations: [{Range: 0xcdde00..0xcdde01, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 109
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0xcdde20..0xcdde21]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 176 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0xcdde20..0xcdde21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 110
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd9f60..0xcd9fc2]
       InlinePCRanges:
@@ -3323,28 +3356,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda206..0xcda23e]
           RootRanges: [0xcda1a0..0xcda265]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda313..0xcda351]
           RootRanges: [0xcda300..0xcda405]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda3bb..0xcda3f3]
           RootRanges: [0xcda300..0xcda405]
       Variables: []
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3358,7 +3391,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 115
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3383,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 324
+      ID: 325
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 325 PointerType *main.deepSlice3
+      Pointee: 326 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 351
+      ID: 352
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 352 PointerType *main.deepSlice8
+      Pointee: 353 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 357
+      ID: 358
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 358 PointerType *main.deepSlice9
+      Pointee: 359 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3404,373 +3437,373 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 320
+      ID: 321
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 157 PointerType *main.t
+      Pointee: 158 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 530560
+      GoRuntimeType: 530624
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 151 PointerType *table<[4]int,[4]int>
+      Pointee: 152 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 146 PointerType *table<[4]int,uint8>
+      Pointee: 147 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 114 PointerType *table<[4]string,[2]int>
+      Pointee: 115 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<bool,main.node>
+      Pointee: 127 PointerType *table<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 332
+      ID: 333
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 333 PointerType *table<int,*main.deepMap3>
+      Pointee: 334 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 368
+      ID: 369
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 369 PointerType *table<int,*main.deepMap8>
+      Pointee: 370 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 383
+      ID: 384
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 384 PointerType *table<int,*main.deepMap9>
+      Pointee: 385 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 94 PointerType *table<int,int>
+      Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 399 PointerType *table<int,interface {}>
+      Pointee: 400 PointerType *table<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 131 PointerType *table<int,uint8>
+      Pointee: 132 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 121 PointerType *table<string,[]main.structWithMap>
+      Pointee: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 109 PointerType *table<string,[]string>
+      Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 104 PointerType *table<string,int>
+      Pointee: 105 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 99 PointerType *table<string,main.nestedStruct>
+      Pointee: 100 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 141 PointerType *table<uint8,[4]int>
+      Pointee: 142 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 136 PointerType *table<uint8,uint8>
+      Pointee: 137 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 182
+      ID: 183
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 328
+      ID: 329
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 327 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 328 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 355
+      ID: 356
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 354 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 355 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 361
+      ID: 362
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 360 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 361 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 179
+      ID: 180
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []*string.array
+      Pointee: 179 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 296
+      ID: 297
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 295 GoSliceDataType [][]uint.array
+      Pointee: 296 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 302
+      ID: 303
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 301 GoSliceDataType []bool.array
+      Pointee: 302 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 364
+      ID: 365
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 363 GoSliceDataType []interface {}.array
+      Pointee: 364 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 345
+      ID: 346
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 344 GoSliceDataType []main.structWithMap.array
+      Pointee: 345 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 298
+      ID: 299
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 297 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 298 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 300
+      ID: 301
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 299 GoSliceDataType []string.array
+      Pointee: 300 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 161
+      ID: 162
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 159 GoSliceHeaderType []uint
+      Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 294
+      ID: 295
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType []uint.array
+      Pointee: 294 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 303 GoSliceDataType []uint16.array
+      Pointee: 304 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 393024
+      GoRuntimeType: 393088
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 391936
+      GoRuntimeType: 392000
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 392896
+      GoRuntimeType: 392960
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 392960
+      GoRuntimeType: 393024
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
       ID: 26
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 392576
+      GoRuntimeType: 392640
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 392192
+      GoRuntimeType: 392256
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 392320
+      GoRuntimeType: 392384
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 392448
+      GoRuntimeType: 392512
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 392064
+      GoRuntimeType: 392128
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
       ID: 88
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 393152
+      GoRuntimeType: 393216
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 189
+      ID: 190
       Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 385856
+      GoKind: 22
+      Pointee: 191 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 341
+      Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385792
       GoKind: 22
-      Pointee: 190 StructureType main.deepMap2
-    - __kind: PointerType
-      ID: 340
-      Name: '*main.deepMap3'
-      ByteSize: 8
-      GoRuntimeType: 385728
-      GoKind: 22
-      Pointee: 341 UnresolvedPointeeType main.deepMap3
+      Pointee: 342 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 385472
+      GoRuntimeType: 385536
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 376
+      ID: 377
       Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 385472
+      GoKind: 22
+      Pointee: 378 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 392
+      Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385408
       GoKind: 22
-      Pointee: 377 StructureType main.deepMap8
-    - __kind: PointerType
-      ID: 391
-      Name: '*main.deepMap9'
-      ByteSize: 8
-      GoRuntimeType: 385344
-      GoKind: 22
-      Pointee: 392 StructureType main.deepMap9
+      Pointee: 393 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 386368
+      GoRuntimeType: 386432
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 305
+      ID: 306
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 386304
+      GoRuntimeType: 386368
       GoKind: 22
-      Pointee: 306 UnresolvedPointeeType main.deepPtr3
+      Pointee: 307 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 386048
+      GoRuntimeType: 386112
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 346
+      ID: 347
       Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 386048
+      GoKind: 22
+      Pointee: 348 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 349
+      Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 385984
       GoKind: 22
-      Pointee: 347 StructureType main.deepPtr8
-    - __kind: PointerType
-      ID: 348
-      Name: '*main.deepPtr9'
-      ByteSize: 8
-      GoRuntimeType: 385920
-      GoKind: 22
-      Pointee: 349 StructureType main.deepPtr9
+      Pointee: 350 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 386944
+      GoRuntimeType: 387008
       GoKind: 22
-      Pointee: 180 StructureType main.deepSlice2
+      Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 325
+      ID: 326
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 386880
+      GoRuntimeType: 386944
       GoKind: 22
-      Pointee: 326 UnresolvedPointeeType main.deepSlice3
+      Pointee: 327 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 386624
+      GoRuntimeType: 386688
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 352
+      ID: 353
       Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 386624
+      GoKind: 22
+      Pointee: 354 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 359
+      Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 353 StructureType main.deepSlice8
+      Pointee: 360 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 358
-      Name: '*main.deepSlice9'
-      ByteSize: 8
-      GoRuntimeType: 386496
-      GoKind: 22
-      Pointee: 359 StructureType main.deepSlice9
-    - __kind: PointerType
-      ID: 175
+      ID: 176
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 174 StructureType main.emptyStruct
+      Pointee: 175 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 387072
+      GoRuntimeType: 387136
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 156
+      ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 387136
+      GoRuntimeType: 387200
       GoKind: 22
-      Pointee: 155 StructureType main.node
+      Pointee: 156 StructureType main.node
     - __kind: PointerType
-      ID: 170
+      ID: 171
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 StructureType main.oneStringStruct
+      Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -3778,371 +3811,371 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 308
+      ID: 309
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType main.stringType1.str
+      Pointee: 308 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 309 UnresolvedPointeeType main.stringType2
+      Pointee: 310 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 241
+      ID: 242
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 385280
+      GoRuntimeType: 385344
       GoKind: 22
-      Pointee: 89 StructureType main.structWithMap
+      Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 163
+      ID: 164
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 164 StructureType main.structWithNoStrings
+      Pointee: 165 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 153
+      ID: 154
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 154 StructureType main.structWithTwoValues
+      Pointee: 155 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 157
+      ID: 158
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 158 GoSliceHeaderType main.t
+      Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 322
+      ID: 323
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 321 GoSliceDataType main.t.array
+      Pointee: 322 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 169
+      ID: 170
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 168 StructureType main.threeStringStruct
+      Pointee: 169 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 148
+      ID: 149
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 149 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 143
+      ID: 144
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 144 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 111
+      ID: 112
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 112 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 123
+      ID: 124
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 330
+      ID: 331
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 366
+      ID: 367
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 381
+      ID: 382
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 91
+      ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 92 GoSwissMapHeaderType map<int,int>
+      Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 396
+      ID: 397
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 397 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
-      ID: 128
+      ID: 129
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 129 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 106
+      ID: 107
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 107 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 101
+      ID: 102
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 102 GoSwissMapHeaderType map<string,int>
+      Pointee: 103 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 96
+      ID: 97
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 138
+      ID: 139
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 139 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 133
+      ID: 134
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 134 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 116
+      ID: 117
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 GoMapType map[string]int
+      Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 287
+      ID: 288
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 288 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 279
+      ID: 280
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 280 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 227
+      ID: 228
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 228 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 246
+      ID: 247
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 247 StructureType noalg.map.group[bool]main.node
+      Pointee: 248 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 185
+      ID: 186
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 336
+      ID: 337
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 337 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 372
+      ID: 373
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 387
+      ID: 388
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 388 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 195
+      ID: 196
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[int]int
+      Pointee: 197 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 402
+      ID: 403
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 403 StructureType noalg.map.group[int]interface {}
+      Pointee: 404 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 254
+      ID: 255
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 255 StructureType noalg.map.group[int]uint8
+      Pointee: 256 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 236
+      ID: 237
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 237 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 219
+      ID: 220
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 220 StructureType noalg.map.group[string][]string
+      Pointee: 221 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 211
+      ID: 212
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 212 StructureType noalg.map.group[string]int
+      Pointee: 213 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 203
+      ID: 204
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 270
+      ID: 271
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 271 StructureType noalg.map.group[uint8][4]int
+      Pointee: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 262
+      ID: 263
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 263 StructureType noalg.map.group[uint8]uint8
+      Pointee: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 392000
+      GoRuntimeType: 392064
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 177
+      ID: 178
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 176 GoStringDataType string.str
+      Pointee: 177 GoStringDataType string.str
     - __kind: PointerType
-      ID: 151
+      ID: 152
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 285 StructureType table<[4]int,[4]int>
+      Pointee: 286 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 146
+      ID: 147
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 277 StructureType table<[4]int,uint8>
+      Pointee: 278 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 114
+      ID: 115
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 225 StructureType table<[4]string,[2]int>
+      Pointee: 226 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 126
+      ID: 127
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 244 StructureType table<bool,main.node>
+      Pointee: 245 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 183 StructureType table<int,*main.deepMap2>
+      Pointee: 184 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 333
+      ID: 334
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 334 StructureType table<int,*main.deepMap3>
+      Pointee: 335 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 369
+      ID: 370
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 370 StructureType table<int,*main.deepMap8>
+      Pointee: 371 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 384
+      ID: 385
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 385 StructureType table<int,*main.deepMap9>
+      Pointee: 386 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 94
+      ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 193 StructureType table<int,int>
+      Pointee: 194 StructureType table<int,int>
     - __kind: PointerType
-      ID: 399
+      ID: 400
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 400 StructureType table<int,interface {}>
+      Pointee: 401 StructureType table<int,interface {}>
     - __kind: PointerType
-      ID: 131
+      ID: 132
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 252 StructureType table<int,uint8>
+      Pointee: 253 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 122
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 234 StructureType table<string,[]main.structWithMap>
+      Pointee: 235 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 109
+      ID: 110
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 217 StructureType table<string,[]string>
+      Pointee: 218 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 104
+      ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 209 StructureType table<string,int>
+      Pointee: 210 StructureType table<string,int>
     - __kind: PointerType
-      ID: 99
+      ID: 100
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 201 StructureType table<string,main.nestedStruct>
+      Pointee: 202 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 141
+      ID: 142
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 268 StructureType table<uint8,[4]int>
+      Pointee: 269 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 136
+      ID: 137
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 260 StructureType table<uint8,uint8>
+      Pointee: 261 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 392640
+      GoRuntimeType: 392704
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 392256
+      GoRuntimeType: 392320
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 392384
+      GoRuntimeType: 392448
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 392512
+      GoRuntimeType: 392576
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 392128
+      GoRuntimeType: 392192
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 392704
+      GoRuntimeType: 392768
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 504
+      ID: 506
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 462
+      ID: 463
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4157,7 +4190,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 460
+      ID: 461
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4172,7 +4205,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 424
+      ID: 425
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4187,7 +4220,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 422
+      ID: 423
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4202,7 +4235,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 469
+      ID: 471
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4210,14 +4243,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 ArrayType [2]map[string]int
+            Type: 116 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 423
+      ID: 424
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4232,7 +4265,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 442
+      ID: 443
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4247,7 +4280,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 411
+      ID: 412
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4262,7 +4295,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 408
+      ID: 409
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4277,7 +4310,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 485
+      ID: 487
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4285,14 +4318,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 152 GoChannelType chan bool
+            Type: 153 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: c}
+                  Variable: {subprogram: 79, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 483
+      ID: 485
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4303,7 +4336,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: w}
+                  Variable: {subprogram: 77, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4312,7 +4345,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: x}
+                  Variable: {subprogram: 77, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4321,11 +4354,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: y}
+                  Variable: {subprogram: 77, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 493
+      ID: 495
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4333,14 +4366,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 157 PointerType *main.t
+            Type: 158 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: t}
+                  Variable: {subprogram: 87, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 447
+      ID: 448
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4355,7 +4388,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 448
+      ID: 449
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4370,7 +4403,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 443
+      ID: 444
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4385,7 +4418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 444
+      ID: 445
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4400,7 +4433,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 445
+      ID: 446
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4415,7 +4448,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 446
+      ID: 447
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4430,7 +4463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4438,10 +4471,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4450,11 +4483,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 495
+      ID: 497
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4462,14 +4495,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 512
+      ID: 514
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4480,11 +4513,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 515
+      ID: 517
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4492,14 +4525,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 PointerType *main.emptyStruct
+            Type: 176 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 109, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 514
+      ID: 516
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4507,14 +4540,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 174 StructureType main.emptyStruct
+            Type: 175 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 461
+      ID: 462
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4529,7 +4562,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 452
+      ID: 453
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4544,7 +4577,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 451
+      ID: 452
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4559,7 +4592,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 458
+      ID: 459
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4574,7 +4607,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 457
+      ID: 458
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4589,7 +4622,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 453
+      ID: 454
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4604,7 +4637,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 455
+      ID: 456
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4619,10 +4652,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 517
+      ID: 519
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 454
+      ID: 455
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4646,16 +4679,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 518
+      ID: 520
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 519
+      ID: 521
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 456
+      ID: 457
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 516
+      ID: 518
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4666,11 +4699,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 522
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4681,11 +4714,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: x}
+                  Variable: {subprogram: 114, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 521
+      ID: 523
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4696,11 +4729,11 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: a}
+                  Variable: {subprogram: 115, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 414
+      ID: 415
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4715,7 +4748,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 415
+      ID: 416
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4730,7 +4763,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 416
+      ID: 417
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4745,7 +4778,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 413
+      ID: 414
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4760,7 +4793,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 412
+      ID: 413
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4775,7 +4808,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 459
+      ID: 460
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4790,7 +4823,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 487
+      ID: 489
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4798,14 +4831,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 StructureType main.node
+            Type: 156 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 467
+      ID: 469
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4813,14 +4846,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[[4]string][2]int
+            Type: 111 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 475
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4828,14 +4861,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 117 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 471
+      ID: 473
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4843,14 +4876,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 90 GoMapType map[int]int
+            Type: 91 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 482
+      ID: 484
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4858,14 +4891,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 147 GoMapType map[[4]int][4]int
+            Type: 148 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 483
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4873,14 +4906,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 142 GoMapType map[[4]int]uint8
+            Type: 143 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 474
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4888,14 +4921,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 117 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 482
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4903,14 +4936,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[uint8][4]int
+            Type: 138 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 481
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4918,14 +4951,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 465
+      ID: 467
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4933,14 +4966,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 466
+      ID: 468
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4948,14 +4981,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[string][]string
+            Type: 106 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 466
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4963,14 +4996,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 95 GoMapType map[string]main.nestedStruct
+            Type: 96 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 476
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4978,14 +5011,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[bool]main.node
+            Type: 123 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 480
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4993,14 +5026,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 479
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5008,14 +5041,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 478
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5023,14 +5056,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 477
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5038,14 +5071,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 510
+      ID: 512
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5056,11 +5089,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 484
+      ID: 486
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5071,7 +5104,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -5080,7 +5113,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: b}
+                  Variable: {subprogram: 78, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -5089,7 +5122,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: c}
+                  Variable: {subprogram: 78, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -5098,7 +5131,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 3, name: d}
+                  Variable: {subprogram: 78, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -5107,11 +5140,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 4, name: e}
+                  Variable: {subprogram: 78, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 492
+      ID: 494
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5122,7 +5155,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -5131,11 +5164,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: a}
+                  Variable: {subprogram: 86, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5143,10 +5176,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5155,11 +5188,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5170,16 +5203,16 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: a}
+                  Variable: {subprogram: 95, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 166 GoSliceHeaderType []bool
+            Type: 167 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: s}
+                  Variable: {subprogram: 95, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5188,11 +5221,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 2, name: x}
+                  Variable: {subprogram: 95, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 502
+      ID: 504
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5200,14 +5233,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 167 GoSliceHeaderType []uint16
+            Type: 168 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 509
+      ID: 511
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5215,14 +5248,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.oneStringStruct
+            Type: 171 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: a}
+                  Variable: {subprogram: 103, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 488
+      ID: 490
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5230,14 +5263,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.node
+            Type: 157 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 470
+      ID: 472
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5245,14 +5278,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 PointerType *map[string]int
+            Type: 117 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 486
+      ID: 488
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5260,14 +5293,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 153 PointerType *main.structWithTwoValues
+            Type: 154 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 409
+      ID: 410
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5282,7 +5315,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 428
+      ID: 429
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5297,7 +5330,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 426
+      ID: 427
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5312,7 +5345,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 439
+      ID: 440
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5327,7 +5360,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 440
+      ID: 441
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5342,7 +5375,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 431
+      ID: 432
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5357,7 +5390,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 432
+      ID: 433
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5372,7 +5405,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 433
+      ID: 434
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5387,7 +5420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 430
+      ID: 431
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5402,7 +5435,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 429
+      ID: 430
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5417,7 +5450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 427
+      ID: 428
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5432,7 +5465,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 505
+      ID: 507
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5443,11 +5476,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 436
+      ID: 437
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5462,7 +5495,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 437
+      ID: 438
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5477,7 +5510,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 438
+      ID: 439
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5492,7 +5525,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 435
+      ID: 436
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5507,7 +5540,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 434
+      ID: 435
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5522,7 +5555,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5530,14 +5563,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType [][]uint
+            Type: 161 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: u}
+                  Variable: {subprogram: 90, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 468
+      ID: 470
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5545,14 +5578,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 410
+      ID: 411
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5567,7 +5600,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 491
+      ID: 493
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5578,11 +5611,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 502
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5590,14 +5623,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 165 GoSliceHeaderType []string
+            Type: 166 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: s}
+                  Variable: {subprogram: 94, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 449
+      ID: 450
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5612,7 +5645,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 450
+      ID: 451
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5627,7 +5660,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 499
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5635,10 +5668,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5647,11 +5680,26 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 463
+      ID: 464
+      Name: Probe[main.testStructWithAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 89 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 465
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5659,14 +5707,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 89 StructureType main.structWithMap
+            Type: 90 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 513
+      ID: 515
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5674,14 +5722,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 172 StructureType main.aStruct
+            Type: 173 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 508
+      ID: 510
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5689,14 +5737,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.threeStringStruct
+            Type: 170 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 507
+      ID: 509
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5704,14 +5752,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 StructureType main.threeStringStruct
+            Type: 169 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 506
+      ID: 508
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5722,7 +5770,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5731,7 +5779,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: y}
+                  Variable: {subprogram: 100, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5740,11 +5788,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: z}
+                  Variable: {subprogram: 100, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 441
+      ID: 442
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5759,7 +5807,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 419
+      ID: 420
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5774,7 +5822,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 420
+      ID: 421
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5789,7 +5837,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 421
+      ID: 422
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5804,7 +5852,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 418
+      ID: 419
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5819,7 +5867,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 417
+      ID: 418
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5834,7 +5882,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 490
+      ID: 492
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5845,11 +5893,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 494
+      ID: 496
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5857,14 +5905,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 513
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5875,11 +5923,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 491
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5890,11 +5938,11 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 425
+      ID: 426
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5909,7 +5957,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 503
+      ID: 505
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5917,10 +5965,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: xs}
+                  Variable: {subprogram: 97, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5959,7 +6007,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 683008
+      GoRuntimeType: 683072
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5976,7 +6024,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 684352
+      GoRuntimeType: 684416
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5998,18 +6046,18 @@ Types:
       HasCount: true
       Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 115
+      ID: 116
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 100 GoMapType map[string]int
+      Element: 101 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 684448
+      GoRuntimeType: 684512
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6042,7 +6090,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 684544
+      GoRuntimeType: 684608
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6051,25 +6099,25 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 684256
+      GoRuntimeType: 684320
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 274
+      ID: 275
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 682624
+      GoRuntimeType: 682688
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 231
+      ID: 232
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 682912
+      GoRuntimeType: 682976
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6086,7 +6134,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 477632
+      GoRuntimeType: 477696
       GoKind: 23
       RawFields:
         - Name: array
@@ -6098,83 +6146,83 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 181 GoSliceDataType []*main.deepSlice2.array
+      Data: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 182
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 323
+      ID: 324
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 477568
+      GoRuntimeType: 477632
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 324 PointerType **main.deepSlice3
+          Type: 325 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 327 GoSliceDataType []*main.deepSlice3.array
+      Data: 328 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 327
+      ID: 328
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 325 PointerType *main.deepSlice3
+      Element: 326 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 350
+      ID: 351
       Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 477312
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 352 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 355 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 355
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 353 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 357
+      Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477248
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 351 PointerType **main.deepSlice8
+          Type: 358 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 354 GoSliceDataType []*main.deepSlice8.array
+      Data: 361 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 354
-      Name: '[]*main.deepSlice8.array'
-      ByteSize: 2048
-      Element: 352 PointerType *main.deepSlice8
-    - __kind: GoSliceHeaderType
-      ID: 356
-      Name: '[]*main.deepSlice9'
-      ByteSize: 24
-      GoRuntimeType: 477184
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 357 PointerType **main.deepSlice9
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 360 GoSliceDataType []*main.deepSlice9.array
-    - __kind: GoSliceDataType
-      ID: 360
+      ID: 361
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 358 PointerType *main.deepSlice9
+      Element: 359 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 478656
+      GoRuntimeType: 478720
       GoKind: 23
       RawFields:
         - Name: array
@@ -6186,123 +6234,123 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 178 GoSliceDataType []*string.array
+      Data: 179 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 179
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 292
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 151 PointerType *table<[4]int,[4]int>
+      Element: 152 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 146 PointerType *table<[4]int,uint8>
+      Element: 147 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 233
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 114 PointerType *table<[4]string,[2]int>
+      Element: 115 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<bool,main.node>
+      Element: 127 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 342
+      ID: 343
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 333 PointerType *table<int,*main.deepMap3>
+      Element: 334 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 378
+      ID: 379
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 369 PointerType *table<int,*main.deepMap8>
+      Element: 370 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 393
+      ID: 394
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 384 PointerType *table<int,*main.deepMap9>
+      Element: 385 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 94 PointerType *table<int,int>
+      Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 407
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 399 PointerType *table<int,interface {}>
+      Element: 400 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 259
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 131 PointerType *table<int,uint8>
+      Element: 132 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 243
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 121 PointerType *table<string,[]main.structWithMap>
+      Element: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 109 PointerType *table<string,[]string>
+      Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 104 PointerType *table<string,int>
+      Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 208
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 99 PointerType *table<string,main.nestedStruct>
+      Element: 100 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 276
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 141 PointerType *table<uint8,[4]int>
+      Element: 142 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 267
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 136 PointerType *table<uint8,uint8>
+      Element: 137 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 161
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType *[]uint
+          Type: 162 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 295 GoSliceDataType [][]uint.array
+      Data: 296 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 296
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 159 GoSliceHeaderType []uint
+      Element: 160 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 486976
+      GoRuntimeType: 487040
       GoKind: 23
       RawFields:
         - Name: array
@@ -6314,17 +6362,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 301 GoSliceDataType []bool.array
+      Data: 302 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 301
+      ID: 302
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 362
+      ID: 363
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 487296
+      GoRuntimeType: 487360
       GoKind: 23
       RawFields:
         - Name: array
@@ -6336,145 +6384,145 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 363 GoSliceDataType []interface {}.array
+      Data: 364 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 363
+      ID: 364
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 240
+      ID: 241
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 477888
+      GoRuntimeType: 477952
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 241 PointerType *main.structWithMap
+          Type: 242 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 344 GoSliceDataType []main.structWithMap.array
+      Data: 345 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 345
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 89 StructureType main.structWithMap
+      Element: 90 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 163
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *main.structWithNoStrings
+          Type: 164 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 297 GoSliceDataType []main.structWithNoStrings.array
+      Data: 298 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 297
+      ID: 298
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 164 StructureType main.structWithNoStrings
+      Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 293
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 288 StructureType noalg.map.group[[4]int][4]int
+      Element: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 285
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 280 StructureType noalg.map.group[[4]int]uint8
+      Element: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 234
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 228 StructureType noalg.map.group[[4]string][2]int
+      Element: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 252
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 247 StructureType noalg.map.group[bool]main.node
+      Element: 248 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 193
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 186 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 344
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 337 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 379
+      ID: 380
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 373 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 395
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 388 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 201
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 196 StructureType noalg.map.group[int]int
+      Element: 197 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 408
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 403 StructureType noalg.map.group[int]interface {}
+      Element: 404 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 260
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 255 StructureType noalg.map.group[int]uint8
+      Element: 256 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 244
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 237 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 225
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 220 StructureType noalg.map.group[string][]string
+      Element: 221 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 217
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 212 StructureType noalg.map.group[string]int
+      Element: 213 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 209
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 204 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 277
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 271 StructureType noalg.map.group[uint8][4]int
+      Element: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 268
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 263 StructureType noalg.map.group[uint8]uint8
+      Element: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 487104
+      GoRuntimeType: 487168
       GoKind: 23
       RawFields:
         - Name: array
@@ -6486,17 +6534,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 299 GoSliceDataType []string.array
+      Data: 300 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 299
+      ID: 300
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 486592
+      GoRuntimeType: 486656
       GoKind: 23
       RawFields:
         - Name: array
@@ -6508,17 +6556,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType []uint.array
+      Data: 294 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 294
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 17 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 485952
+      GoRuntimeType: 486016
       GoKind: 23
       RawFields:
         - Name: array
@@ -6530,9 +6578,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 303 GoSliceDataType []uint16.array
+      Data: 304 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 303
+      ID: 304
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -6540,35 +6588,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 584928
+      GoRuntimeType: 584992
       GoKind: 1
     - __kind: GoChannelType
-      ID: 152
+      ID: 153
       Name: chan bool
-      GoRuntimeType: 596256
+      GoRuntimeType: 596320
       GoKind: 18
     - __kind: GoChannelType
       ID: 80
       Name: chan struct {}
-      GoRuntimeType: 595168
+      GoRuntimeType: 595232
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 584736
+      GoRuntimeType: 584800
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 584672
+      GoRuntimeType: 584736
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.026688e+06
+      GoRuntimeType: 1.026752e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6581,293 +6629,293 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 584800
+      GoRuntimeType: 584864
       GoKind: 13
     - __kind: BaseType
       ID: 15
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 584864
+      GoRuntimeType: 584928
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 475776
+      GoRuntimeType: 475840
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 286
+      ID: 287
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 287 PointerType *noalg.map.group[[4]int][4]int
+          Type: 288 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 292 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 293 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 278
+      ID: 279
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 279 PointerType *noalg.map.group[[4]int]uint8
+          Type: 280 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 284 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 285 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 226
+      ID: 227
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 227 PointerType *noalg.map.group[[4]string][2]int
+          Type: 228 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 233 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 245
+      ID: 246
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 246 PointerType *noalg.map.group[bool]main.node
+          Type: 247 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 247 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 248 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 252 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 184
+      ID: 185
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 185 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 186 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 335
+      ID: 336
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 336 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 337 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 344 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 372
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 373 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 380 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 386
+      ID: 387
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 387 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 388 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 394 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 395 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 195
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[int]int
+          Type: 196 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[int]int
-      GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 197 StructureType noalg.map.group[int]int
+      GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 401
+      ID: 402
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 402 PointerType *noalg.map.group[int]interface {}
+          Type: 403 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 403 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 404 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 408 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 253
+      ID: 254
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 254 PointerType *noalg.map.group[int]uint8
+          Type: 255 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 255 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 256 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 260 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 235
+      ID: 236
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 236 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 237 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 218
+      ID: 219
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 219 PointerType *noalg.map.group[string][]string
+          Type: 220 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 220 StructureType noalg.map.group[string][]string
-      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 221 StructureType noalg.map.group[string][]string
+      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 210
+      ID: 211
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 211 PointerType *noalg.map.group[string]int
+          Type: 212 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 212 StructureType noalg.map.group[string]int
-      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 213 StructureType noalg.map.group[string]int
+      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 203
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 204 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 269
+      ID: 270
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 270 PointerType *noalg.map.group[uint8][4]int
+          Type: 271 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 271 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 276 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 272 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 277 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 261
+      ID: 262
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 262 PointerType *noalg.map.group[uint8]uint8
+          Type: 263 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 263 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 264 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 584480
+      GoRuntimeType: 584544
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 584096
+      GoRuntimeType: 584160
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 584224
+      GoRuntimeType: 584288
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 584352
+      GoRuntimeType: 584416
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 583968
+      GoRuntimeType: 584032
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 847840
+      GoRuntimeType: 847904
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6877,10 +6925,10 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 312
+      ID: 313
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.472896e+06
+      GoRuntimeType: 1.473088e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6893,7 +6941,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.02272e+06
+      GoRuntimeType: 1.022784e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6903,7 +6951,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6919,12 +6967,12 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 173 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.022336e+06
+      GoRuntimeType: 1.0224e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6952,61 +7000,61 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.185792e+06
+      GoRuntimeType: 1.185984e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 190
+      ID: 191
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.185664e+06
+      GoRuntimeType: 1.185856e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 329 GoMapType map[int]*main.deepMap3
+          Type: 330 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 342
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
       ID: 74
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.185024e+06
+      GoRuntimeType: 1.185216e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 365 GoMapType map[int]*main.deepMap8
+          Type: 366 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 377
+      ID: 378
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.184896e+06
+      GoRuntimeType: 1.185088e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 380 GoMapType map[int]*main.deepMap9
+          Type: 381 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 392
+      ID: 393
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.184768e+06
+      GoRuntimeType: 1.18496e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 395 GoMapType map[int]interface {}
+          Type: 396 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.186944e+06
+      GoRuntimeType: 1.187136e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7016,41 +7064,41 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.186816e+06
+      GoRuntimeType: 1.187008e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 305 PointerType *main.deepPtr3
+          Type: 306 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 306
+      ID: 307
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.186176e+06
+      GoRuntimeType: 1.186368e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 346 PointerType *main.deepPtr8
+          Type: 347 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 347
+      ID: 348
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.186048e+06
+      GoRuntimeType: 1.18624e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 348 PointerType *main.deepPtr9
+          Type: 349 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 349
+      ID: 350
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.18592e+06
+      GoRuntimeType: 1.186112e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7060,58 +7108,58 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.188096e+06
+      GoRuntimeType: 1.188288e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 180
+      ID: 181
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.187968e+06
+      GoRuntimeType: 1.18816e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 323 GoSliceHeaderType []*main.deepSlice3
+          Type: 324 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 326
+      ID: 327
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.187328e+06
+      GoRuntimeType: 1.18752e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 350 GoSliceHeaderType []*main.deepSlice8
+          Type: 351 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 353
+      ID: 354
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.1872e+06
+      GoRuntimeType: 1.187392e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 356 GoSliceHeaderType []*main.deepSlice9
+          Type: 357 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 359
+      ID: 360
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.187072e+06
+      GoRuntimeType: 1.187264e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 362 GoSliceHeaderType []interface {}
+          Type: 363 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 174
+      ID: 175
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7119,7 +7167,7 @@ Types:
       ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.833856e+06
+      GoRuntimeType: 1.834048e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7127,21 +7175,21 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 310 StructureType sync.Mutex
+          Type: 311 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 313 StructureType sync.Once
+          Type: 314 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 316 StructureType sync.WaitGroup
+          Type: 317 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 319 StructureType sync/atomic.Int32
+          Type: 320 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.967168e+06
+      GoRuntimeType: 1.96736e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7166,10 +7214,10 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.461536e+06
+      GoRuntimeType: 1.461728e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7179,10 +7227,10 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 155
+      ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.461376e+06
+      GoRuntimeType: 1.461568e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7190,9 +7238,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 156 PointerType *main.node
+          Type: 157 PointerType *main.node
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7204,7 +7252,7 @@ Types:
       ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.022464e+06
+      GoRuntimeType: 1.022528e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7221,31 +7269,41 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *main.stringType1.str
+          Type: 309 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 307 GoStringDataType main.stringType1.str
+      Data: 308 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 308
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 309
+      ID: 310
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
       ID: 89
+      Name: main.structWithAny
+      ByteSize: 16
+      GoRuntimeType: 1.184704e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.18464e+06
+      GoRuntimeType: 1.184832e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 90 GoMapType map[int]int
+          Type: 91 GoMapType map[int]int
     - __kind: StructureType
-      ID: 164
+      ID: 165
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7257,7 +7315,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 154
+      ID: 155
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7269,28 +7327,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 159
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 320 PointerType **main.t
+          Type: 321 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 321 GoSliceDataType main.t.array
+      Data: 322 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 321
+      ID: 322
       Name: main.t.array
       ByteSize: 2048
-      Element: 157 PointerType *main.t
+      Element: 158 PointerType *main.t
     - __kind: StructureType
-      ID: 168
+      ID: 169
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7310,7 +7368,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 149
+      ID: 150
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7323,7 +7381,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 150 PointerType **table<[4]int,[4]int>
+          Type: 151 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7342,10 +7400,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 291 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 292 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 144
+      ID: 145
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7358,7 +7416,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 145 PointerType **table<[4]int,uint8>
+          Type: 146 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7377,10 +7435,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 283 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 284 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 112
+      ID: 113
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -7393,7 +7451,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 113 PointerType **table<[4]string,[2]int>
+          Type: 114 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7412,10 +7470,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 232 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 233 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 125
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -7428,7 +7486,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<bool,main.node>
+          Type: 126 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7447,8 +7505,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 247 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 251 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 248 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -7482,10 +7540,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 331
+      ID: 332
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7498,7 +7556,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 332 PointerType **table<int,*main.deepMap3>
+          Type: 333 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7517,10 +7575,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 342 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 343 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 367
+      ID: 368
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7533,7 +7591,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 368 PointerType **table<int,*main.deepMap8>
+          Type: 369 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7552,10 +7610,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 379 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 382
+      ID: 383
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7568,7 +7626,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 383 PointerType **table<int,*main.deepMap9>
+          Type: 384 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7587,10 +7645,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 393 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 394 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
-      ID: 92
+      ID: 93
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -7603,7 +7661,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 93 PointerType **table<int,int>
+          Type: 94 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7622,10 +7680,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
-      GroupType: 196 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
+      GroupType: 197 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 397
+      ID: 398
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7638,7 +7696,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 398 PointerType **table<int,interface {}>
+          Type: 399 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7657,10 +7715,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 406 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 403 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 407 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 404 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 129
+      ID: 130
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7673,7 +7731,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 130 PointerType **table<int,uint8>
+          Type: 131 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7692,10 +7750,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 255 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 259 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 256 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 119
+      ID: 120
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -7708,7 +7766,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 120 PointerType **table<string,[]main.structWithMap>
+          Type: 121 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7727,10 +7785,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 107
+      ID: 108
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -7743,7 +7801,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 108 PointerType **table<string,[]string>
+          Type: 109 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7762,10 +7820,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 223 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 220 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 221 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 102
+      ID: 103
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -7778,7 +7836,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 103 PointerType **table<string,int>
+          Type: 104 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7797,10 +7855,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 215 GoSliceDataType []*table<string,int>.array
-      GroupType: 212 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 216 GoSliceDataType []*table<string,int>.array
+      GroupType: 213 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 97
+      ID: 98
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -7813,7 +7871,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 98 PointerType **table<string,main.nestedStruct>
+          Type: 99 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7832,10 +7890,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 207 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 208 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 139
+      ID: 140
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7848,7 +7906,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 140 PointerType **table<uint8,[4]int>
+          Type: 141 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7867,10 +7925,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 275 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 271 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 276 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 134
+      ID: 135
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7883,7 +7941,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 135 PointerType **table<uint8,uint8>
+          Type: 136 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7902,285 +7960,285 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 263 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 267 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 147
+      ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.129536e+06
+      GoRuntimeType: 1.1296e+06
       GoKind: 21
-      HeaderType: 149 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 142
+      ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.129664e+06
+      GoRuntimeType: 1.129728e+06
       GoKind: 21
-      HeaderType: 144 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 110
+      ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.129792e+06
+      GoRuntimeType: 1.129856e+06
       GoKind: 21
-      HeaderType: 112 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 122
+      ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.12992e+06
+      GoRuntimeType: 1.129984e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.129408e+06
+      GoRuntimeType: 1.129472e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 329
+      ID: 330
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.12928e+06
+      GoRuntimeType: 1.129344e+06
       GoKind: 21
-      HeaderType: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 365
+      ID: 366
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.12864e+06
+      GoRuntimeType: 1.128704e+06
       GoKind: 21
-      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 380
+      ID: 381
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.128512e+06
+      GoRuntimeType: 1.128576e+06
       GoKind: 21
-      HeaderType: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 90
+      ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.128e+06
+      GoRuntimeType: 1.128064e+06
       GoKind: 21
-      HeaderType: 92 GoSwissMapHeaderType map<int,int>
+      HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 395
+      ID: 396
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.128384e+06
+      GoRuntimeType: 1.128448e+06
       GoKind: 21
-      HeaderType: 397 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
-      ID: 127
+      ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.130048e+06
+      GoRuntimeType: 1.130112e+06
       GoKind: 21
-      HeaderType: 129 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 117
+      ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.130176e+06
+      GoRuntimeType: 1.13024e+06
       GoKind: 21
-      HeaderType: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 105
+      ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.130304e+06
+      GoRuntimeType: 1.130368e+06
       GoKind: 21
-      HeaderType: 107 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 100
+      ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.130432e+06
+      GoRuntimeType: 1.130496e+06
       GoKind: 21
-      HeaderType: 102 GoSwissMapHeaderType map<string,int>
+      HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 95
+      ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.13056e+06
+      GoRuntimeType: 1.130624e+06
       GoKind: 21
-      HeaderType: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 137
+      ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.130688e+06
+      GoRuntimeType: 1.130752e+06
       GoKind: 21
-      HeaderType: 139 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 132
+      ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.130816e+06
+      GoRuntimeType: 1.13088e+06
       GoKind: 21
-      HeaderType: 134 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 289
+      ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 682720
+      GoRuntimeType: 682784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 290 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 291 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 281
+      ID: 282
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 682816
+      GoRuntimeType: 682880
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 282 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 283 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 229
+      ID: 230
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 683104
+      GoRuntimeType: 683168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 230 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 231 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 248
+      ID: 249
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 683200
+      GoRuntimeType: 683264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 249 StructureType noalg.struct { key bool; elem main.node }
+      Element: 250 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 187
+      ID: 188
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 682048
+      GoRuntimeType: 682112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 338
+      ID: 339
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 681952
+      GoRuntimeType: 682016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 339 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 340 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 374
+      ID: 375
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 681472
+      GoRuntimeType: 681536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 376 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 389
+      ID: 390
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 681376
+      GoRuntimeType: 681440
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 390 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 391 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 197
+      ID: 198
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 680128
+      GoRuntimeType: 680192
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key int; elem int }
+      Element: 199 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 404
+      ID: 405
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 681280
+      GoRuntimeType: 681344
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 405 StructureType noalg.struct { key int; elem interface {} }
+      Element: 406 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 256
+      ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 683296
+      GoRuntimeType: 683360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 257 StructureType noalg.struct { key int; elem uint8 }
+      Element: 258 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 238
+      ID: 239
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 683392
+      GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 239 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 240 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 221
+      ID: 222
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 683488
+      GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem []string }
+      Element: 223 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 213
+      ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 683584
+      GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 214 StructureType noalg.struct { key string; elem int }
+      Element: 215 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 205
+      ID: 206
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 683680
+      GoRuntimeType: 683744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 207 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 272
+      ID: 273
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 683776
+      GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 273 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 274 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 264
+      ID: 265
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 683872
+      GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 265 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 266 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 288
+      ID: 289
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.294656e+06
+      GoRuntimeType: 1.294848e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8188,12 +8246,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 289 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 290 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 280
+      ID: 281
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.294912e+06
+      GoRuntimeType: 1.295104e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8201,12 +8259,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 281 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 282 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 228
+      ID: 229
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.295168e+06
+      GoRuntimeType: 1.29536e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8214,12 +8272,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 229 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 230 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 247
+      ID: 248
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.295424e+06
+      GoRuntimeType: 1.295616e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8227,12 +8285,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 248 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 249 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 186
+      ID: 187
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.2944e+06
+      GoRuntimeType: 1.294592e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8240,12 +8298,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 337
+      ID: 338
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.294144e+06
+      GoRuntimeType: 1.294336e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8253,12 +8311,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 338 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 339 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 373
+      ID: 374
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.292864e+06
+      GoRuntimeType: 1.293056e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8266,12 +8324,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 375 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 388
+      ID: 389
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.292608e+06
+      GoRuntimeType: 1.2928e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8279,12 +8337,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 389 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 390 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 196
+      ID: 197
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.291584e+06
+      GoRuntimeType: 1.291776e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8292,12 +8350,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 198 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 403
+      ID: 404
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.292352e+06
+      GoRuntimeType: 1.292544e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8305,12 +8363,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 404 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 405 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 255
+      ID: 256
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.29568e+06
+      GoRuntimeType: 1.295872e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8318,12 +8376,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 256 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 257 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 237
+      ID: 238
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.295936e+06
+      GoRuntimeType: 1.296128e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8331,12 +8389,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 238 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 239 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 220
+      ID: 221
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.296192e+06
+      GoRuntimeType: 1.296384e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8344,12 +8402,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 212
+      ID: 213
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.296448e+06
+      GoRuntimeType: 1.29664e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8357,12 +8415,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 213 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 204
+      ID: 205
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.296704e+06
+      GoRuntimeType: 1.296896e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8370,12 +8428,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 206 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 271
+      ID: 272
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.29696e+06
+      GoRuntimeType: 1.297152e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8383,12 +8441,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 272 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 273 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 263
+      ID: 264
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.297216e+06
+      GoRuntimeType: 1.297408e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8396,51 +8454,51 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 264 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 265 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 290
+      ID: 291
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.294528e+06
+      GoRuntimeType: 1.29472e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
     - __kind: StructureType
-      ID: 282
+      ID: 283
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.294784e+06
+      GoRuntimeType: 1.294976e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 230
+      ID: 231
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.29504e+06
+      GoRuntimeType: 1.295232e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 231 ArrayType [4]string
+          Type: 232 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 249
+      ID: 250
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.295296e+06
+      GoRuntimeType: 1.295488e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8448,12 +8506,12 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 155 StructureType main.node
+          Type: 156 StructureType main.node
     - __kind: StructureType
-      ID: 188
+      ID: 189
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.294272e+06
+      GoRuntimeType: 1.294464e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8461,12 +8519,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 189 PointerType *main.deepMap2
+          Type: 190 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 339
+      ID: 340
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.294016e+06
+      GoRuntimeType: 1.294208e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8474,12 +8532,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 340 PointerType *main.deepMap3
+          Type: 341 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 375
+      ID: 376
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.292736e+06
+      GoRuntimeType: 1.292928e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8487,12 +8545,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 376 PointerType *main.deepMap8
+          Type: 377 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 390
+      ID: 391
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.29248e+06
+      GoRuntimeType: 1.292672e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8500,12 +8558,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 391 PointerType *main.deepMap9
+          Type: 392 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 198
+      ID: 199
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.291456e+06
+      GoRuntimeType: 1.291648e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8515,10 +8573,10 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 405
+      ID: 406
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.292224e+06
+      GoRuntimeType: 1.292416e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8528,10 +8586,10 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 257
+      ID: 258
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.295552e+06
+      GoRuntimeType: 1.295744e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8541,10 +8599,10 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 239
+      ID: 240
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.295808e+06
+      GoRuntimeType: 1.296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8552,12 +8610,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 240 GoSliceHeaderType []main.structWithMap
+          Type: 241 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 222
+      ID: 223
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.296064e+06
+      GoRuntimeType: 1.296256e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8565,12 +8623,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 165 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 214
+      ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.29632e+06
+      GoRuntimeType: 1.296512e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8580,10 +8638,10 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 206
+      ID: 207
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.296576e+06
+      GoRuntimeType: 1.296768e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8591,12 +8649,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 173 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 273
+      ID: 274
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.296832e+06
+      GoRuntimeType: 1.297024e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8604,12 +8662,12 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
     - __kind: StructureType
-      ID: 265
+      ID: 266
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.297088e+06
+      GoRuntimeType: 1.29728e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8622,127 +8680,127 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 583904
+      GoRuntimeType: 583968
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 177 PointerType *string.str
+          Type: 178 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 176 GoStringDataType string.str
+      Data: 177 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 176
+      ID: 177
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 310
+      ID: 311
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.462816e+06
+      GoRuntimeType: 1.463008e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 312 StructureType internal/sync.Mutex
+          Type: 313 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 313
+      ID: 314
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.611712e+06
+      GoRuntimeType: 1.611904e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 314 StructureType sync/atomic.Bool
+          Type: 315 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 310 StructureType sync.Mutex
+          Type: 311 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 316
+      ID: 317
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.61152e+06
+      GoRuntimeType: 1.611712e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 317 StructureType sync/atomic.Uint64
+          Type: 318 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 311
+      ID: 312
       Name: sync.noCopy
-      GoRuntimeType: 988128
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 314
-      Name: sync/atomic.Bool
-      ByteSize: 4
-      GoRuntimeType: 1.463936e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 2 BaseType uint32
-    - __kind: StructureType
-      ID: 319
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.464096e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 10 BaseType int32
-    - __kind: StructureType
-      ID: 317
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.612096e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 318 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 8 BaseType uint64
-    - __kind: StructureType
-      ID: 318
-      Name: sync/atomic.align64
-      GoRuntimeType: 988320
+      GoRuntimeType: 988192
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 315
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 988224
+      Name: sync/atomic.Bool
+      ByteSize: 4
+      GoRuntimeType: 1.464128e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 2 BaseType uint32
+    - __kind: StructureType
+      ID: 320
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.464288e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 10 BaseType int32
+    - __kind: StructureType
+      ID: 318
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.612288e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 319 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 8 BaseType uint64
+    - __kind: StructureType
+      ID: 319
+      Name: sync/atomic.align64
+      GoRuntimeType: 988384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 285
+      ID: 316
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 988288
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 286
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -8764,9 +8822,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 286 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 287 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 277
+      ID: 278
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8788,9 +8846,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 278 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 279 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 225
+      ID: 226
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -8812,9 +8870,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 226 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 227 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 244
+      ID: 245
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -8836,9 +8894,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 245 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 246 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 183
+      ID: 184
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -8860,9 +8918,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 334
+      ID: 335
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8884,9 +8942,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 335 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 336 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 370
+      ID: 371
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8908,9 +8966,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 372 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 385
+      ID: 386
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8932,9 +8990,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 386 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 387 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 193
+      ID: 194
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -8956,9 +9014,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<int,int>
+          Type: 195 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 400
+      ID: 401
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8980,9 +9038,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 401 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 402 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 252
+      ID: 253
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9004,9 +9062,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 253 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 254 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 234
+      ID: 235
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -9028,9 +9086,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 235 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 236 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 217
+      ID: 218
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9052,9 +9110,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 218 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 209
+      ID: 210
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -9076,9 +9134,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 210 GoSwissMapGroupsType groupReference<string,int>
+          Type: 211 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 201
+      ID: 202
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -9100,9 +9158,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 203 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 268
+      ID: 269
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -9124,9 +9182,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 269 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 270 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 260
+      ID: 261
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9148,49 +9206,49 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 261 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 17
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 584544
+      GoRuntimeType: 584608
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 584160
+      GoRuntimeType: 584224
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 584288
+      GoRuntimeType: 584352
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 584416
+      GoRuntimeType: 584480
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 584032
+      GoRuntimeType: 584096
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 584608
+      GoRuntimeType: 584672
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 584992
+      GoRuntimeType: 585056
       GoKind: 26
-MaxTypeID: 521
+MaxTypeID: 523
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17ff520", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -3383,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 311
+      ID: 324
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 312 PointerType *main.deepSlice3
+      Pointee: 325 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 336
+      ID: 351
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 337 PointerType *main.deepSlice8
+      Pointee: 352 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 342
+      ID: 357
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 343 PointerType *main.deepSlice9
+      Pointee: 358 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3404,7 +3404,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 403
+      ID: 320
       Name: '**main.t'
       ByteSize: 8
       Pointee: 157 PointerType *main.t
@@ -3441,30 +3441,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 319
+      ID: 332
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 320 PointerType *table<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 353
-      Name: '**table<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 354 PointerType *table<int,*main.deepMap8>
+      Pointee: 333 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 368
+      Name: '**table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 369 PointerType *table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 383
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 369 PointerType *table<int,*main.deepMap9>
+      Pointee: 384 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 93
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 94 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 383
+      ID: 398
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 384 PointerType *table<int,interface {}>
+      Pointee: 399 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 130
       Name: '**table<int,uint8>'
@@ -3506,20 +3506,20 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 315
+      ID: 328
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 314 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 327 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 340
+      ID: 355
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 339 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 354 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 346
+      ID: 361
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 345 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 360 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 179
       Name: '*[]*string.array'
@@ -3536,15 +3536,15 @@ Types:
       ByteSize: 8
       Pointee: 301 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 349
+      ID: 364
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 348 GoSliceDataType []interface {}.array
+      Pointee: 363 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 407
+      ID: 345
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 406 GoSliceDataType []main.structWithMap.array
+      Pointee: 344 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 298
       Name: '*[]main.structWithNoStrings.array'
@@ -3648,12 +3648,12 @@ Types:
       GoKind: 22
       Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 327
+      ID: 340
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385728
       GoKind: 22
-      Pointee: 328 UnresolvedPointeeType main.deepMap3
+      Pointee: 341 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3662,19 +3662,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 361
+      ID: 376
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 385408
       GoKind: 22
-      Pointee: 362 StructureType main.deepMap8
+      Pointee: 377 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 376
+      ID: 391
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385344
       GoKind: 22
-      Pointee: 377 StructureType main.deepMap9
+      Pointee: 392 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3697,19 +3697,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 331
+      ID: 346
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 385984
       GoKind: 22
-      Pointee: 332 StructureType main.deepPtr8
+      Pointee: 347 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 333
+      ID: 348
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 385920
       GoKind: 22
-      Pointee: 334 StructureType main.deepPtr9
+      Pointee: 349 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3718,12 +3718,12 @@ Types:
       GoKind: 22
       Pointee: 180 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 312
+      ID: 325
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 386880
       GoKind: 22
-      Pointee: 313 UnresolvedPointeeType main.deepSlice3
+      Pointee: 326 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3732,19 +3732,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 337
+      ID: 352
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 338 StructureType main.deepSlice8
+      Pointee: 353 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 343
+      ID: 358
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386496
       GoKind: 22
-      Pointee: 344 StructureType main.deepSlice9
+      Pointee: 359 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 175
       Name: '*main.emptyStruct'
@@ -3813,10 +3813,10 @@ Types:
       GoKind: 22
       Pointee: 158 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 405
+      ID: 322
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 404 GoSliceDataType main.t.array
+      Pointee: 321 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 169
       Name: '*main.threeStringStruct'
@@ -3849,30 +3849,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 317
+      ID: 330
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 351
-      Name: '*map<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 352 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 366
+      Name: '*map<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 381
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 91
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 92 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 381
+      ID: 396
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 382 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 397 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 128
       Name: '*map<int,uint8>'
@@ -3940,30 +3940,30 @@ Types:
       ByteSize: 8
       Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 323
+      ID: 336
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 357
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 358 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 372
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 387
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 195
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 196 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 387
+      ID: 402
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 388 StructureType noalg.map.group[int]interface {}
+      Pointee: 403 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 254
       Name: '*noalg.map.group[int]uint8'
@@ -4037,30 +4037,30 @@ Types:
       ByteSize: 8
       Pointee: 183 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 320
+      ID: 333
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 321 StructureType table<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 354
-      Name: '*table<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 355 StructureType table<int,*main.deepMap8>
+      Pointee: 334 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 369
+      Name: '*table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 370 StructureType table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 384
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 370 StructureType table<int,*main.deepMap9>
+      Pointee: 385 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 193 StructureType table<int,int>
     - __kind: PointerType
-      ID: 384
+      ID: 399
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 385 StructureType table<int,interface {}>
+      Pointee: 400 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '*table<int,uint8>'
@@ -6105,7 +6105,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 310
+      ID: 323
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477568
@@ -6113,21 +6113,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 311 PointerType **main.deepSlice3
+          Type: 324 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 314 GoSliceDataType []*main.deepSlice3.array
+      Data: 327 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 314
+      ID: 327
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 312 PointerType *main.deepSlice3
+      Element: 325 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 335
+      ID: 350
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477248
@@ -6135,21 +6135,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 336 PointerType **main.deepSlice8
+          Type: 351 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 339 GoSliceDataType []*main.deepSlice8.array
+      Data: 354 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 354
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 337 PointerType *main.deepSlice8
+      Element: 352 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 341
+      ID: 356
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477184
@@ -6157,19 +6157,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 342 PointerType **main.deepSlice9
+          Type: 357 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 345 GoSliceDataType []*main.deepSlice9.array
+      Data: 360 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 360
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 343 PointerType *main.deepSlice9
+      Element: 358 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6218,30 +6218,30 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 342
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 320 PointerType *table<int,*main.deepMap3>
-    - __kind: GoSliceDataType
-      ID: 363
-      Name: '[]*table<int,*main.deepMap8>.array'
-      ByteSize: 8192
-      Element: 354 PointerType *table<int,*main.deepMap8>
+      Element: 333 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 378
+      Name: '[]*table<int,*main.deepMap8>.array'
+      ByteSize: 8192
+      Element: 369 PointerType *table<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 393
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 369 PointerType *table<int,*main.deepMap9>
+      Element: 384 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 199
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 94 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 406
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 384 PointerType *table<int,interface {}>
+      Element: 399 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]*table<int,uint8>.array'
@@ -6321,7 +6321,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 347
+      ID: 362
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -6336,9 +6336,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 348 GoSliceDataType []interface {}.array
+      Data: 363 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 348
+      ID: 363
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
@@ -6358,9 +6358,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 406 GoSliceDataType []main.structWithMap.array
+      Data: 344 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 344
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 89 StructureType main.structWithMap
@@ -6411,30 +6411,30 @@ Types:
       ByteSize: 2048
       Element: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 330
+      ID: 343
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 324 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: GoSliceDataType
-      ID: 364
-      Name: '[]noalg.map.group[int]*main.deepMap8.array'
-      ByteSize: 2048
-      Element: 358 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 379
+      Name: '[]noalg.map.group[int]*main.deepMap8.array'
+      ByteSize: 2048
+      Element: 373 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSliceDataType
+      ID: 394
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 373 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 196 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 392
+      ID: 407
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 388 StructureType noalg.map.group[int]interface {}
+      Element: 403 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]noalg.map.group[int]uint8.array'
@@ -6666,47 +6666,47 @@ Types:
       GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 322
+      ID: 335
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 323 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 336 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 356
+      ID: 371
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 357 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 372 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 358 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 364 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 386
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 387 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 394 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 194
       Name: groupReference<int,int>
@@ -6722,19 +6722,19 @@ Types:
       GroupType: 196 StructureType noalg.map.group[int]int
       GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 386
+      ID: 401
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 387 PointerType *noalg.map.group[int]interface {}
+          Type: 402 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 388 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 392 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 403 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 253
       Name: groupReference<int,uint8>
@@ -6877,7 +6877,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 395
+      ID: 312
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.472896e+06
@@ -6967,9 +6967,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 316 GoMapType map[int]*main.deepMap3
+          Type: 329 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 328
+      ID: 341
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -6981,9 +6981,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 350 GoMapType map[int]*main.deepMap8
+          Type: 365 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 362
+      ID: 377
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.184896e+06
@@ -6991,9 +6991,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 365 GoMapType map[int]*main.deepMap9
+          Type: 380 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 377
+      ID: 392
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.184768e+06
@@ -7001,7 +7001,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 380 GoMapType map[int]interface {}
+          Type: 395 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7035,9 +7035,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 331 PointerType *main.deepPtr8
+          Type: 346 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 332
+      ID: 347
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.186048e+06
@@ -7045,9 +7045,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 333 PointerType *main.deepPtr9
+          Type: 348 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 334
+      ID: 349
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18592e+06
@@ -7075,9 +7075,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 310 GoSliceHeaderType []*main.deepSlice3
+          Type: 323 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 313
+      ID: 326
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7089,9 +7089,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 335 GoSliceHeaderType []*main.deepSlice8
+          Type: 350 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 338
+      ID: 353
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.1872e+06
@@ -7099,9 +7099,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 341 GoSliceHeaderType []*main.deepSlice9
+          Type: 356 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 344
+      ID: 359
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.187072e+06
@@ -7109,7 +7109,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 347 GoSliceHeaderType []interface {}
+          Type: 362 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 174
       Name: main.emptyStruct
@@ -7127,16 +7127,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 393 StructureType sync.Mutex
+          Type: 310 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 396 StructureType sync.Once
+          Type: 313 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 399 StructureType sync.WaitGroup
+          Type: 316 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 402 StructureType sync/atomic.Int32
+          Type: 319 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -7276,16 +7276,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 403 PointerType **main.t
+          Type: 320 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 404 GoSliceDataType main.t.array
+      Data: 321 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 404
+      ID: 321
       Name: main.t.array
       ByteSize: 2048
       Element: 157 PointerType *main.t
@@ -7485,7 +7485,7 @@ Types:
       TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 318
+      ID: 331
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7498,7 +7498,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 319 PointerType **table<int,*main.deepMap3>
+          Type: 332 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7517,10 +7517,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 342 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 352
+      ID: 367
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7533,7 +7533,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 353 PointerType **table<int,*main.deepMap8>
+          Type: 368 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7552,10 +7552,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 363 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 358 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 367
+      ID: 382
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7568,7 +7568,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 368 PointerType **table<int,*main.deepMap9>
+          Type: 383 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7587,8 +7587,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 393 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 92
       Name: map<int,int>
@@ -7625,7 +7625,7 @@ Types:
       TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
       GroupType: 196 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 382
+      ID: 397
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7638,7 +7638,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 383 PointerType **table<int,interface {}>
+          Type: 398 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7657,8 +7657,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 391 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 388 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 406 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 403 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 129
       Name: map<int,uint8>
@@ -7940,26 +7940,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 316
+      ID: 329
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.12928e+06
       GoKind: 21
-      HeaderType: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 350
+      ID: 365
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.12864e+06
       GoKind: 21
-      HeaderType: 352 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 365
+      ID: 380
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.128512e+06
       GoKind: 21
-      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 90
       Name: map[int]int
@@ -7968,12 +7968,12 @@ Types:
       GoKind: 21
       HeaderType: 92 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 380
+      ID: 395
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.128384e+06
       GoKind: 21
-      HeaderType: 382 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 397 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 127
       Name: map[int]uint8
@@ -8069,32 +8069,32 @@ Types:
       HasCount: true
       Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 325
+      ID: 338
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 681952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 339 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 359
+      ID: 374
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 360 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 374
+      ID: 389
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 390 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 197
       Name: noalg.[8]struct { key int; elem int }
@@ -8105,14 +8105,14 @@ Types:
       HasCount: true
       Element: 198 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 389
+      ID: 404
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 390 StructureType noalg.struct { key int; elem interface {} }
+      Element: 405 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 256
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -8242,7 +8242,7 @@ Types:
           Offset: 8
           Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 324
+      ID: 337
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.294144e+06
@@ -8253,9 +8253,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 338 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 358
+      ID: 373
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.292864e+06
@@ -8266,9 +8266,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 359 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 373
+      ID: 388
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.292608e+06
@@ -8279,7 +8279,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 389 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 196
       Name: noalg.map.group[int]int
@@ -8294,7 +8294,7 @@ Types:
           Offset: 8
           Type: 197 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 388
+      ID: 403
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.292352e+06
@@ -8305,7 +8305,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 389 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 404 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 255
       Name: noalg.map.group[int]uint8
@@ -8463,7 +8463,7 @@ Types:
           Offset: 8
           Type: 189 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 326
+      ID: 339
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.294016e+06
@@ -8474,9 +8474,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 327 PointerType *main.deepMap3
+          Type: 340 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 360
+      ID: 375
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.292736e+06
@@ -8487,9 +8487,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 361 PointerType *main.deepMap8
+          Type: 376 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 375
+      ID: 390
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.29248e+06
@@ -8500,7 +8500,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 376 PointerType *main.deepMap9
+          Type: 391 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 198
       Name: noalg.struct { key int; elem int }
@@ -8515,7 +8515,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 390
+      ID: 405
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.292224e+06
@@ -8637,7 +8637,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 393
+      ID: 310
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.462816e+06
@@ -8645,12 +8645,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 395 StructureType internal/sync.Mutex
+          Type: 312 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 396
+      ID: 313
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.611712e+06
@@ -8658,15 +8658,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 397 StructureType sync/atomic.Bool
+          Type: 314 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 393 StructureType sync.Mutex
+          Type: 310 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 399
+      ID: 316
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.61152e+06
@@ -8674,21 +8674,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 400 StructureType sync/atomic.Uint64
+          Type: 317 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 394
+      ID: 311
       Name: sync.noCopy
       GoRuntimeType: 988128
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 397
+      ID: 314
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.463936e+06
@@ -8696,12 +8696,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 402
+      ID: 319
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464096e+06
@@ -8709,12 +8709,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 400
+      ID: 317
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612096e+06
@@ -8722,21 +8722,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 401 StructureType sync/atomic.align64
+          Type: 318 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 401
+      ID: 318
       Name: sync/atomic.align64
       GoRuntimeType: 988320
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 398
+      ID: 315
       Name: sync/atomic.noCopy
       GoRuntimeType: 988224
       GoKind: 25
@@ -8862,7 +8862,7 @@ Types:
           Offset: 16
           Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 321
+      ID: 334
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8884,9 +8884,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 335 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 355
+      ID: 370
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8908,9 +8908,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 356 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 370
+      ID: 385
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8932,7 +8932,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 386 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 193
       Name: table<int,int>
@@ -8958,7 +8958,7 @@ Types:
           Offset: 16
           Type: 194 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 385
+      ID: 400
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8980,7 +8980,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 386 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 401 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 252
       Name: table<int,uint8>

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -3445,7 +3445,7 @@ Types:
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 530624
+      GoRuntimeType: 530816
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
@@ -3607,175 +3607,175 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 393088
+      GoRuntimeType: 393280
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 392000
+      GoRuntimeType: 392192
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 392960
+      GoRuntimeType: 393152
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 393024
+      GoRuntimeType: 393216
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
       ID: 26
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 392640
+      GoRuntimeType: 392832
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 392256
+      GoRuntimeType: 392448
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 392384
+      GoRuntimeType: 392576
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 392512
+      GoRuntimeType: 392704
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 392128
+      GoRuntimeType: 392320
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
       ID: 88
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 393216
+      GoRuntimeType: 393408
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 385856
+      GoRuntimeType: 386048
       GoKind: 22
       Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
       ID: 341
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 385792
+      GoRuntimeType: 385984
       GoKind: 22
       Pointee: 342 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 385536
+      GoRuntimeType: 385728
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
       ID: 377
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 385472
+      GoRuntimeType: 385664
       GoKind: 22
       Pointee: 378 StructureType main.deepMap8
     - __kind: PointerType
       ID: 392
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 385408
+      GoRuntimeType: 385600
       GoKind: 22
       Pointee: 393 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 386432
+      GoRuntimeType: 386624
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 306
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 386368
+      GoRuntimeType: 386560
       GoKind: 22
       Pointee: 307 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 386112
+      GoRuntimeType: 386304
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 347
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 386048
+      GoRuntimeType: 386240
       GoKind: 22
       Pointee: 348 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 349
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 385984
+      GoRuntimeType: 386176
       GoKind: 22
       Pointee: 350 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 387008
+      GoRuntimeType: 387200
       GoKind: 22
       Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 326
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 386944
+      GoRuntimeType: 387136
       GoKind: 22
       Pointee: 327 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 386688
+      GoRuntimeType: 386880
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 353
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 386624
+      GoRuntimeType: 386816
       GoKind: 22
       Pointee: 354 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 359
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 386560
+      GoRuntimeType: 386752
       GoKind: 22
       Pointee: 360 StructureType main.deepSlice9
     - __kind: PointerType
@@ -3788,14 +3788,14 @@ Types:
       ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 387136
+      GoRuntimeType: 387328
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 387200
+      GoRuntimeType: 387392
       GoKind: 22
       Pointee: 156 StructureType main.node
     - __kind: PointerType
@@ -3825,7 +3825,7 @@ Types:
       ID: 242
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 385344
+      GoRuntimeType: 385536
       GoKind: 22
       Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
@@ -4036,7 +4036,7 @@ Types:
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 392064
+      GoRuntimeType: 392256
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -4133,42 +4133,42 @@ Types:
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 392704
+      GoRuntimeType: 392896
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 392320
+      GoRuntimeType: 392512
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 392448
+      GoRuntimeType: 392640
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 392576
+      GoRuntimeType: 392768
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 392192
+      GoRuntimeType: 392384
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 392768
+      GoRuntimeType: 392960
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -6007,7 +6007,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 683072
+      GoRuntimeType: 683264
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6024,7 +6024,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 684416
+      GoRuntimeType: 684608
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6057,7 +6057,7 @@ Types:
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 684512
+      GoRuntimeType: 684704
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6090,7 +6090,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 684608
+      GoRuntimeType: 684800
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6099,7 +6099,7 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 684320
+      GoRuntimeType: 684512
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6108,7 +6108,7 @@ Types:
       ID: 275
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 682688
+      GoRuntimeType: 682880
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6117,7 +6117,7 @@ Types:
       ID: 232
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 682976
+      GoRuntimeType: 683168
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6134,7 +6134,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 477696
+      GoRuntimeType: 477888
       GoKind: 23
       RawFields:
         - Name: array
@@ -6156,7 +6156,7 @@ Types:
       ID: 324
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 477632
+      GoRuntimeType: 477824
       GoKind: 23
       RawFields:
         - Name: array
@@ -6178,7 +6178,7 @@ Types:
       ID: 351
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 477312
+      GoRuntimeType: 477504
       GoKind: 23
       RawFields:
         - Name: array
@@ -6200,7 +6200,7 @@ Types:
       ID: 357
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 477248
+      GoRuntimeType: 477440
       GoKind: 23
       RawFields:
         - Name: array
@@ -6222,7 +6222,7 @@ Types:
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 478720
+      GoRuntimeType: 478912
       GoKind: 23
       RawFields:
         - Name: array
@@ -6350,7 +6350,7 @@ Types:
       ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 487040
+      GoRuntimeType: 487232
       GoKind: 23
       RawFields:
         - Name: array
@@ -6372,7 +6372,7 @@ Types:
       ID: 363
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 487360
+      GoRuntimeType: 487552
       GoKind: 23
       RawFields:
         - Name: array
@@ -6394,7 +6394,7 @@ Types:
       ID: 241
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 477952
+      GoRuntimeType: 478144
       GoKind: 23
       RawFields:
         - Name: array
@@ -6522,7 +6522,7 @@ Types:
       ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 487168
+      GoRuntimeType: 487360
       GoKind: 23
       RawFields:
         - Name: array
@@ -6544,7 +6544,7 @@ Types:
       ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 486656
+      GoRuntimeType: 486848
       GoKind: 23
       RawFields:
         - Name: array
@@ -6566,7 +6566,7 @@ Types:
       ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 486016
+      GoRuntimeType: 486208
       GoKind: 23
       RawFields:
         - Name: array
@@ -6588,35 +6588,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 584992
+      GoRuntimeType: 585184
       GoKind: 1
     - __kind: GoChannelType
       ID: 153
       Name: chan bool
-      GoRuntimeType: 596320
+      GoRuntimeType: 596512
       GoKind: 18
     - __kind: GoChannelType
       ID: 80
       Name: chan struct {}
-      GoRuntimeType: 595232
+      GoRuntimeType: 595424
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 584800
+      GoRuntimeType: 584992
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 584736
+      GoRuntimeType: 584928
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.026752e+06
+      GoRuntimeType: 1.026944e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6629,19 +6629,19 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 584864
+      GoRuntimeType: 585056
       GoKind: 13
     - __kind: BaseType
       ID: 15
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 584928
+      GoRuntimeType: 585120
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 475840
+      GoRuntimeType: 476032
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 287
@@ -6885,37 +6885,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 584544
+      GoRuntimeType: 584736
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 584160
+      GoRuntimeType: 584352
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 584288
+      GoRuntimeType: 584480
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 584416
+      GoRuntimeType: 584608
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 584032
+      GoRuntimeType: 584224
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 847904
+      GoRuntimeType: 848096
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6928,7 +6928,7 @@ Types:
       ID: 313
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.473088e+06
+      GoRuntimeType: 1.473536e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6941,7 +6941,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.022784e+06
+      GoRuntimeType: 1.022976e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6972,7 +6972,7 @@ Types:
       ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.0224e+06
+      GoRuntimeType: 1.022592e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7000,7 +7000,7 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.185984e+06
+      GoRuntimeType: 1.186432e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7010,7 +7010,7 @@ Types:
       ID: 191
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.185856e+06
+      GoRuntimeType: 1.186304e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7024,7 +7024,7 @@ Types:
       ID: 74
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.185216e+06
+      GoRuntimeType: 1.185664e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7034,7 +7034,7 @@ Types:
       ID: 378
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.185088e+06
+      GoRuntimeType: 1.185536e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7044,7 +7044,7 @@ Types:
       ID: 393
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.18496e+06
+      GoRuntimeType: 1.185408e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7054,7 +7054,7 @@ Types:
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.187136e+06
+      GoRuntimeType: 1.187584e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7064,7 +7064,7 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.187008e+06
+      GoRuntimeType: 1.187456e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7078,7 +7078,7 @@ Types:
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.186368e+06
+      GoRuntimeType: 1.186816e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7088,7 +7088,7 @@ Types:
       ID: 348
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.18624e+06
+      GoRuntimeType: 1.186688e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7098,7 +7098,7 @@ Types:
       ID: 350
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.186112e+06
+      GoRuntimeType: 1.18656e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7108,7 +7108,7 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.188288e+06
+      GoRuntimeType: 1.188736e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7118,7 +7118,7 @@ Types:
       ID: 181
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.18816e+06
+      GoRuntimeType: 1.188608e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7132,7 +7132,7 @@ Types:
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.18752e+06
+      GoRuntimeType: 1.187968e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7142,7 +7142,7 @@ Types:
       ID: 354
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.187392e+06
+      GoRuntimeType: 1.18784e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7152,7 +7152,7 @@ Types:
       ID: 360
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.187264e+06
+      GoRuntimeType: 1.187712e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7167,7 +7167,7 @@ Types:
       ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.834048e+06
+      GoRuntimeType: 1.834496e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7189,7 +7189,7 @@ Types:
       ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.96736e+06
+      GoRuntimeType: 1.967808e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7217,7 +7217,7 @@ Types:
       ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.461728e+06
+      GoRuntimeType: 1.462176e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7230,7 +7230,7 @@ Types:
       ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.461568e+06
+      GoRuntimeType: 1.462016e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7252,7 +7252,7 @@ Types:
       ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.022528e+06
+      GoRuntimeType: 1.02272e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7286,7 +7286,7 @@ Types:
       ID: 89
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.184704e+06
+      GoRuntimeType: 1.185152e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7296,7 +7296,7 @@ Types:
       ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.184832e+06
+      GoRuntimeType: 1.18528e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -7966,126 +7966,126 @@ Types:
       ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.1296e+06
+      GoRuntimeType: 1.129792e+06
       GoKind: 21
       HeaderType: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.129728e+06
+      GoRuntimeType: 1.12992e+06
       GoKind: 21
       HeaderType: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.129856e+06
+      GoRuntimeType: 1.130048e+06
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.129984e+06
+      GoRuntimeType: 1.130176e+06
       GoKind: 21
       HeaderType: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.129472e+06
+      GoRuntimeType: 1.129664e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 330
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.129344e+06
+      GoRuntimeType: 1.129536e+06
       GoKind: 21
       HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 366
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.128704e+06
+      GoRuntimeType: 1.128896e+06
       GoKind: 21
       HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 381
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.128576e+06
+      GoRuntimeType: 1.128768e+06
       GoKind: 21
       HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.128064e+06
+      GoRuntimeType: 1.128256e+06
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 396
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.128448e+06
+      GoRuntimeType: 1.12864e+06
       GoKind: 21
       HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.130112e+06
+      GoRuntimeType: 1.130304e+06
       GoKind: 21
       HeaderType: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.13024e+06
+      GoRuntimeType: 1.130432e+06
       GoKind: 21
       HeaderType: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.130368e+06
+      GoRuntimeType: 1.13056e+06
       GoKind: 21
       HeaderType: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.130496e+06
+      GoRuntimeType: 1.130688e+06
       GoKind: 21
       HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.130624e+06
+      GoRuntimeType: 1.130816e+06
       GoKind: 21
       HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.130752e+06
+      GoRuntimeType: 1.130944e+06
       GoKind: 21
       HeaderType: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.13088e+06
+      GoRuntimeType: 1.131072e+06
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
       ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 682784
+      GoRuntimeType: 682976
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8094,7 +8094,7 @@ Types:
       ID: 282
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 682880
+      GoRuntimeType: 683072
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8103,7 +8103,7 @@ Types:
       ID: 230
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 683168
+      GoRuntimeType: 683360
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8112,7 +8112,7 @@ Types:
       ID: 249
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 683264
+      GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8121,7 +8121,7 @@ Types:
       ID: 188
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 682112
+      GoRuntimeType: 682304
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8130,7 +8130,7 @@ Types:
       ID: 339
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 682016
+      GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8139,7 +8139,7 @@ Types:
       ID: 375
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 681536
+      GoRuntimeType: 681728
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8148,7 +8148,7 @@ Types:
       ID: 390
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 681440
+      GoRuntimeType: 681632
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8157,7 +8157,7 @@ Types:
       ID: 198
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 680192
+      GoRuntimeType: 680384
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8166,7 +8166,7 @@ Types:
       ID: 405
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 681344
+      GoRuntimeType: 681536
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8175,7 +8175,7 @@ Types:
       ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 683360
+      GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8184,7 +8184,7 @@ Types:
       ID: 239
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 683456
+      GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8193,7 +8193,7 @@ Types:
       ID: 222
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 683552
+      GoRuntimeType: 683744
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8202,7 +8202,7 @@ Types:
       ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 683648
+      GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8211,7 +8211,7 @@ Types:
       ID: 206
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 683744
+      GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8220,7 +8220,7 @@ Types:
       ID: 273
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 683840
+      GoRuntimeType: 684032
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8229,7 +8229,7 @@ Types:
       ID: 265
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 683936
+      GoRuntimeType: 684128
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8238,7 +8238,7 @@ Types:
       ID: 289
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.294848e+06
+      GoRuntimeType: 1.295296e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8251,7 +8251,7 @@ Types:
       ID: 281
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.295104e+06
+      GoRuntimeType: 1.295552e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8264,7 +8264,7 @@ Types:
       ID: 229
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.29536e+06
+      GoRuntimeType: 1.295808e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8277,7 +8277,7 @@ Types:
       ID: 248
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.295616e+06
+      GoRuntimeType: 1.296064e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8290,7 +8290,7 @@ Types:
       ID: 187
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.294592e+06
+      GoRuntimeType: 1.29504e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8303,7 +8303,7 @@ Types:
       ID: 338
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.294336e+06
+      GoRuntimeType: 1.294784e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8316,7 +8316,7 @@ Types:
       ID: 374
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.293056e+06
+      GoRuntimeType: 1.293504e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8329,7 +8329,7 @@ Types:
       ID: 389
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.2928e+06
+      GoRuntimeType: 1.293248e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8342,7 +8342,7 @@ Types:
       ID: 197
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.291776e+06
+      GoRuntimeType: 1.292224e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8355,7 +8355,7 @@ Types:
       ID: 404
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.292544e+06
+      GoRuntimeType: 1.292992e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8368,7 +8368,7 @@ Types:
       ID: 256
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.295872e+06
+      GoRuntimeType: 1.29632e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8381,7 +8381,7 @@ Types:
       ID: 238
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.296128e+06
+      GoRuntimeType: 1.296576e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8394,7 +8394,7 @@ Types:
       ID: 221
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.296384e+06
+      GoRuntimeType: 1.296832e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8407,7 +8407,7 @@ Types:
       ID: 213
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.29664e+06
+      GoRuntimeType: 1.297088e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8420,7 +8420,7 @@ Types:
       ID: 205
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.296896e+06
+      GoRuntimeType: 1.297344e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8433,7 +8433,7 @@ Types:
       ID: 272
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.297152e+06
+      GoRuntimeType: 1.2976e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8446,7 +8446,7 @@ Types:
       ID: 264
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.297408e+06
+      GoRuntimeType: 1.297856e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8459,7 +8459,7 @@ Types:
       ID: 291
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.29472e+06
+      GoRuntimeType: 1.295168e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8472,7 +8472,7 @@ Types:
       ID: 283
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.294976e+06
+      GoRuntimeType: 1.295424e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8485,7 +8485,7 @@ Types:
       ID: 231
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.295232e+06
+      GoRuntimeType: 1.29568e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8498,7 +8498,7 @@ Types:
       ID: 250
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.295488e+06
+      GoRuntimeType: 1.295936e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8511,7 +8511,7 @@ Types:
       ID: 189
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.294464e+06
+      GoRuntimeType: 1.294912e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8524,7 +8524,7 @@ Types:
       ID: 340
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.294208e+06
+      GoRuntimeType: 1.294656e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8537,7 +8537,7 @@ Types:
       ID: 376
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.292928e+06
+      GoRuntimeType: 1.293376e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8550,7 +8550,7 @@ Types:
       ID: 391
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.292672e+06
+      GoRuntimeType: 1.29312e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8563,7 +8563,7 @@ Types:
       ID: 199
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.291648e+06
+      GoRuntimeType: 1.292096e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8576,7 +8576,7 @@ Types:
       ID: 406
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.292416e+06
+      GoRuntimeType: 1.292864e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8589,7 +8589,7 @@ Types:
       ID: 258
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.295744e+06
+      GoRuntimeType: 1.296192e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8602,7 +8602,7 @@ Types:
       ID: 240
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.296e+06
+      GoRuntimeType: 1.296448e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8615,7 +8615,7 @@ Types:
       ID: 223
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.296256e+06
+      GoRuntimeType: 1.296704e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8628,7 +8628,7 @@ Types:
       ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.296512e+06
+      GoRuntimeType: 1.29696e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8641,7 +8641,7 @@ Types:
       ID: 207
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.296768e+06
+      GoRuntimeType: 1.297216e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8654,7 +8654,7 @@ Types:
       ID: 274
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.297024e+06
+      GoRuntimeType: 1.297472e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8667,7 +8667,7 @@ Types:
       ID: 266
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.29728e+06
+      GoRuntimeType: 1.297728e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8680,7 +8680,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 583968
+      GoRuntimeType: 584160
       GoKind: 24
       RawFields:
         - Name: str
@@ -8698,7 +8698,7 @@ Types:
       ID: 311
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.463008e+06
+      GoRuntimeType: 1.463456e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8711,7 +8711,7 @@ Types:
       ID: 314
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.611904e+06
+      GoRuntimeType: 1.612352e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8727,7 +8727,7 @@ Types:
       ID: 317
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.611712e+06
+      GoRuntimeType: 1.61216e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -8742,14 +8742,14 @@ Types:
     - __kind: StructureType
       ID: 312
       Name: sync.noCopy
-      GoRuntimeType: 988192
+      GoRuntimeType: 988384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 315
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.464128e+06
+      GoRuntimeType: 1.464576e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8762,7 +8762,7 @@ Types:
       ID: 320
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.464288e+06
+      GoRuntimeType: 1.464736e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8775,7 +8775,7 @@ Types:
       ID: 318
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.612288e+06
+      GoRuntimeType: 1.612736e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8790,13 +8790,13 @@ Types:
     - __kind: StructureType
       ID: 319
       Name: sync/atomic.align64
-      GoRuntimeType: 988384
+      GoRuntimeType: 988576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 316
       Name: sync/atomic.noCopy
-      GoRuntimeType: 988288
+      GoRuntimeType: 988480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -9211,43 +9211,43 @@ Types:
       ID: 17
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 584608
+      GoRuntimeType: 584800
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 584224
+      GoRuntimeType: 584416
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 584352
+      GoRuntimeType: 584544
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 584480
+      GoRuntimeType: 584672
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 584096
+      GoRuntimeType: 584288
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 584672
+      GoRuntimeType: 584864
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 585056
+      GoRuntimeType: 585248
       GoKind: 26
 MaxTypeID: 523
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 506 EventRootType Probe[main.stackC]
+          Type: 1185 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcdd8ca", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 461 EventRootType Probe[main.testAny]
+          Type: 1140 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda74a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 463 EventRootType Probe[main.testAnyPtr]
+          Type: 1142 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcda7ea", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 423 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1102 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 425 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1104 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 471 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1150 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcdaee0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 424 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1103 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 443 EventRootType Probe[main.testBigStruct]
+          Type: 1122 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 412 EventRootType Probe[main.testBoolArray]
+          Type: 1091 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 409 EventRootType Probe[main.testByteArray]
+          Type: 1088 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 487 EventRootType Probe[main.testChannel]
+          Type: 1166 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdcba0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 485 EventRootType Probe[main.testCombinedByte]
+          Type: 1164 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcdc7c0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 495 EventRootType Probe[main.testCycle]
+          Type: 1174 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdcf40", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 448 EventRootType Probe[main.testDeepMap1]
+          Type: 1127 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9700", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 449 EventRootType Probe[main.testDeepMap7]
+          Type: 1128 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9720", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 444 EventRootType Probe[main.testDeepPtr1]
+          Type: 1123 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd93e0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 445 EventRootType Probe[main.testDeepPtr7]
+          Type: 1124 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9400", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 446 EventRootType Probe[main.testDeepSlice1]
+          Type: 1125 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd9580", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 447 EventRootType Probe[main.testDeepSlice7]
+          Type: 1126 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 497 EventRootType Probe[main.testEmptySlice]
+          Type: 1176 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdd480", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 500 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1179 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdd4e0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 514 EventRootType Probe[main.testEmptyString]
+          Type: 1193 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -337,7 +337,7 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - ID: 108
-          Type: 516 EventRootType Probe[main.testEmptyStruct]
+          Type: 1195 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcdde00", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -350,7 +350,7 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - ID: 109
-          Type: 517 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1196 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcdde20", Frameless: true}]
           Condition: null
     - id: testError
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 462 EventRootType Probe[main.testError]
+          Type: 1141 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcda7c0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 453 EventRootType Probe[main.testEsotericHeap]
+          Type: 1132 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9cca", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 452 EventRootType Probe[main.testEsotericStack]
+          Type: 1131 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 458 EventRootType Probe[main.testFrameless]
+          Type: 1137 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda420", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 459 EventRootType Probe[main.testFramelessArray]
+          Type: 1138 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda444", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 454 EventRootType Probe[main.testInlinedBA]
+          Type: 1133 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda10a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 455 EventRootType Probe[main.testInlinedBB]
+          Type: 1134 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda1ae", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 456 EventRootType Probe[main.testInlinedBBA]
+          Type: 1135 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda28a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -476,7 +476,7 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - ID: 111
-          Type: 519 EventRootType Probe[main.testInlinedBBB]
+          Type: 1198 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda206", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 457 EventRootType Probe[main.testInlinedBC]
+          Type: 1136 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda30e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -504,7 +504,7 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - ID: 112
-          Type: 520 EventRootType Probe[main.testInlinedBCA]
+          Type: 1199 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda313", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -518,7 +518,7 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - ID: 113
-          Type: 521 EventRootType Probe[main.testInlinedBCB]
+          Type: 1200 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda3bb", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - ID: 110
-          Type: 518 EventRootType Probe[main.testInlinedPrint]
+          Type: 1197 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd9f6a"
               Frameless: false
@@ -557,7 +557,7 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - ID: 114
-          Type: 522 EventRootType Probe[main.testInlinedSq]
+          Type: 1201 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda421", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -572,7 +572,7 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - ID: 115
-          Type: 523 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1202 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda465"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 415 EventRootType Probe[main.testInt16Array]
+          Type: 1094 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 416 EventRootType Probe[main.testInt32Array]
+          Type: 1095 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 417 EventRootType Probe[main.testInt64Array]
+          Type: 1096 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 414 EventRootType Probe[main.testInt8Array]
+          Type: 1093 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 413 EventRootType Probe[main.testIntArray]
+          Type: 1092 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 460 EventRootType Probe[main.testInterface]
+          Type: 1139 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda720", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 489 EventRootType Probe[main.testLinkedList]
+          Type: 1168 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdcd60", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 469 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1148 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcdaea0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 475 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1154 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcdaf60", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 473 EventRootType Probe[main.testMapIntToInt]
+          Type: 1152 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcdaf20", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 484 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1163 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb080", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 483 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1162 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcdb060", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 474 EventRootType Probe[main.testMapMassive]
+          Type: 1153 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdaf40", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 482 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1161 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb040", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 481 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1160 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcdb020", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 467 EventRootType Probe[main.testMapStringToInt]
+          Type: 1146 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcdae60", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 468 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1147 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcdae80", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 466 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1145 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 476 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1155 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcdaf80", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 479 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1158 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcdafe0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 480 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1159 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcdb000", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 477 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1156 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcdafa0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 478 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1157 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcdafc0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 512 EventRootType Probe[main.testMassiveString]
+          Type: 1191 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 486 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1165 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdc980", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 494 EventRootType Probe[main.testNilPointer]
+          Type: 1173 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdcf00", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 504 EventRootType Probe[main.testNilSlice]
+          Type: 1183 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdd560", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 501 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1180 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdd500", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 503 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1182 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdd540", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 511 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1190 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdd9a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 490 EventRootType Probe[main.testPointerLoop]
+          Type: 1169 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdcd80", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 472 EventRootType Probe[main.testPointerToMap]
+          Type: 1151 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcdaf00", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 488 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1167 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdcd40", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 410 EventRootType Probe[main.testRuneArray]
+          Type: 1089 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 429 EventRootType Probe[main.testSingleBool]
+          Type: 1108 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 427 EventRootType Probe[main.testSingleByte]
+          Type: 1106 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd8fe0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 440 EventRootType Probe[main.testSingleFloat32]
+          Type: 1119 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 441 EventRootType Probe[main.testSingleFloat64]
+          Type: 1120 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 430 EventRootType Probe[main.testSingleInt]
+          Type: 1109 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 432 EventRootType Probe[main.testSingleInt16]
+          Type: 1111 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 433 EventRootType Probe[main.testSingleInt32]
+          Type: 1112 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 434 EventRootType Probe[main.testSingleInt64]
+          Type: 1113 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 431 EventRootType Probe[main.testSingleInt8]
+          Type: 1110 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 428 EventRootType Probe[main.testSingleRune]
+          Type: 1107 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9000", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 507 EventRootType Probe[main.testSingleString]
+          Type: 1186 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 435 EventRootType Probe[main.testSingleUint]
+          Type: 1114 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 437 EventRootType Probe[main.testSingleUint16]
+          Type: 1116 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 438 EventRootType Probe[main.testSingleUint32]
+          Type: 1117 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 439 EventRootType Probe[main.testSingleUint64]
+          Type: 1118 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 436 EventRootType Probe[main.testSingleUint8]
+          Type: 1115 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 498 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1177 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdd4a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 470 EventRootType Probe[main.testSmallMap]
+          Type: 1149 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcdaec0", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 411 EventRootType Probe[main.testStringArray]
+          Type: 1090 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 493 EventRootType Probe[main.testStringPointer]
+          Type: 1172 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdcec0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 502 EventRootType Probe[main.testStringSlice]
+          Type: 1181 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdd520", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 450 EventRootType Probe[main.testStringType1]
+          Type: 1129 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 451 EventRootType Probe[main.testStringType2]
+          Type: 1130 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1394,7 +1394,7 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - ID: 107
-          Type: 515 EventRootType Probe[main.testStruct]
+          Type: 1194 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcddc80", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 499 EventRootType Probe[main.testStructSlice]
+          Type: 1178 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdd4c0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,7 +1425,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 464 EventRootType Probe[main.testStructWithAny]
+          Type: 1143 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcda840", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1439,7 +1439,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 465 EventRootType Probe[main.testStructWithMap]
+          Type: 1144 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdae20", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1453,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 508 EventRootType Probe[main.testThreeStrings]
+          Type: 1187 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1467,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 509 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1188 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdd960", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1481,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 510 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1189 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdd980", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 442 EventRootType Probe[main.testTypeAlias]
+          Type: 1121 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 420 EventRootType Probe[main.testUint16Array]
+          Type: 1099 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 421 EventRootType Probe[main.testUint32Array]
+          Type: 1100 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 422 EventRootType Probe[main.testUint64Array]
+          Type: 1101 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 419 EventRootType Probe[main.testUint8Array]
+          Type: 1098 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 418 EventRootType Probe[main.testUintArray]
+          Type: 1097 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1579,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 492 EventRootType Probe[main.testUintPointer]
+          Type: 1171 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdcde0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1593,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 496 EventRootType Probe[main.testUintSlice]
+          Type: 1175 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1607,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 513 EventRootType Probe[main.testUnitializedString]
+          Type: 1192 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdd9e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1621,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 491 EventRootType Probe[main.testUnsafePointer]
+          Type: 1170 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdcda0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 426 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1105 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1649,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 505 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1184 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3416,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 325
+      ID: 1004
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 326 PointerType *main.deepSlice3
+      Pointee: 1005 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 352
+      ID: 1031
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 353 PointerType *main.deepSlice8
+      Pointee: 1032 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 358
+      ID: 1037
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 359 PointerType *main.deepSlice9
+      Pointee: 1038 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3437,7 +3437,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 321
+      ID: 1000
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3474,30 +3474,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 333
+      ID: 1012
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 334 PointerType *table<int,*main.deepMap3>
+      Pointee: 1013 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 369
+      ID: 1048
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 370 PointerType *table<int,*main.deepMap8>
+      Pointee: 1049 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 384
+      ID: 1063
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 385 PointerType *table<int,*main.deepMap9>
+      Pointee: 1064 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 399
+      ID: 1078
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 400 PointerType *table<int,interface {}>
+      Pointee: 1079 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '**table<int,uint8>'
@@ -3513,6 +3513,11 @@ Types:
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
+    - __kind: PointerType
+      ID: 743
+      Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 744 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3539,20 +3544,20 @@ Types:
       ByteSize: 8
       Pointee: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 329
+      ID: 1008
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 328 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1007 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 356
+      ID: 1035
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 355 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1034 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 362
+      ID: 1041
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 361 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1040 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 180
       Name: '*[]*string.array'
@@ -3569,15 +3574,20 @@ Types:
       ByteSize: 8
       Pointee: 302 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 365
+      ID: 783
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 782 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 1044
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 364 GoSliceDataType []interface {}.array
+      Pointee: 1043 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 346
+      ID: 1025
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 345 GoSliceDataType []main.structWithMap.array
+      Pointee: 1024 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 299
       Name: '*[]main.structWithNoStrings.array'
@@ -3604,6 +3614,72 @@ Types:
       ByteSize: 8
       Pointee: 304 GoSliceDataType []uint16.array
     - __kind: PointerType
+      ID: 781
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 780 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 913
+      Name: '*archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.985952e+06
+      GoKind: 22
+      Pointee: 914 UnresolvedPointeeType archive/tar.Writer
+    - __kind: PointerType
+      ID: 543
+      Name: '*archive/tar.headerError'
+      ByteSize: 8
+      GoRuntimeType: 931392
+      GoKind: 22
+      Pointee: 544 GoSliceHeaderType archive/tar.headerError
+    - __kind: PointerType
+      ID: 546
+      Name: '*archive/tar.headerError.array'
+      ByteSize: 8
+      Pointee: 545 GoSliceDataType archive/tar.headerError.array
+    - __kind: PointerType
+      ID: 848
+      Name: '*archive/tar.regFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.435072e+06
+      GoKind: 22
+      Pointee: 849 UnresolvedPointeeType archive/tar.regFileWriter
+    - __kind: PointerType
+      ID: 796
+      Name: '*archive/zip.countWriter'
+      ByteSize: 8
+      GoRuntimeType: 931584
+      GoKind: 22
+      Pointee: 797 UnresolvedPointeeType archive/zip.countWriter
+    - __kind: PointerType
+      ID: 798
+      Name: '*archive/zip.dirWriter'
+      ByteSize: 8
+      GoRuntimeType: 931680
+      GoKind: 22
+      Pointee: 799 StructureType archive/zip.dirWriter
+    - __kind: PointerType
+      ID: 892
+      Name: '*archive/zip.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.904096e+06
+      GoKind: 22
+      Pointee: 893 UnresolvedPointeeType archive/zip.fileWriter
+    - __kind: PointerType
+      ID: 824
+      Name: '*archive/zip.nopCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.057792e+06
+      GoKind: 22
+      Pointee: 825 StructureType archive/zip.nopCloser
+    - __kind: PointerType
+      ID: 826
+      Name: '*archive/zip.pooledFlateWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.058048e+06
+      GoKind: 22
+      Pointee: 827 UnresolvedPointeeType archive/zip.pooledFlateWriter
+    - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
@@ -3611,12 +3687,456 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
+      ID: 871
+      Name: '*bufio.Reader'
+      ByteSize: 8
+      GoRuntimeType: 2.174048e+06
+      GoKind: 22
+      Pointee: 872 UnresolvedPointeeType bufio.Reader
+    - __kind: PointerType
+      ID: 900
+      Name: '*bufio.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.948832e+06
+      GoKind: 22
+      Pointee: 901 UnresolvedPointeeType bufio.Writer
+    - __kind: PointerType
+      ID: 951
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.266912e+06
+      GoKind: 22
+      Pointee: 952 UnresolvedPointeeType bytes.Buffer
+    - __kind: PointerType
+      ID: 453
+      Name: '*compress/flate.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 913824
+      GoKind: 22
+      Pointee: 342 BaseType compress/flate.CorruptInputError
+    - __kind: PointerType
+      ID: 454
+      Name: '*compress/flate.InternalError'
+      ByteSize: 8
+      GoRuntimeType: 913920
+      GoKind: 22
+      Pointee: 343 GoStringHeaderType compress/flate.InternalError
+    - __kind: PointerType
+      ID: 345
+      Name: '*compress/flate.InternalError.str'
+      ByteSize: 8
+      Pointee: 344 GoStringDataType compress/flate.InternalError.str
+    - __kind: PointerType
+      ID: 846
+      Name: '*compress/flate.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.424672e+06
+      GoKind: 22
+      Pointee: 847 UnresolvedPointeeType compress/flate.Writer
+    - __kind: PointerType
+      ID: 792
+      Name: '*compress/flate.dictWriter'
+      ByteSize: 8
+      GoRuntimeType: 914016
+      GoKind: 22
+      Pointee: 793 UnresolvedPointeeType compress/flate.dictWriter
+    - __kind: PointerType
+      ID: 868
+      Name: '*compress/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.725376e+06
+      GoKind: 22
+      Pointee: 869 UnresolvedPointeeType compress/gzip.Writer
+    - __kind: PointerType
+      ID: 691
+      Name: '*context.deadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.203328e+06
+      GoKind: 22
+      Pointee: 692 StructureType context.deadlineExceededError
+    - __kind: PointerType
+      ID: 535
+      Name: '*crypto/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 926016
+      GoKind: 22
+      Pointee: 356 BaseType crypto/aes.KeySizeError
+    - __kind: PointerType
+      ID: 536
+      Name: '*crypto/des.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 926208
+      GoKind: 22
+      Pointee: 357 BaseType crypto/des.KeySizeError
+    - __kind: PointerType
+      ID: 537
+      Name: '*crypto/internal/fips140/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 926496
+      GoKind: 22
+      Pointee: 358 BaseType crypto/internal/fips140/aes.KeySizeError
+    - __kind: PointerType
+      ID: 863
+      Name: '*crypto/internal/fips140/hmac.HMAC'
+      ByteSize: 8
+      GoRuntimeType: 1.666112e+06
+      GoKind: 22
+      Pointee: 864 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+    - __kind: PointerType
+      ID: 640
+      Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
+      ByteSize: 8
+      GoRuntimeType: 1.0656e+06
+      GoKind: 22
+      Pointee: 641 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+    - __kind: PointerType
+      ID: 894
+      Name: '*crypto/internal/fips140/sha256.Digest'
+      ByteSize: 8
+      GoRuntimeType: 1.904608e+06
+      GoKind: 22
+      Pointee: 895 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+    - __kind: PointerType
+      ID: 924
+      Name: '*crypto/internal/fips140/sha3.Digest'
+      ByteSize: 8
+      GoRuntimeType: 2.1192e+06
+      GoKind: 22
+      Pointee: 925 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+    - __kind: PointerType
+      ID: 898
+      Name: '*crypto/internal/fips140/sha3.SHAKE'
+      ByteSize: 8
+      GoRuntimeType: 1.90512e+06
+      GoKind: 22
+      Pointee: 899 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+    - __kind: PointerType
+      ID: 896
+      Name: '*crypto/internal/fips140/sha512.Digest'
+      ByteSize: 8
+      GoRuntimeType: 1.904864e+06
+      GoKind: 22
+      Pointee: 897 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+    - __kind: PointerType
+      ID: 890
+      Name: '*crypto/md5.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.902304e+06
+      GoKind: 22
+      Pointee: 891 UnresolvedPointeeType crypto/md5.digest
+    - __kind: PointerType
+      ID: 538
+      Name: '*crypto/rc4.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 926784
+      GoKind: 22
+      Pointee: 359 BaseType crypto/rc4.KeySizeError
+    - __kind: PointerType
+      ID: 911
+      Name: '*crypto/sha1.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.983072e+06
+      GoKind: 22
+      Pointee: 912 UnresolvedPointeeType crypto/sha1.digest
+    - __kind: PointerType
+      ID: 886
+      Name: '*crypto/sha3.SHA3'
+      ByteSize: 8
+      GoRuntimeType: 1.87168e+06
+      GoKind: 22
+      Pointee: 887 UnresolvedPointeeType crypto/sha3.SHA3
+    - __kind: PointerType
+      ID: 461
+      Name: '*crypto/tls.AlertError'
+      ByteSize: 8
+      GoRuntimeType: 915648
+      GoKind: 22
+      Pointee: 346 BaseType crypto/tls.AlertError
+    - __kind: PointerType
+      ID: 629
+      Name: '*crypto/tls.CertificateVerificationError'
+      ByteSize: 8
+      GoRuntimeType: 1.0464e+06
+      GoKind: 22
+      Pointee: 630 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+    - __kind: PointerType
+      ID: 977
+      Name: '*crypto/tls.Conn'
+      ByteSize: 8
+      GoRuntimeType: 2.378432e+06
+      GoKind: 22
+      Pointee: 978 UnresolvedPointeeType crypto/tls.Conn
+    - __kind: PointerType
+      ID: 457
+      Name: '*crypto/tls.ECHRejectionError'
+      ByteSize: 8
+      GoRuntimeType: 915360
+      GoKind: 22
+      Pointee: 458 UnresolvedPointeeType crypto/tls.ECHRejectionError
+    - __kind: PointerType
+      ID: 455
+      Name: '*crypto/tls.RecordHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 915264
+      GoKind: 22
+      Pointee: 456 StructureType crypto/tls.RecordHeaderError
+    - __kind: PointerType
+      ID: 628
+      Name: '*crypto/tls.alert'
+      ByteSize: 8
+      GoRuntimeType: 1.044736e+06
+      GoKind: 22
+      Pointee: 583 BaseType crypto/tls.alert
+    - __kind: PointerType
+      ID: 856
+      Name: '*crypto/tls.cthWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.558976e+06
+      GoKind: 22
+      Pointee: 857 UnresolvedPointeeType crypto/tls.cthWrapper
+    - __kind: PointerType
+      ID: 459
+      Name: '*crypto/tls.echConfigErr'
+      ByteSize: 8
+      GoRuntimeType: 915456
+      GoKind: 22
+      Pointee: 460 UnresolvedPointeeType crypto/tls.echConfigErr
+    - __kind: PointerType
+      ID: 861
+      Name: '*crypto/tls.finishedHash'
+      ByteSize: 8
+      GoRuntimeType: 1.641152e+06
+      GoKind: 22
+      Pointee: 862 UnresolvedPointeeType crypto/tls.finishedHash
+    - __kind: PointerType
+      ID: 726
+      Name: '*crypto/tls.permanentError'
+      ByteSize: 8
+      GoRuntimeType: 1.425152e+06
+      GoKind: 22
+      Pointee: 727 UnresolvedPointeeType crypto/tls.permanentError
+    - __kind: PointerType
+      ID: 745
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.04224e+06
+      GoKind: 22
+      Pointee: 746 UnresolvedPointeeType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 531
+      Name: '*crypto/x509.CertificateInvalidError'
+      ByteSize: 8
+      GoRuntimeType: 925056
+      GoKind: 22
+      Pointee: 532 StructureType crypto/x509.CertificateInvalidError
+    - __kind: PointerType
+      ID: 525
+      Name: '*crypto/x509.ConstraintViolationError'
+      ByteSize: 8
+      GoRuntimeType: 924576
+      GoKind: 22
+      Pointee: 526 StructureType crypto/x509.ConstraintViolationError
+    - __kind: PointerType
+      ID: 527
+      Name: '*crypto/x509.HostnameError'
+      ByteSize: 8
+      GoRuntimeType: 924672
+      GoKind: 22
+      Pointee: 528 StructureType crypto/x509.HostnameError
+    - __kind: PointerType
+      ID: 524
+      Name: '*crypto/x509.InsecureAlgorithmError'
+      ByteSize: 8
+      GoRuntimeType: 924480
+      GoKind: 22
+      Pointee: 355 BaseType crypto/x509.InsecureAlgorithmError
+    - __kind: PointerType
+      ID: 634
+      Name: '*crypto/x509.SystemRootsError'
+      ByteSize: 8
+      GoRuntimeType: 1.05216e+06
+      GoKind: 22
+      Pointee: 635 StructureType crypto/x509.SystemRootsError
+    - __kind: PointerType
+      ID: 533
+      Name: '*crypto/x509.UnhandledCriticalExtension'
+      ByteSize: 8
+      GoRuntimeType: 925152
+      GoKind: 22
+      Pointee: 534 StructureType crypto/x509.UnhandledCriticalExtension
+    - __kind: PointerType
+      ID: 529
+      Name: '*crypto/x509.UnknownAuthorityError'
+      ByteSize: 8
+      GoRuntimeType: 924960
+      GoKind: 22
+      Pointee: 530 StructureType crypto/x509.UnknownAuthorityError
+    - __kind: PointerType
+      ID: 547
+      Name: '*encoding/asn1.StructuralError'
+      ByteSize: 8
+      GoRuntimeType: 931872
+      GoKind: 22
+      Pointee: 548 StructureType encoding/asn1.StructuralError
+    - __kind: PointerType
+      ID: 551
+      Name: '*encoding/asn1.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 932064
+      GoKind: 22
+      Pointee: 552 StructureType encoding/asn1.SyntaxError
+    - __kind: PointerType
+      ID: 549
+      Name: '*encoding/asn1.invalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 931968
+      GoKind: 22
+      Pointee: 550 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+    - __kind: PointerType
+      ID: 442
+      Name: '*encoding/base64.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 911808
+      GoKind: 22
+      Pointee: 337 BaseType encoding/base64.CorruptInputError
+    - __kind: PointerType
+      ID: 814
+      Name: '*encoding/base64.encoder'
+      ByteSize: 8
+      GoRuntimeType: 1.041792e+06
+      GoKind: 22
+      Pointee: 815 UnresolvedPointeeType encoding/base64.encoder
+    - __kind: PointerType
+      ID: 445
+      Name: '*encoding/hex.InvalidByteError'
+      ByteSize: 8
+      GoRuntimeType: 912672
+      GoKind: 22
+      Pointee: 338 BaseType encoding/hex.InvalidByteError
+    - __kind: PointerType
+      ID: 413
+      Name: '*encoding/json.InvalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 906624
+      GoKind: 22
+      Pointee: 414 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+    - __kind: PointerType
+      ID: 618
+      Name: '*encoding/json.MarshalerError'
+      ByteSize: 8
+      GoRuntimeType: 1.037952e+06
+      GoKind: 22
+      Pointee: 619 UnresolvedPointeeType encoding/json.MarshalerError
+    - __kind: PointerType
+      ID: 405
+      Name: '*encoding/json.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 906240
+      GoKind: 22
+      Pointee: 406 UnresolvedPointeeType encoding/json.SyntaxError
+    - __kind: PointerType
+      ID: 411
+      Name: '*encoding/json.UnmarshalTypeError'
+      ByteSize: 8
+      GoRuntimeType: 906528
+      GoKind: 22
+      Pointee: 412 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+    - __kind: PointerType
+      ID: 409
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 906432
+      GoKind: 22
+      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 407
+      Name: '*encoding/json.UnsupportedValueError'
+      ByteSize: 8
+      GoRuntimeType: 906336
+      GoKind: 22
+      Pointee: 408 UnresolvedPointeeType encoding/json.UnsupportedValueError
+    - __kind: PointerType
+      ID: 957
+      Name: '*encoding/json.encodeState'
+      ByteSize: 8
+      GoRuntimeType: 2.292448e+06
+      GoKind: 22
+      Pointee: 958 UnresolvedPointeeType encoding/json.encodeState
+    - __kind: PointerType
+      ID: 415
+      Name: '*encoding/json.jsonError'
+      ByteSize: 8
+      GoRuntimeType: 907008
+      GoKind: 22
+      Pointee: 416 StructureType encoding/json.jsonError
+    - __kind: PointerType
+      ID: 822
+      Name: '*encoding/pem.lineBreaker'
+      ByteSize: 8
+      GoRuntimeType: 1.05472e+06
+      GoKind: 22
+      Pointee: 823 UnresolvedPointeeType encoding/pem.lineBreaker
+    - __kind: PointerType
+      ID: 519
+      Name: '*encoding/xml.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 923520
+      GoKind: 22
+      Pointee: 520 UnresolvedPointeeType encoding/xml.SyntaxError
+    - __kind: PointerType
+      ID: 517
+      Name: '*encoding/xml.TagPathError'
+      ByteSize: 8
+      GoRuntimeType: 923424
+      GoKind: 22
+      Pointee: 518 UnresolvedPointeeType encoding/xml.TagPathError
+    - __kind: PointerType
+      ID: 521
+      Name: '*encoding/xml.UnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 923616
+      GoKind: 22
+      Pointee: 352 GoStringHeaderType encoding/xml.UnmarshalError
+    - __kind: PointerType
+      ID: 354
+      Name: '*encoding/xml.UnmarshalError.str'
+      ByteSize: 8
+      Pointee: 353 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: PointerType
+      ID: 522
+      Name: '*encoding/xml.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 923712
+      GoKind: 22
+      Pointee: 523 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 935
+      Name: '*encoding/xml.printer'
+      ByteSize: 8
+      GoRuntimeType: 2.15904e+06
+      GoKind: 22
+      Pointee: 936 UnresolvedPointeeType encoding/xml.printer
+    - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 392192
       GoKind: 22
       Pointee: 13 GoInterfaceType error
+    - __kind: PointerType
+      ID: 381
+      Name: '*errors.errorString'
+      ByteSize: 8
+      GoRuntimeType: 896640
+      GoKind: 22
+      Pointee: 382 UnresolvedPointeeType errors.errorString
+    - __kind: PointerType
+      ID: 585
+      Name: '*errors.joinError'
+      ByteSize: 8
+      GoRuntimeType: 1.022848e+06
+      GoKind: 22
+      Pointee: 586 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -3631,6 +4151,814 @@ Types:
       GoRuntimeType: 393216
       GoKind: 22
       Pointee: 15 BaseType float64
+    - __kind: PointerType
+      ID: 945
+      Name: '*fmt.pp'
+      ByteSize: 8
+      GoRuntimeType: 2.259232e+06
+      GoKind: 22
+      Pointee: 946 UnresolvedPointeeType fmt.pp
+    - __kind: PointerType
+      ID: 587
+      Name: '*fmt.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.02464e+06
+      GoKind: 22
+      Pointee: 588 UnresolvedPointeeType fmt.wrapError
+    - __kind: PointerType
+      ID: 589
+      Name: '*fmt.wrapErrors'
+      ByteSize: 8
+      GoRuntimeType: 1.024768e+06
+      GoKind: 22
+      Pointee: 590 UnresolvedPointeeType fmt.wrapErrors
+    - __kind: PointerType
+      ID: 443
+      Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 912192
+      GoKind: 22
+      Pointee: 444 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+    - __kind: PointerType
+      ID: 424
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 909408
+      GoKind: 22
+      Pointee: 425 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+    - __kind: PointerType
+      ID: 426
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 909504
+      GoKind: 22
+      Pointee: 427 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+    - __kind: PointerType
+      ID: 758
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
+      ByteSize: 8
+      GoRuntimeType: 909216
+      GoKind: 22
+      Pointee: 759 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+    - __kind: PointerType
+      ID: 430
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
+      ByteSize: 8
+      GoRuntimeType: 909792
+      GoKind: 22
+      Pointee: 431 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+    - __kind: PointerType
+      ID: 760
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
+      ByteSize: 8
+      GoRuntimeType: 909312
+      GoKind: 22
+      Pointee: 761 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+    - __kind: PointerType
+      ID: 428
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
+      ByteSize: 8
+      GoRuntimeType: 909600
+      GoKind: 22
+      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+    - __kind: PointerType
+      ID: 333
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
+      ByteSize: 8
+      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: PointerType
+      ID: 423
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
+      ByteSize: 8
+      GoRuntimeType: 909120
+      GoKind: 22
+      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+    - __kind: PointerType
+      ID: 330
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
+      ByteSize: 8
+      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: PointerType
+      ID: 429
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
+      ByteSize: 8
+      GoRuntimeType: 909696
+      GoKind: 22
+      Pointee: 334 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+    - __kind: PointerType
+      ID: 336
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
+      ByteSize: 8
+      Pointee: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: PointerType
+      ID: 834
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.208832e+06
+      GoKind: 22
+      Pointee: 835 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+    - __kind: PointerType
+      ID: 921
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.057248e+06
+      GoKind: 22
+      Pointee: 922 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+    - __kind: PointerType
+      ID: 541
+      Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
+      ByteSize: 8
+      GoRuntimeType: 930336
+      GoKind: 22
+      Pointee: 542 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+    - __kind: PointerType
+      ID: 700
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
+      ByteSize: 8
+      GoRuntimeType: 1.212416e+06
+      GoKind: 22
+      Pointee: 701 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+    - __kind: PointerType
+      ID: 953
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
+      ByteSize: 8
+      GoRuntimeType: 2.26896e+06
+      GoKind: 22
+      Pointee: 954 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+    - __kind: PointerType
+      ID: 468
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
+      ByteSize: 8
+      GoRuntimeType: 919008
+      GoKind: 22
+      Pointee: 469 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+    - __kind: PointerType
+      ID: 475
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
+      ByteSize: 8
+      GoRuntimeType: 920064
+      GoKind: 22
+      Pointee: 476 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+    - __kind: PointerType
+      ID: 470
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
+      ByteSize: 8
+      GoRuntimeType: 919776
+      GoKind: 22
+      Pointee: 351 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+    - __kind: PointerType
+      ID: 473
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
+      ByteSize: 8
+      GoRuntimeType: 919968
+      GoKind: 22
+      Pointee: 474 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+    - __kind: PointerType
+      ID: 471
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
+      ByteSize: 8
+      GoRuntimeType: 919872
+      GoKind: 22
+      Pointee: 472 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+    - __kind: PointerType
+      ID: 491
+      Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
+      ByteSize: 8
+      GoRuntimeType: 921984
+      GoKind: 22
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+    - __kind: PointerType
+      ID: 495
+      Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
+      ByteSize: 8
+      GoRuntimeType: 922176
+      GoKind: 22
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+    - __kind: PointerType
+      ID: 493
+      Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
+      ByteSize: 8
+      GoRuntimeType: 922080
+      GoKind: 22
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+    - __kind: PointerType
+      ID: 489
+      Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
+      ByteSize: 8
+      GoRuntimeType: 921888
+      GoKind: 22
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+    - __kind: PointerType
+      ID: 785
+      Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 8
+      Pointee: 784 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: PointerType
+      ID: 503
+      Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
+      ByteSize: 8
+      GoRuntimeType: 922560
+      GoKind: 22
+      Pointee: 504 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+    - __kind: PointerType
+      ID: 497
+      Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
+      ByteSize: 8
+      GoRuntimeType: 922272
+      GoKind: 22
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+    - __kind: PointerType
+      ID: 501
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
+      ByteSize: 8
+      GoRuntimeType: 922464
+      GoKind: 22
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+    - __kind: PointerType
+      ID: 499
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
+      ByteSize: 8
+      GoRuntimeType: 922368
+      GoKind: 22
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+    - __kind: PointerType
+      ID: 505
+      Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
+      ByteSize: 8
+      GoRuntimeType: 922656
+      GoKind: 22
+      Pointee: 506 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+    - __kind: PointerType
+      ID: 511
+      Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
+      ByteSize: 8
+      GoRuntimeType: 922944
+      GoKind: 22
+      Pointee: 512 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+    - __kind: PointerType
+      ID: 513
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
+      ByteSize: 8
+      GoRuntimeType: 923040
+      GoKind: 22
+      Pointee: 514 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+    - __kind: PointerType
+      ID: 509
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
+      ByteSize: 8
+      GoRuntimeType: 922848
+      GoKind: 22
+      Pointee: 510 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+    - __kind: PointerType
+      ID: 507
+      Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
+      ByteSize: 8
+      GoRuntimeType: 922752
+      GoKind: 22
+      Pointee: 508 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+    - __kind: PointerType
+      ID: 515
+      Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
+      ByteSize: 8
+      GoRuntimeType: 923232
+      GoKind: 22
+      Pointee: 516 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+    - __kind: PointerType
+      ID: 432
+      Name: '*github.com/cihub/seelog.baseError'
+      ByteSize: 8
+      GoRuntimeType: 910944
+      GoKind: 22
+      Pointee: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: PointerType
+      ID: 874
+      Name: '*github.com/cihub/seelog.bufferedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.80224e+06
+      GoKind: 22
+      Pointee: 875 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+    - __kind: PointerType
+      ID: 434
+      Name: '*github.com/cihub/seelog.cannotOpenFileError'
+      ByteSize: 8
+      GoRuntimeType: 911040
+      GoKind: 22
+      Pointee: 435 StructureType github.com/cihub/seelog.cannotOpenFileError
+    - __kind: PointerType
+      ID: 854
+      Name: '*github.com/cihub/seelog.connWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.557696e+06
+      GoKind: 22
+      Pointee: 855 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+    - __kind: PointerType
+      ID: 810
+      Name: '*github.com/cihub/seelog.consoleWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.04064e+06
+      GoKind: 22
+      Pointee: 811 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+    - __kind: PointerType
+      ID: 844
+      Name: '*github.com/cihub/seelog.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.422752e+06
+      GoKind: 22
+      Pointee: 845 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+    - __kind: PointerType
+      ID: 438
+      Name: '*github.com/cihub/seelog.missingArgumentError'
+      ByteSize: 8
+      GoRuntimeType: 911232
+      GoKind: 22
+      Pointee: 439 StructureType github.com/cihub/seelog.missingArgumentError
+    - __kind: PointerType
+      ID: 909
+      Name: '*github.com/cihub/seelog.rollingFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.975296e+06
+      GoKind: 22
+      Pointee: 910 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+    - __kind: PointerType
+      ID: 928
+      Name: '*github.com/cihub/seelog.rollingFileWriterSize'
+      ByteSize: 8
+      GoRuntimeType: 2.13184e+06
+      GoKind: 22
+      Pointee: 923 StructureType github.com/cihub/seelog.rollingFileWriterSize
+    - __kind: PointerType
+      ID: 927
+      Name: '*github.com/cihub/seelog.rollingFileWriterTime'
+      ByteSize: 8
+      GoRuntimeType: 2.131456e+06
+      GoKind: 22
+      Pointee: 926 StructureType github.com/cihub/seelog.rollingFileWriterTime
+    - __kind: PointerType
+      ID: 812
+      Name: '*github.com/cihub/seelog.smtpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.040768e+06
+      GoKind: 22
+      Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+    - __kind: PointerType
+      ID: 436
+      Name: '*github.com/cihub/seelog.unexpectedAttributeError'
+      ByteSize: 8
+      GoRuntimeType: 911136
+      GoKind: 22
+      Pointee: 437 StructureType github.com/cihub/seelog.unexpectedAttributeError
+    - __kind: PointerType
+      ID: 440
+      Name: '*github.com/cihub/seelog.unexpectedChildElementError'
+      ByteSize: 8
+      GoRuntimeType: 911328
+      GoKind: 22
+      Pointee: 441 StructureType github.com/cihub/seelog.unexpectedChildElementError
+    - __kind: PointerType
+      ID: 876
+      Name: '*github.com/cihub/seelog/archive/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.804032e+06
+      GoKind: 22
+      Pointee: 877 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+    - __kind: PointerType
+      ID: 917
+      Name: '*github.com/cihub/seelog/archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.011424e+06
+      GoKind: 22
+      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+    - __kind: PointerType
+      ID: 919
+      Name: '*github.com/cihub/seelog/archive/zip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.04192e+06
+      GoKind: 22
+      Pointee: 920 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+    - __kind: PointerType
+      ID: 731
+      Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
+      ByteSize: 8
+      GoRuntimeType: 1.437472e+06
+      GoKind: 22
+      Pointee: 732 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+    - __kind: PointerType
+      ID: 644
+      Name: '*github.com/go-viper/mapstructure/v2.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.066368e+06
+      GoKind: 22
+      Pointee: 645 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+    - __kind: PointerType
+      ID: 642
+      Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.06624e+06
+      GoKind: 22
+      Pointee: 643 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+    - __kind: PointerType
+      ID: 646
+      Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.070336e+06
+      GoKind: 22
+      Pointee: 647 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 648
+      Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
+      ByteSize: 8
+      GoRuntimeType: 1.070464e+06
+      GoKind: 22
+      Pointee: 649 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+    - __kind: PointerType
+      ID: 865
+      Name: '*github.com/gogo/protobuf/proto.textWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.668416e+06
+      GoKind: 22
+      Pointee: 866 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+    - __kind: PointerType
+      ID: 636
+      Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.0528e+06
+      GoKind: 22
+      Pointee: 637 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 446
+      Name: '*github.com/google/uuid.invalidLengthError'
+      ByteSize: 8
+      GoRuntimeType: 912864
+      GoKind: 22
+      Pointee: 447 StructureType github.com/google/uuid.invalidLengthError
+    - __kind: PointerType
+      ID: 969
+      Name: '*github.com/json-iterator/go.Stream'
+      ByteSize: 8
+      GoRuntimeType: 2.35488e+06
+      GoKind: 22
+      Pointee: 970 UnresolvedPointeeType github.com/json-iterator/go.Stream
+    - __kind: PointerType
+      ID: 702
+      Name: '*github.com/pkg/errors.fundamental'
+      ByteSize: 8
+      GoRuntimeType: 1.220992e+06
+      GoKind: 22
+      Pointee: 703 UnresolvedPointeeType github.com/pkg/errors.fundamental
+    - __kind: PointerType
+      ID: 675
+      Name: '*github.com/tinylib/msgp/msgp.ArrayError'
+      ByteSize: 8
+      GoRuntimeType: 1.199872e+06
+      GoKind: 22
+      Pointee: 676 StructureType github.com/tinylib/msgp/msgp.ArrayError
+    - __kind: PointerType
+      ID: 669
+      Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
+      ByteSize: 8
+      GoRuntimeType: 1.199488e+06
+      GoKind: 22
+      Pointee: 670 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+    - __kind: PointerType
+      ID: 604
+      Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.031936e+06
+      GoKind: 22
+      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+    - __kind: PointerType
+      ID: 681
+      Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.200256e+06
+      GoKind: 22
+      Pointee: 682 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+    - __kind: PointerType
+      ID: 603
+      Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.031808e+06
+      GoKind: 22
+      Pointee: 582 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+    - __kind: PointerType
+      ID: 673
+      Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
+      ByteSize: 8
+      GoRuntimeType: 1.199744e+06
+      GoKind: 22
+      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+    - __kind: PointerType
+      ID: 671
+      Name: '*github.com/tinylib/msgp/msgp.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.199616e+06
+      GoKind: 22
+      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.TypeError
+    - __kind: PointerType
+      ID: 679
+      Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
+      ByteSize: 8
+      GoRuntimeType: 1.200128e+06
+      GoKind: 22
+      Pointee: 680 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+    - __kind: PointerType
+      ID: 677
+      Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.2e+06
+      GoKind: 22
+      Pointee: 678 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+    - __kind: PointerType
+      ID: 973
+      Name: '*github.com/tinylib/msgp/msgp.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.367488e+06
+      GoKind: 22
+      Pointee: 974 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+    - __kind: PointerType
+      ID: 685
+      Name: '*github.com/tinylib/msgp/msgp.errFatal'
+      ByteSize: 8
+      GoRuntimeType: 1.20064e+06
+      GoKind: 22
+      Pointee: 686 StructureType github.com/tinylib/msgp/msgp.errFatal
+    - __kind: PointerType
+      ID: 608
+      Name: '*github.com/tinylib/msgp/msgp.errRecursion'
+      ByteSize: 8
+      GoRuntimeType: 1.032192e+06
+      GoKind: 22
+      Pointee: 609 StructureType github.com/tinylib/msgp/msgp.errRecursion
+    - __kind: PointerType
+      ID: 606
+      Name: '*github.com/tinylib/msgp/msgp.errShort'
+      ByteSize: 8
+      GoRuntimeType: 1.032064e+06
+      GoKind: 22
+      Pointee: 607 StructureType github.com/tinylib/msgp/msgp.errShort
+    - __kind: PointerType
+      ID: 683
+      Name: '*github.com/tinylib/msgp/msgp.errWrapped'
+      ByteSize: 8
+      GoRuntimeType: 1.200512e+06
+      GoKind: 22
+      Pointee: 684 StructureType github.com/tinylib/msgp/msgp.errWrapped
+    - __kind: PointerType
+      ID: 563
+      Name: '*go.opentelemetry.io/otel/trace.errorConst'
+      ByteSize: 8
+      GoRuntimeType: 944832
+      GoKind: 22
+      Pointee: 364 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+    - __kind: PointerType
+      ID: 366
+      Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
+      ByteSize: 8
+      Pointee: 365 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: PointerType
+      ID: 748
+      Name: '*go.uber.org/multierr.multiError'
+      ByteSize: 8
+      GoRuntimeType: 1.66688e+06
+      GoKind: 22
+      Pointee: 749 UnresolvedPointeeType go.uber.org/multierr.multiError
+    - __kind: PointerType
+      ID: 652
+      Name: '*go.uber.org/zap.errArrayElem'
+      ByteSize: 8
+      GoRuntimeType: 1.085184e+06
+      GoKind: 22
+      Pointee: 653 StructureType go.uber.org/zap.errArrayElem
+    - __kind: PointerType
+      ID: 840
+      Name: '*go.uber.org/zap.nopCloserSink'
+      ByteSize: 8
+      GoRuntimeType: 1.2608e+06
+      GoKind: 22
+      Pointee: 841 StructureType go.uber.org/zap.nopCloserSink
+    - __kind: PointerType
+      ID: 933
+      Name: '*go.uber.org/zap/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.1472e+06
+      GoKind: 22
+      Pointee: 934 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+    - __kind: PointerType
+      ID: 828
+      Name: '*go.uber.org/zap/zapcore.writerWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.087488e+06
+      GoKind: 22
+      Pointee: 829 StructureType go.uber.org/zap/zapcore.writerWrapper
+    - __kind: PointerType
+      ID: 564
+      Name: '*golang.org/x/net/http2.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 946080
+      GoKind: 22
+      Pointee: 367 BaseType golang.org/x/net/http2.ConnectionError
+    - __kind: PointerType
+      ID: 710
+      Name: '*golang.org/x/net/http2.StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.262464e+06
+      GoKind: 22
+      Pointee: 711 StructureType golang.org/x/net/http2.StreamError
+    - __kind: PointerType
+      ID: 567
+      Name: '*golang.org/x/net/http2.connError'
+      ByteSize: 8
+      GoRuntimeType: 946368
+      GoKind: 22
+      Pointee: 568 StructureType golang.org/x/net/http2.connError
+    - __kind: PointerType
+      ID: 566
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 946272
+      GoKind: 22
+      Pointee: 371 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 373
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 372 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 570
+      Name: '*golang.org/x/net/http2.headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 946560
+      GoKind: 22
+      Pointee: 377 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+    - __kind: PointerType
+      ID: 379
+      Name: '*golang.org/x/net/http2.headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 378 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: PointerType
+      ID: 569
+      Name: '*golang.org/x/net/http2.headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 946464
+      GoKind: 22
+      Pointee: 374 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+    - __kind: PointerType
+      ID: 376
+      Name: '*golang.org/x/net/http2.headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 375 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: PointerType
+      ID: 565
+      Name: '*golang.org/x/net/http2.pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 946176
+      GoKind: 22
+      Pointee: 368 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+    - __kind: PointerType
+      ID: 370
+      Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 369 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 931
+      Name: '*golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.14528e+06
+      GoKind: 22
+      Pointee: 932 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 571
+      Name: '*golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 946656
+      GoKind: 22
+      Pointee: 572 StructureType golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 573
+      Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 946752
+      GoKind: 22
+      Pointee: 380 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 559
+      Name: '*google.golang.org/grpc.dropError'
+      ByteSize: 8
+      GoRuntimeType: 940032
+      GoKind: 22
+      Pointee: 560 StructureType google.golang.org/grpc.dropError
+    - __kind: PointerType
+      ID: 708
+      Name: '*google.golang.org/grpc/internal/status.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.25952e+06
+      GoKind: 22
+      Pointee: 709 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+    - __kind: PointerType
+      ID: 733
+      Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 1.444832e+06
+      GoKind: 22
+      Pointee: 734 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+    - __kind: PointerType
+      ID: 561
+      Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
+      ByteSize: 8
+      GoRuntimeType: 943104
+      GoKind: 22
+      Pointee: 562 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+    - __kind: PointerType
+      ID: 880
+      Name: '*google.golang.org/grpc/internal/transport.bufConn'
+      ByteSize: 8
+      GoRuntimeType: 1.809632e+06
+      GoKind: 22
+      Pointee: 881 StructureType google.golang.org/grpc/internal/transport.bufConn
+    - __kind: PointerType
+      ID: 838
+      Name: '*google.golang.org/grpc/internal/transport.bufWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.256064e+06
+      GoKind: 22
+      Pointee: 839 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+    - __kind: PointerType
+      ID: 650
+      Name: '*google.golang.org/grpc/internal/transport.ioError'
+      ByteSize: 8
+      GoRuntimeType: 1.079424e+06
+      GoKind: 22
+      Pointee: 651 StructureType google.golang.org/grpc/internal/transport.ioError
+    - __kind: PointerType
+      ID: 800
+      Name: '*google.golang.org/grpc/mem.writer'
+      ByteSize: 8
+      GoRuntimeType: 943200
+      GoKind: 22
+      Pointee: 801 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+    - __kind: PointerType
+      ID: 539
+      Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
+      ByteSize: 8
+      GoRuntimeType: 928224
+      GoKind: 22
+      Pointee: 540 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+    - __kind: PointerType
+      ID: 638
+      Name: '*google.golang.org/protobuf/internal/errors.prefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.056128e+06
+      GoKind: 22
+      Pointee: 639 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+    - __kind: PointerType
+      ID: 706
+      Name: '*google.golang.org/protobuf/internal/errors.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.227392e+06
+      GoKind: 22
+      Pointee: 707 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+    - __kind: PointerType
+      ID: 704
+      Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
+      ByteSize: 8
+      GoRuntimeType: 1.227136e+06
+      GoKind: 22
+      Pointee: 705 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+    - __kind: PointerType
+      ID: 553
+      Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
+      ByteSize: 8
+      GoRuntimeType: 932928
+      GoKind: 22
+      Pointee: 554 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+    - __kind: PointerType
+      ID: 555
+      Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
+      ByteSize: 8
+      GoRuntimeType: 933024
+      GoKind: 22
+      Pointee: 556 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+    - __kind: PointerType
+      ID: 483
+      Name: '*gopkg.in/yaml%2ev3.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 920448
+      GoKind: 22
+      Pointee: 484 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+    - __kind: PointerType
+      ID: 888
+      Name: '*hash/crc32.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.900256e+06
+      GoKind: 22
+      Pointee: 889 UnresolvedPointeeType hash/crc32.digest
+    - __kind: PointerType
+      ID: 574
+      Name: '*html/template.Error'
+      ByteSize: 8
+      GoRuntimeType: 947520
+      GoKind: 22
+      Pointee: 575 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -3674,6 +5002,116 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
+      ID: 735
+      Name: '*internal/abi.Type'
+      ByteSize: 8
+      GoRuntimeType: 2.211552e+06
+      GoKind: 22
+      Pointee: 736 UnresolvedPointeeType internal/abi.Type
+    - __kind: PointerType
+      ID: 451
+      Name: '*internal/bisect.parseError'
+      ByteSize: 8
+      GoRuntimeType: 913536
+      GoKind: 22
+      Pointee: 452 UnresolvedPointeeType internal/bisect.parseError
+    - __kind: PointerType
+      ID: 449
+      Name: '*internal/chacha8rand.errUnmarshalChaCha8'
+      ByteSize: 8
+      GoRuntimeType: 913440
+      GoKind: 22
+      Pointee: 450 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+    - __kind: PointerType
+      ID: 786
+      Name: '*internal/godebug.runtimeStderr'
+      ByteSize: 8
+      GoRuntimeType: 901440
+      GoKind: 22
+      Pointee: 787 UnresolvedPointeeType internal/godebug.runtimeStderr
+    - __kind: PointerType
+      ID: 667
+      Name: '*internal/poll.DeadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.19872e+06
+      GoKind: 22
+      Pointee: 668 UnresolvedPointeeType internal/poll.DeadlineExceededError
+    - __kind: PointerType
+      ID: 975
+      Name: '*internal/poll.FD'
+      ByteSize: 8
+      GoRuntimeType: 2.373152e+06
+      GoKind: 22
+      Pointee: 976 UnresolvedPointeeType internal/poll.FD
+    - __kind: PointerType
+      ID: 665
+      Name: '*internal/poll.errNetClosing'
+      ByteSize: 8
+      GoRuntimeType: 1.198592e+06
+      GoKind: 22
+      Pointee: 666 StructureType internal/poll.errNetClosing
+    - __kind: PointerType
+      ID: 385
+      Name: '*internal/reflectlite.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 900672
+      GoKind: 22
+      Pointee: 386 UnresolvedPointeeType internal/reflectlite.ValueError
+    - __kind: PointerType
+      ID: 448
+      Name: '*internal/runtime/cgroup.stringError'
+      ByteSize: 8
+      GoRuntimeType: 913248
+      GoKind: 22
+      Pointee: 339 GoStringHeaderType internal/runtime/cgroup.stringError
+    - __kind: PointerType
+      ID: 341
+      Name: '*internal/runtime/cgroup.stringError.str'
+      ByteSize: 8
+      Pointee: 340 GoStringDataType internal/runtime/cgroup.stringError.str
+    - __kind: PointerType
+      ID: 622
+      Name: '*internal/runtime/maps.unhashableTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.043072e+06
+      GoKind: 22
+      Pointee: 623 StructureType internal/runtime/maps.unhashableTypeError
+    - __kind: PointerType
+      ID: 832
+      Name: '*io.PipeWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.190016e+06
+      GoKind: 22
+      Pointee: 833 UnresolvedPointeeType io.PipeWriter
+    - __kind: PointerType
+      ID: 830
+      Name: '*io.discard'
+      ByteSize: 8
+      GoRuntimeType: 1.189632e+06
+      GoKind: 22
+      Pointee: 831 StructureType io.discard
+    - __kind: PointerType
+      ID: 804
+      Name: '*io.multiWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.023104e+06
+      GoKind: 22
+      Pointee: 805 UnresolvedPointeeType io.multiWriter
+    - __kind: PointerType
+      ID: 663
+      Name: '*io/fs.PathError'
+      ByteSize: 8
+      GoRuntimeType: 1.19808e+06
+      GoKind: 22
+      Pointee: 664 UnresolvedPointeeType io/fs.PathError
+    - __kind: PointerType
+      ID: 878
+      Name: '*log/slog/internal/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 1.804256e+06
+      GoKind: 22
+      Pointee: 879 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+    - __kind: PointerType
       ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
@@ -3681,12 +5119,12 @@ Types:
       GoKind: 22
       Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 341
+      ID: 1020
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385984
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType main.deepMap3
+      Pointee: 1021 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3695,19 +5133,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 377
+      ID: 1056
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 385664
       GoKind: 22
-      Pointee: 378 StructureType main.deepMap8
+      Pointee: 1057 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 392
+      ID: 1071
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385600
       GoKind: 22
-      Pointee: 393 StructureType main.deepMap9
+      Pointee: 1072 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3716,12 +5154,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 306
+      ID: 979
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 307 UnresolvedPointeeType main.deepPtr3
+      Pointee: 980 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3730,19 +5168,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 347
+      ID: 1026
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386240
       GoKind: 22
-      Pointee: 348 StructureType main.deepPtr8
+      Pointee: 1027 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 349
+      ID: 1028
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386176
       GoKind: 22
-      Pointee: 350 StructureType main.deepPtr9
+      Pointee: 1029 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3751,12 +5189,12 @@ Types:
       GoKind: 22
       Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 326
+      ID: 1005
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387136
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1006 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3765,19 +5203,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 353
+      ID: 1032
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386816
       GoKind: 22
-      Pointee: 354 StructureType main.deepSlice8
+      Pointee: 1033 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 359
+      ID: 1038
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386752
       GoKind: 22
-      Pointee: 360 StructureType main.deepSlice9
+      Pointee: 1039 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 176
       Name: '*main.emptyStruct'
@@ -3792,6 +5230,13 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
+      ID: 996
+      Name: '*main.firstBehavior'
+      ByteSize: 8
+      GoRuntimeType: 896352
+      GoKind: 22
+      Pointee: 997 StructureType main.firstBehavior
+    - __kind: PointerType
       ID: 157
       Name: '*main.node'
       ByteSize: 8
@@ -3805,22 +5250,36 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
+      ID: 998
+      Name: '*main.secondBehavior'
+      ByteSize: 8
+      GoRuntimeType: 896448
+      GoKind: 22
+      Pointee: 999 StructureType main.secondBehavior
+    - __kind: PointerType
+      ID: 984
+      Name: '*main.somethingImpl'
+      ByteSize: 8
+      GoRuntimeType: 896544
+      GoKind: 22
+      Pointee: 985 UnresolvedPointeeType main.somethingImpl
+    - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
       ByteSize: 8
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 309
+      ID: 982
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType main.stringType1.str
+      Pointee: 981 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 310 UnresolvedPointeeType main.stringType2
+      Pointee: 983 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 242
       Name: '*main.structWithMap'
@@ -3846,10 +5305,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 323
+      ID: 1002
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 322 GoSliceDataType main.t.array
+      Pointee: 1001 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -3882,30 +5341,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 331
+      ID: 1010
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1011 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 367
+      ID: 1046
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1047 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 382
+      ID: 1061
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1062 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 397
+      ID: 1076
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 398 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1077 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 129
       Name: '*map<int,uint8>'
@@ -3921,6 +5380,11 @@ Types:
       Name: '*map<string,[]string>'
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 741
+      Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 742 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -3948,6 +5412,452 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
+      ID: 487
+      Name: '*math/big.ErrNaN'
+      ByteSize: 8
+      GoRuntimeType: 921312
+      GoKind: 22
+      Pointee: 488 StructureType math/big.ErrNaN
+    - __kind: PointerType
+      ID: 794
+      Name: '*mime/multipart.writerOnly·1'
+      ByteSize: 8
+      GoRuntimeType: 916128
+      GoKind: 22
+      Pointee: 795 StructureType mime/multipart.writerOnly·1
+    - __kind: PointerType
+      ID: 694
+      Name: '*net.AddrError'
+      ByteSize: 8
+      GoRuntimeType: 1.206656e+06
+      GoKind: 22
+      Pointee: 695 UnresolvedPointeeType net.AddrError
+    - __kind: PointerType
+      ID: 720
+      Name: '*net.DNSError'
+      ByteSize: 8
+      GoRuntimeType: 1.420992e+06
+      GoKind: 22
+      Pointee: 721 UnresolvedPointeeType net.DNSError
+    - __kind: PointerType
+      ID: 939
+      Name: '*net.IPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.231904e+06
+      GoKind: 22
+      Pointee: 940 UnresolvedPointeeType net.IPConn
+    - __kind: PointerType
+      ID: 718
+      Name: '*net.OpError'
+      ByteSize: 8
+      GoRuntimeType: 1.420672e+06
+      GoKind: 22
+      Pointee: 719 UnresolvedPointeeType net.OpError
+    - __kind: PointerType
+      ID: 696
+      Name: '*net.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.206784e+06
+      GoKind: 22
+      Pointee: 697 UnresolvedPointeeType net.ParseError
+    - __kind: PointerType
+      ID: 949
+      Name: '*net.TCPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.260256e+06
+      GoKind: 22
+      Pointee: 950 UnresolvedPointeeType net.TCPConn
+    - __kind: PointerType
+      ID: 959
+      Name: '*net.UDPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.30576e+06
+      GoKind: 22
+      Pointee: 960 UnresolvedPointeeType net.UDPConn
+    - __kind: PointerType
+      ID: 947
+      Name: '*net.UnixConn'
+      ByteSize: 8
+      GoRuntimeType: 2.259744e+06
+      GoKind: 22
+      Pointee: 948 UnresolvedPointeeType net.UnixConn
+    - __kind: PointerType
+      ID: 693
+      Name: '*net.UnknownNetworkError'
+      ByteSize: 8
+      GoRuntimeType: 1.205888e+06
+      GoKind: 22
+      Pointee: 656 GoStringHeaderType net.UnknownNetworkError
+    - __kind: PointerType
+      ID: 658
+      Name: '*net.UnknownNetworkError.str'
+      ByteSize: 8
+      Pointee: 657 GoStringDataType net.UnknownNetworkError.str
+    - __kind: PointerType
+      ID: 620
+      Name: '*net.canceledError'
+      ByteSize: 8
+      GoRuntimeType: 1.038848e+06
+      GoKind: 22
+      Pointee: 621 StructureType net.canceledError
+    - __kind: PointerType
+      ID: 915
+      Name: '*net.conn'
+      ByteSize: 8
+      GoRuntimeType: 2.008832e+06
+      GoKind: 22
+      Pointee: 916 UnresolvedPointeeType net.conn
+    - __kind: PointerType
+      ID: 767
+      Name: '*net.dialResult·1'
+      ByteSize: 8
+      GoRuntimeType: 1.84704e+06
+      GoKind: 22
+      Pointee: 768 StructureType net.dialResult·1
+    - __kind: PointerType
+      ID: 961
+      Name: '*net.netFD'
+      ByteSize: 8
+      GoRuntimeType: 2.310016e+06
+      GoKind: 22
+      Pointee: 962 UnresolvedPointeeType net.netFD
+    - __kind: PointerType
+      ID: 417
+      Name: '*net.notFoundError'
+      ByteSize: 8
+      GoRuntimeType: 907968
+      GoKind: 22
+      Pointee: 418 UnresolvedPointeeType net.notFoundError
+    - __kind: PointerType
+      ID: 419
+      Name: '*net.result·2'
+      ByteSize: 8
+      GoRuntimeType: 908640
+      GoKind: 22
+      Pointee: 420 StructureType net.result·2
+    - __kind: PointerType
+      ID: 943
+      Name: '*net.tcpConnWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.246272e+06
+      GoKind: 22
+      Pointee: 944 StructureType net.tcpConnWithoutReadFrom
+    - __kind: PointerType
+      ID: 941
+      Name: '*net.tcpConnWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.245792e+06
+      GoKind: 22
+      Pointee: 942 StructureType net.tcpConnWithoutWriteTo
+    - __kind: PointerType
+      ID: 698
+      Name: '*net.temporaryError'
+      ByteSize: 8
+      GoRuntimeType: 1.207424e+06
+      GoKind: 22
+      Pointee: 699 UnresolvedPointeeType net.temporaryError
+    - __kind: PointerType
+      ID: 722
+      Name: '*net.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.421152e+06
+      GoKind: 22
+      Pointee: 723 UnresolvedPointeeType net.timeoutError
+    - __kind: PointerType
+      ID: 610
+      Name: '*net/http.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 1.034624e+06
+      GoKind: 22
+      Pointee: 611 UnresolvedPointeeType net/http.ProtocolError
+    - __kind: PointerType
+      ID: 788
+      Name: '*net/http.bufioFlushWriter'
+      ByteSize: 8
+      GoRuntimeType: 903744
+      GoKind: 22
+      Pointee: 789 StructureType net/http.bufioFlushWriter
+    - __kind: PointerType
+      ID: 394
+      Name: '*net/http.http2ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 904416
+      GoKind: 22
+      Pointee: 309 BaseType net/http.http2ConnectionError
+    - __kind: PointerType
+      ID: 395
+      Name: '*net/http.http2GoAwayError'
+      ByteSize: 8
+      GoRuntimeType: 904512
+      GoKind: 22
+      Pointee: 396 StructureType net/http.http2GoAwayError
+    - __kind: PointerType
+      ID: 714
+      Name: '*net/http.http2StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.416672e+06
+      GoKind: 22
+      Pointee: 715 StructureType net/http.http2StreamError
+    - __kind: PointerType
+      ID: 399
+      Name: '*net/http.http2connError'
+      ByteSize: 8
+      GoRuntimeType: 905088
+      GoKind: 22
+      Pointee: 400 StructureType net/http.http2connError
+    - __kind: PointerType
+      ID: 850
+      Name: '*net/http.http2dataBuffer'
+      ByteSize: 8
+      GoRuntimeType: 1.554176e+06
+      GoKind: 22
+      Pointee: 851 UnresolvedPointeeType net/http.http2dataBuffer
+    - __kind: PointerType
+      ID: 398
+      Name: '*net/http.http2duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 904992
+      GoKind: 22
+      Pointee: 313 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 315
+      Name: '*net/http.http2duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 402
+      Name: '*net/http.http2headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 905280
+      GoKind: 22
+      Pointee: 319 GoStringHeaderType net/http.http2headerFieldNameError
+    - __kind: PointerType
+      ID: 321
+      Name: '*net/http.http2headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 320 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: PointerType
+      ID: 401
+      Name: '*net/http.http2headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 905184
+      GoKind: 22
+      Pointee: 316 GoStringHeaderType net/http.http2headerFieldValueError
+    - __kind: PointerType
+      ID: 318
+      Name: '*net/http.http2headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 317 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: PointerType
+      ID: 689
+      Name: '*net/http.http2httpError'
+      ByteSize: 8
+      GoRuntimeType: 1.20256e+06
+      GoKind: 22
+      Pointee: 690 UnresolvedPointeeType net/http.http2httpError
+    - __kind: PointerType
+      ID: 616
+      Name: '*net/http.http2noCachedConnError'
+      ByteSize: 8
+      GoRuntimeType: 1.035264e+06
+      GoKind: 22
+      Pointee: 617 StructureType net/http.http2noCachedConnError
+    - __kind: PointerType
+      ID: 904
+      Name: '*net/http.http2pipe'
+      ByteSize: 8
+      GoRuntimeType: 1.951136e+06
+      GoKind: 22
+      Pointee: 905 UnresolvedPointeeType net/http.http2pipe
+    - __kind: PointerType
+      ID: 397
+      Name: '*net/http.http2pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 904896
+      GoKind: 22
+      Pointee: 310 GoStringHeaderType net/http.http2pseudoHeaderError
+    - __kind: PointerType
+      ID: 312
+      Name: '*net/http.http2pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 790
+      Name: '*net/http.http2stickyErrWriter'
+      ByteSize: 8
+      GoRuntimeType: 905376
+      GoKind: 22
+      Pointee: 791 StructureType net/http.http2stickyErrWriter
+    - __kind: PointerType
+      ID: 612
+      Name: '*net/http.nothingWrittenError'
+      ByteSize: 8
+      GoRuntimeType: 1.03488e+06
+      GoKind: 22
+      Pointee: 613 StructureType net/http.nothingWrittenError
+    - __kind: PointerType
+      ID: 852
+      Name: '*net/http.persistConn'
+      ByteSize: 8
+      GoRuntimeType: 2.175296e+06
+      GoKind: 22
+      Pointee: 853 UnresolvedPointeeType net/http.persistConn
+    - __kind: PointerType
+      ID: 808
+      Name: '*net/http.persistConnWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.034752e+06
+      GoKind: 22
+      Pointee: 809 StructureType net/http.persistConnWriter
+    - __kind: PointerType
+      ID: 842
+      Name: '*net/http.readWriteCloserBody'
+      ByteSize: 8
+      GoRuntimeType: 1.416832e+06
+      GoKind: 22
+      Pointee: 843 StructureType net/http.readWriteCloserBody
+    - __kind: PointerType
+      ID: 403
+      Name: '*net/http.requestBodyReadError'
+      ByteSize: 8
+      GoRuntimeType: 905472
+      GoKind: 22
+      Pointee: 404 StructureType net/http.requestBodyReadError
+    - __kind: PointerType
+      ID: 716
+      Name: '*net/http.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.417952e+06
+      GoKind: 22
+      Pointee: 717 UnresolvedPointeeType net/http.timeoutError
+    - __kind: PointerType
+      ID: 687
+      Name: '*net/http.tlsHandshakeTimeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.202432e+06
+      GoKind: 22
+      Pointee: 688 StructureType net/http.tlsHandshakeTimeoutError
+    - __kind: PointerType
+      ID: 614
+      Name: '*net/http.transportReadFromServerError'
+      ByteSize: 8
+      GoRuntimeType: 1.035008e+06
+      GoKind: 22
+      Pointee: 615 StructureType net/http.transportReadFromServerError
+    - __kind: PointerType
+      ID: 884
+      Name: '*net/http.unencryptedNetConnInTLSConn'
+      ByteSize: 8
+      GoRuntimeType: 1.84368e+06
+      GoKind: 22
+      Pointee: 885 StructureType net/http.unencryptedNetConnInTLSConn
+    - __kind: PointerType
+      ID: 392
+      Name: '*net/http.unsupportedTEError'
+      ByteSize: 8
+      GoRuntimeType: 903648
+      GoKind: 22
+      Pointee: 393 UnresolvedPointeeType net/http.unsupportedTEError
+    - __kind: PointerType
+      ID: 906
+      Name: '*net/http/internal.FlushAfterChunkWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.952928e+06
+      GoKind: 22
+      Pointee: 907 StructureType net/http/internal.FlushAfterChunkWriter
+    - __kind: PointerType
+      ID: 818
+      Name: '*net/http/internal.chunkedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.047552e+06
+      GoKind: 22
+      Pointee: 819 UnresolvedPointeeType net/http/internal.chunkedWriter
+    - __kind: PointerType
+      ID: 479
+      Name: '*net/netip.parseAddrError'
+      ByteSize: 8
+      GoRuntimeType: 920256
+      GoKind: 22
+      Pointee: 480 StructureType net/netip.parseAddrError
+    - __kind: PointerType
+      ID: 477
+      Name: '*net/netip.parsePrefixError'
+      ByteSize: 8
+      GoRuntimeType: 920160
+      GoKind: 22
+      Pointee: 478 StructureType net/netip.parsePrefixError
+    - __kind: PointerType
+      ID: 858
+      Name: '*net/smtp.Client'
+      ByteSize: 8
+      GoRuntimeType: 2.117792e+06
+      GoKind: 22
+      Pointee: 859 UnresolvedPointeeType net/smtp.Client
+    - __kind: PointerType
+      ID: 820
+      Name: '*net/smtp.dataCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.052416e+06
+      GoKind: 22
+      Pointee: 821 StructureType net/smtp.dataCloser
+    - __kind: PointerType
+      ID: 463
+      Name: '*net/textproto.Error'
+      ByteSize: 8
+      GoRuntimeType: 916320
+      GoKind: 22
+      Pointee: 464 UnresolvedPointeeType net/textproto.Error
+    - __kind: PointerType
+      ID: 462
+      Name: '*net/textproto.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 916224
+      GoKind: 22
+      Pointee: 347 GoStringHeaderType net/textproto.ProtocolError
+    - __kind: PointerType
+      ID: 349
+      Name: '*net/textproto.ProtocolError.str'
+      ByteSize: 8
+      Pointee: 348 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: PointerType
+      ID: 816
+      Name: '*net/textproto.dotWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.046784e+06
+      GoKind: 22
+      Pointee: 817 UnresolvedPointeeType net/textproto.dotWriter
+    - __kind: PointerType
+      ID: 724
+      Name: '*net/url.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.421472e+06
+      GoKind: 22
+      Pointee: 725 UnresolvedPointeeType net/url.Error
+    - __kind: PointerType
+      ID: 421
+      Name: '*net/url.EscapeError'
+      ByteSize: 8
+      GoRuntimeType: 908736
+      GoKind: 22
+      Pointee: 322 GoStringHeaderType net/url.EscapeError
+    - __kind: PointerType
+      ID: 324
+      Name: '*net/url.EscapeError.str'
+      ByteSize: 8
+      Pointee: 323 GoStringDataType net/url.EscapeError.str
+    - __kind: PointerType
+      ID: 422
+      Name: '*net/url.InvalidHostError'
+      ByteSize: 8
+      GoRuntimeType: 908832
+      GoKind: 22
+      Pointee: 325 GoStringHeaderType net/url.InvalidHostError
+    - __kind: PointerType
+      ID: 327
+      Name: '*net/url.InvalidHostError.str'
+      ByteSize: 8
+      Pointee: 326 GoStringDataType net/url.InvalidHostError.str
+    - __kind: PointerType
       ID: 288
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
@@ -3973,30 +5883,30 @@ Types:
       ByteSize: 8
       Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 337
+      ID: 1016
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 338 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1017 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 373
+      ID: 1052
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 374 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1053 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 388
+      ID: 1067
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 389 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1068 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 196
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 197 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 403
+      ID: 1082
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 404 StructureType noalg.map.group[int]interface {}
+      Pointee: 1083 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 255
       Name: '*noalg.map.group[int]uint8'
@@ -4012,6 +5922,11 @@ Types:
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
       Pointee: 221 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 774
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 212
       Name: '*noalg.map.group[string]int'
@@ -4033,6 +5948,175 @@ Types:
       ByteSize: 8
       Pointee: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
+      ID: 967
+      Name: '*os.File'
+      ByteSize: 8
+      GoRuntimeType: 2.349504e+06
+      GoKind: 22
+      Pointee: 968 UnresolvedPointeeType os.File
+    - __kind: PointerType
+      ID: 591
+      Name: '*os.LinkError'
+      ByteSize: 8
+      GoRuntimeType: 1.02592e+06
+      GoKind: 22
+      Pointee: 592 UnresolvedPointeeType os.LinkError
+    - __kind: PointerType
+      ID: 659
+      Name: '*os.SyscallError'
+      ByteSize: 8
+      GoRuntimeType: 1.191424e+06
+      GoKind: 22
+      Pointee: 660 UnresolvedPointeeType os.SyscallError
+    - __kind: PointerType
+      ID: 965
+      Name: '*os.fileWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.348032e+06
+      GoKind: 22
+      Pointee: 966 StructureType os.fileWithoutReadFrom
+    - __kind: PointerType
+      ID: 963
+      Name: '*os.fileWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.347296e+06
+      GoKind: 22
+      Pointee: 964 StructureType os.fileWithoutWriteTo
+    - __kind: PointerType
+      ID: 624
+      Name: '*os/exec.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.043456e+06
+      GoKind: 22
+      Pointee: 625 UnresolvedPointeeType os/exec.Error
+    - __kind: PointerType
+      ID: 770
+      Name: '*os/exec.ExitError'
+      ByteSize: 8
+      GoRuntimeType: 2.089056e+06
+      GoKind: 22
+      Pointee: 771 UnresolvedPointeeType os/exec.ExitError
+    - __kind: PointerType
+      ID: 836
+      Name: '*os/exec.prefixSuffixSaver'
+      ByteSize: 8
+      GoRuntimeType: 1.213696e+06
+      GoKind: 22
+      Pointee: 837 UnresolvedPointeeType os/exec.prefixSuffixSaver
+    - __kind: PointerType
+      ID: 626
+      Name: '*os/exec.wrappedError'
+      ByteSize: 8
+      GoRuntimeType: 1.043584e+06
+      GoKind: 22
+      Pointee: 627 StructureType os/exec.wrappedError
+    - __kind: PointerType
+      ID: 558
+      Name: '*os/user.UnknownGroupIdError'
+      ByteSize: 8
+      GoRuntimeType: 938112
+      GoKind: 22
+      Pointee: 361 GoStringHeaderType os/user.UnknownGroupIdError
+    - __kind: PointerType
+      ID: 363
+      Name: '*os/user.UnknownGroupIdError.str'
+      ByteSize: 8
+      Pointee: 362 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: PointerType
+      ID: 557
+      Name: '*os/user.UnknownUserIdError'
+      ByteSize: 8
+      GoRuntimeType: 938016
+      GoKind: 22
+      Pointee: 360 BaseType os/user.UnknownUserIdError
+    - __kind: PointerType
+      ID: 387
+      Name: '*reflect.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 901344
+      GoKind: 22
+      Pointee: 388 UnresolvedPointeeType reflect.ValueError
+    - __kind: PointerType
+      ID: 485
+      Name: '*regexp/syntax.Error'
+      ByteSize: 8
+      GoRuntimeType: 920928
+      GoKind: 22
+      Pointee: 486 UnresolvedPointeeType regexp/syntax.Error
+    - __kind: PointerType
+      ID: 595
+      Name: '*runtime.PanicNilError'
+      ByteSize: 8
+      GoRuntimeType: 1.027456e+06
+      GoKind: 22
+      Pointee: 596 UnresolvedPointeeType runtime.PanicNilError
+    - __kind: PointerType
+      ID: 599
+      Name: '*runtime.TypeAssertionError'
+      ByteSize: 8
+      GoRuntimeType: 1.029248e+06
+      GoKind: 22
+      Pointee: 600 UnresolvedPointeeType runtime.TypeAssertionError
+    - __kind: PointerType
+      ID: 597
+      Name: '*runtime.boundsError'
+      ByteSize: 8
+      GoRuntimeType: 1.027584e+06
+      GoKind: 22
+      Pointee: 598 StructureType runtime.boundsError
+    - __kind: PointerType
+      ID: 661
+      Name: '*runtime.errorAddressString'
+      ByteSize: 8
+      GoRuntimeType: 1.196928e+06
+      GoKind: 22
+      Pointee: 662 StructureType runtime.errorAddressString
+    - __kind: PointerType
+      ID: 593
+      Name: '*runtime.errorString'
+      ByteSize: 8
+      GoRuntimeType: 1.027072e+06
+      GoKind: 22
+      Pointee: 576 GoStringHeaderType runtime.errorString
+    - __kind: PointerType
+      ID: 578
+      Name: '*runtime.errorString.str'
+      ByteSize: 8
+      Pointee: 577 GoStringDataType runtime.errorString.str
+    - __kind: PointerType
+      ID: 594
+      Name: '*runtime.plainError'
+      ByteSize: 8
+      GoRuntimeType: 1.0272e+06
+      GoKind: 22
+      Pointee: 579 GoStringHeaderType runtime.plainError
+    - __kind: PointerType
+      ID: 581
+      Name: '*runtime.plainError.str'
+      ByteSize: 8
+      Pointee: 580 GoStringDataType runtime.plainError.str
+    - __kind: PointerType
+      ID: 737
+      Name: '*runtime.synctestBubble'
+      ByteSize: 8
+      GoRuntimeType: 1.551936e+06
+      GoKind: 22
+      Pointee: 738 UnresolvedPointeeType runtime.synctestBubble
+    - __kind: PointerType
+      ID: 383
+      Name: '*runtime.synctestDeadlockError'
+      ByteSize: 8
+      GoRuntimeType: 900000
+      GoKind: 22
+      Pointee: 384 StructureType runtime.synctestDeadlockError
+    - __kind: PointerType
+      ID: 601
+      Name: '*strconv.NumError'
+      ByteSize: 8
+      GoRuntimeType: 1.029504e+06
+      GoKind: 22
+      Pointee: 602 UnresolvedPointeeType strconv.NumError
+    - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
@@ -4044,6 +6128,34 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 177 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 902
+      Name: '*strings.Builder'
+      ByteSize: 8
+      GoRuntimeType: 1.949856e+06
+      GoKind: 22
+      Pointee: 903 UnresolvedPointeeType strings.Builder
+    - __kind: PointerType
+      ID: 806
+      Name: '*strings.appendSliceWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.029632e+06
+      GoKind: 22
+      Pointee: 807 UnresolvedPointeeType strings.appendSliceWriter
+    - __kind: PointerType
+      ID: 802
+      Name: '*struct { io.Writer }'
+      ByteSize: 8
+      GoRuntimeType: 971104
+      GoKind: 22
+      Pointee: 803 StructureType struct { io.Writer }
+    - __kind: PointerType
+      ID: 713
+      Name: '*syscall.Errno'
+      ByteSize: 8
+      GoRuntimeType: 1.416032e+06
+      GoKind: 22
+      Pointee: 712 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
@@ -4070,30 +6182,30 @@ Types:
       ByteSize: 8
       Pointee: 184 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 334
+      ID: 1013
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 335 StructureType table<int,*main.deepMap3>
+      Pointee: 1014 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 370
+      ID: 1049
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 371 StructureType table<int,*main.deepMap8>
+      Pointee: 1050 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 385
+      ID: 1064
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 386 StructureType table<int,*main.deepMap9>
+      Pointee: 1065 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 194 StructureType table<int,int>
     - __kind: PointerType
-      ID: 400
+      ID: 1079
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 401 StructureType table<int,interface {}>
+      Pointee: 1080 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*table<int,uint8>'
@@ -4109,6 +6221,11 @@ Types:
       Name: '*table<string,[]string>'
       ByteSize: 8
       Pointee: 218 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 744
+      Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 772 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
@@ -4129,6 +6246,46 @@ Types:
       Name: '*table<uint8,uint8>'
       ByteSize: 8
       Pointee: 261 StructureType table<uint8,uint8>
+    - __kind: PointerType
+      ID: 937
+      Name: '*text/tabwriter.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.159424e+06
+      GoKind: 22
+      Pointee: 938 UnresolvedPointeeType text/tabwriter.Writer
+    - __kind: PointerType
+      ID: 654
+      Name: '*text/template.ExecError'
+      ByteSize: 8
+      GoRuntimeType: 1.089024e+06
+      GoKind: 22
+      Pointee: 655 StructureType text/template.ExecError
+    - __kind: PointerType
+      ID: 729
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.622144e+06
+      GoKind: 22
+      Pointee: 730 UnresolvedPointeeType time.Location
+    - __kind: PointerType
+      ID: 390
+      Name: '*time.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 902208
+      GoKind: 22
+      Pointee: 391 UnresolvedPointeeType time.ParseError
+    - __kind: PointerType
+      ID: 389
+      Name: '*time.fileSizeError'
+      ByteSize: 8
+      GoRuntimeType: 902112
+      GoKind: 22
+      Pointee: 306 GoStringHeaderType time.fileSizeError
+    - __kind: PointerType
+      ID: 308
+      Name: '*time.fileSizeError.str'
+      ByteSize: 8
+      Pointee: 307 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4171,11 +6328,53 @@ Types:
       GoRuntimeType: 392960
       GoKind: 22
       Pointee: 1 BaseType uintptr
+    - __kind: PointerType
+      ID: 481
+      Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
+      ByteSize: 8
+      GoRuntimeType: 920352
+      GoKind: 22
+      Pointee: 482 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+    - __kind: PointerType
+      ID: 929
+      Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.134912e+06
+      GoKind: 22
+      Pointee: 930 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 465
+      Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 916512
+      GoKind: 22
+      Pointee: 466 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 467
+      Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 916608
+      GoKind: 22
+      Pointee: 350 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 631
+      Name: '*vendor/golang.org/x/net/idna.labelError'
+      ByteSize: 8
+      GoRuntimeType: 1.047296e+06
+      GoKind: 22
+      Pointee: 632 StructureType vendor/golang.org/x/net/idna.labelError
+    - __kind: PointerType
+      ID: 633
+      Name: '*vendor/golang.org/x/net/idna.runeError'
+      ByteSize: 8
+      GoRuntimeType: 1.047424e+06
+      GoKind: 22
+      Pointee: 584 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 506
+      ID: 1185
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 463
+      ID: 1142
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4190,7 +6389,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 461
+      ID: 1140
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4205,7 +6404,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 425
+      ID: 1104
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4220,7 +6419,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 423
+      ID: 1102
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4235,7 +6434,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 471
+      ID: 1150
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4250,7 +6449,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 424
+      ID: 1103
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4265,7 +6464,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 443
+      ID: 1122
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4280,7 +6479,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 412
+      ID: 1091
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4295,7 +6494,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 409
+      ID: 1088
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4310,7 +6509,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 487
+      ID: 1166
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4325,7 +6524,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 485
+      ID: 1164
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4358,7 +6557,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 495
+      ID: 1174
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4373,7 +6572,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 448
+      ID: 1127
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4388,7 +6587,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 449
+      ID: 1128
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4403,7 +6602,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 444
+      ID: 1123
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4418,7 +6617,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 445
+      ID: 1124
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4433,7 +6632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 446
+      ID: 1125
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4448,7 +6647,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 447
+      ID: 1126
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4463,7 +6662,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 1179
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4487,7 +6686,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 1176
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4502,7 +6701,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 514
+      ID: 1193
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4517,7 +6716,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 517
+      ID: 1196
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4532,7 +6731,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 516
+      ID: 1195
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4547,7 +6746,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 462
+      ID: 1141
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4562,7 +6761,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 453
+      ID: 1132
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4577,7 +6776,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 452
+      ID: 1131
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4592,7 +6791,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 459
+      ID: 1138
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4607,7 +6806,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 458
+      ID: 1137
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4622,7 +6821,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 454
+      ID: 1133
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4637,7 +6836,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 456
+      ID: 1135
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4652,10 +6851,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 519
+      ID: 1198
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 455
+      ID: 1134
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4679,16 +6878,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 1199
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 521
+      ID: 1200
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 457
+      ID: 1136
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 518
+      ID: 1197
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4703,7 +6902,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 522
+      ID: 1201
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4718,7 +6917,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 523
+      ID: 1202
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4733,7 +6932,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 415
+      ID: 1094
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4748,7 +6947,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 416
+      ID: 1095
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4763,7 +6962,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 417
+      ID: 1096
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4778,7 +6977,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 414
+      ID: 1093
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4793,7 +6992,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 413
+      ID: 1092
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4808,7 +7007,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 460
+      ID: 1139
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4823,7 +7022,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 1168
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4838,7 +7037,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 469
+      ID: 1148
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4853,7 +7052,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 1154
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4868,7 +7067,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 1152
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4883,7 +7082,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 484
+      ID: 1163
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4898,7 +7097,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 483
+      ID: 1162
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4913,7 +7112,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 1153
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4928,7 +7127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 482
+      ID: 1161
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4943,7 +7142,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 1160
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4958,7 +7157,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 467
+      ID: 1146
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4973,7 +7172,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 468
+      ID: 1147
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4988,7 +7187,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 466
+      ID: 1145
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5003,7 +7202,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 1155
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5018,7 +7217,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 1159
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5033,7 +7232,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 1158
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5048,7 +7247,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 1157
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5063,7 +7262,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 1156
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5078,7 +7277,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 512
+      ID: 1191
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5093,7 +7292,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 486
+      ID: 1165
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5144,7 +7343,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 494
+      ID: 1173
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5168,7 +7367,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 1180
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5192,7 +7391,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 503
+      ID: 1182
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5225,7 +7424,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 504
+      ID: 1183
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5240,7 +7439,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 1190
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5255,7 +7454,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 490
+      ID: 1169
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5270,7 +7469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 1151
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5285,7 +7484,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 488
+      ID: 1167
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5300,7 +7499,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 410
+      ID: 1089
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5315,7 +7514,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 429
+      ID: 1108
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5330,7 +7529,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 427
+      ID: 1106
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5345,7 +7544,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 440
+      ID: 1119
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5360,7 +7559,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 441
+      ID: 1120
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5375,7 +7574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 432
+      ID: 1111
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5390,7 +7589,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 433
+      ID: 1112
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5405,7 +7604,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 434
+      ID: 1113
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5420,7 +7619,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 431
+      ID: 1110
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5435,7 +7634,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 430
+      ID: 1109
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5450,7 +7649,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 428
+      ID: 1107
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5465,7 +7664,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 507
+      ID: 1186
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5480,7 +7679,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 437
+      ID: 1116
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5495,7 +7694,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 438
+      ID: 1117
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5510,7 +7709,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 439
+      ID: 1118
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5525,7 +7724,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 436
+      ID: 1115
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5540,7 +7739,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 435
+      ID: 1114
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5555,7 +7754,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 1177
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5570,7 +7769,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 470
+      ID: 1149
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5585,7 +7784,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 411
+      ID: 1090
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5600,7 +7799,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 493
+      ID: 1172
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5615,7 +7814,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 502
+      ID: 1181
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5630,7 +7829,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 450
+      ID: 1129
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5645,7 +7844,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 451
+      ID: 1130
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5660,7 +7859,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 1178
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5684,7 +7883,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 1143
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5699,7 +7898,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 465
+      ID: 1144
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5714,7 +7913,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 515
+      ID: 1194
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5729,7 +7928,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 510
+      ID: 1189
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5744,7 +7943,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 509
+      ID: 1188
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5759,7 +7958,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 508
+      ID: 1187
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5792,7 +7991,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 442
+      ID: 1121
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5807,7 +8006,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 420
+      ID: 1099
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5822,7 +8021,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 421
+      ID: 1100
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5837,7 +8036,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 1101
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5852,7 +8051,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 419
+      ID: 1098
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5867,7 +8066,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 418
+      ID: 1097
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5882,7 +8081,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 492
+      ID: 1171
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5897,7 +8096,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 1175
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5912,7 +8111,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 513
+      ID: 1192
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5927,7 +8126,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 491
+      ID: 1170
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5942,7 +8141,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 426
+      ID: 1105
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5957,7 +8156,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 505
+      ID: 1184
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6130,6 +8329,15 @@ Types:
       Count: 5
       HasCount: true
       Element: 7 BaseType int
+    - __kind: ArrayType
+      ID: 762
+      Name: '[5]uint8'
+      ByteSize: 5
+      GoRuntimeType: 684416
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*main.deepSlice2'
@@ -6153,7 +8361,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 324
+      ID: 1003
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477824
@@ -6161,21 +8369,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 325 PointerType **main.deepSlice3
+          Type: 1004 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 328 GoSliceDataType []*main.deepSlice3.array
+      Data: 1007 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 1007
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 326 PointerType *main.deepSlice3
+      Element: 1005 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 351
+      ID: 1030
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477504
@@ -6183,21 +8391,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 352 PointerType **main.deepSlice8
+          Type: 1031 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 355 GoSliceDataType []*main.deepSlice8.array
+      Data: 1034 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 355
+      ID: 1034
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 353 PointerType *main.deepSlice8
+      Element: 1032 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 357
+      ID: 1036
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477440
@@ -6205,19 +8413,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 358 PointerType **main.deepSlice9
+          Type: 1037 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 361 GoSliceDataType []*main.deepSlice9.array
+      Data: 1040 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 1040
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 359 PointerType *main.deepSlice9
+      Element: 1038 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6266,30 +8474,30 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 1022
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 334 PointerType *table<int,*main.deepMap3>
+      Element: 1013 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 379
+      ID: 1058
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 370 PointerType *table<int,*main.deepMap8>
+      Element: 1049 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 1073
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 385 PointerType *table<int,*main.deepMap9>
+      Element: 1064 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 1086
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 400 PointerType *table<int,interface {}>
+      Element: 1079 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]*table<int,uint8>.array'
@@ -6305,6 +8513,11 @@ Types:
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 778
+      Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
+      ByteSize: 8192
+      Element: 744 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 216
       Name: '[]*table<string,int>.array'
@@ -6369,7 +8582,29 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 363
+      ID: 757
+      Name: '[]float64'
+      ByteSize: 24
+      GoRuntimeType: 487104
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 25 PointerType *float64
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 782 GoSliceDataType []float64.array
+    - __kind: GoSliceDataType
+      ID: 782
+      Name: '[]float64.array'
+      ByteSize: 2048
+      Element: 15 BaseType float64
+    - __kind: GoSliceHeaderType
+      ID: 1042
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487552
@@ -6384,9 +8619,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 364 GoSliceDataType []interface {}.array
+      Data: 1043 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 1043
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
@@ -6406,9 +8641,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 345 GoSliceDataType []main.structWithMap.array
+      Data: 1024 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 1024
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -6459,30 +8694,30 @@ Types:
       ByteSize: 2048
       Element: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 1023
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 338 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1017 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 1059
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 374 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1053 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 1074
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 389 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1068 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 201
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 197 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 408
+      ID: 1087
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 404 StructureType noalg.map.group[int]interface {}
+      Element: 1083 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]noalg.map.group[int]uint8.array'
@@ -6498,6 +8733,11 @@ Types:
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 221 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 779
+      Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 2048
+      Element: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 217
       Name: '[]noalg.map.group[string]int.array'
@@ -6584,12 +8824,104 @@ Types:
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
+    - __kind: GoSliceHeaderType
+      ID: 751
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 486080
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 5 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 780 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 780
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 914
+      Name: archive/tar.Writer
+      ByteSize: 8
+    - __kind: GoSliceHeaderType
+      ID: 544
+      Name: archive/tar.headerError
+      ByteSize: 24
+      GoRuntimeType: 931488
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 22 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 545 GoSliceDataType archive/tar.headerError.array
+    - __kind: GoSliceDataType
+      ID: 545
+      Name: archive/tar.headerError.array
+      ByteSize: 2048
+      Element: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 849
+      Name: archive/tar.regFileWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 797
+      Name: archive/zip.countWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 799
+      Name: archive/zip.dirWriter
+      GoRuntimeType: 1.12032e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 893
+      Name: archive/zip.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 825
+      Name: archive/zip.nopCloser
+      ByteSize: 16
+      GoRuntimeType: 1.564896e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 827
+      Name: archive/zip.pooledFlateWriter
+      ByteSize: 8
     - __kind: BaseType
       ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 585184
       GoKind: 1
+    - __kind: UnresolvedPointeeType
+      ID: 872
+      Name: bufio.Reader
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 901
+      Name: bufio.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 952
+      Name: bytes.Buffer
+      ByteSize: 8
     - __kind: GoChannelType
       ID: 153
       Name: chan bool
@@ -6612,6 +8944,365 @@ Types:
       ByteSize: 8
       GoRuntimeType: 584928
       GoKind: 15
+    - __kind: BaseType
+      ID: 342
+      Name: compress/flate.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 834656
+      GoKind: 6
+    - __kind: GoStringHeaderType
+      ID: 343
+      Name: compress/flate.InternalError
+      ByteSize: 16
+      GoRuntimeType: 834752
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 345 PointerType *compress/flate.InternalError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 344 GoStringDataType compress/flate.InternalError.str
+    - __kind: GoStringDataType
+      ID: 344
+      Name: compress/flate.InternalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 847
+      Name: compress/flate.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 793
+      Name: compress/flate.dictWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 869
+      Name: compress/gzip.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 692
+      Name: context.deadlineExceededError
+      GoRuntimeType: 1.479296e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 356
+      Name: crypto/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 837248
+      GoKind: 2
+    - __kind: BaseType
+      ID: 357
+      Name: crypto/des.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 837344
+      GoKind: 2
+    - __kind: BaseType
+      ID: 358
+      Name: crypto/internal/fips140/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 837440
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 864
+      Name: crypto/internal/fips140/hmac.HMAC
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 641
+      Name: crypto/internal/fips140/hmac.errCloneUnsupported
+      GoRuntimeType: 1.28928e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 895
+      Name: crypto/internal/fips140/sha256.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 925
+      Name: crypto/internal/fips140/sha3.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 899
+      Name: crypto/internal/fips140/sha3.SHAKE
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 897
+      Name: crypto/internal/fips140/sha512.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 891
+      Name: crypto/md5.digest
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 359
+      Name: crypto/rc4.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 837536
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 912
+      Name: crypto/sha1.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 887
+      Name: crypto/sha3.SHA3
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 346
+      Name: crypto/tls.AlertError
+      ByteSize: 1
+      GoRuntimeType: 835232
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 630
+      Name: crypto/tls.CertificateVerificationError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 978
+      Name: crypto/tls.Conn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 458
+      Name: crypto/tls.ECHRejectionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 456
+      Name: crypto/tls.RecordHeaderError
+      ByteSize: 40
+      GoRuntimeType: 1.729984e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: RecordHeader
+          Offset: 16
+          Type: 762 ArrayType [5]uint8
+        - Name: Conn
+          Offset: 24
+          Type: 763 GoInterfaceType net.Conn
+    - __kind: BaseType
+      ID: 583
+      Name: crypto/tls.alert
+      ByteSize: 1
+      GoRuntimeType: 993472
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 857
+      Name: crypto/tls.cthWrapper
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 460
+      Name: crypto/tls.echConfigErr
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 862
+      Name: crypto/tls.finishedHash
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 727
+      Name: crypto/tls.permanentError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 746
+      Name: crypto/x509.Certificate
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 532
+      Name: crypto/x509.CertificateInvalidError
+      ByteSize: 32
+      GoRuntimeType: 1.732864e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 745 PointerType *crypto/x509.Certificate
+        - Name: Reason
+          Offset: 8
+          Type: 765 BaseType crypto/x509.InvalidReason
+        - Name: Detail
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 526
+      Name: crypto/x509.ConstraintViolationError
+      GoRuntimeType: 1.117888e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 528
+      Name: crypto/x509.HostnameError
+      ByteSize: 24
+      GoRuntimeType: 1.599008e+06
+      GoKind: 25
+      RawFields:
+        - Name: Certificate
+          Offset: 0
+          Type: 745 PointerType *crypto/x509.Certificate
+        - Name: Host
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 355
+      Name: crypto/x509.InsecureAlgorithmError
+      ByteSize: 8
+      GoRuntimeType: 836864
+      GoKind: 2
+    - __kind: BaseType
+      ID: 765
+      Name: crypto/x509.InvalidReason
+      ByteSize: 8
+      GoRuntimeType: 590368
+      GoKind: 2
+    - __kind: StructureType
+      ID: 635
+      Name: crypto/x509.SystemRootsError
+      ByteSize: 16
+      GoRuntimeType: 1.560896e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 534
+      Name: crypto/x509.UnhandledCriticalExtension
+      GoRuntimeType: 1.118144e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 530
+      Name: crypto/x509.UnknownAuthorityError
+      ByteSize: 32
+      GoRuntimeType: 1.732672e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 745 PointerType *crypto/x509.Certificate
+        - Name: hintErr
+          Offset: 8
+          Type: 13 GoInterfaceType error
+        - Name: hintCert
+          Offset: 24
+          Type: 745 PointerType *crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 548
+      Name: encoding/asn1.StructuralError
+      ByteSize: 16
+      GoRuntimeType: 1.435712e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 552
+      Name: encoding/asn1.SyntaxError
+      ByteSize: 16
+      GoRuntimeType: 1.435872e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 550
+      Name: encoding/asn1.invalidUnmarshalError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 337
+      Name: encoding/base64.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 834176
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 815
+      Name: encoding/base64.encoder
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 338
+      Name: encoding/hex.InvalidByteError
+      ByteSize: 1
+      GoRuntimeType: 834368
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 414
+      Name: encoding/json.InvalidUnmarshalError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 619
+      Name: encoding/json.MarshalerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 406
+      Name: encoding/json.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 412
+      Name: encoding/json.UnmarshalTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 410
+      Name: encoding/json.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 408
+      Name: encoding/json.UnsupportedValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 958
+      Name: encoding/json.encodeState
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 416
+      Name: encoding/json.jsonError
+      ByteSize: 16
+      GoRuntimeType: 1.419712e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 823
+      Name: encoding/pem.lineBreaker
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 520
+      Name: encoding/xml.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 518
+      Name: encoding/xml.TagPathError
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 352
+      Name: encoding/xml.UnmarshalError
+      ByteSize: 16
+      GoRuntimeType: 836768
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 354 PointerType *encoding/xml.UnmarshalError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 353 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: GoStringDataType
+      ID: 353
+      Name: encoding/xml.UnmarshalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 523
+      Name: encoding/xml.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 936
+      Name: encoding/xml.printer
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 13
       Name: error
@@ -6625,6 +9316,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 382
+      Name: errors.errorString
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 586
+      Name: errors.joinError
+      ByteSize: 8
     - __kind: BaseType
       ID: 18
       Name: float32
@@ -6637,12 +9336,1062 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585120
       GoKind: 14
+    - __kind: UnresolvedPointeeType
+      ID: 946
+      Name: fmt.pp
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 588
+      Name: fmt.wrapError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 590
+      Name: fmt.wrapErrors
+      ByteSize: 8
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
       GoRuntimeType: 476032
       GoKind: 19
+    - __kind: UnresolvedPointeeType
+      ID: 444
+      Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 425
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      ByteSize: 216
+      GoRuntimeType: 1.728832e+06
+      GoKind: 25
+      RawFields:
+        - Name: Metric
+          Offset: 0
+          Type: 755 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+        - Name: ChannelSize
+          Offset: 192
+          Type: 7 BaseType int
+        - Name: Msg
+          Offset: 200
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 427
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 759
+      Name: github.com/DataDog/datadog-go/v5/statsd.Event
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 431
+      Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      GoRuntimeType: 1.114176e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 761
+      Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 331
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      ByteSize: 16
+      GoRuntimeType: 833600
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: GoStringDataType
+      ID: 332
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 755
+      Name: github.com/DataDog/datadog-go/v5/statsd.metric
+      ByteSize: 192
+      GoRuntimeType: 2.21872e+06
+      GoKind: 25
+      RawFields:
+        - Name: metricType
+          Offset: 0
+          Type: 756 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+        - Name: namespace
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+        - Name: globalTags
+          Offset: 24
+          Type: 166 GoSliceHeaderType []string
+        - Name: name
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fvalue
+          Offset: 64
+          Type: 15 BaseType float64
+        - Name: fvalues
+          Offset: 72
+          Type: 757 GoSliceHeaderType []float64
+        - Name: ivalue
+          Offset: 96
+          Type: 12 BaseType int64
+        - Name: svalue
+          Offset: 104
+          Type: 9 GoStringHeaderType string
+        - Name: evalue
+          Offset: 120
+          Type: 758 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+        - Name: scvalue
+          Offset: 128
+          Type: 760 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+        - Name: tags
+          Offset: 136
+          Type: 166 GoSliceHeaderType []string
+        - Name: stags
+          Offset: 160
+          Type: 9 GoStringHeaderType string
+        - Name: rate
+          Offset: 176
+          Type: 15 BaseType float64
+        - Name: timestamp
+          Offset: 184
+          Type: 12 BaseType int64
+    - __kind: BaseType
+      ID: 756
+      Name: github.com/DataDog/datadog-go/v5/statsd.metricType
+      ByteSize: 8
+      GoRuntimeType: 586976
+      GoKind: 2
+    - __kind: GoStringHeaderType
+      ID: 328
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      ByteSize: 16
+      GoRuntimeType: 833504
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: GoStringDataType
+      ID: 329
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 334
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      ByteSize: 16
+      GoRuntimeType: 833696
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 336 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: GoStringDataType
+      ID: 335
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 835
+      Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 922
+      Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 542
+      Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 701
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 954
+      Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 469
+      Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 476
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      GoRuntimeType: 1.11712e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 351
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      ByteSize: 8
+      GoRuntimeType: 835904
+      GoKind: 2
+    - __kind: StructureType
+      ID: 474
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      GoRuntimeType: 1.116992e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 472
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      ByteSize: 32
+      GoRuntimeType: 1.597088e+06
+      GoKind: 25
+      RawFields:
+        - Name: OS
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Arch
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 492
+      Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      ByteSize: 32
+      GoRuntimeType: 1.597888e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 496
+      Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      ByteSize: 32
+      GoRuntimeType: 1.732096e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Size
+          Offset: 16
+          Type: 12 BaseType int64
+        - Name: MaxSize
+          Offset: 24
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 494
+      Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      ByteSize: 16
+      GoRuntimeType: 1.429632e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 490
+      Name: github.com/DataDog/go-tuf/client.ErrNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.429312e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 740
+      Name: github.com/DataDog/go-tuf/data.Hashes
+      ByteSize: 8
+      GoRuntimeType: 1.500096e+06
+      GoKind: 21
+      HeaderType: 742 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+    - __kind: GoSliceHeaderType
+      ID: 764
+      Name: github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 24
+      GoRuntimeType: 1.05088e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 5 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 784 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: GoSliceDataType
+      ID: 784
+      Name: github.com/DataDog/go-tuf/data.HexBytes.array
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: StructureType
+      ID: 504
+      Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      ByteSize: 16
+      GoRuntimeType: 1.598208e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 740 GoMapType github.com/DataDog/go-tuf/data.Hashes
+        - Name: Actual
+          Offset: 8
+          Type: 740 GoMapType github.com/DataDog/go-tuf/data.Hashes
+    - __kind: StructureType
+      ID: 498
+      Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      ByteSize: 16
+      GoRuntimeType: 1.429792e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 502
+      Name: github.com/DataDog/go-tuf/util.ErrWrongHash
+      ByteSize: 64
+      GoRuntimeType: 1.732288e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Expected
+          Offset: 16
+          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+        - Name: Actual
+          Offset: 40
+          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: StructureType
+      ID: 500
+      Name: github.com/DataDog/go-tuf/util.ErrWrongLength
+      ByteSize: 16
+      GoRuntimeType: 1.598048e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: Actual
+          Offset: 8
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 506
+      Name: github.com/DataDog/go-tuf/verify.ErrExpired
+      ByteSize: 24
+      GoRuntimeType: 1.429952e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expired
+          Offset: 0
+          Type: 728 StructureType time.Time
+    - __kind: StructureType
+      ID: 512
+      Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
+      ByteSize: 16
+      GoRuntimeType: 1.598528e+06
+      GoKind: 25
+      RawFields:
+        - Name: Actual
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: Current
+          Offset: 8
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 514
+      Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
+      ByteSize: 16
+      GoRuntimeType: 1.430272e+06
+      GoKind: 25
+      RawFields:
+        - Name: KeyID
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 510
+      Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      ByteSize: 16
+      GoRuntimeType: 1.598368e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: Actual
+          Offset: 8
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 508
+      Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      ByteSize: 16
+      GoRuntimeType: 1.430112e+06
+      GoKind: 25
+      RawFields:
+        - Name: Role
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 516
+      Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      ByteSize: 16
+      GoRuntimeType: 1.598688e+06
+      GoKind: 25
+      RawFields:
+        - Name: Given
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: Expected
+          Offset: 8
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 433
+      Name: github.com/cihub/seelog.baseError
+      ByteSize: 16
+      GoRuntimeType: 1.421952e+06
+      GoKind: 25
+      RawFields:
+        - Name: message
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 875
+      Name: github.com/cihub/seelog.bufferedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 435
+      Name: github.com/cihub/seelog.cannotOpenFileError
+      ByteSize: 16
+      GoRuntimeType: 1.422112e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 855
+      Name: github.com/cihub/seelog.connWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 811
+      Name: github.com/cihub/seelog.consoleWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 845
+      Name: github.com/cihub/seelog.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 439
+      Name: github.com/cihub/seelog.missingArgumentError
+      ByteSize: 16
+      GoRuntimeType: 1.422432e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 910
+      Name: github.com/cihub/seelog.rollingFileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 923
+      Name: github.com/cihub/seelog.rollingFileWriterSize
+      ByteSize: 16
+      GoRuntimeType: 2.106208e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 909 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: maxFileSize
+          Offset: 8
+          Type: 12 BaseType int64
+    - __kind: StructureType
+      ID: 926
+      Name: github.com/cihub/seelog.rollingFileWriterTime
+      ByteSize: 40
+      GoRuntimeType: 2.131072e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 909 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: timePattern
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+        - Name: currentTimeFileName
+          Offset: 24
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 813
+      Name: github.com/cihub/seelog.smtpWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 437
+      Name: github.com/cihub/seelog.unexpectedAttributeError
+      ByteSize: 16
+      GoRuntimeType: 1.422272e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: StructureType
+      ID: 441
+      Name: github.com/cihub/seelog.unexpectedChildElementError
+      ByteSize: 16
+      GoRuntimeType: 1.422592e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 877
+      Name: github.com/cihub/seelog/archive/gzip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 918
+      Name: github.com/cihub/seelog/archive/tar.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 920
+      Name: github.com/cihub/seelog/archive/zip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 732
+      Name: github.com/go-viper/mapstructure/v2.DecodeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 645
+      Name: github.com/go-viper/mapstructure/v2.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 643
+      Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 647
+      Name: github.com/gogo/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 649
+      Name: github.com/gogo/protobuf/proto.invalidUTF8Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 866
+      Name: github.com/gogo/protobuf/proto.textWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 637
+      Name: github.com/golang/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 447
+      Name: github.com/google/uuid.invalidLengthError
+      ByteSize: 8
+      GoRuntimeType: 1.423552e+06
+      GoKind: 25
+      RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
+    - __kind: UnresolvedPointeeType
+      ID: 970
+      Name: github.com/json-iterator/go.Stream
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 703
+      Name: github.com/pkg/errors.fundamental
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 676
+      Name: github.com/tinylib/msgp/msgp.ArrayError
+      ByteSize: 24
+      GoRuntimeType: 1.841888e+06
+      GoKind: 25
+      RawFields:
+        - Name: Wanted
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Got
+          Offset: 4
+          Type: 2 BaseType uint32
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 670
+      Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 605
+      Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
+      ByteSize: 2
+      GoRuntimeType: 1.701536e+06
+      GoKind: 25
+      RawFields:
+        - Name: Got
+          Offset: 0
+          Type: 16 BaseType int8
+        - Name: Want
+          Offset: 1
+          Type: 16 BaseType int8
+    - __kind: StructureType
+      ID: 682
+      Name: github.com/tinylib/msgp/msgp.IntOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.842336e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 582
+      Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
+      ByteSize: 1
+      GoRuntimeType: 990784
+      GoKind: 8
+    - __kind: StructureType
+      ID: 674
+      Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
+      ByteSize: 32
+      GoRuntimeType: 1.841664e+06
+      GoKind: 25
+      RawFields:
+        - Name: Nanos
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: FieldLength
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 766
+      Name: github.com/tinylib/msgp/msgp.Type
+      ByteSize: 1
+      GoRuntimeType: 831776
+      GoKind: 8
+    - __kind: StructureType
+      ID: 672
+      Name: github.com/tinylib/msgp/msgp.TypeError
+      ByteSize: 24
+      GoRuntimeType: 1.84144e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 766 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: Encoded
+          Offset: 1
+          Type: 766 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 680
+      Name: github.com/tinylib/msgp/msgp.UintBelowZero
+      ByteSize: 24
+      GoRuntimeType: 1.755488e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 678
+      Name: github.com/tinylib/msgp/msgp.UintOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.842112e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 974
+      Name: github.com/tinylib/msgp/msgp.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 686
+      Name: github.com/tinylib/msgp/msgp.errFatal
+      ByteSize: 16
+      GoRuntimeType: 1.623104e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctx
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 609
+      Name: github.com/tinylib/msgp/msgp.errRecursion
+      GoRuntimeType: 1.283264e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 607
+      Name: github.com/tinylib/msgp/msgp.errShort
+      GoRuntimeType: 1.283136e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 684
+      Name: github.com/tinylib/msgp/msgp.errWrapped
+      ByteSize: 32
+      GoRuntimeType: 1.75568e+06
+      GoKind: 25
+      RawFields:
+        - Name: cause
+          Offset: 0
+          Type: 13 GoInterfaceType error
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 364
+      Name: go.opentelemetry.io/otel/trace.errorConst
+      ByteSize: 16
+      GoRuntimeType: 839360
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 366 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 365 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: GoStringDataType
+      ID: 365
+      Name: go.opentelemetry.io/otel/trace.errorConst.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 749
+      Name: go.uber.org/multierr.multiError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 653
+      Name: go.uber.org/zap.errArrayElem
+      ByteSize: 16
+      GoRuntimeType: 1.447552e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 841
+      Name: go.uber.org/zap.nopCloserSink
+      ByteSize: 16
+      GoRuntimeType: 1.677248e+06
+      GoKind: 25
+      RawFields:
+        - Name: WriteSyncer
+          Offset: 0
+          Type: 867 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+    - __kind: UnresolvedPointeeType
+      ID: 934
+      Name: go.uber.org/zap/buffer.Buffer
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 867
+      Name: go.uber.org/zap/zapcore.WriteSyncer
+      ByteSize: 16
+      GoRuntimeType: 1.127872e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 829
+      Name: go.uber.org/zap/zapcore.writerWrapper
+      ByteSize: 16
+      GoRuntimeType: 1.569696e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 367
+      Name: golang.org/x/net/http2.ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 839936
+      GoKind: 10
+    - __kind: BaseType
+      ID: 747
+      Name: golang.org/x/net/http2.ErrCode
+      ByteSize: 4
+      GoRuntimeType: 1.003936e+06
+      GoKind: 10
+    - __kind: StructureType
+      ID: 711
+      Name: golang.org/x/net/http2.StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.880416e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 747 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 568
+      Name: golang.org/x/net/http2.connError
+      ByteSize: 24
+      GoRuntimeType: 1.605728e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 747 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 371
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 840128
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 373 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 372 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 372
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 377
+      Name: golang.org/x/net/http2.headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 840320
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 379 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 378 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 378
+      Name: golang.org/x/net/http2.headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 374
+      Name: golang.org/x/net/http2.headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 840224
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 376 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 375 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 375
+      Name: golang.org/x/net/http2.headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 368
+      Name: golang.org/x/net/http2.pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 840032
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 370 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 369 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 369
+      Name: golang.org/x/net/http2.pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 932
+      Name: golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 572
+      Name: golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.448192e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: BaseType
+      ID: 380
+      Name: golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 840416
+      GoKind: 2
+    - __kind: StructureType
+      ID: 560
+      Name: google.golang.org/grpc.dropError
+      ByteSize: 16
+      GoRuntimeType: 1.443232e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 709
+      Name: google.golang.org/grpc/internal/status.Error
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 734
+      Name: google.golang.org/grpc/internal/transport.ConnectionError
+      ByteSize: 40
+      GoRuntimeType: 1.908192e+06
+      GoKind: 25
+      RawFields:
+        - Name: Desc
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: temp
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: err
+          Offset: 24
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 562
+      Name: google.golang.org/grpc/internal/transport.NewStreamError
+      ByteSize: 24
+      GoRuntimeType: 1.605248e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+        - Name: AllowTransparentRetry
+          Offset: 16
+          Type: 4 BaseType bool
+    - __kind: StructureType
+      ID: 881
+      Name: google.golang.org/grpc/internal/transport.bufConn
+      ByteSize: 32
+      GoRuntimeType: 1.96624e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 763 GoInterfaceType net.Conn
+        - Name: r
+          Offset: 16
+          Type: 908 GoInterfaceType io.Reader
+    - __kind: UnresolvedPointeeType
+      ID: 839
+      Name: google.golang.org/grpc/internal/transport.bufWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 651
+      Name: google.golang.org/grpc/internal/transport.ioError
+      ByteSize: 16
+      GoRuntimeType: 1.567296e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 801
+      Name: google.golang.org/grpc/mem.writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 540
+      Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 639
+      Name: google.golang.org/protobuf/internal/errors.prefixError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 707
+      Name: google.golang.org/protobuf/internal/errors.wrapError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 705
+      Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      GoRuntimeType: 1.510816e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 554
+      Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.436512e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 556
+      Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
+      ByteSize: 16
+      GoRuntimeType: 1.436672e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 484
+      Name: gopkg.in/yaml%2ev3.TypeError
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
       ID: 287
       Name: groupReference<[4]int,[4]int>
@@ -6714,47 +10463,47 @@ Types:
       GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 336
+      ID: 1015
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 337 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1016 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 344 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1017 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1023 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 372
+      ID: 1051
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 373 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1052 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 380 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1053 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1059 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 387
+      ID: 1066
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 388 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1067 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 395 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1068 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1074 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 195
       Name: groupReference<int,int>
@@ -6770,19 +10519,19 @@ Types:
       GroupType: 197 StructureType noalg.map.group[int]int
       GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 402
+      ID: 1081
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 403 PointerType *noalg.map.group[int]interface {}
+          Type: 1082 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 404 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 408 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1083 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1087 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 254
       Name: groupReference<int,uint8>
@@ -6825,6 +10574,20 @@ Types:
           Type: 8 BaseType uint64
       GroupType: 221 StructureType noalg.map.group[string][]string
       GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 773
+      Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 774 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 779 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 211
       Name: groupReference<string,int>
@@ -6881,6 +10644,14 @@ Types:
           Type: 8 BaseType uint64
       GroupType: 264 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
+    - __kind: UnresolvedPointeeType
+      ID: 889
+      Name: hash/crc32.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 575
+      Name: html/template.Error
+      ByteSize: 8
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6924,8 +10695,70 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 736
+      Name: internal/abi.Type
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 452
+      Name: internal/bisect.parseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 450
+      Name: internal/chacha8rand.errUnmarshalChaCha8
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 787
+      Name: internal/godebug.runtimeStderr
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 668
+      Name: internal/poll.DeadlineExceededError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 976
+      Name: internal/poll.FD
+      ByteSize: 8
     - __kind: StructureType
-      ID: 313
+      ID: 666
+      Name: internal/poll.errNetClosing
+      GoRuntimeType: 1.476096e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 386
+      Name: internal/reflectlite.ValueError
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 339
+      Name: internal/runtime/cgroup.stringError
+      ByteSize: 16
+      GoRuntimeType: 834560
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 341 PointerType *internal/runtime/cgroup.stringError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 340 GoStringDataType internal/runtime/cgroup.stringError.str
+    - __kind: GoStringDataType
+      ID: 340
+      Name: internal/runtime/cgroup.stringError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 623
+      Name: internal/runtime/maps.unhashableTypeError
+      ByteSize: 8
+      GoRuntimeType: 1.558656e+06
+      GoKind: 25
+      RawFields:
+        - Name: typ
+          Offset: 0
+          Type: 735 PointerType *internal/abi.Type
+    - __kind: StructureType
+      ID: 988
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.473536e+06
@@ -6937,6 +10770,49 @@ Types:
         - Name: sema
           Offset: 4
           Type: 2 BaseType uint32
+    - __kind: UnresolvedPointeeType
+      ID: 833
+      Name: io.PipeWriter
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 873
+      Name: io.ReadWriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.18976e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 908
+      Name: io.Reader
+      ByteSize: 16
+      GoRuntimeType: 1.023232e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 860
+      Name: io.WriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.110464e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 55
       Name: io.Writer
@@ -6950,6 +10826,24 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 831
+      Name: io.discard
+      GoRuntimeType: 1.462656e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 805
+      Name: io.multiWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 664
+      Name: io/fs.PathError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 879
+      Name: log/slog/internal/buffer.Buffer
+      ByteSize: 8
     - __kind: StructureType
       ID: 173
       Name: main.aStruct
@@ -7015,9 +10909,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 330 GoMapType map[int]*main.deepMap3
+          Type: 1009 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 1021
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7029,9 +10923,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 366 GoMapType map[int]*main.deepMap8
+          Type: 1045 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 378
+      ID: 1057
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.185536e+06
@@ -7039,9 +10933,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 381 GoMapType map[int]*main.deepMap9
+          Type: 1060 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 393
+      ID: 1072
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.185408e+06
@@ -7049,7 +10943,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 396 GoMapType map[int]interface {}
+          Type: 1075 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7069,9 +10963,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 306 PointerType *main.deepPtr3
+          Type: 979 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 307
+      ID: 980
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7083,9 +10977,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 347 PointerType *main.deepPtr8
+          Type: 1026 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 348
+      ID: 1027
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.186688e+06
@@ -7093,9 +10987,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 349 PointerType *main.deepPtr9
+          Type: 1028 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 350
+      ID: 1029
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18656e+06
@@ -7123,9 +11017,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 324 GoSliceHeaderType []*main.deepSlice3
+          Type: 1003 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 1006
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7137,9 +11031,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 351 GoSliceHeaderType []*main.deepSlice8
+          Type: 1030 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 354
+      ID: 1033
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.18784e+06
@@ -7147,9 +11041,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 357 GoSliceHeaderType []*main.deepSlice9
+          Type: 1036 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 360
+      ID: 1039
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.187712e+06
@@ -7157,7 +11051,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 363 GoSliceHeaderType []interface {}
+          Type: 1042 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 175
       Name: main.emptyStruct
@@ -7175,16 +11069,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 311 StructureType sync.Mutex
+          Type: 986 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 314 StructureType sync.Once
+          Type: 989 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 317 StructureType sync.WaitGroup
+          Type: 992 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 320 StructureType sync/atomic.Int32
+          Type: 995 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -7213,6 +11107,16 @@ Types:
         - Name: foo
           Offset: 56
           Type: 83 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 997
+      Name: main.firstBehavior
+      ByteSize: 16
+      GoRuntimeType: 1.412192e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
       ID: 174
       Name: main.nestedStruct
@@ -7248,6 +11152,13 @@ Types:
         - Name: a
           Offset: 0
           Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 999
+      Name: main.secondBehavior
+      ByteSize: 8
+      GoRuntimeType: 1.412352e+06
+      GoKind: 25
+      RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 82
       Name: main.something
@@ -7261,6 +11172,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 985
+      Name: main.somethingImpl
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 76
       Name: main.stringType1
@@ -7269,17 +11184,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *main.stringType1.str
+          Type: 982 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 308 GoStringDataType main.stringType1.str
+      Data: 981 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 981
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 310
+      ID: 983
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -7334,16 +11249,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 321 PointerType **main.t
+          Type: 1000 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 322 GoSliceDataType main.t.array
+      Data: 1001 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 322
+      ID: 1001
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -7543,7 +11458,7 @@ Types:
       TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 332
+      ID: 1011
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7556,7 +11471,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 333 PointerType **table<int,*main.deepMap3>
+          Type: 1012 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7575,10 +11490,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 343 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1022 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1017 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 368
+      ID: 1047
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7591,7 +11506,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 369 PointerType **table<int,*main.deepMap8>
+          Type: 1048 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7610,10 +11525,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 379 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1058 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1053 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 383
+      ID: 1062
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7626,7 +11541,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 384 PointerType **table<int,*main.deepMap9>
+          Type: 1063 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7645,8 +11560,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 394 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1073 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1068 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 93
       Name: map<int,int>
@@ -7683,7 +11598,7 @@ Types:
       TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
       GroupType: 197 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 398
+      ID: 1077
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7696,7 +11611,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 399 PointerType **table<int,interface {}>
+          Type: 1078 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7715,8 +11630,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 407 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 404 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1086 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1083 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 130
       Name: map<int,uint8>
@@ -7822,6 +11737,41 @@ Types:
           Type: 8 BaseType uint64
       TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
       GroupType: 221 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 742
+      Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 743 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 778 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -7998,26 +11948,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 330
+      ID: 1009
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.129536e+06
       GoKind: 21
-      HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1011 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 366
+      ID: 1045
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.128896e+06
       GoKind: 21
-      HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1047 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 381
+      ID: 1060
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.128768e+06
       GoKind: 21
-      HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1062 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
@@ -8026,12 +11976,12 @@ Types:
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 396
+      ID: 1075
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.12864e+06
       GoKind: 21
-      HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1077 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
@@ -8081,6 +12031,601 @@ Types:
       GoRuntimeType: 1.131072e+06
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: StructureType
+      ID: 488
+      Name: math/big.ErrNaN
+      ByteSize: 16
+      GoRuntimeType: 1.428832e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 795
+      Name: mime/multipart.writerOnly·1
+      ByteSize: 16
+      GoRuntimeType: 1.425632e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 695
+      Name: net.AddrError
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 763
+      Name: net.Conn
+      ByteSize: 16
+      GoRuntimeType: 1.595808e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 721
+      Name: net.DNSError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 940
+      Name: net.IPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 719
+      Name: net.OpError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 697
+      Name: net.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 950
+      Name: net.TCPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 960
+      Name: net.UDPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 948
+      Name: net.UnixConn
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 656
+      Name: net.UnknownNetworkError
+      ByteSize: 16
+      GoRuntimeType: 1.113792e+06
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 658 PointerType *net.UnknownNetworkError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 657 GoStringDataType net.UnknownNetworkError.str
+    - __kind: GoStringDataType
+      ID: 657
+      Name: net.UnknownNetworkError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 621
+      Name: net.canceledError
+      GoRuntimeType: 1.284288e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 916
+      Name: net.conn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 768
+      Name: net.dialResult·1
+      ByteSize: 40
+      GoRuntimeType: 2.105504e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 763 GoInterfaceType net.Conn
+        - Name: error
+          Offset: 16
+          Type: 13 GoInterfaceType error
+        - Name: primary
+          Offset: 32
+          Type: 4 BaseType bool
+        - Name: done
+          Offset: 33
+          Type: 4 BaseType bool
+    - __kind: UnresolvedPointeeType
+      ID: 962
+      Name: net.netFD
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 956
+      Name: net.noReadFrom
+      GoRuntimeType: 1.114048e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 955
+      Name: net.noWriteTo
+      GoRuntimeType: 1.11392e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 418
+      Name: net.notFoundError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 420
+      Name: net.result·2
+      ByteSize: 112
+      GoRuntimeType: 1.72864e+06
+      GoKind: 25
+      RawFields:
+        - Name: p
+          Offset: 0
+          Type: 750 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+        - Name: server
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: error
+          Offset: 96
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 944
+      Name: net.tcpConnWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.288512e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 956 StructureType net.noReadFrom
+        - Name: TCPConn
+          Offset: 0
+          Type: 949 PointerType *net.TCPConn
+    - __kind: StructureType
+      ID: 942
+      Name: net.tcpConnWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.287968e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 955 StructureType net.noWriteTo
+        - Name: TCPConn
+          Offset: 0
+          Type: 949 PointerType *net.TCPConn
+    - __kind: UnresolvedPointeeType
+      ID: 699
+      Name: net.temporaryError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 723
+      Name: net.timeoutError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 611
+      Name: net/http.ProtocolError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 789
+      Name: net/http.bufioFlushWriter
+      ByteSize: 16
+      GoRuntimeType: 1.417152e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 309
+      Name: net/http.http2ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 832256
+      GoKind: 10
+    - __kind: BaseType
+      ID: 739
+      Name: net/http.http2ErrCode
+      ByteSize: 4
+      GoRuntimeType: 990880
+      GoKind: 10
+    - __kind: StructureType
+      ID: 396
+      Name: net/http.http2GoAwayError
+      ByteSize: 24
+      GoRuntimeType: 1.726912e+06
+      GoKind: 25
+      RawFields:
+        - Name: LastStreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: ErrCode
+          Offset: 4
+          Type: 739 BaseType net/http.http2ErrCode
+        - Name: DebugData
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 715
+      Name: net/http.http2StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.89872e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 739 BaseType net/http.http2ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 400
+      Name: net/http.http2connError
+      ByteSize: 24
+      GoRuntimeType: 1.595328e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 739 BaseType net/http.http2ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 851
+      Name: net/http.http2dataBuffer
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 313
+      Name: net/http.http2duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 832448
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 315 PointerType *net/http.http2duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 314
+      Name: net/http.http2duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 319
+      Name: net/http.http2headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 832640
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 321 PointerType *net/http.http2headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 320 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 320
+      Name: net/http.http2headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 316
+      Name: net/http.http2headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 832544
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 318 PointerType *net/http.http2headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 317 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 317
+      Name: net/http.http2headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 690
+      Name: net/http.http2httpError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 617
+      Name: net/http.http2noCachedConnError
+      GoRuntimeType: 1.28352e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 905
+      Name: net/http.http2pipe
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 310
+      Name: net/http.http2pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 832352
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 312 PointerType *net/http.http2pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 311
+      Name: net/http.http2pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 791
+      Name: net/http.http2stickyErrWriter
+      ByteSize: 48
+      GoRuntimeType: 1.824576e+06
+      GoKind: 25
+      RawFields:
+        - Name: group
+          Offset: 0
+          Type: 882 GoInterfaceType net/http.http2synctestGroupInterface
+        - Name: conn
+          Offset: 16
+          Type: 763 GoInterfaceType net.Conn
+        - Name: timeout
+          Offset: 32
+          Type: 883 BaseType time.Duration
+        - Name: err
+          Offset: 40
+          Type: 33 PointerType *error
+    - __kind: GoInterfaceType
+      ID: 882
+      Name: net/http.http2synctestGroupInterface
+      ByteSize: 16
+      GoRuntimeType: 1.416352e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: ArrayType
+      ID: 870
+      Name: net/http.incomparable
+      GoRuntimeType: 903456
+      GoKind: 17
+      HasCount: true
+      Element: 83 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 613
+      Name: net/http.nothingWrittenError
+      ByteSize: 16
+      GoRuntimeType: 1.554816e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 853
+      Name: net/http.persistConn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 809
+      Name: net/http.persistConnWriter
+      ByteSize: 8
+      GoRuntimeType: 1.554656e+06
+      GoKind: 25
+      RawFields:
+        - Name: pc
+          Offset: 0
+          Type: 852 PointerType *net/http.persistConn
+    - __kind: StructureType
+      ID: 843
+      Name: net/http.readWriteCloserBody
+      ByteSize: 24
+      GoRuntimeType: 1.799552e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 870 ArrayType net/http.incomparable
+        - Name: br
+          Offset: 0
+          Type: 871 PointerType *bufio.Reader
+        - Name: ReadWriteCloser
+          Offset: 8
+          Type: 873 GoInterfaceType io.ReadWriteCloser
+    - __kind: StructureType
+      ID: 404
+      Name: net/http.requestBodyReadError
+      ByteSize: 16
+      GoRuntimeType: 1.418112e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 717
+      Name: net/http.timeoutError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 688
+      Name: net/http.tlsHandshakeTimeoutError
+      GoRuntimeType: 1.478976e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 615
+      Name: net/http.transportReadFromServerError
+      ByteSize: 16
+      GoRuntimeType: 1.554976e+06
+      GoKind: 25
+      RawFields:
+        - Name: err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: StructureType
+      ID: 885
+      Name: net/http.unencryptedNetConnInTLSConn
+      ByteSize: 32
+      GoRuntimeType: 2.025216e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 763 GoInterfaceType net.Conn
+        - Name: conn
+          Offset: 16
+          Type: 763 GoInterfaceType net.Conn
+    - __kind: UnresolvedPointeeType
+      ID: 393
+      Name: net/http.unsupportedTEError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 907
+      Name: net/http/internal.FlushAfterChunkWriter
+      ByteSize: 8
+      GoRuntimeType: 2.04096e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 900 PointerType *bufio.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 819
+      Name: net/http/internal.chunkedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 480
+      Name: net/netip.parseAddrError
+      ByteSize: 48
+      GoRuntimeType: 1.731712e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: at
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 478
+      Name: net/netip.parsePrefixError
+      ByteSize: 32
+      GoRuntimeType: 1.597248e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 859
+      Name: net/smtp.Client
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 821
+      Name: net/smtp.dataCloser
+      ByteSize: 24
+      GoRuntimeType: 1.599168e+06
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 858 PointerType *net/smtp.Client
+        - Name: WriteCloser
+          Offset: 8
+          Type: 860 GoInterfaceType io.WriteCloser
+    - __kind: UnresolvedPointeeType
+      ID: 464
+      Name: net/textproto.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 347
+      Name: net/textproto.ProtocolError
+      ByteSize: 16
+      GoRuntimeType: 835328
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 349 PointerType *net/textproto.ProtocolError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 348 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: GoStringDataType
+      ID: 348
+      Name: net/textproto.ProtocolError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 817
+      Name: net/textproto.dotWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 725
+      Name: net/url.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 322
+      Name: net/url.EscapeError
+      ByteSize: 16
+      GoRuntimeType: 833216
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 324 PointerType *net/url.EscapeError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 323 GoStringDataType net/url.EscapeError.str
+    - __kind: GoStringDataType
+      ID: 323
+      Name: net/url.EscapeError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 325
+      Name: net/url.InvalidHostError
+      ByteSize: 16
+      GoRuntimeType: 833312
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 327 PointerType *net/url.InvalidHostError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 326 GoStringDataType net/url.InvalidHostError.str
+    - __kind: GoStringDataType
+      ID: 326
+      Name: net/url.InvalidHostError.str
+      ByteSize: 2048
     - __kind: ArrayType
       ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
@@ -8127,32 +12672,32 @@ Types:
       HasCount: true
       Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 339
+      ID: 1018
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 340 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1019 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 375
+      ID: 1054
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 376 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1055 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 390
+      ID: 1069
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681632
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 391 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1070 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 198
       Name: noalg.[8]struct { key int; elem int }
@@ -8163,14 +12708,14 @@ Types:
       HasCount: true
       Element: 199 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 405
+      ID: 1084
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 406 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1085 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -8198,6 +12743,15 @@ Types:
       Count: 8
       HasCount: true
       Element: 223 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 776
+      Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      ByteSize: 320
+      GoRuntimeType: 759488
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 777 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 214
       Name: noalg.[8]struct { key string; elem int }
@@ -8300,7 +12854,7 @@ Types:
           Offset: 8
           Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 338
+      ID: 1017
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.294784e+06
@@ -8311,9 +12865,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 339 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1018 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 374
+      ID: 1053
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.293504e+06
@@ -8324,9 +12878,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 375 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1054 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 389
+      ID: 1068
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.293248e+06
@@ -8337,7 +12891,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 390 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1069 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 197
       Name: noalg.map.group[int]int
@@ -8352,7 +12906,7 @@ Types:
           Offset: 8
           Type: 198 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 404
+      ID: 1083
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.292992e+06
@@ -8363,7 +12917,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 405 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1084 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 256
       Name: noalg.map.group[int]uint8
@@ -8403,6 +12957,19 @@ Types:
         - Name: slots
           Offset: 8
           Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 775
+      Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 328
+      GoRuntimeType: 1.35776e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 776 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 213
       Name: noalg.map.group[string]int
@@ -8521,7 +13088,7 @@ Types:
           Offset: 8
           Type: 190 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 340
+      ID: 1019
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.294656e+06
@@ -8532,9 +13099,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 341 PointerType *main.deepMap3
+          Type: 1020 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 376
+      ID: 1055
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.293376e+06
@@ -8545,9 +13112,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 377 PointerType *main.deepMap8
+          Type: 1056 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 391
+      ID: 1070
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.29312e+06
@@ -8558,7 +13125,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 392 PointerType *main.deepMap9
+          Type: 1071 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 199
       Name: noalg.struct { key int; elem int }
@@ -8573,7 +13140,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 406
+      ID: 1085
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.292864e+06
@@ -8624,6 +13191,19 @@ Types:
         - Name: elem
           Offset: 16
           Type: 166 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 777
+      Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      ByteSize: 40
+      GoRuntimeType: 1.357632e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 215
       Name: noalg.struct { key string; elem int }
@@ -8676,6 +13256,216 @@ Types:
         - Name: elem
           Offset: 1
           Type: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 968
+      Name: os.File
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 592
+      Name: os.LinkError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 660
+      Name: os.SyscallError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 966
+      Name: os.fileWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.35888e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 972 StructureType os.noReadFrom
+        - Name: File
+          Offset: 0
+          Type: 967 PointerType *os.File
+    - __kind: StructureType
+      ID: 964
+      Name: os.fileWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.35808e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 971 StructureType os.noWriteTo
+        - Name: File
+          Offset: 0
+          Type: 967 PointerType *os.File
+    - __kind: StructureType
+      ID: 972
+      Name: os.noReadFrom
+      GoRuntimeType: 1.11136e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 971
+      Name: os.noWriteTo
+      GoRuntimeType: 1.111232e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 625
+      Name: os/exec.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 771
+      Name: os/exec.ExitError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 837
+      Name: os/exec.prefixSuffixSaver
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 627
+      Name: os/exec.wrappedError
+      ByteSize: 32
+      GoRuntimeType: 1.702112e+06
+      GoKind: 25
+      RawFields:
+        - Name: prefix
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: err
+          Offset: 16
+          Type: 13 GoInterfaceType error
+    - __kind: GoStringHeaderType
+      ID: 361
+      Name: os/user.UnknownGroupIdError
+      ByteSize: 16
+      GoRuntimeType: 838592
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 363 PointerType *os/user.UnknownGroupIdError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 362 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: GoStringDataType
+      ID: 362
+      Name: os/user.UnknownGroupIdError.str
+      ByteSize: 2048
+    - __kind: BaseType
+      ID: 360
+      Name: os/user.UnknownUserIdError
+      ByteSize: 8
+      GoRuntimeType: 838496
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 388
+      Name: reflect.ValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 486
+      Name: regexp/syntax.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 596
+      Name: runtime.PanicNilError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 600
+      Name: runtime.TypeAssertionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 598
+      Name: runtime.boundsError
+      ByteSize: 24
+      GoRuntimeType: 1.887584e+06
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 12 BaseType int64
+        - Name: y
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: signed
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: code
+          Offset: 17
+          Type: 769 BaseType runtime.boundsErrorCode
+    - __kind: BaseType
+      ID: 769
+      Name: runtime.boundsErrorCode
+      ByteSize: 1
+      GoRuntimeType: 585312
+      GoKind: 8
+    - __kind: StructureType
+      ID: 662
+      Name: runtime.errorAddressString
+      ByteSize: 24
+      GoRuntimeType: 1.752416e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: addr
+          Offset: 16
+          Type: 1 BaseType uintptr
+    - __kind: GoStringHeaderType
+      ID: 576
+      Name: runtime.errorString
+      ByteSize: 16
+      GoRuntimeType: 989440
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 578 PointerType *runtime.errorString.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 577 GoStringDataType runtime.errorString.str
+    - __kind: GoStringDataType
+      ID: 577
+      Name: runtime.errorString.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 579
+      Name: runtime.plainError
+      ByteSize: 16
+      GoRuntimeType: 989536
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 581 PointerType *runtime.plainError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 580 GoStringDataType runtime.plainError.str
+    - __kind: GoStringDataType
+      ID: 580
+      Name: runtime.plainError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 738
+      Name: runtime.synctestBubble
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 384
+      Name: runtime.synctestDeadlockError
+      ByteSize: 24
+      GoRuntimeType: 1.595008e+06
+      GoKind: 25
+      RawFields:
+        - Name: reason
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: bubble
+          Offset: 16
+          Type: 737 PointerType *runtime.synctestBubble
+    - __kind: UnresolvedPointeeType
+      ID: 602
+      Name: strconv.NumError
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
@@ -8694,8 +13484,26 @@ Types:
       ID: 177
       Name: string.str
       ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 903
+      Name: strings.Builder
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 807
+      Name: strings.appendSliceWriter
+      ByteSize: 8
     - __kind: StructureType
-      ID: 311
+      ID: 803
+      Name: struct { io.Writer }
+      ByteSize: 16
+      GoRuntimeType: 1.454912e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 986
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.463456e+06
@@ -8703,12 +13511,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 987 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 313 StructureType internal/sync.Mutex
+          Type: 988 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 314
+      ID: 989
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.612352e+06
@@ -8716,15 +13524,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 987 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 315 StructureType sync/atomic.Bool
+          Type: 990 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 311 StructureType sync.Mutex
+          Type: 986 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 317
+      ID: 992
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.61216e+06
@@ -8732,21 +13540,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 987 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 318 StructureType sync/atomic.Uint64
+          Type: 993 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 312
+      ID: 987
       Name: sync.noCopy
       GoRuntimeType: 988384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 315
+      ID: 990
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.464576e+06
@@ -8754,12 +13562,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 991 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 320
+      ID: 995
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464736e+06
@@ -8767,12 +13575,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 991 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 318
+      ID: 993
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612736e+06
@@ -8780,25 +13588,31 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 991 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 319 StructureType sync/atomic.align64
+          Type: 994 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 319
+      ID: 994
       Name: sync/atomic.align64
       GoRuntimeType: 988576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 316
+      ID: 991
       Name: sync/atomic.noCopy
       GoRuntimeType: 988480
       GoKind: 25
       RawFields: []
+    - __kind: BaseType
+      ID: 712
+      Name: syscall.Errno
+      ByteSize: 8
+      GoRuntimeType: 1.28288e+06
+      GoKind: 12
     - __kind: StructureType
       ID: 286
       Name: table<[4]int,[4]int>
@@ -8920,7 +13734,7 @@ Types:
           Offset: 16
           Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 335
+      ID: 1014
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8942,9 +13756,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 336 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1015 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 371
+      ID: 1050
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8966,9 +13780,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 372 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1051 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 386
+      ID: 1065
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8990,7 +13804,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 387 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1066 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 194
       Name: table<int,int>
@@ -9016,7 +13830,7 @@ Types:
           Offset: 16
           Type: 195 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 401
+      ID: 1080
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9038,7 +13852,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 402 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1081 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 253
       Name: table<int,uint8>
@@ -9111,6 +13925,30 @@ Types:
         - Name: groups
           Offset: 16
           Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 772
+      Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 773 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 210
       Name: table<string,int>
@@ -9207,6 +14045,71 @@ Types:
         - Name: groups
           Offset: 16
           Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
+    - __kind: UnresolvedPointeeType
+      ID: 938
+      Name: text/tabwriter.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 655
+      Name: text/template.ExecError
+      ByteSize: 32
+      GoRuntimeType: 1.706528e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 13 GoInterfaceType error
+    - __kind: BaseType
+      ID: 883
+      Name: time.Duration
+      ByteSize: 8
+      GoRuntimeType: 1.91504e+06
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 730
+      Name: time.Location
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 391
+      Name: time.ParseError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 728
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.372192e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 12 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 729 PointerType *time.Location
+    - __kind: GoStringHeaderType
+      ID: 306
+      Name: time.fileSizeError
+      ByteSize: 16
+      GoRuntimeType: 831392
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 308 PointerType *time.fileSizeError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 307 GoStringDataType time.fileSizeError.str
+    - __kind: GoStringDataType
+      ID: 307
+      Name: time.fileSizeError.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -9249,6 +14152,120 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585248
       GoKind: 26
-MaxTypeID: 523
+    - __kind: StructureType
+      ID: 750
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
+      ByteSize: 80
+      GoRuntimeType: 2.062688e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 751 GoSliceHeaderType []uint8
+        - Name: header
+          Offset: 24
+          Type: 752 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+        - Name: section
+          Offset: 36
+          Type: 753 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+        - Name: off
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: index
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: resHeaderValid
+          Offset: 56
+          Type: 4 BaseType bool
+        - Name: resHeaderOffset
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: resHeaderType
+          Offset: 72
+          Type: 754 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+        - Name: resHeaderLength
+          Offset: 74
+          Type: 6 BaseType uint16
+    - __kind: BaseType
+      ID: 754
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Type
+      ByteSize: 2
+      GoRuntimeType: 995104
+      GoKind: 9
+    - __kind: StructureType
+      ID: 752
+      Name: vendor/golang.org/x/net/dns/dnsmessage.header
+      ByteSize: 12
+      GoRuntimeType: 1.926048e+06
+      GoKind: 25
+      RawFields:
+        - Name: id
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: bits
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: questions
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: answers
+          Offset: 6
+          Type: 6 BaseType uint16
+        - Name: authorities
+          Offset: 8
+          Type: 6 BaseType uint16
+        - Name: additionals
+          Offset: 10
+          Type: 6 BaseType uint16
+    - __kind: UnresolvedPointeeType
+      ID: 482
+      Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 753
+      Name: vendor/golang.org/x/net/dns/dnsmessage.section
+      ByteSize: 1
+      GoRuntimeType: 588896
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 930
+      Name: vendor/golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 466
+      Name: vendor/golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.425952e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 13 GoInterfaceType error
+    - __kind: BaseType
+      ID: 350
+      Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 835424
+      GoKind: 2
+    - __kind: StructureType
+      ID: 632
+      Name: vendor/golang.org/x/net/idna.labelError
+      ByteSize: 32
+      GoRuntimeType: 1.702304e+06
+      GoKind: 25
+      RawFields:
+        - Name: label
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: code_
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 584
+      Name: vendor/golang.org/x/net/idna.runeError
+      ByteSize: 4
+      GoRuntimeType: 993952
+      GoKind: 5
+MaxTypeID: 1202
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17ff520", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 503 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcdd6aa", Frameless: false}]
+        - ID: 97
+          Type: 504 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcdd80a", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -26,7 +26,21 @@ Probes:
       events:
         - ID: 53
           Type: 460 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xcda78a", Frameless: false}]
+          InjectionPoints: [{PC: "0xcda74a", Frameless: false}]
+          Condition: null
+    - id: testAnyPtr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAnyPtr}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 55}
+      events:
+        - ID: 55
+          Type: 462 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xcda7ea", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -64,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 468 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcdacc0", Frameless: true}]
+        - ID: 62
+          Type: 469 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcdae20", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 484 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcdc980", Frameless: true}]
+        - ID: 78
+          Type: 485 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcdcae0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 482 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcdc5a0", Frameless: true}]
+        - ID: 76
+          Type: 483 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcdc700", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 492 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcdcd20", Frameless: true}]
+        - ID: 86
+          Type: 493 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcdce80", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -278,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 494 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
+        - ID: 88
+          Type: 495 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdd3c0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 497 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
+        - ID: 91
+          Type: 498 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -306,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 511 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcdd7e0", Frameless: true}]
+        - ID: 105
+          Type: 512 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -320,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 513 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcddbe0", Frameless: true}]
+        - ID: 107
+          Type: 514 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcddd40", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -333,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 514 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcddc00", Frameless: true}]
+        - ID: 108
+          Type: 515 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcddd60", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -351,7 +365,7 @@ Probes:
       events:
         - ID: 54
           Type: 461 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcda800", Frameless: true}]
+          InjectionPoints: [{PC: "0xcda7c0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -459,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 516 EventRootType Probe[main.testInlinedBBB]
+        - ID: 110
+          Type: 517 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda206", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -487,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 517 EventRootType Probe[main.testInlinedBCA]
+        - ID: 111
+          Type: 518 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda313", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -501,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 518 EventRootType Probe[main.testInlinedBCB]
+        - ID: 112
+          Type: 519 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda3bb", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -516,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 515 EventRootType Probe[main.testInlinedPrint]
+        - ID: 109
+          Type: 516 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd9f6a"
               Frameless: false
@@ -540,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 519 EventRootType Probe[main.testInlinedSq]
+        - ID: 113
+          Type: 520 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda421", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -555,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 520 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 114
+          Type: 521 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda465"
               Frameless: false
@@ -647,7 +661,7 @@ Probes:
       events:
         - ID: 52
           Type: 459 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcda72a", Frameless: false}]
+          InjectionPoints: [{PC: "0xcda720", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -657,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 486 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcdcb40", Frameless: true}]
+        - ID: 80
+          Type: 487 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -671,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 466 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcdac80", Frameless: true}]
+        - ID: 60
+          Type: 467 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcdade0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -685,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 472 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcdad40", Frameless: true}]
+        - ID: 66
+          Type: 473 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcdaea0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -699,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 470 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcdad00", Frameless: true}]
+        - ID: 64
+          Type: 471 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcdae60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -713,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 481 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcdae60", Frameless: true}]
+        - ID: 75
+          Type: 482 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdafc0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -727,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 480 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
+        - ID: 74
+          Type: 481 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcdafa0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -741,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 471 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcdad20", Frameless: true}]
+        - ID: 65
+          Type: 472 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcdae80", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -755,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 479 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcdae20", Frameless: true}]
+        - ID: 73
+          Type: 480 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdaf80", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -769,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 478 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcdae00", Frameless: true}]
+        - ID: 72
+          Type: 479 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcdaf60", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -783,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 464 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcdac40", Frameless: true}]
+        - ID: 58
+          Type: 465 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcdada0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -797,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 465 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcdac60", Frameless: true}]
+        - ID: 59
+          Type: 466 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcdadc0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -811,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 463 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcdac20", Frameless: true}]
+        - ID: 57
+          Type: 464 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcdad80", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -825,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 473 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcdad60", Frameless: true}]
+        - ID: 67
+          Type: 474 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcdaec0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -839,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 476 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcdadc0", Frameless: true}]
+        - ID: 70
+          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcdaf20", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -853,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcdade0", Frameless: true}]
+        - ID: 71
+          Type: 478 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcdaf40", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -867,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 474 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcdad80", Frameless: true}]
+        - ID: 68
+          Type: 475 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcdaee0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -881,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 475 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcdada0", Frameless: true}]
+        - ID: 69
+          Type: 476 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcdaf00", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -895,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 509 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdd7a0", Frameless: true}]
+        - ID: 103
+          Type: 510 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdd900", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -909,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 483 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcdc760", Frameless: true}]
+        - ID: 77
+          Type: 484 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcdc8c0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -923,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 491 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
+        - ID: 85
+          Type: 492 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcdce40", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -937,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 501 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdd340", Frameless: true}]
+        - ID: 95
+          Type: 502 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdd4a0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -951,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 498 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcdd2e0", Frameless: true}]
+        - ID: 92
+          Type: 499 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdd440", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -965,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 500 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdd320", Frameless: true}]
+        - ID: 94
+          Type: 501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdd480", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -979,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 508 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcdd780", Frameless: true}]
+        - ID: 102
+          Type: 509 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcdd8e0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -993,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 487 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcdcb60", Frameless: true}]
+        - ID: 81
+          Type: 488 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcdccc0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1007,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 469 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcdace0", Frameless: true}]
+        - ID: 63
+          Type: 470 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1021,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 485 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcdcb20", Frameless: true}]
+        - ID: 79
+          Type: 486 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcdcc80", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1189,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 504 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcdd700", Frameless: true}]
+        - ID: 98
+          Type: 505 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcdd860", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1273,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 495 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
+        - ID: 89
+          Type: 496 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1287,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 467 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcdaca0", Frameless: true}]
+        - ID: 61
+          Type: 468 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcdae00", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1315,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 490 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
+        - ID: 84
+          Type: 491 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcdce00", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1329,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 499 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
+        - ID: 93
+          Type: 500 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1377,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 512 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcdda60", Frameless: true}]
+        - ID: 106
+          Type: 513 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcddbc0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1391,11 +1405,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 496 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
+        - ID: 90
+          Type: 497 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdd400", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1405,11 +1419,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 55
-          Type: 462 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcdac00", Frameless: true}]
+        - ID: 56
+          Type: 463 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcdad60", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1419,11 +1433,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 505 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcdd720", Frameless: true}]
+        - ID: 99
+          Type: 506 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcdd880", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1433,11 +1447,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 506 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcdd740", Frameless: true}]
+        - ID: 100
+          Type: 507 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcdd8a0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1447,11 +1461,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 507 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcdd760", Frameless: true}]
+        - ID: 101
+          Type: 508 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcdd8c0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1545,11 +1559,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 489 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcdcbc0", Frameless: true}]
+        - ID: 83
+          Type: 490 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcdcd20", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1559,11 +1573,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 493 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
+        - ID: 87
+          Type: 494 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1573,11 +1587,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 510 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcdd7c0", Frameless: true}]
+        - ID: 104
+          Type: 511 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1587,11 +1601,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 488 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcdcb80", Frameless: true}]
+        - ID: 82
+          Type: 489 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1615,11 +1629,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 502 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdd360", Frameless: true}]
+        - ID: 96
+          Type: 503 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdd4c0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2353,46 +2367,35 @@ Subprograms:
           IsReturn: true
     - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcda720..0xcda763]
+      OutOfLinePCRanges: [0xcda720..0xcda721]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 87 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcda720..0xcda73f
+            - Range: 0xcda720..0xcda721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcda73f..0xcda742
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcda720..0xcda763, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
     - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0xcda780..0xcda7e6]
+      OutOfLinePCRanges: [0xcda740..0xcda7a6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 81 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcda780..0xcda7a9
+            - Range: 0xcda740..0xcda769
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcda7a9..0xcda7ae
+            - Range: 0xcda769..0xcda76e
               Pieces:
                 - Size: 8
                   Op: null
@@ -2402,18 +2405,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcda780..0xcda7e6, Pieces: []}]
+          Locations: [{Range: 0xcda740..0xcda7a6, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0xcda800..0xcda801]
+      OutOfLinePCRanges: [0xcda7c0..0xcda7c1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcda800..0xcda801
+            - Range: 0xcda7c0..0xcda7c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2422,308 +2425,325 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 55
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcdac00..0xcdac01]
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0xcda7e0..0xcda834]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 88 StructureType main.structWithMap
+        - Name: a
+          Type: 88 PointerType *interface {}
           Locations:
-            - Range: 0xcdac00..0xcdac01
+            - Range: 0xcda7e0..0xcda806
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations: [{Range: 0xcda7e0..0xcda834, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 56
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcdac20..0xcdac21]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 94 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcdac20..0xcdac21
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 57
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcdac40..0xcdac41]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 99 GoMapType map[string]int
-          Locations:
-            - Range: 0xcdac40..0xcdac41
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcdac60..0xcdac61]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcdac60..0xcdac61
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcdac80..0xcdac81]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcdac80..0xcdac81
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcdaca0..0xcdaca1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 99 GoMapType map[string]int
-          Locations:
-            - Range: 0xcdaca0..0xcdaca1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcdacc0..0xcdacc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 114 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcdacc0..0xcdacc1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcdace0..0xcdace1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 115 PointerType *map[string]int
-          Locations:
-            - Range: 0xcdace0..0xcdace1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 63
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcdad00..0xcdad01]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 89 GoMapType map[int]int
-          Locations:
-            - Range: 0xcdad00..0xcdad01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 64
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcdad20..0xcdad21]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 116 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcdad20..0xcdad21
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 65
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcdad40..0xcdad41]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcdad40..0xcdad41
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 66
-      Name: main.testMapWithLinkedList
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0xcdad60..0xcdad61]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 121 GoMapType map[bool]main.node
+        - Name: s
+          Type: 89 StructureType main.structWithMap
           Locations:
             - Range: 0xcdad60..0xcdad61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallValue
+    - ID: 57
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcdad80..0xcdad81]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 126 GoMapType map[int]uint8
+          Type: 95 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcdad80..0xcdad81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValueMassive
+    - ID: 58
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcdada0..0xcdada1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 126 GoMapType map[int]uint8
+        - Name: m
+          Type: 100 GoMapType map[string]int
           Locations:
             - Range: 0xcdada0..0xcdada1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 59
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcdadc0..0xcdadc1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 105 GoMapType map[string][]string
           Locations:
             - Range: 0xcdadc0..0xcdadc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 60
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcdade0..0xcdade1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 110 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcdade0..0xcdade1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapSmallKeySmallValue
+    - ID: 61
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcdae00..0xcdae01]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 100 GoMapType map[string]int
           Locations:
             - Range: 0xcdae00..0xcdae01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 62
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcdae20..0xcdae21]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 GoMapType map[uint8][4]int
+          Type: 115 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcdae20..0xcdae21
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapLargeKeySmallValue
+    - ID: 63
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcdae40..0xcdae41]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 141 GoMapType map[[4]int]uint8
+          Type: 116 PointerType *map[string]int
           Locations:
             - Range: 0xcdae40..0xcdae41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 64
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcdae60..0xcdae61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[[4]int][4]int
+          Type: 90 GoMapType map[int]int
           Locations:
             - Range: 0xcdae60..0xcdae61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 65
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xcdae80..0xcdae81]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 117 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcdae80..0xcdae81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 66
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xcdaea0..0xcdaea1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 117 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcdaea0..0xcdaea1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 67
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xcdaec0..0xcdaec1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 122 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0xcdaec0..0xcdaec1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xcdaee0..0xcdaee1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 127 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcdaee0..0xcdaee1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xcdaf00..0xcdaf01]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 127 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcdaf00..0xcdaf01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcdaf20..0xcdaf21]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 132 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdaf20..0xcdaf21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcdaf40..0xcdaf41]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 132 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdaf40..0xcdaf41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcdaf60..0xcdaf61]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 132 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdaf60..0xcdaf61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcdaf80..0xcdaf81]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 137 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcdaf80..0xcdaf81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcdafa0..0xcdafa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 142 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcdafa0..0xcdafa1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 75
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcdafc0..0xcdafc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 147 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcdafc0..0xcdafc1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 76
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdc5a0..0xcdc5a1]
+      OutOfLinePCRanges: [0xcdc700..0xcdc701]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc5a0..0xcdc5a1
+            - Range: 0xcdc700..0xcdc701
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc5a0..0xcdc5a1
+            - Range: 0xcdc700..0xcdc701
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdc5a0..0xcdc5a1
+            - Range: 0xcdc700..0xcdc701
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdc760..0xcdc761]
+      OutOfLinePCRanges: [0xcdc8c0..0xcdc8c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdc760..0xcdc761
+            - Range: 0xcdc8c0..0xcdc8c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc760..0xcdc761
+            - Range: 0xcdc8c0..0xcdc8c1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcdc760..0xcdc761
+            - Range: 0xcdc8c0..0xcdc8c1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdc760..0xcdc761
+            - Range: 0xcdc8c0..0xcdc8c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc760..0xcdc761
+            - Range: 0xcdc8c0..0xcdc8c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2731,39 +2751,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdc980..0xcdc981]
+      OutOfLinePCRanges: [0xcdcae0..0xcdcae1]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 151 GoChannelType chan bool
+          Type: 152 GoChannelType chan bool
           Locations:
-            - Range: 0xcdc980..0xcdc981
+            - Range: 0xcdcae0..0xcdcae1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdcb20..0xcdcb21]
+      OutOfLinePCRanges: [0xcdcc80..0xcdcc81]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 152 PointerType *main.structWithTwoValues
+          Type: 153 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdcb20..0xcdcb21
+            - Range: 0xcdcc80..0xcdcc81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdcb40..0xcdcb41]
+      OutOfLinePCRanges: [0xcdcca0..0xcdcca1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 154 StructureType main.node
+          Type: 155 StructureType main.node
           Locations:
-            - Range: 0xcdcb40..0xcdcb41
+            - Range: 0xcdcca0..0xcdcca1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2771,112 +2791,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdcb60..0xcdcb61]
+      OutOfLinePCRanges: [0xcdccc0..0xcdccc1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 PointerType *main.node
+          Type: 156 PointerType *main.node
           Locations:
-            - Range: 0xcdcb60..0xcdcb61
+            - Range: 0xcdccc0..0xcdccc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdcb80..0xcdcb81]
+      OutOfLinePCRanges: [0xcdcce0..0xcdcce1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcdcb80..0xcdcb81
+            - Range: 0xcdcce0..0xcdcce1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdcbc0..0xcdcbc1]
+      OutOfLinePCRanges: [0xcdcd20..0xcdcd21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xcdcbc0..0xcdcbc1
+            - Range: 0xcdcd20..0xcdcd21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdcca0..0xcdcca1]
+      OutOfLinePCRanges: [0xcdce00..0xcdce01]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xcdcca0..0xcdcca1
+            - Range: 0xcdce00..0xcdce01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdcce0..0xcdcce1]
+      OutOfLinePCRanges: [0xcdce40..0xcdce41]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdce40..0xcdce41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdce40..0xcdce41
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdcd20..0xcdcd21]
+      OutOfLinePCRanges: [0xcdce80..0xcdce81]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 156 PointerType *main.t
+          Type: 157 PointerType *main.t
           Locations:
-            - Range: 0xcdcd20..0xcdcd21
+            - Range: 0xcdce80..0xcdce81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdd240..0xcdd241]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 158 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdd240..0xcdd241
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 87
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdd260..0xcdd261]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcdd3a0..0xcdd3a1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 158 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd260..0xcdd261
+            - Range: 0xcdd3a0..0xcdd3a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2887,14 +2889,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdd280..0xcdd281]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcdd3c0..0xcdd3c1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType [][]uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd280..0xcdd281
+            - Range: 0xcdd3c0..0xcdd3c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2905,14 +2907,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdd2a0..0xcdd2a1]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 160 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcdd2a0..0xcdd2a1
+            - Range: 0xcdd3e0..0xcdd3e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2920,24 +2922,17 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd2a0..0xcdd2a1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 90
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcdd400..0xcdd401]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdd2c0..0xcdd2c1
+            - Range: 0xcdd400..0xcdd401
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2950,19 +2945,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd2c0..0xcdd2c1
+            - Range: 0xcdd400..0xcdd401
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 91
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdd2e0..0xcdd2e1]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcdd420..0xcdd421]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdd2e0..0xcdd2e1
+            - Range: 0xcdd420..0xcdd421
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2975,19 +2970,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd2e0..0xcdd2e1
+            - Range: 0xcdd420..0xcdd421
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdd300..0xcdd301]
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcdd440..0xcdd441]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 164 GoSliceHeaderType []string
+        - Name: xs
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdd300..0xcdd301
+            - Range: 0xcdd440..0xcdd441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2997,22 +2992,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd440..0xcdd441
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 93
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcdd460..0xcdd461]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 165 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcdd460..0xcdd461
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdd320..0xcdd321]
+      OutOfLinePCRanges: [0xcdd480..0xcdd481]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcdd320..0xcdd321
+            - Range: 0xcdd480..0xcdd481
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 165 GoSliceHeaderType []bool
+          Type: 166 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdd320..0xcdd321
+            - Range: 0xcdd480..0xcdd481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3025,37 +3045,19 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdd320..0xcdd321
+            - Range: 0xcdd480..0xcdd481
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdd340..0xcdd341]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 166 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcdd340..0xcdd341
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 95
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdd360..0xcdd361]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcdd4a0..0xcdd4a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 158 GoSliceHeaderType []uint
+          Type: 167 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcdd360..0xcdd361
+            - Range: 0xcdd4a0..0xcdd4a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3066,24 +3068,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 96
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcdd4c0..0xcdd4c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 159 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdd4c0..0xcdd4c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 97
       Name: main.stackC
-      OutOfLinePCRanges: [0xcdd6a0..0xcdd6f2]
+      OutOfLinePCRanges: [0xcdd800..0xcdd852]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcdd6a0..0xcdd6f2, Pieces: []}]
+          Locations: [{Range: 0xcdd800..0xcdd852, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcdd700..0xcdd701]
+      OutOfLinePCRanges: [0xcdd860..0xcdd861]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd700..0xcdd701
+            - Range: 0xcdd860..0xcdd861
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3091,15 +3111,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcdd720..0xcdd721]
+      OutOfLinePCRanges: [0xcdd880..0xcdd881]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd720..0xcdd721
+            - Range: 0xcdd880..0xcdd881
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3110,7 +3130,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd720..0xcdd721
+            - Range: 0xcdd880..0xcdd881
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3121,7 +3141,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd720..0xcdd721
+            - Range: 0xcdd880..0xcdd881
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3129,15 +3149,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 100
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcdd740..0xcdd75f]
+      OutOfLinePCRanges: [0xcdd8a0..0xcdd8bf]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 167 StructureType main.threeStringStruct
+          Type: 168 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcdd740..0xcdd75f
+            - Range: 0xcdd8a0..0xcdd8bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3153,55 +3173,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcdd760..0xcdd761]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xcdd760..0xcdd761
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 101
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcdd780..0xcdd781]
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0xcdd8c0..0xcdd8c1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 169 PointerType *main.oneStringStruct
+          Type: 169 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcdd780..0xcdd781
+            - Range: 0xcdd8c0..0xcdd8c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcdd7a0..0xcdd7a1]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xcdd8e0..0xcdd8e1]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 170 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcdd7a0..0xcdd7a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdd8e0..0xcdd8e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcdd7c0..0xcdd7c1]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcdd900..0xcdd901]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd7c0..0xcdd7c1
+            - Range: 0xcdd900..0xcdd901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3210,14 +3214,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 104
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcdd7e0..0xcdd7e1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcdd920..0xcdd921]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd7e0..0xcdd7e1
+            - Range: 0xcdd920..0xcdd921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3226,14 +3230,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testStruct
-      OutOfLinePCRanges: [0xcdda60..0xcdda83]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcdd940..0xcdd941]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 171 StructureType main.aStruct
+          Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdda60..0xcdda83
+            - Range: 0xcdd940..0xcdd941
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 106
+      Name: main.testStruct
+      OutOfLinePCRanges: [0xcddbc0..0xcddbe3]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 172 StructureType main.aStruct
+          Locations:
+            - Range: 0xcddbc0..0xcddbe3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3251,29 +3271,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 106
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcddbe0..0xcddbe1]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 173 StructureType main.emptyStruct
-          Locations: [{Range: 0xcddbe0..0xcddbe1, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 107
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcddc00..0xcddc01]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0xcddd40..0xcddd41]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 174 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0xcddc00..0xcddc01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 174 StructureType main.emptyStruct
+          Locations: [{Range: 0xcddd40..0xcddd41, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0xcddd60..0xcddd61]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 175 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0xcddd60..0xcddd61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd9f60..0xcd9fc2]
       InlinePCRanges:
@@ -3303,28 +3323,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 110
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda206..0xcda23e]
           RootRanges: [0xcda1a0..0xcda265]
       Variables: []
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda313..0xcda351]
           RootRanges: [0xcda300..0xcda405]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda3bb..0xcda3f3]
           RootRanges: [0xcda300..0xcda405]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3338,7 +3358,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3363,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 310
+      ID: 311
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 311 PointerType *main.deepSlice3
+      Pointee: 312 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 335
+      ID: 336
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 336 PointerType *main.deepSlice8
+      Pointee: 337 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 341
+      ID: 342
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 342 PointerType *main.deepSlice9
+      Pointee: 343 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3387,7 +3407,7 @@ Types:
       ID: 403
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 156 PointerType *main.t
+      Pointee: 157 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3396,35 +3416,35 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 149
+      ID: 150
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<[4]int,[4]int>
+      Pointee: 151 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 144
+      ID: 145
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 145 PointerType *table<[4]int,uint8>
+      Pointee: 146 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 112
+      ID: 113
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 113 PointerType *table<[4]string,[2]int>
+      Pointee: 114 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 124
+      ID: 125
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 125 PointerType *table<bool,main.node>
+      Pointee: 126 PointerType *table<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 318
+      ID: 319
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 319 PointerType *table<int,*main.deepMap3>
+      Pointee: 320 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 353
       Name: '**table<int,*main.deepMap8>'
@@ -3436,85 +3456,85 @@ Types:
       ByteSize: 8
       Pointee: 369 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 92
+      ID: 93
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 93 PointerType *table<int,int>
+      Pointee: 94 PointerType *table<int,int>
     - __kind: PointerType
       ID: 383
       Name: '**table<int,interface {}>'
       ByteSize: 8
       Pointee: 384 PointerType *table<int,interface {}>
     - __kind: PointerType
-      ID: 129
+      ID: 130
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 130 PointerType *table<int,uint8>
+      Pointee: 131 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 120
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 120 PointerType *table<string,[]main.structWithMap>
+      Pointee: 121 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 107
+      ID: 108
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 108 PointerType *table<string,[]string>
+      Pointee: 109 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 103
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 103 PointerType *table<string,int>
+      Pointee: 104 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 97
+      ID: 98
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 98 PointerType *table<string,main.nestedStruct>
+      Pointee: 99 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 139
+      ID: 140
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<uint8,[4]int>
+      Pointee: 141 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 134
+      ID: 135
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 135 PointerType *table<uint8,uint8>
+      Pointee: 136 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 314
+      ID: 315
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 313 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 314 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 339
+      ID: 340
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 338 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 339 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 345
+      ID: 346
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 344 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 345 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 178
+      ID: 179
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []*string.array
+      Pointee: 178 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 295
+      ID: 296
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType [][]uint.array
+      Pointee: 295 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 301
+      ID: 302
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []bool.array
+      Pointee: 301 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 349
       Name: '*[]interface {}.array'
@@ -3526,30 +3546,30 @@ Types:
       ByteSize: 8
       Pointee: 406 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 297
+      ID: 298
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 297 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 299
+      ID: 300
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []string.array
+      Pointee: 299 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 160
+      ID: 161
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 158 GoSliceHeaderType []uint
+      Pointee: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 293
+      ID: 294
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []uint.array
+      Pointee: 293 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 303
+      ID: 304
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []uint16.array
+      Pointee: 303 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3614,26 +3634,26 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 347
+      ID: 88
       Name: '*interface {}'
       ByteSize: 8
       GoRuntimeType: 393152
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 188
+      ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 385792
       GoKind: 22
-      Pointee: 189 StructureType main.deepMap2
+      Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 326
+      ID: 327
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385728
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType main.deepMap3
+      Pointee: 328 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3663,12 +3683,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386304
       GoKind: 22
-      Pointee: 305 UnresolvedPointeeType main.deepPtr3
+      Pointee: 306 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3677,33 +3697,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 330
+      ID: 331
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 385984
       GoKind: 22
-      Pointee: 331 StructureType main.deepPtr8
+      Pointee: 332 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 332
+      ID: 333
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 385920
       GoKind: 22
-      Pointee: 333 StructureType main.deepPtr9
+      Pointee: 334 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 386944
       GoKind: 22
-      Pointee: 179 StructureType main.deepSlice2
+      Pointee: 180 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 311
+      ID: 312
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 386880
       GoKind: 22
-      Pointee: 312 UnresolvedPointeeType main.deepSlice3
+      Pointee: 313 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3712,25 +3732,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 336
+      ID: 337
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 337 StructureType main.deepSlice8
+      Pointee: 338 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 342
+      ID: 343
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386496
       GoKind: 22
-      Pointee: 343 StructureType main.deepSlice9
+      Pointee: 344 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 174
+      ID: 175
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 173 StructureType main.emptyStruct
+      Pointee: 174 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
@@ -3739,18 +3759,18 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 155
+      ID: 156
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 387136
       GoKind: 22
-      Pointee: 154 StructureType main.node
+      Pointee: 155 StructureType main.node
     - __kind: PointerType
-      ID: 169
+      ID: 170
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 170 StructureType main.oneStringStruct
+      Pointee: 171 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -3758,81 +3778,81 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 307
+      ID: 308
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType main.stringType1.str
+      Pointee: 307 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 308 UnresolvedPointeeType main.stringType2
+      Pointee: 309 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 240
+      ID: 241
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 385280
       GoKind: 22
-      Pointee: 88 StructureType main.structWithMap
+      Pointee: 89 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 162
+      ID: 163
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 163 StructureType main.structWithNoStrings
+      Pointee: 164 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 152
+      ID: 153
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 153 StructureType main.structWithTwoValues
+      Pointee: 154 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 156
+      ID: 157
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 GoSliceHeaderType main.t
+      Pointee: 158 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 405
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 404 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 168
+      ID: 169
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 167 StructureType main.threeStringStruct
+      Pointee: 168 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 147
+      ID: 148
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 149 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 142
+      ID: 143
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 143 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 144 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 110
+      ID: 111
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 111 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 112 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 122
+      ID: 123
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 123 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 124 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 316
+      ID: 317
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 317 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 351
       Name: '*map<int,*main.deepMap8>'
@@ -3844,86 +3864,86 @@ Types:
       ByteSize: 8
       Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 90
+      ID: 91
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 91 GoSwissMapHeaderType map<int,int>
+      Pointee: 92 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
       ID: 381
       Name: '*map<int,interface {}>'
       ByteSize: 8
       Pointee: 382 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
-      ID: 127
+      ID: 128
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 128 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 129 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 117
+      ID: 118
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 105
+      ID: 106
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 106 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 107 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 100
+      ID: 101
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 101 GoSwissMapHeaderType map<string,int>
+      Pointee: 102 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 95
+      ID: 96
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 137
+      ID: 138
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 139 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 132
+      ID: 133
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 133 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 134 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 115
+      ID: 116
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 GoMapType map[string]int
+      Pointee: 100 GoMapType map[string]int
     - __kind: PointerType
-      ID: 286
+      ID: 287
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 287 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 278
+      ID: 279
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 279 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 226
+      ID: 227
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 227 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 245
+      ID: 246
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 246 StructureType noalg.map.group[bool]main.node
+      Pointee: 247 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 184
+      ID: 185
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 322
+      ID: 323
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 323 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 357
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -3935,50 +3955,50 @@ Types:
       ByteSize: 8
       Pointee: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 194
+      ID: 195
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 195 StructureType noalg.map.group[int]int
+      Pointee: 196 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 387
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 388 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 253
+      ID: 254
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 254 StructureType noalg.map.group[int]uint8
+      Pointee: 255 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 235
+      ID: 236
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 236 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 218
+      ID: 219
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 219 StructureType noalg.map.group[string][]string
+      Pointee: 220 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 210
+      ID: 211
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 211 StructureType noalg.map.group[string]int
+      Pointee: 212 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 202
+      ID: 203
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 269
+      ID: 270
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 270 StructureType noalg.map.group[uint8][4]int
+      Pointee: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 261
+      ID: 262
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 262 StructureType noalg.map.group[uint8]uint8
+      Pointee: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3987,40 +4007,40 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 176
+      ID: 177
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 175 GoStringDataType string.str
+      Pointee: 176 GoStringDataType string.str
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 284 StructureType table<[4]int,[4]int>
+      Pointee: 285 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 276 StructureType table<[4]int,uint8>
+      Pointee: 277 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 224 StructureType table<[4]string,[2]int>
+      Pointee: 225 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 243 StructureType table<bool,main.node>
+      Pointee: 244 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 182 StructureType table<int,*main.deepMap2>
+      Pointee: 183 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 319
+      ID: 320
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 320 StructureType table<int,*main.deepMap3>
+      Pointee: 321 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 354
       Name: '*table<int,*main.deepMap8>'
@@ -4032,50 +4052,50 @@ Types:
       ByteSize: 8
       Pointee: 370 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 192 StructureType table<int,int>
+      Pointee: 193 StructureType table<int,int>
     - __kind: PointerType
       ID: 384
       Name: '*table<int,interface {}>'
       ByteSize: 8
       Pointee: 385 StructureType table<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 251 StructureType table<int,uint8>
+      Pointee: 252 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 233 StructureType table<string,[]main.structWithMap>
+      Pointee: 234 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 216 StructureType table<string,[]string>
+      Pointee: 217 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 208 StructureType table<string,int>
+      Pointee: 209 StructureType table<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 200 StructureType table<string,main.nestedStruct>
+      Pointee: 201 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 267 StructureType table<uint8,[4]int>
+      Pointee: 268 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 259 StructureType table<uint8,uint8>
+      Pointee: 260 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4119,8 +4139,23 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 503
+      ID: 504
       Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 462
+      Name: Probe[main.testAnyPtr]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 88 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 460
       Name: Probe[main.testAny]
@@ -4167,7 +4202,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 468
+      ID: 469
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4175,10 +4210,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 114 ArrayType [2]map[string]int
+            Type: 115 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4242,7 +4277,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 484
+      ID: 485
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4250,14 +4285,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 151 GoChannelType chan bool
+            Type: 152 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: c}
+                  Variable: {subprogram: 78, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 482
+      ID: 483
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4268,7 +4303,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: w}
+                  Variable: {subprogram: 76, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4277,7 +4312,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 1, name: x}
+                  Variable: {subprogram: 76, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4286,11 +4321,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 2, name: y}
+                  Variable: {subprogram: 76, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 492
+      ID: 493
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4298,10 +4333,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.t
+            Type: 157 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: t}
+                  Variable: {subprogram: 86, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4395,7 +4430,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 498
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4403,10 +4438,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4415,11 +4450,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 494
+      ID: 495
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4427,14 +4462,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 512
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4445,11 +4480,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 514
+      ID: 515
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4457,14 +4492,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 174 PointerType *main.emptyStruct
+            Type: 175 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 513
+      ID: 514
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4472,10 +4507,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 173 StructureType main.emptyStruct
+            Type: 174 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: e}
+                  Variable: {subprogram: 107, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -4584,7 +4619,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 516
+      ID: 517
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 454
@@ -4611,16 +4646,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 517
+      ID: 518
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 518
+      ID: 519
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 456
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 515
+      ID: 516
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4631,11 +4666,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 519
+      ID: 520
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4646,11 +4681,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: x}
+                  Variable: {subprogram: 113, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 521
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4661,7 +4696,7 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4755,7 +4790,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 486
+      ID: 487
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4763,14 +4798,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 154 StructureType main.node
+            Type: 155 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 466
+      ID: 467
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4778,14 +4813,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 109 GoMapType map[[4]string][2]int
+            Type: 110 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 473
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4793,14 +4828,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 GoMapType map[string][]main.structWithMap
+            Type: 117 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 470
+      ID: 471
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4808,14 +4843,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 89 GoMapType map[int]int
+            Type: 90 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 482
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4823,14 +4858,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[[4]int][4]int
+            Type: 147 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 481
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4838,14 +4873,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 141 GoMapType map[[4]int]uint8
+            Type: 142 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 471
+      ID: 472
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4853,14 +4888,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 116 GoMapType map[string][]main.structWithMap
+            Type: 117 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 480
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4868,14 +4903,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[uint8][4]int
+            Type: 137 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 479
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4883,14 +4918,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 465
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4898,14 +4933,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 465
+      ID: 466
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4913,14 +4948,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 104 GoMapType map[string][]string
+            Type: 105 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 463
+      ID: 464
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4928,14 +4963,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[string]main.nestedStruct
+            Type: 95 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 474
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4943,14 +4978,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[bool]main.node
+            Type: 122 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 478
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4958,14 +4993,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 477
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4973,14 +5008,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 476
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4988,14 +5023,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 126 GoMapType map[int]uint8
+            Type: 127 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 475
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5003,14 +5038,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 126 GoMapType map[int]uint8
+            Type: 127 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 509
+      ID: 510
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5021,11 +5056,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 483
+      ID: 484
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5036,7 +5071,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -5045,7 +5080,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: b}
+                  Variable: {subprogram: 77, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -5054,7 +5089,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: c}
+                  Variable: {subprogram: 77, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -5063,7 +5098,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 3, name: d}
+                  Variable: {subprogram: 77, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -5072,11 +5107,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 4, name: e}
+                  Variable: {subprogram: 77, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 491
+      ID: 492
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5087,7 +5122,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -5096,11 +5131,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: a}
+                  Variable: {subprogram: 85, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 499
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5108,10 +5143,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5120,11 +5155,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 501
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5135,16 +5170,16 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 94, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 165 GoSliceHeaderType []bool
+            Type: 166 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: s}
+                  Variable: {subprogram: 94, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5153,11 +5188,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 2, name: x}
+                  Variable: {subprogram: 94, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 502
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5165,14 +5200,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 166 GoSliceHeaderType []uint16
+            Type: 167 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 508
+      ID: 509
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5180,14 +5215,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.oneStringStruct
+            Type: 170 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 487
+      ID: 488
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5195,14 +5230,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 PointerType *main.node
+            Type: 156 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 469
+      ID: 470
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5210,14 +5245,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 PointerType *map[string]int
+            Type: 116 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 485
+      ID: 486
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5225,10 +5260,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 152 PointerType *main.structWithTwoValues
+            Type: 153 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5397,7 +5432,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 504
+      ID: 505
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5408,7 +5443,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5487,7 +5522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 495
+      ID: 496
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5495,14 +5530,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType [][]uint
+            Type: 160 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 467
+      ID: 468
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5510,10 +5545,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5532,7 +5567,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 490
+      ID: 491
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5543,11 +5578,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 500
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5555,10 +5590,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []string
+            Type: 165 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: s}
+                  Variable: {subprogram: 93, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5592,7 +5627,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 497
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5600,10 +5635,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5612,11 +5647,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 462
+      ID: 463
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5624,14 +5659,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 88 StructureType main.structWithMap
+            Type: 89 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: s}
+                  Variable: {subprogram: 56, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 512
+      ID: 513
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5639,14 +5674,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 171 StructureType main.aStruct
+            Type: 172 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 507
+      ID: 508
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5654,14 +5689,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 PointerType *main.threeStringStruct
+            Type: 169 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 506
+      ID: 507
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5669,14 +5704,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 167 StructureType main.threeStringStruct
+            Type: 168 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 505
+      ID: 506
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5687,7 +5722,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5696,7 +5731,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: y}
+                  Variable: {subprogram: 99, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5705,7 +5740,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: z}
+                  Variable: {subprogram: 99, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5799,7 +5834,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 490
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5810,11 +5845,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 493
+      ID: 494
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5822,14 +5857,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 510
+      ID: 511
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5840,11 +5875,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 488
+      ID: 489
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5855,7 +5890,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5874,7 +5909,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 502
+      ID: 503
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5882,10 +5917,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5963,13 +5998,13 @@ Types:
       HasCount: true
       Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 114
+      ID: 115
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 99 GoMapType map[string]int
+      Element: 100 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -6022,7 +6057,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 273
+      ID: 274
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 682624
@@ -6031,7 +6066,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 230
+      ID: 231
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 682912
@@ -6063,14 +6098,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 180 GoSliceDataType []*main.deepSlice2.array
+      Data: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 181
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 309
+      ID: 310
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477568
@@ -6078,21 +6113,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 310 PointerType **main.deepSlice3
+          Type: 311 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 313 GoSliceDataType []*main.deepSlice3.array
+      Data: 314 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 313
+      ID: 314
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 311 PointerType *main.deepSlice3
+      Element: 312 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 334
+      ID: 335
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477248
@@ -6100,21 +6135,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 335 PointerType **main.deepSlice8
+          Type: 336 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 338 GoSliceDataType []*main.deepSlice8.array
+      Data: 339 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 338
+      ID: 339
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 336 PointerType *main.deepSlice8
+      Element: 337 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 340
+      ID: 341
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477184
@@ -6122,19 +6157,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 341 PointerType **main.deepSlice9
+          Type: 342 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 344 GoSliceDataType []*main.deepSlice9.array
+      Data: 345 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 345
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 342 PointerType *main.deepSlice9
+      Element: 343 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6151,42 +6186,42 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 177 GoSliceDataType []*string.array
+      Data: 178 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 178
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 291
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<[4]int,[4]int>
+      Element: 151 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 283
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 145 PointerType *table<[4]int,uint8>
+      Element: 146 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 232
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 113 PointerType *table<[4]string,[2]int>
+      Element: 114 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 250
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 125 PointerType *table<bool,main.node>
+      Element: 126 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 329
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 319 PointerType *table<int,*main.deepMap3>
+      Element: 320 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 363
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -6198,73 +6233,73 @@ Types:
       ByteSize: 8192
       Element: 369 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 199
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 93 PointerType *table<int,int>
+      Element: 94 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 391
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
       Element: 384 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 258
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 130 PointerType *table<int,uint8>
+      Element: 131 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 242
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 120 PointerType *table<string,[]main.structWithMap>
+      Element: 121 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 223
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 108 PointerType *table<string,[]string>
+      Element: 109 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 215
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 103 PointerType *table<string,int>
+      Element: 104 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 207
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 98 PointerType *table<string,main.nestedStruct>
+      Element: 99 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 275
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 140 PointerType *table<uint8,[4]int>
+      Element: 141 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 266
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 135 PointerType *table<uint8,uint8>
+      Element: 136 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 160 PointerType *[]uint
+          Type: 161 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 294 GoSliceDataType [][]uint.array
+      Data: 295 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 295
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 158 GoSliceHeaderType []uint
+      Element: 159 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 166
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 486976
@@ -6279,14 +6314,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 300 GoSliceDataType []bool.array
+      Data: 301 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 301
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 346
+      ID: 347
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -6294,7 +6329,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 347 PointerType *interface {}
+          Type: 88 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -6308,7 +6343,7 @@ Types:
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 239
+      ID: 240
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 477888
@@ -6316,7 +6351,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 240 PointerType *main.structWithMap
+          Type: 241 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -6328,58 +6363,58 @@ Types:
       ID: 406
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 88 StructureType main.structWithMap
+      Element: 89 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 162
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *main.structWithNoStrings
+          Type: 163 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 296 GoSliceDataType []main.structWithNoStrings.array
+      Data: 297 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 297
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 163 StructureType main.structWithNoStrings
+      Element: 164 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 292
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 287 StructureType noalg.map.group[[4]int][4]int
+      Element: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 279 StructureType noalg.map.group[[4]int]uint8
+      Element: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 233
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 227 StructureType noalg.map.group[[4]string][2]int
+      Element: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 246 StructureType noalg.map.group[bool]main.node
+      Element: 247 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 330
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 323 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 364
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -6391,52 +6426,52 @@ Types:
       ByteSize: 2048
       Element: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 195 StructureType noalg.map.group[int]int
+      Element: 196 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 392
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
       Element: 388 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 259
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 254 StructureType noalg.map.group[int]uint8
+      Element: 255 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 243
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 236 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 219 StructureType noalg.map.group[string][]string
+      Element: 220 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 211 StructureType noalg.map.group[string]int
+      Element: 212 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 208
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 203 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 276
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 270 StructureType noalg.map.group[uint8][4]int
+      Element: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 267
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 262 StructureType noalg.map.group[uint8]uint8
+      Element: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 165
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 487104
@@ -6451,14 +6486,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 298 GoSliceDataType []string.array
+      Data: 299 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 299
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 159
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 486592
@@ -6473,14 +6508,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType []uint.array
+      Data: 293 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 293
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 17 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -6495,9 +6530,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 302 GoSliceDataType []uint16.array
+      Data: 303 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 303
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -6508,7 +6543,7 @@ Types:
       GoRuntimeType: 584928
       GoKind: 1
     - __kind: GoChannelType
-      ID: 151
+      ID: 152
       Name: chan bool
       GoRuntimeType: 596256
       GoKind: 18
@@ -6561,89 +6596,89 @@ Types:
       GoRuntimeType: 475776
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 285
+      ID: 286
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 286 PointerType *noalg.map.group[[4]int][4]int
+          Type: 287 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 287 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 291 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 292 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 277
+      ID: 278
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 278 PointerType *noalg.map.group[[4]int]uint8
+          Type: 279 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 279 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 283 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 284 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 225
+      ID: 226
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 226 PointerType *noalg.map.group[[4]string][2]int
+          Type: 227 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 227 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 233 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 244
+      ID: 245
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 245 PointerType *noalg.map.group[bool]main.node
+          Type: 246 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 246 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 250 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 247 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 184
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 185 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 191 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 321
+      ID: 322
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 322 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 323 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 323 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 329 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 356
       Name: groupReference<int,*main.deepMap8>
@@ -6673,19 +6708,19 @@ Types:
       GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 193
+      ID: 194
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 194 PointerType *noalg.map.group[int]int
+          Type: 195 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 195 StructureType noalg.map.group[int]int
-      GroupSliceType: 199 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 196 StructureType noalg.map.group[int]int
+      GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 386
       Name: groupReference<int,interface {}>
@@ -6701,103 +6736,103 @@ Types:
       GroupType: 388 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 392 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 252
+      ID: 253
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 253 PointerType *noalg.map.group[int]uint8
+          Type: 254 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 254 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 255 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 234
+      ID: 235
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 235 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 236 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 236 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 217
+      ID: 218
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 218 PointerType *noalg.map.group[string][]string
+          Type: 219 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 219 StructureType noalg.map.group[string][]string
-      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 220 StructureType noalg.map.group[string][]string
+      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 209
+      ID: 210
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 210 PointerType *noalg.map.group[string]int
+          Type: 211 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 211 StructureType noalg.map.group[string]int
-      GroupSliceType: 215 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 212 StructureType noalg.map.group[string]int
+      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 202
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 203 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 207 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 268
+      ID: 269
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 269 PointerType *noalg.map.group[uint8][4]int
+          Type: 270 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 270 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 275 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 271 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 276 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 260
+      ID: 261
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 261 PointerType *noalg.map.group[uint8]uint8
+          Type: 262 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 262 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 266 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 263 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6868,7 +6903,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6884,7 +6919,7 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 172 StructureType main.nestedStruct
+          Type: 173 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
@@ -6924,7 +6959,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 189
+      ID: 190
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.185664e+06
@@ -6932,9 +6967,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 315 GoMapType map[int]*main.deepMap3
+          Type: 316 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 328
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -6986,9 +7021,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 304 PointerType *main.deepPtr3
+          Type: 305 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 305
+      ID: 306
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7000,9 +7035,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 330 PointerType *main.deepPtr8
+          Type: 331 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 331
+      ID: 332
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.186048e+06
@@ -7010,9 +7045,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 332 PointerType *main.deepPtr9
+          Type: 333 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 333
+      ID: 334
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18592e+06
@@ -7032,7 +7067,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 179
+      ID: 180
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.187968e+06
@@ -7040,9 +7075,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 309 GoSliceHeaderType []*main.deepSlice3
+          Type: 310 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 312
+      ID: 313
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7054,9 +7089,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 334 GoSliceHeaderType []*main.deepSlice8
+          Type: 335 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 337
+      ID: 338
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.1872e+06
@@ -7064,9 +7099,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 340 GoSliceHeaderType []*main.deepSlice9
+          Type: 341 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 343
+      ID: 344
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.187072e+06
@@ -7074,9 +7109,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 346 GoSliceHeaderType []interface {}
+          Type: 347 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7131,7 +7166,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.461536e+06
@@ -7144,7 +7179,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 154
+      ID: 155
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.461376e+06
@@ -7155,9 +7190,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 155 PointerType *main.node
+          Type: 156 PointerType *main.node
     - __kind: StructureType
-      ID: 170
+      ID: 171
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7186,21 +7221,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *main.stringType1.str
+          Type: 308 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 306 GoStringDataType main.stringType1.str
+      Data: 307 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 307
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 308
+      ID: 309
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
-      ID: 88
+      ID: 89
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.18464e+06
@@ -7208,9 +7243,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 89 GoMapType map[int]int
+          Type: 90 GoMapType map[int]int
     - __kind: StructureType
-      ID: 163
+      ID: 164
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7222,7 +7257,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 153
+      ID: 154
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7234,7 +7269,7 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 157
+      ID: 158
       Name: main.t
       ByteSize: 24
       GoKind: 23
@@ -7253,9 +7288,9 @@ Types:
       ID: 404
       Name: main.t.array
       ByteSize: 2048
-      Element: 156 PointerType *main.t
+      Element: 157 PointerType *main.t
     - __kind: StructureType
-      ID: 167
+      ID: 168
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7275,7 +7310,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 149
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7288,7 +7323,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<[4]int,[4]int>
+          Type: 150 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7307,10 +7342,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 290 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 287 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 291 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 143
+      ID: 144
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7323,7 +7358,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 144 PointerType **table<[4]int,uint8>
+          Type: 145 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7342,10 +7377,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 282 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 279 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 283 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 111
+      ID: 112
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -7358,7 +7393,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 112 PointerType **table<[4]string,[2]int>
+          Type: 113 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7377,10 +7412,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 227 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 232 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 123
+      ID: 124
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -7393,7 +7428,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 124 PointerType **table<bool,main.node>
+          Type: 125 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7412,8 +7447,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 249 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 246 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 250 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 247 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -7447,10 +7482,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 190 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 185 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 317
+      ID: 318
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7463,7 +7498,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 318 PointerType **table<int,*main.deepMap3>
+          Type: 319 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7482,8 +7517,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 328 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 323 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 352
       Name: map<int,*main.deepMap8>
@@ -7555,7 +7590,7 @@ Types:
       TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap9>.array
       GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
-      ID: 91
+      ID: 92
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -7568,7 +7603,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 92 PointerType **table<int,int>
+          Type: 93 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7587,8 +7622,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 198 GoSliceDataType []*table<int,int>.array
-      GroupType: 195 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
+      GroupType: 196 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 382
       Name: map<int,interface {}>
@@ -7625,7 +7660,7 @@ Types:
       TablePtrSliceType: 391 GoSliceDataType []*table<int,interface {}>.array
       GroupType: 388 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 128
+      ID: 129
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7638,7 +7673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 129 PointerType **table<int,uint8>
+          Type: 130 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7657,10 +7692,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 254 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 258 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 255 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 118
+      ID: 119
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -7673,7 +7708,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 119 PointerType **table<string,[]main.structWithMap>
+          Type: 120 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7692,10 +7727,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 241 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 236 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 106
+      ID: 107
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -7708,7 +7743,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 107 PointerType **table<string,[]string>
+          Type: 108 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7727,10 +7762,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 222 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 219 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 223 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 220 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 101
+      ID: 102
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -7743,7 +7778,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 102 PointerType **table<string,int>
+          Type: 103 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7762,10 +7797,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 214 GoSliceDataType []*table<string,int>.array
-      GroupType: 211 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 215 GoSliceDataType []*table<string,int>.array
+      GroupType: 212 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 96
+      ID: 97
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -7778,7 +7813,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 97 PointerType **table<string,main.nestedStruct>
+          Type: 98 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7797,10 +7832,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 206 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 203 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 207 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 139
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7813,7 +7848,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<uint8,[4]int>
+          Type: 140 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7832,10 +7867,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 274 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 270 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 275 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 133
+      ID: 134
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7848,7 +7883,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 134 PointerType **table<uint8,uint8>
+          Type: 135 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7867,36 +7902,36 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 265 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 262 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 266 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 146
+      ID: 147
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.129536e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 149 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 141
+      ID: 142
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.129664e+06
       GoKind: 21
-      HeaderType: 143 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 144 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 109
+      ID: 110
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.129792e+06
       GoKind: 21
-      HeaderType: 111 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 112 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 121
+      ID: 122
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.12992e+06
       GoKind: 21
-      HeaderType: 123 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 124 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
@@ -7905,12 +7940,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 315
+      ID: 316
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.12928e+06
       GoKind: 21
-      HeaderType: 317 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 350
       Name: map[int]*main.deepMap8
@@ -7926,12 +7961,12 @@ Types:
       GoKind: 21
       HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 89
+      ID: 90
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.128e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<int,int>
+      HeaderType: 92 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 380
       Name: map[int]interface {}
@@ -7940,108 +7975,108 @@ Types:
       GoKind: 21
       HeaderType: 382 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
-      ID: 126
+      ID: 127
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.130048e+06
       GoKind: 21
-      HeaderType: 128 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 129 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 116
+      ID: 117
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.130176e+06
       GoKind: 21
-      HeaderType: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 104
+      ID: 105
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.130304e+06
       GoKind: 21
-      HeaderType: 106 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 107 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 99
+      ID: 100
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.130432e+06
       GoKind: 21
-      HeaderType: 101 GoSwissMapHeaderType map<string,int>
+      HeaderType: 102 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 94
+      ID: 95
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.13056e+06
       GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 136
+      ID: 137
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.130688e+06
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 139 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 131
+      ID: 132
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.130816e+06
       GoKind: 21
-      HeaderType: 133 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 134 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 288
+      ID: 289
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 682720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 289 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 290 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 280
+      ID: 281
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 682816
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 281 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 282 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 228
+      ID: 229
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 229 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 230 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 247
+      ID: 248
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 248 StructureType noalg.struct { key bool; elem main.node }
+      Element: 249 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 186
+      ID: 187
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682048
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 187 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 324
+      ID: 325
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 681952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 325 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 359
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -8061,14 +8096,14 @@ Types:
       HasCount: true
       Element: 375 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 196
+      ID: 197
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 197 StructureType noalg.struct { key int; elem int }
+      Element: 198 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 389
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -8079,70 +8114,70 @@ Types:
       HasCount: true
       Element: 390 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 255
+      ID: 256
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 683296
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 256 StructureType noalg.struct { key int; elem uint8 }
+      Element: 257 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 237
+      ID: 238
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 683392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 238 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 239 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 220
+      ID: 221
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 221 StructureType noalg.struct { key string; elem []string }
+      Element: 222 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 212
+      ID: 213
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 683584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem int }
+      Element: 214 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 204
+      ID: 205
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 683680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 205 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 206 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 271
+      ID: 272
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 683776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 272 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 273 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 263
+      ID: 264
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 264 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 265 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 287
+      ID: 288
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.294656e+06
@@ -8153,9 +8188,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 288 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 289 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 279
+      ID: 280
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.294912e+06
@@ -8166,9 +8201,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 280 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 281 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 227
+      ID: 228
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.295168e+06
@@ -8179,9 +8214,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 228 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 229 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 246
+      ID: 247
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.295424e+06
@@ -8192,9 +8227,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 247 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 248 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 185
+      ID: 186
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.2944e+06
@@ -8205,9 +8240,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 186 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 323
+      ID: 324
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.294144e+06
@@ -8218,7 +8253,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 324 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 358
       Name: noalg.map.group[int]*main.deepMap8
@@ -8246,7 +8281,7 @@ Types:
           Offset: 8
           Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 195
+      ID: 196
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.291584e+06
@@ -8257,7 +8292,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 196 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 197 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 388
       Name: noalg.map.group[int]interface {}
@@ -8272,7 +8307,7 @@ Types:
           Offset: 8
           Type: 389 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 254
+      ID: 255
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.29568e+06
@@ -8283,9 +8318,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 255 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 256 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 236
+      ID: 237
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.295936e+06
@@ -8296,9 +8331,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 237 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 238 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 219
+      ID: 220
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.296192e+06
@@ -8309,9 +8344,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 220 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 211
+      ID: 212
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.296448e+06
@@ -8322,9 +8357,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 213 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 203
+      ID: 204
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.296704e+06
@@ -8335,9 +8370,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 204 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 205 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 270
+      ID: 271
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.29696e+06
@@ -8348,9 +8383,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 271 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 272 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 262
+      ID: 263
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.297216e+06
@@ -8361,9 +8396,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 263 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 264 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 289
+      ID: 290
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.294528e+06
@@ -8371,12 +8406,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
     - __kind: StructureType
-      ID: 281
+      ID: 282
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.294784e+06
@@ -8384,12 +8419,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 229
+      ID: 230
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.29504e+06
@@ -8397,12 +8432,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 230 ArrayType [4]string
+          Type: 231 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 248
+      ID: 249
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.295296e+06
@@ -8413,9 +8448,9 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 154 StructureType main.node
+          Type: 155 StructureType main.node
     - __kind: StructureType
-      ID: 187
+      ID: 188
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.294272e+06
@@ -8426,9 +8461,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 188 PointerType *main.deepMap2
+          Type: 189 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 325
+      ID: 326
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.294016e+06
@@ -8439,7 +8474,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 326 PointerType *main.deepMap3
+          Type: 327 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 360
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -8467,7 +8502,7 @@ Types:
           Offset: 8
           Type: 376 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 197
+      ID: 198
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.291456e+06
@@ -8493,7 +8528,7 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 256
+      ID: 257
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.295552e+06
@@ -8506,7 +8541,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 238
+      ID: 239
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.295808e+06
@@ -8517,9 +8552,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 239 GoSliceHeaderType []main.structWithMap
+          Type: 240 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 221
+      ID: 222
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.296064e+06
@@ -8530,9 +8565,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 164 GoSliceHeaderType []string
+          Type: 165 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 213
+      ID: 214
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.29632e+06
@@ -8545,7 +8580,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 205
+      ID: 206
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.296576e+06
@@ -8556,9 +8591,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 172 StructureType main.nestedStruct
+          Type: 173 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 272
+      ID: 273
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.296832e+06
@@ -8569,9 +8604,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
     - __kind: StructureType
-      ID: 264
+      ID: 265
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.297088e+06
@@ -8592,13 +8627,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 176 PointerType *string.str
+          Type: 177 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 175 GoStringDataType string.str
+      Data: 176 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 175
+      ID: 176
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -8707,7 +8742,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 284
+      ID: 285
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -8729,9 +8764,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 285 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 286 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 276
+      ID: 277
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8753,9 +8788,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 277 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 278 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 224
+      ID: 225
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -8777,9 +8812,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 225 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 226 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 243
+      ID: 244
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -8801,9 +8836,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 244 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 245 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 182
+      ID: 183
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -8825,9 +8860,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 320
+      ID: 321
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8849,7 +8884,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 321 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 355
       Name: table<int,*main.deepMap8>
@@ -8899,7 +8934,7 @@ Types:
           Offset: 16
           Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 192
+      ID: 193
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -8921,7 +8956,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 193 GoSwissMapGroupsType groupReference<int,int>
+          Type: 194 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 385
       Name: table<int,interface {}>
@@ -8947,7 +8982,7 @@ Types:
           Offset: 16
           Type: 386 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 251
+      ID: 252
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8969,9 +9004,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 252 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 253 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 233
+      ID: 234
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -8993,9 +9028,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 234 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 235 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 216
+      ID: 217
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9017,9 +9052,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 217 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 218 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 208
+      ID: 209
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -9041,9 +9076,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 209 GoSwissMapGroupsType groupReference<string,int>
+          Type: 210 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 200
+      ID: 201
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -9065,9 +9100,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 202 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 267
+      ID: 268
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -9089,9 +9124,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 268 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 269 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 259
+      ID: 260
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9113,7 +9148,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 260 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 261 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -9156,6 +9191,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 584992
       GoKind: 26
-MaxTypeID: 520
+MaxTypeID: 521
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17ff520", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 408 EventRootType Probe[main.stackC]
+          Type: 1054 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x8901ac", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 363 EventRootType Probe[main.testAny]
+          Type: 1009 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88db2c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 365 EventRootType Probe[main.testAnyPtr]
+          Type: 1011 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88dbac", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 325 EventRootType Probe[main.testArrayOfArrays]
+          Type: 971 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 327 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 973 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 373 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1019 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88e200", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 326 EventRootType Probe[main.testArrayOfStrings]
+          Type: 972 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 345 EventRootType Probe[main.testBigStruct]
+          Type: 991 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c890", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 314 EventRootType Probe[main.testBoolArray]
+          Type: 960 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 311 EventRootType Probe[main.testByteArray]
+          Type: 957 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c230", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 389 EventRootType Probe[main.testChannel]
+          Type: 1035 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88f7b0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 387 EventRootType Probe[main.testCombinedByte]
+          Type: 1033 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88f530", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 397 EventRootType Probe[main.testCycle]
+          Type: 1043 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fa50", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 350 EventRootType Probe[main.testDeepMap1]
+          Type: 996 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cc70", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 351 EventRootType Probe[main.testDeepMap7]
+          Type: 997 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88cc80", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 346 EventRootType Probe[main.testDeepPtr1]
+          Type: 992 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c960", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 347 EventRootType Probe[main.testDeepPtr7]
+          Type: 993 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c970", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 348 EventRootType Probe[main.testDeepSlice1]
+          Type: 994 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb10", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 349 EventRootType Probe[main.testDeepSlice7]
+          Type: 995 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb20", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 399 EventRootType Probe[main.testEmptySlice]
+          Type: 1045 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x88fe50", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 402 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1048 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x88fe80", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 416 EventRootType Probe[main.testEmptyString]
+          Type: 1062 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x890290", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -337,7 +337,7 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - ID: 108
-          Type: 418 EventRootType Probe[main.testEmptyStruct]
+          Type: 1064 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x8905a0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -350,7 +350,7 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - ID: 109
-          Type: 419 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1065 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x8905b0", Frameless: true}]
           Condition: null
     - id: testError
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 364 EventRootType Probe[main.testError]
+          Type: 1010 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88db90", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 355 EventRootType Probe[main.testEsotericHeap]
+          Type: 1001 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d12c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 354 EventRootType Probe[main.testEsotericStack]
+          Type: 1000 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d03c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 360 EventRootType Probe[main.testFrameless]
+          Type: 1006 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88d860", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 361 EventRootType Probe[main.testFramelessArray]
+          Type: 1007 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88d870", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 356 EventRootType Probe[main.testInlinedBA]
+          Type: 1002 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d56c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 357 EventRootType Probe[main.testInlinedBB]
+          Type: 1003 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d5fc", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 358 EventRootType Probe[main.testInlinedBBA]
+          Type: 1004 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d6cc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -476,7 +476,7 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - ID: 111
-          Type: 421 EventRootType Probe[main.testInlinedBBB]
+          Type: 1067 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d658", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 359 EventRootType Probe[main.testInlinedBC]
+          Type: 1005 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d74c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -504,7 +504,7 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - ID: 112
-          Type: 422 EventRootType Probe[main.testInlinedBCA]
+          Type: 1068 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d75c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -518,7 +518,7 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - ID: 113
-          Type: 423 EventRootType Probe[main.testInlinedBCB]
+          Type: 1069 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88d810", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - ID: 110
-          Type: 420 EventRootType Probe[main.testInlinedPrint]
+          Type: 1066 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d3cc"
               Frameless: true
@@ -557,7 +557,7 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - ID: 114
-          Type: 424 EventRootType Probe[main.testInlinedSq]
+          Type: 1070 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88d864", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -572,7 +572,7 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - ID: 115
-          Type: 425 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1071 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88d894"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 317 EventRootType Probe[main.testInt16Array]
+          Type: 963 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 318 EventRootType Probe[main.testInt32Array]
+          Type: 964 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 319 EventRootType Probe[main.testInt64Array]
+          Type: 965 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 316 EventRootType Probe[main.testInt8Array]
+          Type: 962 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 315 EventRootType Probe[main.testIntArray]
+          Type: 961 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 362 EventRootType Probe[main.testInterface]
+          Type: 1008 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88db10", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 391 EventRootType Probe[main.testLinkedList]
+          Type: 1037 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88f960", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 371 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1017 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88e1e0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 377 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1023 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88e240", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 375 EventRootType Probe[main.testMapIntToInt]
+          Type: 1021 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88e220", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 386 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1032 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88e2d0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 385 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1031 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88e2c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 376 EventRootType Probe[main.testMapMassive]
+          Type: 1022 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e230", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 384 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1030 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88e2b0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 383 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1029 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88e2a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 369 EventRootType Probe[main.testMapStringToInt]
+          Type: 1015 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88e1c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 370 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1016 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88e1d0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 368 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1014 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88e1b0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 378 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1024 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88e250", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 381 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1027 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88e280", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 382 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1028 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88e290", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 379 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1025 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88e260", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 380 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1026 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88e270", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 414 EventRootType Probe[main.testMassiveString]
+          Type: 1060 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x890270", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 388 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1034 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f610", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 396 EventRootType Probe[main.testNilPointer]
+          Type: 1042 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fa30", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 406 EventRootType Probe[main.testNilSlice]
+          Type: 1052 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x88fec0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 403 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1049 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x88fe90", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 405 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1051 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x88feb0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 413 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1059 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x890260", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 392 EventRootType Probe[main.testPointerLoop]
+          Type: 1038 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88f970", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 374 EventRootType Probe[main.testPointerToMap]
+          Type: 1020 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88e210", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 390 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1036 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88f950", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 312 EventRootType Probe[main.testRuneArray]
+          Type: 958 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 331 EventRootType Probe[main.testSingleBool]
+          Type: 977 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 329 EventRootType Probe[main.testSingleByte]
+          Type: 975 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c690", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 342 EventRootType Probe[main.testSingleFloat32]
+          Type: 988 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 343 EventRootType Probe[main.testSingleFloat64]
+          Type: 989 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 332 EventRootType Probe[main.testSingleInt]
+          Type: 978 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 334 EventRootType Probe[main.testSingleInt16]
+          Type: 980 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 335 EventRootType Probe[main.testSingleInt32]
+          Type: 981 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 336 EventRootType Probe[main.testSingleInt64]
+          Type: 982 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 333 EventRootType Probe[main.testSingleInt8]
+          Type: 979 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 330 EventRootType Probe[main.testSingleRune]
+          Type: 976 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6a0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 409 EventRootType Probe[main.testSingleString]
+          Type: 1055 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x890210", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 337 EventRootType Probe[main.testSingleUint]
+          Type: 983 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 339 EventRootType Probe[main.testSingleUint16]
+          Type: 985 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 340 EventRootType Probe[main.testSingleUint32]
+          Type: 986 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 341 EventRootType Probe[main.testSingleUint64]
+          Type: 987 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 338 EventRootType Probe[main.testSingleUint8]
+          Type: 984 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 400 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1046 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x88fe60", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 372 EventRootType Probe[main.testSmallMap]
+          Type: 1018 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88e1f0", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 313 EventRootType Probe[main.testStringArray]
+          Type: 959 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 395 EventRootType Probe[main.testStringPointer]
+          Type: 1041 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fa10", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 404 EventRootType Probe[main.testStringSlice]
+          Type: 1050 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x88fea0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 352 EventRootType Probe[main.testStringType1]
+          Type: 998 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 353 EventRootType Probe[main.testStringType2]
+          Type: 999 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1394,7 +1394,7 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - ID: 107
-          Type: 417 EventRootType Probe[main.testStruct]
+          Type: 1063 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x8904a0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 401 EventRootType Probe[main.testStructSlice]
+          Type: 1047 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x88fe70", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,7 +1425,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 366 EventRootType Probe[main.testStructWithAny]
+          Type: 1012 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x88dc10", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1439,7 +1439,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 367 EventRootType Probe[main.testStructWithMap]
+          Type: 1013 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e1a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1453,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 410 EventRootType Probe[main.testThreeStrings]
+          Type: 1056 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x890220", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1467,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 411 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1057 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x890230", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1481,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 412 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1058 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x890250", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 344 EventRootType Probe[main.testTypeAlias]
+          Type: 990 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 322 EventRootType Probe[main.testUint16Array]
+          Type: 968 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 323 EventRootType Probe[main.testUint32Array]
+          Type: 969 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 324 EventRootType Probe[main.testUint64Array]
+          Type: 970 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 321 EventRootType Probe[main.testUint8Array]
+          Type: 967 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 320 EventRootType Probe[main.testUintArray]
+          Type: 966 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1579,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 394 EventRootType Probe[main.testUintPointer]
+          Type: 1040 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88f9a0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1593,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 398 EventRootType Probe[main.testUintSlice]
+          Type: 1044 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x88fe40", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1607,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 415 EventRootType Probe[main.testUnitializedString]
+          Type: 1061 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x890280", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1621,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 393 EventRootType Probe[main.testUnsafePointer]
+          Type: 1039 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88f980", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 328 EventRootType Probe[main.testVeryLargeArray]
+          Type: 974 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1649,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 407 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1053 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x88fed0", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3416,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 251
+      ID: 897
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 252 PointerType *main.deepSlice3
+      Pointee: 898 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 272
+      ID: 918
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 273 PointerType *main.deepSlice8
+      Pointee: 919 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 278
+      ID: 924
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 279 PointerType *main.deepSlice9
+      Pointee: 925 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3437,7 +3437,7 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 247
+      ID: 893
       Name: '**main.t'
       ByteSize: 8
       Pointee: 160 PointerType *main.t
@@ -3454,20 +3454,20 @@ Types:
       ByteSize: 8
       Pointee: 184 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 255
+      ID: 901
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 900 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 276
+      ID: 922
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 275 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 921 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 282
+      ID: 928
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 281 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 927 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 182
       Name: '*[]*string.array'
@@ -3484,15 +3484,20 @@ Types:
       ByteSize: 8
       Pointee: 229 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 285
+      ID: 684
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 683 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 931
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType []interface {}.array
+      Pointee: 930 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 266
+      ID: 912
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []main.structWithMap.array
+      Pointee: 911 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 226
       Name: '*[]main.structWithNoStrings.array'
@@ -3518,6 +3523,72 @@ Types:
       Name: '*[]uint16.array'
       ByteSize: 8
       Pointee: 231 GoSliceDataType []uint16.array
+    - __kind: PointerType
+      ID: 682
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 681 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 809
+      Name: '*archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.848928e+06
+      GoKind: 22
+      Pointee: 810 UnresolvedPointeeType archive/tar.Writer
+    - __kind: PointerType
+      ID: 458
+      Name: '*archive/tar.headerError'
+      ByteSize: 8
+      GoRuntimeType: 858432
+      GoKind: 22
+      Pointee: 459 GoSliceHeaderType archive/tar.headerError
+    - __kind: PointerType
+      ID: 461
+      Name: '*archive/tar.headerError.array'
+      ByteSize: 8
+      Pointee: 460 GoSliceDataType archive/tar.headerError.array
+    - __kind: PointerType
+      ID: 749
+      Name: '*archive/tar.regFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.25312e+06
+      GoKind: 22
+      Pointee: 750 UnresolvedPointeeType archive/tar.regFileWriter
+    - __kind: PointerType
+      ID: 697
+      Name: '*archive/zip.countWriter'
+      ByteSize: 8
+      GoRuntimeType: 858624
+      GoKind: 22
+      Pointee: 698 UnresolvedPointeeType archive/zip.countWriter
+    - __kind: PointerType
+      ID: 699
+      Name: '*archive/zip.dirWriter'
+      ByteSize: 8
+      GoRuntimeType: 858720
+      GoKind: 22
+      Pointee: 700 StructureType archive/zip.dirWriter
+    - __kind: PointerType
+      ID: 796
+      Name: '*archive/zip.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.773216e+06
+      GoKind: 22
+      Pointee: 797 UnresolvedPointeeType archive/zip.fileWriter
+    - __kind: PointerType
+      ID: 725
+      Name: '*archive/zip.nopCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.01664e+06
+      GoKind: 22
+      Pointee: 726 StructureType archive/zip.nopCloser
+    - __kind: PointerType
+      ID: 727
+      Name: '*archive/zip.pooledFlateWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.016896e+06
+      GoKind: 22
+      Pointee: 728 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3551,30 +3622,30 @@ Types:
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 259
+      ID: 905
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 260 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 906 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 289
+      ID: 935
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 290 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 936 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 298
+      ID: 944
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 299 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 945 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 96
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 97 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 307
+      ID: 953
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 308 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 954 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 133
       Name: '*bucket<int,uint8>'
@@ -3590,6 +3661,11 @@ Types:
       Name: '*bucket<string,[]string>'
       ByteSize: 8
       Pointee: 112 GoHMapBucketType bucket<string,[]string>
+    - __kind: PointerType
+      ID: 650
+      Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 106
       Name: '*bucket<string,int>'
@@ -3611,12 +3687,414 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
+      ID: 773
+      Name: '*bufio.Reader'
+      ByteSize: 8
+      GoRuntimeType: 2.029408e+06
+      GoKind: 22
+      Pointee: 774 UnresolvedPointeeType bufio.Reader
+    - __kind: PointerType
+      ID: 798
+      Name: '*bufio.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.814656e+06
+      GoKind: 22
+      Pointee: 799 UnresolvedPointeeType bufio.Writer
+    - __kind: PointerType
+      ID: 845
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.122368e+06
+      GoKind: 22
+      Pointee: 846 UnresolvedPointeeType bytes.Buffer
+    - __kind: PointerType
+      ID: 371
+      Name: '*compress/flate.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 841056
+      GoKind: 22
+      Pointee: 266 BaseType compress/flate.CorruptInputError
+    - __kind: PointerType
+      ID: 372
+      Name: '*compress/flate.InternalError'
+      ByteSize: 8
+      GoRuntimeType: 841152
+      GoKind: 22
+      Pointee: 267 GoStringHeaderType compress/flate.InternalError
+    - __kind: PointerType
+      ID: 269
+      Name: '*compress/flate.InternalError.str'
+      ByteSize: 8
+      Pointee: 268 GoStringDataType compress/flate.InternalError.str
+    - __kind: PointerType
+      ID: 747
+      Name: '*compress/flate.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.24336e+06
+      GoKind: 22
+      Pointee: 748 UnresolvedPointeeType compress/flate.Writer
+    - __kind: PointerType
+      ID: 693
+      Name: '*compress/flate.dictWriter'
+      ByteSize: 8
+      GoRuntimeType: 841248
+      GoKind: 22
+      Pointee: 694 UnresolvedPointeeType compress/flate.dictWriter
+    - __kind: PointerType
+      ID: 769
+      Name: '*compress/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.59984e+06
+      GoKind: 22
+      Pointee: 770 UnresolvedPointeeType compress/gzip.Writer
+    - __kind: PointerType
+      ID: 602
+      Name: '*context.deadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.117792e+06
+      GoKind: 22
+      Pointee: 603 StructureType context.deadlineExceededError
+    - __kind: PointerType
+      ID: 451
+      Name: '*crypto/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 853344
+      GoKind: 22
+      Pointee: 280 BaseType crypto/aes.KeySizeError
+    - __kind: PointerType
+      ID: 452
+      Name: '*crypto/des.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 853536
+      GoKind: 22
+      Pointee: 281 BaseType crypto/des.KeySizeError
+    - __kind: PointerType
+      ID: 759
+      Name: '*crypto/hmac.hmac'
+      ByteSize: 8
+      GoRuntimeType: 1.373792e+06
+      GoKind: 22
+      Pointee: 760 UnresolvedPointeeType crypto/hmac.hmac
+    - __kind: PointerType
+      ID: 784
+      Name: '*crypto/md5.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.678848e+06
+      GoKind: 22
+      Pointee: 785 UnresolvedPointeeType crypto/md5.digest
+    - __kind: PointerType
+      ID: 453
+      Name: '*crypto/rc4.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 853824
+      GoKind: 22
+      Pointee: 282 BaseType crypto/rc4.KeySizeError
+    - __kind: PointerType
+      ID: 792
+      Name: '*crypto/sha1.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.7704e+06
+      GoKind: 22
+      Pointee: 793 UnresolvedPointeeType crypto/sha1.digest
+    - __kind: PointerType
+      ID: 786
+      Name: '*crypto/sha256.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.679296e+06
+      GoKind: 22
+      Pointee: 787 UnresolvedPointeeType crypto/sha256.digest
+    - __kind: PointerType
+      ID: 788
+      Name: '*crypto/sha512.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.679744e+06
+      GoKind: 22
+      Pointee: 789 UnresolvedPointeeType crypto/sha512.digest
+    - __kind: PointerType
+      ID: 377
+      Name: '*crypto/tls.AlertError'
+      ByteSize: 8
+      GoRuntimeType: 842688
+      GoKind: 22
+      Pointee: 270 BaseType crypto/tls.AlertError
+    - __kind: PointerType
+      ID: 542
+      Name: '*crypto/tls.CertificateVerificationError'
+      ByteSize: 8
+      GoRuntimeType: 1.00448e+06
+      GoKind: 22
+      Pointee: 543 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+    - __kind: PointerType
+      ID: 871
+      Name: '*crypto/tls.Conn'
+      ByteSize: 8
+      GoRuntimeType: 2.231488e+06
+      GoKind: 22
+      Pointee: 872 UnresolvedPointeeType crypto/tls.Conn
+    - __kind: PointerType
+      ID: 375
+      Name: '*crypto/tls.ECHRejectionError'
+      ByteSize: 8
+      GoRuntimeType: 842496
+      GoKind: 22
+      Pointee: 376 UnresolvedPointeeType crypto/tls.ECHRejectionError
+    - __kind: PointerType
+      ID: 373
+      Name: '*crypto/tls.RecordHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 842400
+      GoKind: 22
+      Pointee: 374 StructureType crypto/tls.RecordHeaderError
+    - __kind: PointerType
+      ID: 541
+      Name: '*crypto/tls.alert'
+      ByteSize: 8
+      GoRuntimeType: 1.002816e+06
+      GoKind: 22
+      Pointee: 498 BaseType crypto/tls.alert
+    - __kind: PointerType
+      ID: 757
+      Name: '*crypto/tls.cthWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.370912e+06
+      GoKind: 22
+      Pointee: 758 UnresolvedPointeeType crypto/tls.cthWrapper
+    - __kind: PointerType
+      ID: 764
+      Name: '*crypto/tls.finishedHash'
+      ByteSize: 8
+      GoRuntimeType: 1.449984e+06
+      GoKind: 22
+      Pointee: 765 UnresolvedPointeeType crypto/tls.finishedHash
+    - __kind: PointerType
+      ID: 637
+      Name: '*crypto/tls.permanentError'
+      ByteSize: 8
+      GoRuntimeType: 1.24368e+06
+      GoKind: 22
+      Pointee: 638 UnresolvedPointeeType crypto/tls.permanentError
+    - __kind: PointerType
+      ID: 652
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.90608e+06
+      GoKind: 22
+      Pointee: 653 UnresolvedPointeeType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 447
+      Name: '*crypto/x509.CertificateInvalidError'
+      ByteSize: 8
+      GoRuntimeType: 852288
+      GoKind: 22
+      Pointee: 448 StructureType crypto/x509.CertificateInvalidError
+    - __kind: PointerType
+      ID: 441
+      Name: '*crypto/x509.ConstraintViolationError'
+      ByteSize: 8
+      GoRuntimeType: 851808
+      GoKind: 22
+      Pointee: 442 StructureType crypto/x509.ConstraintViolationError
+    - __kind: PointerType
+      ID: 443
+      Name: '*crypto/x509.HostnameError'
+      ByteSize: 8
+      GoRuntimeType: 851904
+      GoKind: 22
+      Pointee: 444 StructureType crypto/x509.HostnameError
+    - __kind: PointerType
+      ID: 440
+      Name: '*crypto/x509.InsecureAlgorithmError'
+      ByteSize: 8
+      GoRuntimeType: 851712
+      GoKind: 22
+      Pointee: 279 BaseType crypto/x509.InsecureAlgorithmError
+    - __kind: PointerType
+      ID: 547
+      Name: '*crypto/x509.SystemRootsError'
+      ByteSize: 8
+      GoRuntimeType: 1.010368e+06
+      GoKind: 22
+      Pointee: 548 StructureType crypto/x509.SystemRootsError
+    - __kind: PointerType
+      ID: 449
+      Name: '*crypto/x509.UnhandledCriticalExtension'
+      ByteSize: 8
+      GoRuntimeType: 852384
+      GoKind: 22
+      Pointee: 450 StructureType crypto/x509.UnhandledCriticalExtension
+    - __kind: PointerType
+      ID: 445
+      Name: '*crypto/x509.UnknownAuthorityError'
+      ByteSize: 8
+      GoRuntimeType: 852192
+      GoKind: 22
+      Pointee: 446 StructureType crypto/x509.UnknownAuthorityError
+    - __kind: PointerType
+      ID: 462
+      Name: '*encoding/asn1.StructuralError'
+      ByteSize: 8
+      GoRuntimeType: 858912
+      GoKind: 22
+      Pointee: 463 StructureType encoding/asn1.StructuralError
+    - __kind: PointerType
+      ID: 466
+      Name: '*encoding/asn1.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 859104
+      GoKind: 22
+      Pointee: 467 StructureType encoding/asn1.SyntaxError
+    - __kind: PointerType
+      ID: 464
+      Name: '*encoding/asn1.invalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 859008
+      GoKind: 22
+      Pointee: 465 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+    - __kind: PointerType
+      ID: 363
+      Name: '*encoding/base64.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 839328
+      GoKind: 22
+      Pointee: 264 BaseType encoding/base64.CorruptInputError
+    - __kind: PointerType
+      ID: 715
+      Name: '*encoding/base64.encoder'
+      ByteSize: 8
+      GoRuntimeType: 999616
+      GoKind: 22
+      Pointee: 716 UnresolvedPointeeType encoding/base64.encoder
+    - __kind: PointerType
+      ID: 366
+      Name: '*encoding/hex.InvalidByteError'
+      ByteSize: 8
+      GoRuntimeType: 840192
+      GoKind: 22
+      Pointee: 265 BaseType encoding/hex.InvalidByteError
+    - __kind: PointerType
+      ID: 334
+      Name: '*encoding/json.InvalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 834048
+      GoKind: 22
+      Pointee: 335 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+    - __kind: PointerType
+      ID: 533
+      Name: '*encoding/json.MarshalerError'
+      ByteSize: 8
+      GoRuntimeType: 995264
+      GoKind: 22
+      Pointee: 534 UnresolvedPointeeType encoding/json.MarshalerError
+    - __kind: PointerType
+      ID: 326
+      Name: '*encoding/json.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 833664
+      GoKind: 22
+      Pointee: 327 UnresolvedPointeeType encoding/json.SyntaxError
+    - __kind: PointerType
+      ID: 332
+      Name: '*encoding/json.UnmarshalTypeError'
+      ByteSize: 8
+      GoRuntimeType: 833952
+      GoKind: 22
+      Pointee: 333 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+    - __kind: PointerType
+      ID: 330
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 833856
+      GoKind: 22
+      Pointee: 331 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 328
+      Name: '*encoding/json.UnsupportedValueError'
+      ByteSize: 8
+      GoRuntimeType: 833760
+      GoKind: 22
+      Pointee: 329 UnresolvedPointeeType encoding/json.UnsupportedValueError
+    - __kind: PointerType
+      ID: 851
+      Name: '*encoding/json.encodeState'
+      ByteSize: 8
+      GoRuntimeType: 2.147936e+06
+      GoKind: 22
+      Pointee: 852 UnresolvedPointeeType encoding/json.encodeState
+    - __kind: PointerType
+      ID: 336
+      Name: '*encoding/json.jsonError'
+      ByteSize: 8
+      GoRuntimeType: 834432
+      GoKind: 22
+      Pointee: 337 StructureType encoding/json.jsonError
+    - __kind: PointerType
+      ID: 723
+      Name: '*encoding/pem.lineBreaker'
+      ByteSize: 8
+      GoRuntimeType: 1.013184e+06
+      GoKind: 22
+      Pointee: 724 UnresolvedPointeeType encoding/pem.lineBreaker
+    - __kind: PointerType
+      ID: 435
+      Name: '*encoding/xml.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 850752
+      GoKind: 22
+      Pointee: 436 UnresolvedPointeeType encoding/xml.SyntaxError
+    - __kind: PointerType
+      ID: 433
+      Name: '*encoding/xml.TagPathError'
+      ByteSize: 8
+      GoRuntimeType: 850656
+      GoKind: 22
+      Pointee: 434 UnresolvedPointeeType encoding/xml.TagPathError
+    - __kind: PointerType
+      ID: 437
+      Name: '*encoding/xml.UnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 850848
+      GoKind: 22
+      Pointee: 276 GoStringHeaderType encoding/xml.UnmarshalError
+    - __kind: PointerType
+      ID: 278
+      Name: '*encoding/xml.UnmarshalError.str'
+      ByteSize: 8
+      Pointee: 277 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: PointerType
+      ID: 438
+      Name: '*encoding/xml.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 850944
+      GoKind: 22
+      Pointee: 439 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 829
+      Name: '*encoding/xml.printer'
+      ByteSize: 8
+      GoRuntimeType: 2.017888e+06
+      GoKind: 22
+      Pointee: 830 UnresolvedPointeeType encoding/xml.printer
+    - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 362624
       GoKind: 22
       Pointee: 18 GoInterfaceType error
+    - __kind: PointerType
+      ID: 304
+      Name: '*errors.errorString'
+      ByteSize: 8
+      GoRuntimeType: 824352
+      GoKind: 22
+      Pointee: 305 UnresolvedPointeeType errors.errorString
+    - __kind: PointerType
+      ID: 500
+      Name: '*errors.joinError'
+      ByteSize: 8
+      GoRuntimeType: 979904
+      GoKind: 22
+      Pointee: 501 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -3631,6 +4109,807 @@ Types:
       GoRuntimeType: 363648
       GoKind: 22
       Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 839
+      Name: '*fmt.pp'
+      ByteSize: 8
+      GoRuntimeType: 2.113664e+06
+      GoKind: 22
+      Pointee: 840 UnresolvedPointeeType fmt.pp
+    - __kind: PointerType
+      ID: 502
+      Name: '*fmt.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 981696
+      GoKind: 22
+      Pointee: 503 UnresolvedPointeeType fmt.wrapError
+    - __kind: PointerType
+      ID: 504
+      Name: '*fmt.wrapErrors'
+      ByteSize: 8
+      GoRuntimeType: 981824
+      GoKind: 22
+      Pointee: 505 UnresolvedPointeeType fmt.wrapErrors
+    - __kind: PointerType
+      ID: 364
+      Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 839712
+      GoKind: 22
+      Pointee: 365 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+    - __kind: PointerType
+      ID: 345
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 836832
+      GoKind: 22
+      Pointee: 346 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+    - __kind: PointerType
+      ID: 347
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 836928
+      GoKind: 22
+      Pointee: 348 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+    - __kind: PointerType
+      ID: 665
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
+      ByteSize: 8
+      GoRuntimeType: 836640
+      GoKind: 22
+      Pointee: 666 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+    - __kind: PointerType
+      ID: 351
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
+      ByteSize: 8
+      GoRuntimeType: 837216
+      GoKind: 22
+      Pointee: 352 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+    - __kind: PointerType
+      ID: 667
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
+      ByteSize: 8
+      GoRuntimeType: 836736
+      GoKind: 22
+      Pointee: 668 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+    - __kind: PointerType
+      ID: 349
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
+      ByteSize: 8
+      GoRuntimeType: 837024
+      GoKind: 22
+      Pointee: 258 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+    - __kind: PointerType
+      ID: 260
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
+      ByteSize: 8
+      Pointee: 259 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: PointerType
+      ID: 344
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
+      ByteSize: 8
+      GoRuntimeType: 836544
+      GoKind: 22
+      Pointee: 255 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+    - __kind: PointerType
+      ID: 257
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
+      ByteSize: 8
+      Pointee: 256 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: PointerType
+      ID: 350
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
+      ByteSize: 8
+      GoRuntimeType: 837120
+      GoKind: 22
+      Pointee: 261 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+    - __kind: PointerType
+      ID: 263
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
+      ByteSize: 8
+      Pointee: 262 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: PointerType
+      ID: 737
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.123552e+06
+      GoKind: 22
+      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+    - __kind: PointerType
+      ID: 817
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.921088e+06
+      GoKind: 22
+      Pointee: 818 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+    - __kind: PointerType
+      ID: 456
+      Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
+      ByteSize: 8
+      GoRuntimeType: 857376
+      GoKind: 22
+      Pointee: 457 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+    - __kind: PointerType
+      ID: 611
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
+      ByteSize: 8
+      GoRuntimeType: 1.12688e+06
+      GoKind: 22
+      Pointee: 612 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+    - __kind: PointerType
+      ID: 847
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
+      ByteSize: 8
+      GoRuntimeType: 2.123904e+06
+      GoKind: 22
+      Pointee: 848 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+    - __kind: PointerType
+      ID: 384
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
+      ByteSize: 8
+      GoRuntimeType: 846240
+      GoKind: 22
+      Pointee: 385 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+    - __kind: PointerType
+      ID: 391
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
+      ByteSize: 8
+      GoRuntimeType: 847296
+      GoKind: 22
+      Pointee: 392 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+    - __kind: PointerType
+      ID: 386
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
+      ByteSize: 8
+      GoRuntimeType: 847008
+      GoKind: 22
+      Pointee: 275 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+    - __kind: PointerType
+      ID: 389
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
+      ByteSize: 8
+      GoRuntimeType: 847200
+      GoKind: 22
+      Pointee: 390 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+    - __kind: PointerType
+      ID: 387
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
+      ByteSize: 8
+      GoRuntimeType: 847104
+      GoKind: 22
+      Pointee: 388 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+    - __kind: PointerType
+      ID: 407
+      Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
+      ByteSize: 8
+      GoRuntimeType: 849216
+      GoKind: 22
+      Pointee: 408 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+    - __kind: PointerType
+      ID: 411
+      Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
+      ByteSize: 8
+      GoRuntimeType: 849408
+      GoKind: 22
+      Pointee: 412 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+    - __kind: PointerType
+      ID: 409
+      Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
+      ByteSize: 8
+      GoRuntimeType: 849312
+      GoKind: 22
+      Pointee: 410 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+    - __kind: PointerType
+      ID: 405
+      Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
+      ByteSize: 8
+      GoRuntimeType: 849120
+      GoKind: 22
+      Pointee: 406 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+    - __kind: PointerType
+      ID: 686
+      Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 8
+      Pointee: 685 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: PointerType
+      ID: 419
+      Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
+      ByteSize: 8
+      GoRuntimeType: 849792
+      GoKind: 22
+      Pointee: 420 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+    - __kind: PointerType
+      ID: 413
+      Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
+      ByteSize: 8
+      GoRuntimeType: 849504
+      GoKind: 22
+      Pointee: 414 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+    - __kind: PointerType
+      ID: 417
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
+      ByteSize: 8
+      GoRuntimeType: 849696
+      GoKind: 22
+      Pointee: 418 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+    - __kind: PointerType
+      ID: 415
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
+      ByteSize: 8
+      GoRuntimeType: 849600
+      GoKind: 22
+      Pointee: 416 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+    - __kind: PointerType
+      ID: 421
+      Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
+      ByteSize: 8
+      GoRuntimeType: 849888
+      GoKind: 22
+      Pointee: 422 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+    - __kind: PointerType
+      ID: 427
+      Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
+      ByteSize: 8
+      GoRuntimeType: 850176
+      GoKind: 22
+      Pointee: 428 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+    - __kind: PointerType
+      ID: 429
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
+      ByteSize: 8
+      GoRuntimeType: 850272
+      GoKind: 22
+      Pointee: 430 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+    - __kind: PointerType
+      ID: 425
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
+      ByteSize: 8
+      GoRuntimeType: 850080
+      GoKind: 22
+      Pointee: 426 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+    - __kind: PointerType
+      ID: 423
+      Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
+      ByteSize: 8
+      GoRuntimeType: 849984
+      GoKind: 22
+      Pointee: 424 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+    - __kind: PointerType
+      ID: 431
+      Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
+      ByteSize: 8
+      GoRuntimeType: 850464
+      GoKind: 22
+      Pointee: 432 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+    - __kind: PointerType
+      ID: 353
+      Name: '*github.com/cihub/seelog.baseError'
+      ByteSize: 8
+      GoRuntimeType: 838368
+      GoKind: 22
+      Pointee: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: PointerType
+      ID: 776
+      Name: '*github.com/cihub/seelog.bufferedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.675936e+06
+      GoKind: 22
+      Pointee: 777 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+    - __kind: PointerType
+      ID: 355
+      Name: '*github.com/cihub/seelog.cannotOpenFileError'
+      ByteSize: 8
+      GoRuntimeType: 838464
+      GoKind: 22
+      Pointee: 356 StructureType github.com/cihub/seelog.cannotOpenFileError
+    - __kind: PointerType
+      ID: 755
+      Name: '*github.com/cihub/seelog.connWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.369792e+06
+      GoKind: 22
+      Pointee: 756 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+    - __kind: PointerType
+      ID: 711
+      Name: '*github.com/cihub/seelog.consoleWriter'
+      ByteSize: 8
+      GoRuntimeType: 998592
+      GoKind: 22
+      Pointee: 712 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+    - __kind: PointerType
+      ID: 745
+      Name: '*github.com/cihub/seelog.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.24144e+06
+      GoKind: 22
+      Pointee: 746 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+    - __kind: PointerType
+      ID: 359
+      Name: '*github.com/cihub/seelog.missingArgumentError'
+      ByteSize: 8
+      GoRuntimeType: 838656
+      GoKind: 22
+      Pointee: 360 StructureType github.com/cihub/seelog.missingArgumentError
+    - __kind: PointerType
+      ID: 807
+      Name: '*github.com/cihub/seelog.rollingFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.839136e+06
+      GoKind: 22
+      Pointee: 808 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+    - __kind: PointerType
+      ID: 822
+      Name: '*github.com/cihub/seelog.rollingFileWriterSize'
+      ByteSize: 8
+      GoRuntimeType: 1.992544e+06
+      GoKind: 22
+      Pointee: 819 StructureType github.com/cihub/seelog.rollingFileWriterSize
+    - __kind: PointerType
+      ID: 821
+      Name: '*github.com/cihub/seelog.rollingFileWriterTime'
+      ByteSize: 8
+      GoRuntimeType: 1.99216e+06
+      GoKind: 22
+      Pointee: 820 StructureType github.com/cihub/seelog.rollingFileWriterTime
+    - __kind: PointerType
+      ID: 713
+      Name: '*github.com/cihub/seelog.smtpWriter'
+      ByteSize: 8
+      GoRuntimeType: 998720
+      GoKind: 22
+      Pointee: 714 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+    - __kind: PointerType
+      ID: 357
+      Name: '*github.com/cihub/seelog.unexpectedAttributeError'
+      ByteSize: 8
+      GoRuntimeType: 838560
+      GoKind: 22
+      Pointee: 358 StructureType github.com/cihub/seelog.unexpectedAttributeError
+    - __kind: PointerType
+      ID: 361
+      Name: '*github.com/cihub/seelog.unexpectedChildElementError'
+      ByteSize: 8
+      GoRuntimeType: 838752
+      GoKind: 22
+      Pointee: 362 StructureType github.com/cihub/seelog.unexpectedChildElementError
+    - __kind: PointerType
+      ID: 780
+      Name: '*github.com/cihub/seelog/archive/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.677504e+06
+      GoKind: 22
+      Pointee: 781 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+    - __kind: PointerType
+      ID: 813
+      Name: '*github.com/cihub/seelog/archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.875008e+06
+      GoKind: 22
+      Pointee: 814 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+    - __kind: PointerType
+      ID: 815
+      Name: '*github.com/cihub/seelog/archive/zip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.90576e+06
+      GoKind: 22
+      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+    - __kind: PointerType
+      ID: 642
+      Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
+      ByteSize: 8
+      GoRuntimeType: 1.25552e+06
+      GoKind: 22
+      Pointee: 643 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+    - __kind: PointerType
+      ID: 555
+      Name: '*github.com/go-viper/mapstructure/v2.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.024576e+06
+      GoKind: 22
+      Pointee: 556 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+    - __kind: PointerType
+      ID: 553
+      Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.024448e+06
+      GoKind: 22
+      Pointee: 554 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+    - __kind: PointerType
+      ID: 557
+      Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.028544e+06
+      GoKind: 22
+      Pointee: 558 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 559
+      Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
+      ByteSize: 8
+      GoRuntimeType: 1.028672e+06
+      GoKind: 22
+      Pointee: 560 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+    - __kind: PointerType
+      ID: 766
+      Name: '*github.com/gogo/protobuf/proto.textWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.477632e+06
+      GoKind: 22
+      Pointee: 767 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+    - __kind: PointerType
+      ID: 549
+      Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.011136e+06
+      GoKind: 22
+      Pointee: 550 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 367
+      Name: '*github.com/google/uuid.invalidLengthError'
+      ByteSize: 8
+      GoRuntimeType: 840384
+      GoKind: 22
+      Pointee: 368 StructureType github.com/google/uuid.invalidLengthError
+    - __kind: PointerType
+      ID: 863
+      Name: '*github.com/json-iterator/go.Stream'
+      ByteSize: 8
+      GoRuntimeType: 2.210592e+06
+      GoKind: 22
+      Pointee: 864 UnresolvedPointeeType github.com/json-iterator/go.Stream
+    - __kind: PointerType
+      ID: 613
+      Name: '*github.com/pkg/errors.fundamental'
+      ByteSize: 8
+      GoRuntimeType: 1.135072e+06
+      GoKind: 22
+      Pointee: 614 UnresolvedPointeeType github.com/pkg/errors.fundamental
+    - __kind: PointerType
+      ID: 586
+      Name: '*github.com/tinylib/msgp/msgp.ArrayError'
+      ByteSize: 8
+      GoRuntimeType: 1.113952e+06
+      GoKind: 22
+      Pointee: 587 StructureType github.com/tinylib/msgp/msgp.ArrayError
+    - __kind: PointerType
+      ID: 580
+      Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
+      ByteSize: 8
+      GoRuntimeType: 1.113568e+06
+      GoKind: 22
+      Pointee: 581 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+    - __kind: PointerType
+      ID: 519
+      Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
+      ByteSize: 8
+      GoRuntimeType: 989120
+      GoKind: 22
+      Pointee: 520 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+    - __kind: PointerType
+      ID: 592
+      Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.114336e+06
+      GoKind: 22
+      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+    - __kind: PointerType
+      ID: 518
+      Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
+      ByteSize: 8
+      GoRuntimeType: 988992
+      GoKind: 22
+      Pointee: 497 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+    - __kind: PointerType
+      ID: 584
+      Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
+      ByteSize: 8
+      GoRuntimeType: 1.113824e+06
+      GoKind: 22
+      Pointee: 585 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+    - __kind: PointerType
+      ID: 582
+      Name: '*github.com/tinylib/msgp/msgp.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.113696e+06
+      GoKind: 22
+      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.TypeError
+    - __kind: PointerType
+      ID: 590
+      Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
+      ByteSize: 8
+      GoRuntimeType: 1.114208e+06
+      GoKind: 22
+      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+    - __kind: PointerType
+      ID: 588
+      Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.11408e+06
+      GoKind: 22
+      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+    - __kind: PointerType
+      ID: 867
+      Name: '*github.com/tinylib/msgp/msgp.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.221632e+06
+      GoKind: 22
+      Pointee: 868 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+    - __kind: PointerType
+      ID: 596
+      Name: '*github.com/tinylib/msgp/msgp.errFatal'
+      ByteSize: 8
+      GoRuntimeType: 1.11472e+06
+      GoKind: 22
+      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.errFatal
+    - __kind: PointerType
+      ID: 523
+      Name: '*github.com/tinylib/msgp/msgp.errRecursion'
+      ByteSize: 8
+      GoRuntimeType: 989376
+      GoKind: 22
+      Pointee: 524 StructureType github.com/tinylib/msgp/msgp.errRecursion
+    - __kind: PointerType
+      ID: 521
+      Name: '*github.com/tinylib/msgp/msgp.errShort'
+      ByteSize: 8
+      GoRuntimeType: 989248
+      GoKind: 22
+      Pointee: 522 StructureType github.com/tinylib/msgp/msgp.errShort
+    - __kind: PointerType
+      ID: 594
+      Name: '*github.com/tinylib/msgp/msgp.errWrapped'
+      ByteSize: 8
+      GoRuntimeType: 1.114592e+06
+      GoKind: 22
+      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.errWrapped
+    - __kind: PointerType
+      ID: 478
+      Name: '*go.opentelemetry.io/otel/trace.errorConst'
+      ByteSize: 8
+      GoRuntimeType: 871008
+      GoKind: 22
+      Pointee: 287 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+    - __kind: PointerType
+      ID: 289
+      Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
+      ByteSize: 8
+      Pointee: 288 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: PointerType
+      ID: 655
+      Name: '*go.uber.org/multierr.multiError'
+      ByteSize: 8
+      GoRuntimeType: 1.476096e+06
+      GoKind: 22
+      Pointee: 656 UnresolvedPointeeType go.uber.org/multierr.multiError
+    - __kind: PointerType
+      ID: 563
+      Name: '*go.uber.org/zap.errArrayElem'
+      ByteSize: 8
+      GoRuntimeType: 1.04352e+06
+      GoKind: 22
+      Pointee: 564 StructureType go.uber.org/zap.errArrayElem
+    - __kind: PointerType
+      ID: 743
+      Name: '*go.uber.org/zap.nopCloserSink'
+      ByteSize: 8
+      GoRuntimeType: 1.173984e+06
+      GoKind: 22
+      Pointee: 744 StructureType go.uber.org/zap.nopCloserSink
+    - __kind: PointerType
+      ID: 827
+      Name: '*go.uber.org/zap/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.00752e+06
+      GoKind: 22
+      Pointee: 828 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+    - __kind: PointerType
+      ID: 729
+      Name: '*go.uber.org/zap/zapcore.writerWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.045824e+06
+      GoKind: 22
+      Pointee: 730 StructureType go.uber.org/zap/zapcore.writerWrapper
+    - __kind: PointerType
+      ID: 479
+      Name: '*golang.org/x/net/http2.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 872256
+      GoKind: 22
+      Pointee: 290 BaseType golang.org/x/net/http2.ConnectionError
+    - __kind: PointerType
+      ID: 621
+      Name: '*golang.org/x/net/http2.StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.175648e+06
+      GoKind: 22
+      Pointee: 622 StructureType golang.org/x/net/http2.StreamError
+    - __kind: PointerType
+      ID: 482
+      Name: '*golang.org/x/net/http2.connError'
+      ByteSize: 8
+      GoRuntimeType: 872544
+      GoKind: 22
+      Pointee: 483 StructureType golang.org/x/net/http2.connError
+    - __kind: PointerType
+      ID: 481
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 872448
+      GoKind: 22
+      Pointee: 294 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 296
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 295 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 485
+      Name: '*golang.org/x/net/http2.headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 872736
+      GoKind: 22
+      Pointee: 300 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+    - __kind: PointerType
+      ID: 302
+      Name: '*golang.org/x/net/http2.headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 301 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: PointerType
+      ID: 484
+      Name: '*golang.org/x/net/http2.headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 872640
+      GoKind: 22
+      Pointee: 297 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+    - __kind: PointerType
+      ID: 299
+      Name: '*golang.org/x/net/http2.headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 298 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: PointerType
+      ID: 480
+      Name: '*golang.org/x/net/http2.pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 872352
+      GoKind: 22
+      Pointee: 291 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+    - __kind: PointerType
+      ID: 293
+      Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 292 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 825
+      Name: '*golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.0056e+06
+      GoKind: 22
+      Pointee: 826 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 486
+      Name: '*golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 872832
+      GoKind: 22
+      Pointee: 487 StructureType golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 488
+      Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 872928
+      GoKind: 22
+      Pointee: 303 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 474
+      Name: '*google.golang.org/grpc.dropError'
+      ByteSize: 8
+      GoRuntimeType: 866400
+      GoKind: 22
+      Pointee: 475 StructureType google.golang.org/grpc.dropError
+    - __kind: PointerType
+      ID: 619
+      Name: '*google.golang.org/grpc/internal/status.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.172576e+06
+      GoKind: 22
+      Pointee: 620 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+    - __kind: PointerType
+      ID: 644
+      Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 1.26288e+06
+      GoKind: 22
+      Pointee: 645 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+    - __kind: PointerType
+      ID: 476
+      Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
+      ByteSize: 8
+      GoRuntimeType: 869280
+      GoKind: 22
+      Pointee: 477 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+    - __kind: PointerType
+      ID: 790
+      Name: '*google.golang.org/grpc/internal/transport.bufConn'
+      ByteSize: 8
+      GoRuntimeType: 1.684224e+06
+      GoKind: 22
+      Pointee: 791 StructureType google.golang.org/grpc/internal/transport.bufConn
+    - __kind: PointerType
+      ID: 741
+      Name: '*google.golang.org/grpc/internal/transport.bufWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.16912e+06
+      GoKind: 22
+      Pointee: 742 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+    - __kind: PointerType
+      ID: 561
+      Name: '*google.golang.org/grpc/internal/transport.ioError'
+      ByteSize: 8
+      GoRuntimeType: 1.03776e+06
+      GoKind: 22
+      Pointee: 562 StructureType google.golang.org/grpc/internal/transport.ioError
+    - __kind: PointerType
+      ID: 701
+      Name: '*google.golang.org/grpc/mem.writer'
+      ByteSize: 8
+      GoRuntimeType: 869376
+      GoKind: 22
+      Pointee: 702 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+    - __kind: PointerType
+      ID: 454
+      Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
+      ByteSize: 8
+      GoRuntimeType: 855264
+      GoKind: 22
+      Pointee: 455 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+    - __kind: PointerType
+      ID: 551
+      Name: '*google.golang.org/protobuf/internal/errors.prefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.014592e+06
+      GoKind: 22
+      Pointee: 552 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+    - __kind: PointerType
+      ID: 617
+      Name: '*google.golang.org/protobuf/internal/errors.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.140832e+06
+      GoKind: 22
+      Pointee: 618 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+    - __kind: PointerType
+      ID: 615
+      Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
+      ByteSize: 8
+      GoRuntimeType: 1.140576e+06
+      GoKind: 22
+      Pointee: 616 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+    - __kind: PointerType
+      ID: 468
+      Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
+      ByteSize: 8
+      GoRuntimeType: 859968
+      GoKind: 22
+      Pointee: 469 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+    - __kind: PointerType
+      ID: 470
+      Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
+      ByteSize: 8
+      GoRuntimeType: 860064
+      GoKind: 22
+      Pointee: 471 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+    - __kind: PointerType
+      ID: 399
+      Name: '*gopkg.in/yaml%2ev3.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 847680
+      GoKind: 22
+      Pointee: 400 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+    - __kind: PointerType
+      ID: 778
+      Name: '*hash/crc32.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.676608e+06
+      GoKind: 22
+      Pointee: 779 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 151
       Name: '*hash<[4]int,[4]int>'
@@ -3657,30 +4936,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 257
+      ID: 903
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 258 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 904 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 287
+      ID: 933
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 288 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 934 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 296
+      ID: 942
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 297 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 943 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 95 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 305
+      ID: 951
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 306 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 952 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '*hash<int,uint8>'
@@ -3696,6 +4975,11 @@ Types:
       Name: '*hash<string,[]string>'
       ByteSize: 8
       Pointee: 110 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 648
+      Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 649 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '*hash<string,int>'
@@ -3716,6 +5000,13 @@ Types:
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
       Pointee: 137 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: PointerType
+      ID: 489
+      Name: '*html/template.Error'
+      ByteSize: 8
+      GoRuntimeType: 873696
+      GoKind: 22
+      Pointee: 490 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -3759,6 +5050,83 @@ Types:
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
+      ID: 369
+      Name: '*internal/bisect.parseError'
+      ByteSize: 8
+      GoRuntimeType: 840768
+      GoKind: 22
+      Pointee: 370 UnresolvedPointeeType internal/bisect.parseError
+    - __kind: PointerType
+      ID: 687
+      Name: '*internal/godebug.runtimeStderr'
+      ByteSize: 8
+      GoRuntimeType: 828960
+      GoKind: 22
+      Pointee: 688 UnresolvedPointeeType internal/godebug.runtimeStderr
+    - __kind: PointerType
+      ID: 578
+      Name: '*internal/poll.DeadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.1128e+06
+      GoKind: 22
+      Pointee: 579 UnresolvedPointeeType internal/poll.DeadlineExceededError
+    - __kind: PointerType
+      ID: 869
+      Name: '*internal/poll.FD'
+      ByteSize: 8
+      GoRuntimeType: 2.226304e+06
+      GoKind: 22
+      Pointee: 870 UnresolvedPointeeType internal/poll.FD
+    - __kind: PointerType
+      ID: 576
+      Name: '*internal/poll.errNetClosing'
+      ByteSize: 8
+      GoRuntimeType: 1.112672e+06
+      GoKind: 22
+      Pointee: 577 StructureType internal/poll.errNetClosing
+    - __kind: PointerType
+      ID: 306
+      Name: '*internal/reflectlite.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 828096
+      GoKind: 22
+      Pointee: 307 UnresolvedPointeeType internal/reflectlite.ValueError
+    - __kind: PointerType
+      ID: 733
+      Name: '*io.PipeWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.10384e+06
+      GoKind: 22
+      Pointee: 734 UnresolvedPointeeType io.PipeWriter
+    - __kind: PointerType
+      ID: 731
+      Name: '*io.discard'
+      ByteSize: 8
+      GoRuntimeType: 1.103456e+06
+      GoKind: 22
+      Pointee: 732 StructureType io.discard
+    - __kind: PointerType
+      ID: 705
+      Name: '*io.multiWriter'
+      ByteSize: 8
+      GoRuntimeType: 980160
+      GoKind: 22
+      Pointee: 706 UnresolvedPointeeType io.multiWriter
+    - __kind: PointerType
+      ID: 574
+      Name: '*io/fs.PathError'
+      ByteSize: 8
+      GoRuntimeType: 1.112416e+06
+      GoKind: 22
+      Pointee: 575 UnresolvedPointeeType io/fs.PathError
+    - __kind: PointerType
+      ID: 782
+      Name: '*log/slog/internal/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 1.677728e+06
+      GoKind: 22
+      Pointee: 783 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+    - __kind: PointerType
       ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
@@ -3766,12 +5134,12 @@ Types:
       GoKind: 22
       Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 262
+      ID: 908
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356288
       GoKind: 22
-      Pointee: 263 UnresolvedPointeeType main.deepMap3
+      Pointee: 909 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -3780,19 +5148,19 @@ Types:
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 292
+      ID: 938
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 355968
       GoKind: 22
-      Pointee: 293 StructureType main.deepMap8
+      Pointee: 939 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 301
+      ID: 947
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355904
       GoKind: 22
-      Pointee: 302 StructureType main.deepMap9
+      Pointee: 948 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3801,12 +5169,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 233
+      ID: 873
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356864
       GoKind: 22
-      Pointee: 234 UnresolvedPointeeType main.deepPtr3
+      Pointee: 874 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3815,19 +5183,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 267
+      ID: 913
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356544
       GoKind: 22
-      Pointee: 268 StructureType main.deepPtr8
+      Pointee: 914 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 269
+      ID: 915
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356480
       GoKind: 22
-      Pointee: 270 StructureType main.deepPtr9
+      Pointee: 916 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3836,12 +5204,12 @@ Types:
       GoKind: 22
       Pointee: 183 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 252
+      ID: 898
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357440
       GoKind: 22
-      Pointee: 253 UnresolvedPointeeType main.deepSlice3
+      Pointee: 899 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3850,19 +5218,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 273
+      ID: 919
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357120
       GoKind: 22
-      Pointee: 274 StructureType main.deepSlice8
+      Pointee: 920 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 279
+      ID: 925
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 357056
       GoKind: 22
-      Pointee: 280 StructureType main.deepSlice9
+      Pointee: 926 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 178
       Name: '*main.emptyStruct'
@@ -3877,6 +5245,13 @@ Types:
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
+      ID: 889
+      Name: '*main.firstBehavior'
+      ByteSize: 8
+      GoRuntimeType: 824064
+      GoKind: 22
+      Pointee: 890 StructureType main.firstBehavior
+    - __kind: PointerType
       ID: 159
       Name: '*main.node'
       ByteSize: 8
@@ -3890,22 +5265,36 @@ Types:
       GoKind: 22
       Pointee: 174 StructureType main.oneStringStruct
     - __kind: PointerType
+      ID: 891
+      Name: '*main.secondBehavior'
+      ByteSize: 8
+      GoRuntimeType: 824160
+      GoKind: 22
+      Pointee: 892 StructureType main.secondBehavior
+    - __kind: PointerType
+      ID: 878
+      Name: '*main.somethingImpl'
+      ByteSize: 8
+      GoRuntimeType: 824256
+      GoKind: 22
+      Pointee: 879 UnresolvedPointeeType main.somethingImpl
+    - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
       ByteSize: 8
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 236
+      ID: 876
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 235 GoStringDataType main.stringType1.str
+      Pointee: 875 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 237 UnresolvedPointeeType main.stringType2
+      Pointee: 877 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 206
       Name: '*main.structWithMap'
@@ -3931,10 +5320,10 @@ Types:
       GoKind: 22
       Pointee: 161 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 249
+      ID: 895
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType main.t.array
+      Pointee: 894 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 172
       Name: '*main.threeStringStruct'
@@ -3948,12 +5337,606 @@ Types:
       GoKind: 22
       Pointee: 103 GoMapType map[string]int
     - __kind: PointerType
+      ID: 403
+      Name: '*math/big.ErrNaN'
+      ByteSize: 8
+      GoRuntimeType: 848544
+      GoKind: 22
+      Pointee: 404 StructureType math/big.ErrNaN
+    - __kind: PointerType
+      ID: 695
+      Name: '*mime/multipart.writerOnly·1'
+      ByteSize: 8
+      GoRuntimeType: 843168
+      GoKind: 22
+      Pointee: 696 StructureType mime/multipart.writerOnly·1
+    - __kind: PointerType
+      ID: 605
+      Name: '*net.AddrError'
+      ByteSize: 8
+      GoRuntimeType: 1.12112e+06
+      GoKind: 22
+      Pointee: 606 UnresolvedPointeeType net.AddrError
+    - __kind: PointerType
+      ID: 631
+      Name: '*net.DNSError'
+      ByteSize: 8
+      GoRuntimeType: 1.23968e+06
+      GoKind: 22
+      Pointee: 632 UnresolvedPointeeType net.DNSError
+    - __kind: PointerType
+      ID: 833
+      Name: '*net.IPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.085856e+06
+      GoKind: 22
+      Pointee: 834 UnresolvedPointeeType net.IPConn
+    - __kind: PointerType
+      ID: 629
+      Name: '*net.OpError'
+      ByteSize: 8
+      GoRuntimeType: 1.23936e+06
+      GoKind: 22
+      Pointee: 630 UnresolvedPointeeType net.OpError
+    - __kind: PointerType
+      ID: 607
+      Name: '*net.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.121248e+06
+      GoKind: 22
+      Pointee: 608 UnresolvedPointeeType net.ParseError
+    - __kind: PointerType
+      ID: 843
+      Name: '*net.TCPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.115712e+06
+      GoKind: 22
+      Pointee: 844 UnresolvedPointeeType net.TCPConn
+    - __kind: PointerType
+      ID: 853
+      Name: '*net.UDPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.160672e+06
+      GoKind: 22
+      Pointee: 854 UnresolvedPointeeType net.UDPConn
+    - __kind: PointerType
+      ID: 841
+      Name: '*net.UnixConn'
+      ByteSize: 8
+      GoRuntimeType: 2.1152e+06
+      GoKind: 22
+      Pointee: 842 UnresolvedPointeeType net.UnixConn
+    - __kind: PointerType
+      ID: 604
+      Name: '*net.UnknownNetworkError'
+      ByteSize: 8
+      GoRuntimeType: 1.120352e+06
+      GoKind: 22
+      Pointee: 567 GoStringHeaderType net.UnknownNetworkError
+    - __kind: PointerType
+      ID: 569
+      Name: '*net.UnknownNetworkError.str'
+      ByteSize: 8
+      Pointee: 568 GoStringDataType net.UnknownNetworkError.str
+    - __kind: PointerType
+      ID: 535
+      Name: '*net.canceledError'
+      ByteSize: 8
+      GoRuntimeType: 996032
+      GoKind: 22
+      Pointee: 536 StructureType net.canceledError
+    - __kind: PointerType
+      ID: 811
+      Name: '*net.conn'
+      ByteSize: 8
+      GoRuntimeType: 1.872704e+06
+      GoKind: 22
+      Pointee: 812 UnresolvedPointeeType net.conn
+    - __kind: PointerType
+      ID: 674
+      Name: '*net.dialResult·1'
+      ByteSize: 8
+      GoRuntimeType: 1.716928e+06
+      GoKind: 22
+      Pointee: 675 StructureType net.dialResult·1
+    - __kind: PointerType
+      ID: 855
+      Name: '*net.netFD'
+      ByteSize: 8
+      GoRuntimeType: 2.164928e+06
+      GoKind: 22
+      Pointee: 856 UnresolvedPointeeType net.netFD
+    - __kind: PointerType
+      ID: 338
+      Name: '*net.notFoundError'
+      ByteSize: 8
+      GoRuntimeType: 835392
+      GoKind: 22
+      Pointee: 339 UnresolvedPointeeType net.notFoundError
+    - __kind: PointerType
+      ID: 340
+      Name: '*net.result·2'
+      ByteSize: 8
+      GoRuntimeType: 836064
+      GoKind: 22
+      Pointee: 341 StructureType net.result·2
+    - __kind: PointerType
+      ID: 837
+      Name: '*net.tcpConnWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.099744e+06
+      GoKind: 22
+      Pointee: 838 StructureType net.tcpConnWithoutReadFrom
+    - __kind: PointerType
+      ID: 835
+      Name: '*net.tcpConnWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.099264e+06
+      GoKind: 22
+      Pointee: 836 StructureType net.tcpConnWithoutWriteTo
+    - __kind: PointerType
+      ID: 609
+      Name: '*net.temporaryError'
+      ByteSize: 8
+      GoRuntimeType: 1.121888e+06
+      GoKind: 22
+      Pointee: 610 UnresolvedPointeeType net.temporaryError
+    - __kind: PointerType
+      ID: 633
+      Name: '*net.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.23984e+06
+      GoKind: 22
+      Pointee: 634 UnresolvedPointeeType net.timeoutError
+    - __kind: PointerType
+      ID: 525
+      Name: '*net/http.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 991808
+      GoKind: 22
+      Pointee: 526 UnresolvedPointeeType net/http.ProtocolError
+    - __kind: PointerType
+      ID: 689
+      Name: '*net/http.bufioFlushWriter'
+      ByteSize: 8
+      GoRuntimeType: 831264
+      GoKind: 22
+      Pointee: 690 StructureType net/http.bufioFlushWriter
+    - __kind: PointerType
+      ID: 315
+      Name: '*net/http.http2ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 831936
+      GoKind: 22
+      Pointee: 236 BaseType net/http.http2ConnectionError
+    - __kind: PointerType
+      ID: 316
+      Name: '*net/http.http2GoAwayError'
+      ByteSize: 8
+      GoRuntimeType: 832032
+      GoKind: 22
+      Pointee: 317 StructureType net/http.http2GoAwayError
+    - __kind: PointerType
+      ID: 625
+      Name: '*net/http.http2StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.23552e+06
+      GoKind: 22
+      Pointee: 626 StructureType net/http.http2StreamError
+    - __kind: PointerType
+      ID: 320
+      Name: '*net/http.http2connError'
+      ByteSize: 8
+      GoRuntimeType: 832512
+      GoKind: 22
+      Pointee: 321 StructureType net/http.http2connError
+    - __kind: PointerType
+      ID: 751
+      Name: '*net/http.http2dataBuffer'
+      ByteSize: 8
+      GoRuntimeType: 1.366432e+06
+      GoKind: 22
+      Pointee: 752 UnresolvedPointeeType net/http.http2dataBuffer
+    - __kind: PointerType
+      ID: 319
+      Name: '*net/http.http2duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 832416
+      GoKind: 22
+      Pointee: 240 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 242
+      Name: '*net/http.http2duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 241 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 323
+      Name: '*net/http.http2headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 832704
+      GoKind: 22
+      Pointee: 246 GoStringHeaderType net/http.http2headerFieldNameError
+    - __kind: PointerType
+      ID: 248
+      Name: '*net/http.http2headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 247 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: PointerType
+      ID: 322
+      Name: '*net/http.http2headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 832608
+      GoKind: 22
+      Pointee: 243 GoStringHeaderType net/http.http2headerFieldValueError
+    - __kind: PointerType
+      ID: 245
+      Name: '*net/http.http2headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 244 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: PointerType
+      ID: 600
+      Name: '*net/http.http2httpError'
+      ByteSize: 8
+      GoRuntimeType: 1.116896e+06
+      GoKind: 22
+      Pointee: 601 UnresolvedPointeeType net/http.http2httpError
+    - __kind: PointerType
+      ID: 531
+      Name: '*net/http.http2noCachedConnError'
+      ByteSize: 8
+      GoRuntimeType: 992448
+      GoKind: 22
+      Pointee: 532 StructureType net/http.http2noCachedConnError
+    - __kind: PointerType
+      ID: 802
+      Name: '*net/http.http2pipe'
+      ByteSize: 8
+      GoRuntimeType: 1.816704e+06
+      GoKind: 22
+      Pointee: 803 UnresolvedPointeeType net/http.http2pipe
+    - __kind: PointerType
+      ID: 318
+      Name: '*net/http.http2pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 832320
+      GoKind: 22
+      Pointee: 237 GoStringHeaderType net/http.http2pseudoHeaderError
+    - __kind: PointerType
+      ID: 239
+      Name: '*net/http.http2pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 238 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 691
+      Name: '*net/http.http2stickyErrWriter'
+      ByteSize: 8
+      GoRuntimeType: 832800
+      GoKind: 22
+      Pointee: 692 StructureType net/http.http2stickyErrWriter
+    - __kind: PointerType
+      ID: 527
+      Name: '*net/http.nothingWrittenError'
+      ByteSize: 8
+      GoRuntimeType: 992064
+      GoKind: 22
+      Pointee: 528 StructureType net/http.nothingWrittenError
+    - __kind: PointerType
+      ID: 753
+      Name: '*net/http.persistConn'
+      ByteSize: 8
+      GoRuntimeType: 2.030656e+06
+      GoKind: 22
+      Pointee: 754 UnresolvedPointeeType net/http.persistConn
+    - __kind: PointerType
+      ID: 709
+      Name: '*net/http.persistConnWriter'
+      ByteSize: 8
+      GoRuntimeType: 991936
+      GoKind: 22
+      Pointee: 710 StructureType net/http.persistConnWriter
+    - __kind: PointerType
+      ID: 735
+      Name: '*net/http.readWriteCloserBody'
+      ByteSize: 8
+      GoRuntimeType: 1.115872e+06
+      GoKind: 22
+      Pointee: 736 StructureType net/http.readWriteCloserBody
+    - __kind: PointerType
+      ID: 324
+      Name: '*net/http.requestBodyReadError'
+      ByteSize: 8
+      GoRuntimeType: 832896
+      GoKind: 22
+      Pointee: 325 StructureType net/http.requestBodyReadError
+    - __kind: PointerType
+      ID: 627
+      Name: '*net/http.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.23664e+06
+      GoKind: 22
+      Pointee: 628 UnresolvedPointeeType net/http.timeoutError
+    - __kind: PointerType
+      ID: 598
+      Name: '*net/http.tlsHandshakeTimeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.116768e+06
+      GoKind: 22
+      Pointee: 599 StructureType net/http.tlsHandshakeTimeoutError
+    - __kind: PointerType
+      ID: 529
+      Name: '*net/http.transportReadFromServerError'
+      ByteSize: 8
+      GoRuntimeType: 992192
+      GoKind: 22
+      Pointee: 530 StructureType net/http.transportReadFromServerError
+    - __kind: PointerType
+      ID: 313
+      Name: '*net/http.unsupportedTEError'
+      ByteSize: 8
+      GoRuntimeType: 831168
+      GoKind: 22
+      Pointee: 314 UnresolvedPointeeType net/http.unsupportedTEError
+    - __kind: PointerType
+      ID: 804
+      Name: '*net/http/internal.FlushAfterChunkWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.81824e+06
+      GoKind: 22
+      Pointee: 805 StructureType net/http/internal.FlushAfterChunkWriter
+    - __kind: PointerType
+      ID: 719
+      Name: '*net/http/internal.chunkedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.005504e+06
+      GoKind: 22
+      Pointee: 720 UnresolvedPointeeType net/http/internal.chunkedWriter
+    - __kind: PointerType
+      ID: 395
+      Name: '*net/netip.parseAddrError'
+      ByteSize: 8
+      GoRuntimeType: 847488
+      GoKind: 22
+      Pointee: 396 StructureType net/netip.parseAddrError
+    - __kind: PointerType
+      ID: 393
+      Name: '*net/netip.parsePrefixError'
+      ByteSize: 8
+      GoRuntimeType: 847392
+      GoKind: 22
+      Pointee: 394 StructureType net/netip.parsePrefixError
+    - __kind: PointerType
+      ID: 761
+      Name: '*net/smtp.Client'
+      ByteSize: 8
+      GoRuntimeType: 1.98032e+06
+      GoKind: 22
+      Pointee: 762 UnresolvedPointeeType net/smtp.Client
+    - __kind: PointerType
+      ID: 721
+      Name: '*net/smtp.dataCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.010624e+06
+      GoKind: 22
+      Pointee: 722 StructureType net/smtp.dataCloser
+    - __kind: PointerType
+      ID: 379
+      Name: '*net/textproto.Error'
+      ByteSize: 8
+      GoRuntimeType: 843360
+      GoKind: 22
+      Pointee: 380 UnresolvedPointeeType net/textproto.Error
+    - __kind: PointerType
+      ID: 378
+      Name: '*net/textproto.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 843264
+      GoKind: 22
+      Pointee: 271 GoStringHeaderType net/textproto.ProtocolError
+    - __kind: PointerType
+      ID: 273
+      Name: '*net/textproto.ProtocolError.str'
+      ByteSize: 8
+      Pointee: 272 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: PointerType
+      ID: 717
+      Name: '*net/textproto.dotWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.004864e+06
+      GoKind: 22
+      Pointee: 718 UnresolvedPointeeType net/textproto.dotWriter
+    - __kind: PointerType
+      ID: 635
+      Name: '*net/url.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.24016e+06
+      GoKind: 22
+      Pointee: 636 UnresolvedPointeeType net/url.Error
+    - __kind: PointerType
+      ID: 342
+      Name: '*net/url.EscapeError'
+      ByteSize: 8
+      GoRuntimeType: 836160
+      GoKind: 22
+      Pointee: 249 GoStringHeaderType net/url.EscapeError
+    - __kind: PointerType
+      ID: 251
+      Name: '*net/url.EscapeError.str'
+      ByteSize: 8
+      Pointee: 250 GoStringDataType net/url.EscapeError.str
+    - __kind: PointerType
+      ID: 343
+      Name: '*net/url.InvalidHostError'
+      ByteSize: 8
+      GoRuntimeType: 836256
+      GoKind: 22
+      Pointee: 252 GoStringHeaderType net/url.InvalidHostError
+    - __kind: PointerType
+      ID: 254
+      Name: '*net/url.InvalidHostError.str'
+      ByteSize: 8
+      Pointee: 253 GoStringDataType net/url.InvalidHostError.str
+    - __kind: PointerType
+      ID: 861
+      Name: '*os.File'
+      ByteSize: 8
+      GoRuntimeType: 2.202176e+06
+      GoKind: 22
+      Pointee: 862 UnresolvedPointeeType os.File
+    - __kind: PointerType
+      ID: 506
+      Name: '*os.LinkError'
+      ByteSize: 8
+      GoRuntimeType: 982976
+      GoKind: 22
+      Pointee: 507 UnresolvedPointeeType os.LinkError
+    - __kind: PointerType
+      ID: 570
+      Name: '*os.SyscallError'
+      ByteSize: 8
+      GoRuntimeType: 1.105376e+06
+      GoKind: 22
+      Pointee: 571 UnresolvedPointeeType os.SyscallError
+    - __kind: PointerType
+      ID: 859
+      Name: '*os.fileWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.199232e+06
+      GoKind: 22
+      Pointee: 860 StructureType os.fileWithoutReadFrom
+    - __kind: PointerType
+      ID: 857
+      Name: '*os.fileWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.198496e+06
+      GoKind: 22
+      Pointee: 858 StructureType os.fileWithoutWriteTo
+    - __kind: PointerType
+      ID: 537
+      Name: '*os/exec.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.001536e+06
+      GoKind: 22
+      Pointee: 538 UnresolvedPointeeType os/exec.Error
+    - __kind: PointerType
+      ID: 677
+      Name: '*os/exec.ExitError'
+      ByteSize: 8
+      GoRuntimeType: 1.952288e+06
+      GoKind: 22
+      Pointee: 678 UnresolvedPointeeType os/exec.ExitError
+    - __kind: PointerType
+      ID: 739
+      Name: '*os/exec.prefixSuffixSaver'
+      ByteSize: 8
+      GoRuntimeType: 1.127904e+06
+      GoKind: 22
+      Pointee: 740 UnresolvedPointeeType os/exec.prefixSuffixSaver
+    - __kind: PointerType
+      ID: 539
+      Name: '*os/exec.wrappedError'
+      ByteSize: 8
+      GoRuntimeType: 1.001664e+06
+      GoKind: 22
+      Pointee: 540 StructureType os/exec.wrappedError
+    - __kind: PointerType
+      ID: 473
+      Name: '*os/user.UnknownGroupIdError'
+      ByteSize: 8
+      GoRuntimeType: 864480
+      GoKind: 22
+      Pointee: 284 GoStringHeaderType os/user.UnknownGroupIdError
+    - __kind: PointerType
+      ID: 286
+      Name: '*os/user.UnknownGroupIdError.str'
+      ByteSize: 8
+      Pointee: 285 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: PointerType
+      ID: 472
+      Name: '*os/user.UnknownUserIdError'
+      ByteSize: 8
+      GoRuntimeType: 864384
+      GoKind: 22
+      Pointee: 283 BaseType os/user.UnknownUserIdError
+    - __kind: PointerType
+      ID: 308
+      Name: '*reflect.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 828864
+      GoKind: 22
+      Pointee: 309 UnresolvedPointeeType reflect.ValueError
+    - __kind: PointerType
+      ID: 401
+      Name: '*regexp/syntax.Error'
+      ByteSize: 8
+      GoRuntimeType: 848160
+      GoKind: 22
+      Pointee: 402 UnresolvedPointeeType regexp/syntax.Error
+    - __kind: PointerType
+      ID: 509
+      Name: '*runtime.PanicNilError'
+      ByteSize: 8
+      GoRuntimeType: 984512
+      GoKind: 22
+      Pointee: 510 UnresolvedPointeeType runtime.PanicNilError
+    - __kind: PointerType
+      ID: 514
+      Name: '*runtime.TypeAssertionError'
+      ByteSize: 8
+      GoRuntimeType: 986432
+      GoKind: 22
+      Pointee: 515 UnresolvedPointeeType runtime.TypeAssertionError
+    - __kind: PointerType
+      ID: 511
+      Name: '*runtime.boundsError'
+      ByteSize: 8
+      GoRuntimeType: 984640
+      GoKind: 22
+      Pointee: 512 StructureType runtime.boundsError
+    - __kind: PointerType
+      ID: 572
+      Name: '*runtime.errorAddressString'
+      ByteSize: 8
+      GoRuntimeType: 1.110752e+06
+      GoKind: 22
+      Pointee: 573 StructureType runtime.errorAddressString
+    - __kind: PointerType
+      ID: 508
+      Name: '*runtime.errorString'
+      ByteSize: 8
+      GoRuntimeType: 984256
+      GoKind: 22
+      Pointee: 491 GoStringHeaderType runtime.errorString
+    - __kind: PointerType
+      ID: 493
+      Name: '*runtime.errorString.str'
+      ByteSize: 8
+      Pointee: 492 GoStringDataType runtime.errorString.str
+    - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 366592
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
+    - __kind: PointerType
+      ID: 513
+      Name: '*runtime.plainError'
+      ByteSize: 8
+      GoRuntimeType: 986176
+      GoKind: 22
+      Pointee: 494 GoStringHeaderType runtime.plainError
+    - __kind: PointerType
+      ID: 496
+      Name: '*runtime.plainError.str'
+      ByteSize: 8
+      Pointee: 495 GoStringDataType runtime.plainError.str
+    - __kind: PointerType
+      ID: 516
+      Name: '*strconv.NumError'
+      ByteSize: 8
+      GoRuntimeType: 986688
+      GoKind: 22
+      Pointee: 517 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3966,6 +5949,74 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 179 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 800
+      Name: '*strings.Builder'
+      ByteSize: 8
+      GoRuntimeType: 1.815424e+06
+      GoKind: 22
+      Pointee: 801 UnresolvedPointeeType strings.Builder
+    - __kind: PointerType
+      ID: 707
+      Name: '*strings.appendSliceWriter'
+      ByteSize: 8
+      GoRuntimeType: 986816
+      GoKind: 22
+      Pointee: 708 UnresolvedPointeeType strings.appendSliceWriter
+    - __kind: PointerType
+      ID: 703
+      Name: '*struct { io.Writer }'
+      ByteSize: 8
+      GoRuntimeType: 920000
+      GoKind: 22
+      Pointee: 704 StructureType struct { io.Writer }
+    - __kind: PointerType
+      ID: 624
+      Name: '*syscall.Errno'
+      ByteSize: 8
+      GoRuntimeType: 1.23488e+06
+      GoKind: 22
+      Pointee: 623 BaseType syscall.Errno
+    - __kind: PointerType
+      ID: 831
+      Name: '*text/tabwriter.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.018272e+06
+      GoKind: 22
+      Pointee: 832 UnresolvedPointeeType text/tabwriter.Writer
+    - __kind: PointerType
+      ID: 565
+      Name: '*text/template.ExecError'
+      ByteSize: 8
+      GoRuntimeType: 1.04736e+06
+      GoKind: 22
+      Pointee: 566 StructureType text/template.ExecError
+    - __kind: PointerType
+      ID: 640
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.431552e+06
+      GoKind: 22
+      Pointee: 641 UnresolvedPointeeType time.Location
+    - __kind: PointerType
+      ID: 311
+      Name: '*time.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 829728
+      GoKind: 22
+      Pointee: 312 UnresolvedPointeeType time.ParseError
+    - __kind: PointerType
+      ID: 310
+      Name: '*time.fileSizeError'
+      ByteSize: 8
+      GoRuntimeType: 829632
+      GoKind: 22
+      Pointee: 233 GoStringHeaderType time.fileSizeError
+    - __kind: PointerType
+      ID: 235
+      Name: '*time.fileSizeError.str'
+      ByteSize: 8
+      Pointee: 234 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4008,11 +6059,60 @@ Types:
       GoRuntimeType: 363392
       GoKind: 22
       Pointee: 1 BaseType uintptr
+    - __kind: PointerType
+      ID: 794
+      Name: '*vendor/golang.org/x/crypto/sha3.state'
+      ByteSize: 8
+      GoRuntimeType: 1.77168e+06
+      GoKind: 22
+      Pointee: 795 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+    - __kind: PointerType
+      ID: 397
+      Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
+      ByteSize: 8
+      GoRuntimeType: 847584
+      GoKind: 22
+      Pointee: 398 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+    - __kind: PointerType
+      ID: 823
+      Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 1.994848e+06
+      GoKind: 22
+      Pointee: 824 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 381
+      Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 843744
+      GoKind: 22
+      Pointee: 382 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 383
+      Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 843840
+      GoKind: 22
+      Pointee: 274 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 544
+      Name: '*vendor/golang.org/x/net/idna.labelError'
+      ByteSize: 8
+      GoRuntimeType: 1.005248e+06
+      GoKind: 22
+      Pointee: 545 StructureType vendor/golang.org/x/net/idna.labelError
+    - __kind: PointerType
+      ID: 546
+      Name: '*vendor/golang.org/x/net/idna.runeError'
+      ByteSize: 8
+      GoRuntimeType: 1.005376e+06
+      GoKind: 22
+      Pointee: 499 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 408
+      ID: 1054
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 365
+      ID: 1011
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4027,7 +6127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 1009
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4042,7 +6142,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
+      ID: 973
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4057,7 +6157,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 325
+      ID: 971
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4072,7 +6172,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 373
+      ID: 1019
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4087,7 +6187,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
+      ID: 972
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4102,7 +6202,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 345
+      ID: 991
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4117,7 +6217,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 314
+      ID: 960
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4132,7 +6232,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 311
+      ID: 957
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4147,7 +6247,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 389
+      ID: 1035
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4162,7 +6262,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 387
+      ID: 1033
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4195,7 +6295,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 397
+      ID: 1043
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4210,7 +6310,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 996
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4225,7 +6325,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 997
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4240,7 +6340,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 992
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4255,7 +6355,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 993
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4270,7 +6370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 348
+      ID: 994
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4285,7 +6385,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 349
+      ID: 995
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4300,7 +6400,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 402
+      ID: 1048
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4324,7 +6424,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 399
+      ID: 1045
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4339,7 +6439,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 416
+      ID: 1062
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4354,7 +6454,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 419
+      ID: 1065
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4369,7 +6469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 418
+      ID: 1064
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4384,7 +6484,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 364
+      ID: 1010
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4399,7 +6499,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 355
+      ID: 1001
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4414,7 +6514,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 1000
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4429,7 +6529,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 361
+      ID: 1007
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4444,7 +6544,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 360
+      ID: 1006
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4459,7 +6559,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 356
+      ID: 1002
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4474,7 +6574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 358
+      ID: 1004
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4489,10 +6589,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 421
+      ID: 1067
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 357
+      ID: 1003
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4516,16 +6616,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 1068
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 423
+      ID: 1069
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 359
+      ID: 1005
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 420
+      ID: 1066
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4540,7 +6640,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 424
+      ID: 1070
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4555,7 +6655,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 425
+      ID: 1071
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4570,7 +6670,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 317
+      ID: 963
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4585,7 +6685,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 318
+      ID: 964
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4600,7 +6700,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 965
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4615,7 +6715,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 316
+      ID: 962
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4630,7 +6730,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 315
+      ID: 961
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4645,7 +6745,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 362
+      ID: 1008
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4660,7 +6760,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 391
+      ID: 1037
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4675,7 +6775,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 371
+      ID: 1017
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4690,7 +6790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 377
+      ID: 1023
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4705,7 +6805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 1021
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4720,7 +6820,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 386
+      ID: 1032
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4735,7 +6835,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 385
+      ID: 1031
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4750,7 +6850,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 376
+      ID: 1022
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4765,7 +6865,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 384
+      ID: 1030
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4780,7 +6880,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 383
+      ID: 1029
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4795,7 +6895,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 369
+      ID: 1015
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4810,7 +6910,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 370
+      ID: 1016
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4825,7 +6925,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 368
+      ID: 1014
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4840,7 +6940,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 1024
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4855,7 +6955,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 1028
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4870,7 +6970,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 1027
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4885,7 +6985,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 1026
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4900,7 +7000,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 379
+      ID: 1025
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4915,7 +7015,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 414
+      ID: 1060
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4930,7 +7030,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 388
+      ID: 1034
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4981,7 +7081,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 396
+      ID: 1042
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5005,7 +7105,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 403
+      ID: 1049
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5029,7 +7129,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 405
+      ID: 1051
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5062,7 +7162,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 406
+      ID: 1052
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5077,7 +7177,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 413
+      ID: 1059
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5092,7 +7192,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 392
+      ID: 1038
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5107,7 +7207,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 1020
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5122,7 +7222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 390
+      ID: 1036
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5137,7 +7237,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 958
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5152,7 +7252,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 977
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5167,7 +7267,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 329
+      ID: 975
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5182,7 +7282,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 342
+      ID: 988
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5197,7 +7297,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 343
+      ID: 989
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5212,7 +7312,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 980
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5227,7 +7327,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 335
+      ID: 981
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5242,7 +7342,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 336
+      ID: 982
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5257,7 +7357,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 979
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5272,7 +7372,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 332
+      ID: 978
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5287,7 +7387,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 976
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5302,7 +7402,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 409
+      ID: 1055
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5317,7 +7417,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 339
+      ID: 985
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5332,7 +7432,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 340
+      ID: 986
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5347,7 +7447,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 341
+      ID: 987
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5362,7 +7462,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 984
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5377,7 +7477,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 337
+      ID: 983
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5392,7 +7492,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 400
+      ID: 1046
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5407,7 +7507,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 372
+      ID: 1018
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5422,7 +7522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
+      ID: 959
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5437,7 +7537,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 395
+      ID: 1041
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5452,7 +7552,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 404
+      ID: 1050
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5467,7 +7567,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 352
+      ID: 998
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5482,7 +7582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 999
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5497,7 +7597,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 401
+      ID: 1047
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5521,7 +7621,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 1012
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5536,7 +7636,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 367
+      ID: 1013
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5551,7 +7651,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 417
+      ID: 1063
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5566,7 +7666,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 412
+      ID: 1058
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5581,7 +7681,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 411
+      ID: 1057
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5596,7 +7696,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 410
+      ID: 1056
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5629,7 +7729,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 344
+      ID: 990
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5644,7 +7744,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 322
+      ID: 968
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5659,7 +7759,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 323
+      ID: 969
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5674,7 +7774,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 970
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5689,7 +7789,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 321
+      ID: 967
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5704,7 +7804,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 320
+      ID: 966
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5719,7 +7819,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 394
+      ID: 1040
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5734,7 +7834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 398
+      ID: 1044
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5749,7 +7849,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 415
+      ID: 1061
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5764,7 +7864,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 393
+      ID: 1039
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5779,7 +7879,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 974
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5794,7 +7894,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 407
+      ID: 1053
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5968,6 +8068,15 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
+      ID: 669
+      Name: '[5]uint8'
+      ByteSize: 5
+      GoRuntimeType: 624096
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 3 BaseType uint8
+    - __kind: ArrayType
       ID: 186
       Name: '[8]uint8'
       ByteSize: 8
@@ -5999,7 +8108,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 250
+      ID: 896
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446976
@@ -6007,21 +8116,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 251 PointerType **main.deepSlice3
+          Type: 897 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 254 GoSliceDataType []*main.deepSlice3.array
+      Data: 900 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 900
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 252 PointerType *main.deepSlice3
+      Element: 898 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 271
+      ID: 917
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446656
@@ -6029,21 +8138,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 272 PointerType **main.deepSlice8
+          Type: 918 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 275 GoSliceDataType []*main.deepSlice8.array
+      Data: 921 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 921
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 273 PointerType *main.deepSlice8
+      Element: 919 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 277
+      ID: 923
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446592
@@ -6051,19 +8160,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 278 PointerType **main.deepSlice9
+          Type: 924 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 281 GoSliceDataType []*main.deepSlice9.array
+      Data: 927 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 927
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 279 PointerType *main.deepSlice9
+      Element: 925 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6155,30 +8264,30 @@ Types:
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 910
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 260 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 906 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 940
       Name: '[]bucket<int,*main.deepMap8>.array'
       ByteSize: 2048
-      Element: 290 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 936 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 303
+      ID: 949
       Name: '[]bucket<int,*main.deepMap9>.array'
       ByteSize: 2048
-      Element: 299 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 945 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 193
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 97 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 310
+      ID: 956
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
-      Element: 308 GoHMapBucketType bucket<int,interface {}>
+      Element: 954 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
       ID: 212
       Name: '[]bucket<int,uint8>.array'
@@ -6194,6 +8303,11 @@ Types:
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 112 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 680
+      Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
+      ByteSize: 2048
+      Element: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 197
       Name: '[]bucket<string,int>.array'
@@ -6215,7 +8329,29 @@ Types:
       ByteSize: 2048
       Element: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 283
+      ID: 664
+      Name: '[]float64'
+      ByteSize: 24
+      GoRuntimeType: 454208
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 26 PointerType *float64
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 683 GoSliceDataType []float64.array
+    - __kind: GoSliceDataType
+      ID: 683
+      Name: '[]float64.array'
+      ByteSize: 2048
+      Element: 17 BaseType float64
+    - __kind: GoSliceHeaderType
+      ID: 929
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454656
@@ -6230,9 +8366,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 284 GoSliceDataType []interface {}.array
+      Data: 930 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 930
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
@@ -6294,9 +8430,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 265 GoSliceDataType []main.structWithMap.array
+      Data: 911 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 911
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 92 StructureType main.structWithMap
@@ -6387,6 +8523,28 @@ Types:
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
+    - __kind: GoSliceHeaderType
+      ID: 658
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 453184
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 681 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 681
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 3 BaseType uint8
     - __kind: ArrayType
       ID: 188
       Name: '[]val<*main.deepMap2>'
@@ -6395,26 +8553,26 @@ Types:
       HasCount: true
       Element: 189 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 261
+      ID: 907
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 262 PointerType *main.deepMap3
+      Element: 908 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 291
+      ID: 937
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 292 PointerType *main.deepMap8
+      Element: 938 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 300
+      ID: 946
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 301 PointerType *main.deepMap9
+      Element: 947 PointerType *main.deepMap9
     - __kind: ArrayType
       ID: 202
       Name: '[]val<[2]int>'
@@ -6444,6 +8602,13 @@ Types:
       HasCount: true
       Element: 168 GoSliceHeaderType []string
     - __kind: ArrayType
+      ID: 679
+      Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: ArrayType
       ID: 192
       Name: '[]val<int>'
       ByteSize: 64
@@ -6451,7 +8616,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 309
+      ID: 955
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
@@ -6478,6 +8643,64 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 810
+      Name: archive/tar.Writer
+      ByteSize: 8
+    - __kind: GoSliceHeaderType
+      ID: 459
+      Name: archive/tar.headerError
+      ByteSize: 24
+      GoRuntimeType: 858528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 22 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 460 GoSliceDataType archive/tar.headerError.array
+    - __kind: GoSliceDataType
+      ID: 460
+      Name: archive/tar.headerError.array
+      ByteSize: 2048
+      Element: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 750
+      Name: archive/tar.regFileWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 698
+      Name: archive/zip.countWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 700
+      Name: archive/zip.dirWriter
+      GoRuntimeType: 1.078464e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 797
+      Name: archive/zip.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 726
+      Name: archive/zip.nopCloser
+      ByteSize: 16
+      GoRuntimeType: 1.376512e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 728
+      Name: archive/zip.pooledFlateWriter
+      ByteSize: 8
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -6580,7 +8803,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 189 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 260
+      ID: 906
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
@@ -6592,14 +8815,14 @@ Types:
           Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 261 ArrayType []val<*main.deepMap3>
+          Type: 907 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 259 PointerType *bucket<int,*main.deepMap3>
+          Type: 905 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 262 PointerType *main.deepMap3
+      ValueType: 908 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 290
+      ID: 936
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
@@ -6611,14 +8834,14 @@ Types:
           Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 291 ArrayType []val<*main.deepMap8>
+          Type: 937 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 289 PointerType *bucket<int,*main.deepMap8>
+          Type: 935 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 292 PointerType *main.deepMap8
+      ValueType: 938 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 299
+      ID: 945
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
@@ -6630,12 +8853,12 @@ Types:
           Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 300 ArrayType []val<*main.deepMap9>
+          Type: 946 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 298 PointerType *bucket<int,*main.deepMap9>
+          Type: 944 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 301 PointerType *main.deepMap9
+      ValueType: 947 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 97
       Name: bucket<int,int>
@@ -6656,7 +8879,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 308
+      ID: 954
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
@@ -6668,10 +8891,10 @@ Types:
           Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 309 ArrayType []val<interface {}>
+          Type: 955 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 307 PointerType *bucket<int,interface {}>
+          Type: 953 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -6731,6 +8954,25 @@ Types:
           Type: 111 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 168 GoSliceHeaderType []string
+    - __kind: GoHMapBucketType
+      ID: 651
+      Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 186 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 194 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 679 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: overflow
+          Offset: 328
+          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 107
       Name: bucket<string,int>
@@ -6807,6 +9049,18 @@ Types:
           Type: 138 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 774
+      Name: bufio.Reader
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 799
+      Name: bufio.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 846
+      Name: bytes.Buffer
+      ByteSize: 8
     - __kind: GoChannelType
       ID: 155
       Name: chan bool
@@ -6829,6 +9083,337 @@ Types:
       ByteSize: 8
       GoRuntimeType: 532256
       GoKind: 15
+    - __kind: BaseType
+      ID: 266
+      Name: compress/flate.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 764640
+      GoKind: 6
+    - __kind: GoStringHeaderType
+      ID: 267
+      Name: compress/flate.InternalError
+      ByteSize: 16
+      GoRuntimeType: 764736
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 269 PointerType *compress/flate.InternalError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 268 GoStringDataType compress/flate.InternalError.str
+    - __kind: GoStringDataType
+      ID: 268
+      Name: compress/flate.InternalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 748
+      Name: compress/flate.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 694
+      Name: compress/flate.dictWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 770
+      Name: compress/gzip.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 603
+      Name: context.deadlineExceededError
+      GoRuntimeType: 1.296288e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 280
+      Name: crypto/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 767232
+      GoKind: 2
+    - __kind: BaseType
+      ID: 281
+      Name: crypto/des.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 767328
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 760
+      Name: crypto/hmac.hmac
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 785
+      Name: crypto/md5.digest
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 282
+      Name: crypto/rc4.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 767424
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 793
+      Name: crypto/sha1.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 787
+      Name: crypto/sha256.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 789
+      Name: crypto/sha512.digest
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 270
+      Name: crypto/tls.AlertError
+      ByteSize: 1
+      GoRuntimeType: 765216
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 543
+      Name: crypto/tls.CertificateVerificationError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 872
+      Name: crypto/tls.Conn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 376
+      Name: crypto/tls.ECHRejectionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 374
+      Name: crypto/tls.RecordHeaderError
+      ByteSize: 40
+      GoRuntimeType: 1.605024e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: RecordHeader
+          Offset: 16
+          Type: 669 ArrayType [5]uint8
+        - Name: Conn
+          Offset: 24
+          Type: 670 GoInterfaceType net.Conn
+    - __kind: BaseType
+      ID: 498
+      Name: crypto/tls.alert
+      ByteSize: 1
+      GoRuntimeType: 951488
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 758
+      Name: crypto/tls.cthWrapper
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 765
+      Name: crypto/tls.finishedHash
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 638
+      Name: crypto/tls.permanentError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 653
+      Name: crypto/x509.Certificate
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 448
+      Name: crypto/x509.CertificateInvalidError
+      ByteSize: 32
+      GoRuntimeType: 1.608096e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 652 PointerType *crypto/x509.Certificate
+        - Name: Reason
+          Offset: 8
+          Type: 672 BaseType crypto/x509.InvalidReason
+        - Name: Detail
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 442
+      Name: crypto/x509.ConstraintViolationError
+      GoRuntimeType: 1.075776e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 444
+      Name: crypto/x509.HostnameError
+      ByteSize: 24
+      GoRuntimeType: 1.408864e+06
+      GoKind: 25
+      RawFields:
+        - Name: Certificate
+          Offset: 0
+          Type: 652 PointerType *crypto/x509.Certificate
+        - Name: Host
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 279
+      Name: crypto/x509.InsecureAlgorithmError
+      ByteSize: 8
+      GoRuntimeType: 766848
+      GoKind: 2
+    - __kind: BaseType
+      ID: 672
+      Name: crypto/x509.InvalidReason
+      ByteSize: 8
+      GoRuntimeType: 537760
+      GoKind: 2
+    - __kind: StructureType
+      ID: 548
+      Name: crypto/x509.SystemRootsError
+      ByteSize: 16
+      GoRuntimeType: 1.372832e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 450
+      Name: crypto/x509.UnhandledCriticalExtension
+      GoRuntimeType: 1.076032e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 446
+      Name: crypto/x509.UnknownAuthorityError
+      ByteSize: 32
+      GoRuntimeType: 1.607904e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 652 PointerType *crypto/x509.Certificate
+        - Name: hintErr
+          Offset: 8
+          Type: 18 GoInterfaceType error
+        - Name: hintCert
+          Offset: 24
+          Type: 652 PointerType *crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 463
+      Name: encoding/asn1.StructuralError
+      ByteSize: 16
+      GoRuntimeType: 1.25376e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 467
+      Name: encoding/asn1.SyntaxError
+      ByteSize: 16
+      GoRuntimeType: 1.25392e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 465
+      Name: encoding/asn1.invalidUnmarshalError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 264
+      Name: encoding/base64.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 764256
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 716
+      Name: encoding/base64.encoder
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 265
+      Name: encoding/hex.InvalidByteError
+      ByteSize: 1
+      GoRuntimeType: 764448
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 335
+      Name: encoding/json.InvalidUnmarshalError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 534
+      Name: encoding/json.MarshalerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 327
+      Name: encoding/json.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 333
+      Name: encoding/json.UnmarshalTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 331
+      Name: encoding/json.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 329
+      Name: encoding/json.UnsupportedValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 852
+      Name: encoding/json.encodeState
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 337
+      Name: encoding/json.jsonError
+      ByteSize: 16
+      GoRuntimeType: 1.2384e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 724
+      Name: encoding/pem.lineBreaker
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 436
+      Name: encoding/xml.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 434
+      Name: encoding/xml.TagPathError
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 276
+      Name: encoding/xml.UnmarshalError
+      ByteSize: 16
+      GoRuntimeType: 766752
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 278 PointerType *encoding/xml.UnmarshalError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 277 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: GoStringDataType
+      ID: 277
+      Name: encoding/xml.UnmarshalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 439
+      Name: encoding/xml.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 830
+      Name: encoding/xml.printer
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 18
       Name: error
@@ -6842,6 +9427,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 305
+      Name: errors.errorString
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 501
+      Name: errors.joinError
+      ByteSize: 8
     - __kind: BaseType
       ID: 16
       Name: float32
@@ -6854,12 +9447,1066 @@ Types:
       ByteSize: 8
       GoRuntimeType: 532448
       GoKind: 14
+    - __kind: UnresolvedPointeeType
+      ID: 840
+      Name: fmt.pp
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 503
+      Name: fmt.wrapError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 505
+      Name: fmt.wrapErrors
+      ByteSize: 8
     - __kind: GoSubroutineType
       ID: 85
       Name: func()
       ByteSize: 8
       GoRuntimeType: 445376
       GoKind: 19
+    - __kind: UnresolvedPointeeType
+      ID: 365
+      Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 346
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      ByteSize: 216
+      GoRuntimeType: 1.603296e+06
+      GoKind: 25
+      RawFields:
+        - Name: Metric
+          Offset: 0
+          Type: 662 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+        - Name: ChannelSize
+          Offset: 192
+          Type: 9 BaseType int
+        - Name: Msg
+          Offset: 200
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 348
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 666
+      Name: github.com/DataDog/datadog-go/v5/statsd.Event
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 352
+      Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      GoRuntimeType: 1.072192e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 668
+      Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 258
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      ByteSize: 16
+      GoRuntimeType: 763680
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 260 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 259 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: GoStringDataType
+      ID: 259
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 662
+      Name: github.com/DataDog/datadog-go/v5/statsd.metric
+      ByteSize: 192
+      GoRuntimeType: 2.074112e+06
+      GoKind: 25
+      RawFields:
+        - Name: metricType
+          Offset: 0
+          Type: 663 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+        - Name: namespace
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+        - Name: globalTags
+          Offset: 24
+          Type: 168 GoSliceHeaderType []string
+        - Name: name
+          Offset: 48
+          Type: 11 GoStringHeaderType string
+        - Name: fvalue
+          Offset: 64
+          Type: 17 BaseType float64
+        - Name: fvalues
+          Offset: 72
+          Type: 664 GoSliceHeaderType []float64
+        - Name: ivalue
+          Offset: 96
+          Type: 14 BaseType int64
+        - Name: svalue
+          Offset: 104
+          Type: 11 GoStringHeaderType string
+        - Name: evalue
+          Offset: 120
+          Type: 665 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+        - Name: scvalue
+          Offset: 128
+          Type: 667 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+        - Name: tags
+          Offset: 136
+          Type: 168 GoSliceHeaderType []string
+        - Name: stags
+          Offset: 160
+          Type: 11 GoStringHeaderType string
+        - Name: rate
+          Offset: 176
+          Type: 17 BaseType float64
+        - Name: timestamp
+          Offset: 184
+          Type: 14 BaseType int64
+    - __kind: BaseType
+      ID: 663
+      Name: github.com/DataDog/datadog-go/v5/statsd.metricType
+      ByteSize: 8
+      GoRuntimeType: 534304
+      GoKind: 2
+    - __kind: GoStringHeaderType
+      ID: 255
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      ByteSize: 16
+      GoRuntimeType: 763584
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 257 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 256 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: GoStringDataType
+      ID: 256
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 261
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      ByteSize: 16
+      GoRuntimeType: 763776
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 263 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 262 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: GoStringDataType
+      ID: 262
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 738
+      Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 818
+      Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 457
+      Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 612
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 848
+      Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 385
+      Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 392
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      GoRuntimeType: 1.075008e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 275
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      ByteSize: 8
+      GoRuntimeType: 765888
+      GoKind: 2
+    - __kind: StructureType
+      ID: 390
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      GoRuntimeType: 1.07488e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 388
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      ByteSize: 32
+      GoRuntimeType: 1.406944e+06
+      GoKind: 25
+      RawFields:
+        - Name: OS
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Arch
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 408
+      Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      ByteSize: 32
+      GoRuntimeType: 1.407744e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 412
+      Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      ByteSize: 32
+      GoRuntimeType: 1.607328e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Size
+          Offset: 16
+          Type: 14 BaseType int64
+        - Name: MaxSize
+          Offset: 24
+          Type: 14 BaseType int64
+    - __kind: StructureType
+      ID: 410
+      Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      ByteSize: 16
+      GoRuntimeType: 1.24816e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 406
+      Name: github.com/DataDog/go-tuf/client.ErrNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.24784e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 647
+      Name: github.com/DataDog/go-tuf/data.Hashes
+      ByteSize: 8
+      GoRuntimeType: 1.135328e+06
+      GoKind: 21
+      HeaderType: 649 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+    - __kind: GoSliceHeaderType
+      ID: 671
+      Name: github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 24
+      GoRuntimeType: 1.00896e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 685 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: GoSliceDataType
+      ID: 685
+      Name: github.com/DataDog/go-tuf/data.HexBytes.array
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: StructureType
+      ID: 420
+      Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      ByteSize: 16
+      GoRuntimeType: 1.408064e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 647 GoMapType github.com/DataDog/go-tuf/data.Hashes
+        - Name: Actual
+          Offset: 8
+          Type: 647 GoMapType github.com/DataDog/go-tuf/data.Hashes
+    - __kind: StructureType
+      ID: 414
+      Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      ByteSize: 16
+      GoRuntimeType: 1.24832e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 418
+      Name: github.com/DataDog/go-tuf/util.ErrWrongHash
+      ByteSize: 64
+      GoRuntimeType: 1.60752e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Expected
+          Offset: 16
+          Type: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+        - Name: Actual
+          Offset: 40
+          Type: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: StructureType
+      ID: 416
+      Name: github.com/DataDog/go-tuf/util.ErrWrongLength
+      ByteSize: 16
+      GoRuntimeType: 1.407904e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 14 BaseType int64
+        - Name: Actual
+          Offset: 8
+          Type: 14 BaseType int64
+    - __kind: StructureType
+      ID: 422
+      Name: github.com/DataDog/go-tuf/verify.ErrExpired
+      ByteSize: 24
+      GoRuntimeType: 1.24848e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expired
+          Offset: 0
+          Type: 639 StructureType time.Time
+    - __kind: StructureType
+      ID: 428
+      Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
+      ByteSize: 16
+      GoRuntimeType: 1.408384e+06
+      GoKind: 25
+      RawFields:
+        - Name: Actual
+          Offset: 0
+          Type: 14 BaseType int64
+        - Name: Current
+          Offset: 8
+          Type: 14 BaseType int64
+    - __kind: StructureType
+      ID: 430
+      Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
+      ByteSize: 16
+      GoRuntimeType: 1.2488e+06
+      GoKind: 25
+      RawFields:
+        - Name: KeyID
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 426
+      Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      ByteSize: 16
+      GoRuntimeType: 1.408224e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: Actual
+          Offset: 8
+          Type: 9 BaseType int
+    - __kind: StructureType
+      ID: 424
+      Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      ByteSize: 16
+      GoRuntimeType: 1.24864e+06
+      GoKind: 25
+      RawFields:
+        - Name: Role
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 432
+      Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      ByteSize: 16
+      GoRuntimeType: 1.408544e+06
+      GoKind: 25
+      RawFields:
+        - Name: Given
+          Offset: 0
+          Type: 14 BaseType int64
+        - Name: Expected
+          Offset: 8
+          Type: 14 BaseType int64
+    - __kind: StructureType
+      ID: 354
+      Name: github.com/cihub/seelog.baseError
+      ByteSize: 16
+      GoRuntimeType: 1.24064e+06
+      GoKind: 25
+      RawFields:
+        - Name: message
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 777
+      Name: github.com/cihub/seelog.bufferedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 356
+      Name: github.com/cihub/seelog.cannotOpenFileError
+      ByteSize: 16
+      GoRuntimeType: 1.2408e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 756
+      Name: github.com/cihub/seelog.connWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 712
+      Name: github.com/cihub/seelog.consoleWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 746
+      Name: github.com/cihub/seelog.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 360
+      Name: github.com/cihub/seelog.missingArgumentError
+      ByteSize: 16
+      GoRuntimeType: 1.24112e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 808
+      Name: github.com/cihub/seelog.rollingFileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 819
+      Name: github.com/cihub/seelog.rollingFileWriterSize
+      ByteSize: 16
+      GoRuntimeType: 1.968384e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 807 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: maxFileSize
+          Offset: 8
+          Type: 14 BaseType int64
+    - __kind: StructureType
+      ID: 820
+      Name: github.com/cihub/seelog.rollingFileWriterTime
+      ByteSize: 40
+      GoRuntimeType: 1.991776e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 807 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: timePattern
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+        - Name: currentTimeFileName
+          Offset: 24
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 714
+      Name: github.com/cihub/seelog.smtpWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 358
+      Name: github.com/cihub/seelog.unexpectedAttributeError
+      ByteSize: 16
+      GoRuntimeType: 1.24096e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: StructureType
+      ID: 362
+      Name: github.com/cihub/seelog.unexpectedChildElementError
+      ByteSize: 16
+      GoRuntimeType: 1.24128e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 354 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 781
+      Name: github.com/cihub/seelog/archive/gzip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 814
+      Name: github.com/cihub/seelog/archive/tar.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 816
+      Name: github.com/cihub/seelog/archive/zip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 643
+      Name: github.com/go-viper/mapstructure/v2.DecodeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 556
+      Name: github.com/go-viper/mapstructure/v2.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 554
+      Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 558
+      Name: github.com/gogo/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 560
+      Name: github.com/gogo/protobuf/proto.invalidUTF8Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 767
+      Name: github.com/gogo/protobuf/proto.textWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 550
+      Name: github.com/golang/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 368
+      Name: github.com/google/uuid.invalidLengthError
+      ByteSize: 8
+      GoRuntimeType: 1.24224e+06
+      GoKind: 25
+      RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
+    - __kind: UnresolvedPointeeType
+      ID: 864
+      Name: github.com/json-iterator/go.Stream
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 614
+      Name: github.com/pkg/errors.fundamental
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 587
+      Name: github.com/tinylib/msgp/msgp.ArrayError
+      ByteSize: 24
+      GoRuntimeType: 1.712e+06
+      GoKind: 25
+      RawFields:
+        - Name: Wanted
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Got
+          Offset: 4
+          Type: 2 BaseType uint32
+        - Name: ctx
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 581
+      Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 520
+      Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
+      ByteSize: 2
+      GoRuntimeType: 1.5096e+06
+      GoKind: 25
+      RawFields:
+        - Name: Got
+          Offset: 0
+          Type: 15 BaseType int8
+        - Name: Want
+          Offset: 1
+          Type: 15 BaseType int8
+    - __kind: StructureType
+      ID: 593
+      Name: github.com/tinylib/msgp/msgp.IntOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.712448e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 14 BaseType int64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 497
+      Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
+      ByteSize: 1
+      GoRuntimeType: 948896
+      GoKind: 8
+    - __kind: StructureType
+      ID: 585
+      Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
+      ByteSize: 32
+      GoRuntimeType: 1.711776e+06
+      GoKind: 25
+      RawFields:
+        - Name: Nanos
+          Offset: 0
+          Type: 14 BaseType int64
+        - Name: FieldLength
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 673
+      Name: github.com/tinylib/msgp/msgp.Type
+      ByteSize: 1
+      GoRuntimeType: 761856
+      GoKind: 8
+    - __kind: StructureType
+      ID: 583
+      Name: github.com/tinylib/msgp/msgp.TypeError
+      ByteSize: 24
+      GoRuntimeType: 1.711552e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 673 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: Encoded
+          Offset: 1
+          Type: 673 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: ctx
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 591
+      Name: github.com/tinylib/msgp/msgp.UintBelowZero
+      ByteSize: 24
+      GoRuntimeType: 1.630144e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 14 BaseType int64
+        - Name: ctx
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 589
+      Name: github.com/tinylib/msgp/msgp.UintOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.712224e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 10 BaseType uint64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 868
+      Name: github.com/tinylib/msgp/msgp.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 597
+      Name: github.com/tinylib/msgp/msgp.errFatal
+      ByteSize: 16
+      GoRuntimeType: 1.432512e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctx
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 524
+      Name: github.com/tinylib/msgp/msgp.errRecursion
+      GoRuntimeType: 1.195168e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 522
+      Name: github.com/tinylib/msgp/msgp.errShort
+      GoRuntimeType: 1.19504e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 595
+      Name: github.com/tinylib/msgp/msgp.errWrapped
+      ByteSize: 32
+      GoRuntimeType: 1.630336e+06
+      GoKind: 25
+      RawFields:
+        - Name: cause
+          Offset: 0
+          Type: 18 GoInterfaceType error
+        - Name: ctx
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 287
+      Name: go.opentelemetry.io/otel/trace.errorConst
+      ByteSize: 16
+      GoRuntimeType: 769248
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 289 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 288 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: GoStringDataType
+      ID: 288
+      Name: go.opentelemetry.io/otel/trace.errorConst.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 656
+      Name: go.uber.org/multierr.multiError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 564
+      Name: go.uber.org/zap.errArrayElem
+      ByteSize: 16
+      GoRuntimeType: 1.2656e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 744
+      Name: go.uber.org/zap.nopCloserSink
+      ByteSize: 16
+      GoRuntimeType: 1.486464e+06
+      GoKind: 25
+      RawFields:
+        - Name: WriteSyncer
+          Offset: 0
+          Type: 768 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+    - __kind: UnresolvedPointeeType
+      ID: 828
+      Name: go.uber.org/zap/buffer.Buffer
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 768
+      Name: go.uber.org/zap/zapcore.WriteSyncer
+      ByteSize: 16
+      GoRuntimeType: 1.085888e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 730
+      Name: go.uber.org/zap/zapcore.writerWrapper
+      ByteSize: 16
+      GoRuntimeType: 1.381312e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 290
+      Name: golang.org/x/net/http2.ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 769824
+      GoKind: 10
+    - __kind: BaseType
+      ID: 654
+      Name: golang.org/x/net/http2.ErrCode
+      ByteSize: 4
+      GoRuntimeType: 962144
+      GoKind: 10
+    - __kind: StructureType
+      ID: 622
+      Name: golang.org/x/net/http2.StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.750528e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 654 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 483
+      Name: golang.org/x/net/http2.connError
+      ByteSize: 24
+      GoRuntimeType: 1.415744e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 654 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 294
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 770016
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 296 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 295 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 295
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 300
+      Name: golang.org/x/net/http2.headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 770208
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 302 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 301 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 301
+      Name: golang.org/x/net/http2.headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 297
+      Name: golang.org/x/net/http2.headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 770112
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 299 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 298 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 298
+      Name: golang.org/x/net/http2.headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 291
+      Name: golang.org/x/net/http2.pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 769920
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 293 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 292 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 292
+      Name: golang.org/x/net/http2.pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 826
+      Name: golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 487
+      Name: golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.26624e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: BaseType
+      ID: 303
+      Name: golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 770304
+      GoKind: 2
+    - __kind: StructureType
+      ID: 475
+      Name: google.golang.org/grpc.dropError
+      ByteSize: 16
+      GoRuntimeType: 1.26128e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 620
+      Name: google.golang.org/grpc/internal/status.Error
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 645
+      Name: google.golang.org/grpc/internal/transport.ConnectionError
+      ByteSize: 40
+      GoRuntimeType: 1.776288e+06
+      GoKind: 25
+      RawFields:
+        - Name: Desc
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: temp
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: err
+          Offset: 24
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 477
+      Name: google.golang.org/grpc/internal/transport.NewStreamError
+      ByteSize: 24
+      GoRuntimeType: 1.415264e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+        - Name: AllowTransparentRetry
+          Offset: 16
+          Type: 4 BaseType bool
+    - __kind: StructureType
+      ID: 791
+      Name: google.golang.org/grpc/internal/transport.bufConn
+      ByteSize: 32
+      GoRuntimeType: 1.82976e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 670 GoInterfaceType net.Conn
+        - Name: r
+          Offset: 16
+          Type: 806 GoInterfaceType io.Reader
+    - __kind: UnresolvedPointeeType
+      ID: 742
+      Name: google.golang.org/grpc/internal/transport.bufWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 562
+      Name: google.golang.org/grpc/internal/transport.ioError
+      ByteSize: 16
+      GoRuntimeType: 1.378912e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 702
+      Name: google.golang.org/grpc/mem.writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 455
+      Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 552
+      Name: google.golang.org/protobuf/internal/errors.prefixError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 618
+      Name: google.golang.org/protobuf/internal/errors.wrapError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 616
+      Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      GoRuntimeType: 1.326048e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 469
+      Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.25456e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 471
+      Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
+      ByteSize: 16
+      GoRuntimeType: 1.25472e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 400
+      Name: gopkg.in/yaml%2ev3.TypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 779
+      Name: hash/crc32.digest
+      ByteSize: 8
     - __kind: GoHMapHeaderType
       ID: 152
       Name: hash<[4]int,[4]int>
@@ -7031,7 +10678,7 @@ Types:
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
       BucketsType: 191 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 258
+      ID: 904
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -7052,20 +10699,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 259 PointerType *bucket<int,*main.deepMap3>
+          Type: 905 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 259 PointerType *bucket<int,*main.deepMap3>
+          Type: 905 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 260 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 264 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 906 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 910 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 288
+      ID: 934
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -7086,20 +10733,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 289 PointerType *bucket<int,*main.deepMap8>
+          Type: 935 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 289 PointerType *bucket<int,*main.deepMap8>
+          Type: 935 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 290 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 294 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 936 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 940 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 297
+      ID: 943
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -7120,18 +10767,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 298 PointerType *bucket<int,*main.deepMap9>
+          Type: 944 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 298 PointerType *bucket<int,*main.deepMap9>
+          Type: 944 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 299 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 303 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 945 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 949 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 95
       Name: hash<int,int>
@@ -7167,7 +10814,7 @@ Types:
       BucketType: 97 GoHMapBucketType bucket<int,int>
       BucketsType: 193 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 306
+      ID: 952
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -7188,18 +10835,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 307 PointerType *bucket<int,interface {}>
+          Type: 953 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 307 PointerType *bucket<int,interface {}>
+          Type: 953 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 308 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 310 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 954 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 956 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 132
       Name: hash<int,uint8>
@@ -7302,6 +10949,40 @@ Types:
           Type: 73 PointerType *runtime.mapextra
       BucketType: 112 GoHMapBucketType bucket<string,[]string>
       BucketsType: 199 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: GoHMapHeaderType
+      ID: 649
+      Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 680 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 105
       Name: hash<string,int>
@@ -7438,6 +11119,10 @@ Types:
           Type: 73 PointerType *runtime.mapextra
       BucketType: 139 GoHMapBucketType bucket<uint8,uint8>
       BucketsType: 214 GoSliceDataType []bucket<uint8,uint8>.array
+    - __kind: UnresolvedPointeeType
+      ID: 490
+      Name: html/template.Error
+      ByteSize: 8
     - __kind: BaseType
       ID: 9
       Name: int
@@ -7481,6 +11166,75 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 370
+      Name: internal/bisect.parseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 688
+      Name: internal/godebug.runtimeStderr
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 579
+      Name: internal/poll.DeadlineExceededError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 870
+      Name: internal/poll.FD
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 577
+      Name: internal/poll.errNetClosing
+      GoRuntimeType: 1.293248e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 307
+      Name: internal/reflectlite.ValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 734
+      Name: io.PipeWriter
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 775
+      Name: io.ReadWriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.103584e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 806
+      Name: io.Reader
+      ByteSize: 16
+      GoRuntimeType: 980288
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 763
+      Name: io.WriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.068608e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 55
       Name: io.Writer
@@ -7494,6 +11248,24 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 732
+      Name: io.discard
+      GoRuntimeType: 1.280608e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 706
+      Name: io.multiWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 575
+      Name: io/fs.PathError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 783
+      Name: log/slog/internal/buffer.Buffer
+      ByteSize: 8
     - __kind: StructureType
       ID: 175
       Name: main.aStruct
@@ -7559,9 +11331,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 256 GoMapType map[int]*main.deepMap3
+          Type: 902 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 263
+      ID: 909
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7573,9 +11345,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 286 GoMapType map[int]*main.deepMap8
+          Type: 932 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 293
+      ID: 939
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.09936e+06
@@ -7583,9 +11355,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 295 GoMapType map[int]*main.deepMap9
+          Type: 941 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 302
+      ID: 948
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.099232e+06
@@ -7593,7 +11365,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 304 GoMapType map[int]interface {}
+          Type: 950 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7613,9 +11385,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 233 PointerType *main.deepPtr3
+          Type: 873 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 234
+      ID: 874
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7627,9 +11399,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 267 PointerType *main.deepPtr8
+          Type: 913 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 268
+      ID: 914
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.100512e+06
@@ -7637,9 +11409,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 269 PointerType *main.deepPtr9
+          Type: 915 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 270
+      ID: 916
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.100384e+06
@@ -7667,9 +11439,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 250 GoSliceHeaderType []*main.deepSlice3
+          Type: 896 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 253
+      ID: 899
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7681,9 +11453,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 271 GoSliceHeaderType []*main.deepSlice8
+          Type: 917 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 274
+      ID: 920
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.101664e+06
@@ -7691,9 +11463,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 277 GoSliceHeaderType []*main.deepSlice9
+          Type: 923 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 280
+      ID: 926
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101536e+06
@@ -7701,7 +11473,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 283 GoSliceHeaderType []interface {}
+          Type: 929 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 177
       Name: main.emptyStruct
@@ -7719,16 +11491,16 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 238 StructureType sync.Mutex
+          Type: 880 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 239 StructureType sync.Once
+          Type: 881 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 242 StructureType sync.WaitGroup
+          Type: 884 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 246 StructureType sync/atomic.Int32
+          Type: 888 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
@@ -7757,6 +11529,16 @@ Types:
         - Name: foo
           Offset: 56
           Type: 85 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 890
+      Name: main.firstBehavior
+      ByteSize: 16
+      GoRuntimeType: 1.23168e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
       ID: 176
       Name: main.nestedStruct
@@ -7792,6 +11574,13 @@ Types:
         - Name: a
           Offset: 0
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 892
+      Name: main.secondBehavior
+      ByteSize: 8
+      GoRuntimeType: 1.23184e+06
+      GoKind: 25
+      RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: GoInterfaceType
       ID: 84
       Name: main.something
@@ -7805,6 +11594,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 879
+      Name: main.somethingImpl
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 78
       Name: main.stringType1
@@ -7813,17 +11606,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 236 PointerType *main.stringType1.str
+          Type: 876 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 235 GoStringDataType main.stringType1.str
+      Data: 875 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 235
+      ID: 875
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 237
+      ID: 877
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -7878,16 +11671,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 247 PointerType **main.t
+          Type: 893 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 248 GoSliceDataType main.t.array
+      Data: 894 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 894
       Name: main.t.array
       ByteSize: 2048
       Element: 160 PointerType *main.t
@@ -7947,26 +11740,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 256
+      ID: 902
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879840
       GoKind: 21
-      HeaderType: 258 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 904 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 286
+      ID: 932
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879360
       GoKind: 21
-      HeaderType: 288 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 934 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 295
+      ID: 941
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879264
       GoKind: 21
-      HeaderType: 297 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 943 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 93
       Name: map[int]int
@@ -7975,12 +11768,12 @@ Types:
       GoKind: 21
       HeaderType: 95 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 304
+      ID: 950
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879168
       GoKind: 21
-      HeaderType: 306 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 952 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 130
       Name: map[int]uint8
@@ -8030,9 +11823,768 @@ Types:
       GoRuntimeType: 880992
       GoKind: 21
       HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: StructureType
+      ID: 404
+      Name: math/big.ErrNaN
+      ByteSize: 16
+      GoRuntimeType: 1.24752e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 696
+      Name: mime/multipart.writerOnly·1
+      ByteSize: 16
+      GoRuntimeType: 1.24432e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 606
+      Name: net.AddrError
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 670
+      Name: net.Conn
+      ByteSize: 16
+      GoRuntimeType: 1.405664e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 632
+      Name: net.DNSError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 834
+      Name: net.IPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 630
+      Name: net.OpError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 608
+      Name: net.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 844
+      Name: net.TCPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 854
+      Name: net.UDPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 842
+      Name: net.UnixConn
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 567
+      Name: net.UnknownNetworkError
+      ByteSize: 16
+      GoRuntimeType: 1.071808e+06
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 569 PointerType *net.UnknownNetworkError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 568 GoStringDataType net.UnknownNetworkError.str
+    - __kind: GoStringDataType
+      ID: 568
+      Name: net.UnknownNetworkError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 536
+      Name: net.canceledError
+      GoRuntimeType: 1.196064e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 812
+      Name: net.conn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 675
+      Name: net.dialResult·1
+      ByteSize: 40
+      GoRuntimeType: 1.96768e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 670 GoInterfaceType net.Conn
+        - Name: error
+          Offset: 16
+          Type: 18 GoInterfaceType error
+        - Name: primary
+          Offset: 32
+          Type: 4 BaseType bool
+        - Name: done
+          Offset: 33
+          Type: 4 BaseType bool
+    - __kind: UnresolvedPointeeType
+      ID: 856
+      Name: net.netFD
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 850
+      Name: net.noReadFrom
+      GoRuntimeType: 1.072064e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 849
+      Name: net.noWriteTo
+      GoRuntimeType: 1.071936e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 339
+      Name: net.notFoundError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 341
+      Name: net.result·2
+      ByteSize: 112
+      GoRuntimeType: 1.603104e+06
+      GoKind: 25
+      RawFields:
+        - Name: p
+          Offset: 0
+          Type: 657 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+        - Name: server
+          Offset: 80
+          Type: 11 GoStringHeaderType string
+        - Name: error
+          Offset: 96
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 838
+      Name: net.tcpConnWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.144e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 850 StructureType net.noReadFrom
+        - Name: TCPConn
+          Offset: 0
+          Type: 843 PointerType *net.TCPConn
+    - __kind: StructureType
+      ID: 836
+      Name: net.tcpConnWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.143456e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 849 StructureType net.noWriteTo
+        - Name: TCPConn
+          Offset: 0
+          Type: 843 PointerType *net.TCPConn
+    - __kind: UnresolvedPointeeType
+      ID: 610
+      Name: net.temporaryError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 634
+      Name: net.timeoutError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 526
+      Name: net/http.ProtocolError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 690
+      Name: net/http.bufioFlushWriter
+      ByteSize: 16
+      GoRuntimeType: 1.23584e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 236
+      Name: net/http.http2ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 762336
+      GoKind: 10
+    - __kind: BaseType
+      ID: 646
+      Name: net/http.http2ErrCode
+      ByteSize: 4
+      GoRuntimeType: 948992
+      GoKind: 10
+    - __kind: StructureType
+      ID: 317
+      Name: net/http.http2GoAwayError
+      ByteSize: 24
+      GoRuntimeType: 1.601184e+06
+      GoKind: 25
+      RawFields:
+        - Name: LastStreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: ErrCode
+          Offset: 4
+          Type: 646 BaseType net/http.http2ErrCode
+        - Name: DebugData
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 626
+      Name: net/http.http2StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.76656e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 646 BaseType net/http.http2ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 18 GoInterfaceType error
+    - __kind: StructureType
+      ID: 321
+      Name: net/http.http2connError
+      ByteSize: 24
+      GoRuntimeType: 1.405184e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 646 BaseType net/http.http2ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 752
+      Name: net/http.http2dataBuffer
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 240
+      Name: net/http.http2duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 762528
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 242 PointerType *net/http.http2duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 241 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 241
+      Name: net/http.http2duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 246
+      Name: net/http.http2headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 762720
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 248 PointerType *net/http.http2headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 247 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 247
+      Name: net/http.http2headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 243
+      Name: net/http.http2headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 762624
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 245 PointerType *net/http.http2headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 244 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 244
+      Name: net/http.http2headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 601
+      Name: net/http.http2httpError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 532
+      Name: net/http.http2noCachedConnError
+      GoRuntimeType: 1.195424e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 803
+      Name: net/http.http2pipe
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 237
+      Name: net/http.http2pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 762432
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 239 PointerType *net/http.http2pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 238 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 238
+      Name: net/http.http2pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 692
+      Name: net/http.http2stickyErrWriter
+      ByteSize: 32
+      GoRuntimeType: 1.601952e+06
+      GoKind: 25
+      RawFields:
+        - Name: conn
+          Offset: 0
+          Type: 670 GoInterfaceType net.Conn
+        - Name: timeout
+          Offset: 16
+          Type: 771 BaseType time.Duration
+        - Name: err
+          Offset: 24
+          Type: 33 PointerType *error
+    - __kind: ArrayType
+      ID: 772
+      Name: net/http.incomparable
+      GoRuntimeType: 830976
+      GoKind: 17
+      HasCount: true
+      Element: 85 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 528
+      Name: net/http.nothingWrittenError
+      ByteSize: 16
+      GoRuntimeType: 1.367072e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 754
+      Name: net/http.persistConn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 710
+      Name: net/http.persistConnWriter
+      ByteSize: 8
+      GoRuntimeType: 1.366912e+06
+      GoKind: 25
+      RawFields:
+        - Name: pc
+          Offset: 0
+          Type: 753 PointerType *net/http.persistConn
+    - __kind: StructureType
+      ID: 736
+      Name: net/http.readWriteCloserBody
+      ByteSize: 24
+      GoRuntimeType: 1.673248e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 772 ArrayType net/http.incomparable
+        - Name: br
+          Offset: 0
+          Type: 773 PointerType *bufio.Reader
+        - Name: ReadWriteCloser
+          Offset: 8
+          Type: 775 GoInterfaceType io.ReadWriteCloser
+    - __kind: StructureType
+      ID: 325
+      Name: net/http.requestBodyReadError
+      ByteSize: 16
+      GoRuntimeType: 1.2368e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 628
+      Name: net/http.timeoutError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 599
+      Name: net/http.tlsHandshakeTimeoutError
+      GoRuntimeType: 1.295968e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 530
+      Name: net/http.transportReadFromServerError
+      ByteSize: 16
+      GoRuntimeType: 1.367232e+06
+      GoKind: 25
+      RawFields:
+        - Name: err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 314
+      Name: net/http.unsupportedTEError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 805
+      Name: net/http/internal.FlushAfterChunkWriter
+      ByteSize: 8
+      GoRuntimeType: 1.9048e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 798 PointerType *bufio.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 720
+      Name: net/http/internal.chunkedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 396
+      Name: net/netip.parseAddrError
+      ByteSize: 48
+      GoRuntimeType: 1.606944e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+        - Name: at
+          Offset: 32
+          Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 394
+      Name: net/netip.parsePrefixError
+      ByteSize: 32
+      GoRuntimeType: 1.407104e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 762
+      Name: net/smtp.Client
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 722
+      Name: net/smtp.dataCloser
+      ByteSize: 24
+      GoRuntimeType: 1.409024e+06
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 761 PointerType *net/smtp.Client
+        - Name: WriteCloser
+          Offset: 8
+          Type: 763 GoInterfaceType io.WriteCloser
+    - __kind: UnresolvedPointeeType
+      ID: 380
+      Name: net/textproto.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 271
+      Name: net/textproto.ProtocolError
+      ByteSize: 16
+      GoRuntimeType: 765312
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 273 PointerType *net/textproto.ProtocolError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 272 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: GoStringDataType
+      ID: 272
+      Name: net/textproto.ProtocolError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 718
+      Name: net/textproto.dotWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 636
+      Name: net/url.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 249
+      Name: net/url.EscapeError
+      ByteSize: 16
+      GoRuntimeType: 763296
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 251 PointerType *net/url.EscapeError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 250 GoStringDataType net/url.EscapeError.str
+    - __kind: GoStringDataType
+      ID: 250
+      Name: net/url.EscapeError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 252
+      Name: net/url.InvalidHostError
+      ByteSize: 16
+      GoRuntimeType: 763392
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 254 PointerType *net/url.InvalidHostError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 253 GoStringDataType net/url.InvalidHostError.str
+    - __kind: GoStringDataType
+      ID: 253
+      Name: net/url.InvalidHostError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 862
+      Name: os.File
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 507
+      Name: os.LinkError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 571
+      Name: os.SyscallError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 860
+      Name: os.fileWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.212192e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 866 StructureType os.noReadFrom
+        - Name: File
+          Offset: 0
+          Type: 861 PointerType *os.File
+    - __kind: StructureType
+      ID: 858
+      Name: os.fileWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.211392e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 865 StructureType os.noWriteTo
+        - Name: File
+          Offset: 0
+          Type: 861 PointerType *os.File
+    - __kind: StructureType
+      ID: 866
+      Name: os.noReadFrom
+      GoRuntimeType: 1.069504e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 865
+      Name: os.noWriteTo
+      GoRuntimeType: 1.069376e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 538
+      Name: os/exec.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 678
+      Name: os/exec.ExitError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 740
+      Name: os/exec.prefixSuffixSaver
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 540
+      Name: os/exec.wrappedError
+      ByteSize: 32
+      GoRuntimeType: 1.510176e+06
+      GoKind: 25
+      RawFields:
+        - Name: prefix
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: err
+          Offset: 16
+          Type: 18 GoInterfaceType error
+    - __kind: GoStringHeaderType
+      ID: 284
+      Name: os/user.UnknownGroupIdError
+      ByteSize: 16
+      GoRuntimeType: 768480
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 286 PointerType *os/user.UnknownGroupIdError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 285 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: GoStringDataType
+      ID: 285
+      Name: os/user.UnknownGroupIdError.str
+      ByteSize: 2048
+    - __kind: BaseType
+      ID: 283
+      Name: os/user.UnknownUserIdError
+      ByteSize: 8
+      GoRuntimeType: 768384
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 309
+      Name: reflect.ValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 402
+      Name: regexp/syntax.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 510
+      Name: runtime.PanicNilError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 515
+      Name: runtime.TypeAssertionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 512
+      Name: runtime.boundsError
+      ByteSize: 24
+      GoRuntimeType: 1.756128e+06
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 14 BaseType int64
+        - Name: y
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: signed
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: code
+          Offset: 17
+          Type: 676 BaseType runtime.boundsErrorCode
+    - __kind: BaseType
+      ID: 676
+      Name: runtime.boundsErrorCode
+      ByteSize: 1
+      GoRuntimeType: 532640
+      GoKind: 8
+    - __kind: StructureType
+      ID: 573
+      Name: runtime.errorAddressString
+      ByteSize: 24
+      GoRuntimeType: 1.627072e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: addr
+          Offset: 16
+          Type: 1 BaseType uintptr
+    - __kind: GoStringHeaderType
+      ID: 491
+      Name: runtime.errorString
+      ByteSize: 16
+      GoRuntimeType: 947840
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 493 PointerType *runtime.errorString.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 492 GoStringDataType runtime.errorString.str
+    - __kind: GoStringDataType
+      ID: 492
+      Name: runtime.errorString.str
+      ByteSize: 2048
     - __kind: UnresolvedPointeeType
       ID: 74
       Name: runtime.mapextra
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 494
+      Name: runtime.plainError
+      ByteSize: 16
+      GoRuntimeType: 948416
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 496 PointerType *runtime.plainError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 495 GoStringDataType runtime.plainError.str
+    - __kind: GoStringDataType
+      ID: 495
+      Name: runtime.plainError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 517
+      Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
@@ -8052,8 +12604,26 @@ Types:
       ID: 179
       Name: string.str
       ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 801
+      Name: strings.Builder
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 708
+      Name: strings.appendSliceWriter
+      ByteSize: 8
     - __kind: StructureType
-      ID: 238
+      ID: 704
+      Name: struct { io.Writer }
+      ByteSize: 16
+      GoRuntimeType: 1.272768e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 880
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281408e+06
@@ -8066,7 +12636,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 239
+      ID: 881
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282528e+06
@@ -8074,12 +12644,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 240 StructureType sync/atomic.Uint32
+          Type: 882 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 238 StructureType sync.Mutex
+          Type: 880 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 242
+      ID: 884
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421376e+06
@@ -8087,21 +12657,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 243 StructureType sync.noCopy
+          Type: 885 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 244 StructureType sync/atomic.Uint64
+          Type: 886 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 243
+      ID: 885
       Name: sync.noCopy
       GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 246
+      ID: 888
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282848e+06
@@ -8109,12 +12679,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 241 StructureType sync/atomic.noCopy
+          Type: 883 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 240
+      ID: 882
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.283008e+06
@@ -8122,12 +12692,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 241 StructureType sync/atomic.noCopy
+          Type: 883 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 244
+      ID: 886
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.42176e+06
@@ -8135,25 +12705,96 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 241 StructureType sync/atomic.noCopy
+          Type: 883 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 245 StructureType sync/atomic.align64
+          Type: 887 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 245
+      ID: 887
       Name: sync/atomic.align64
       GoRuntimeType: 946976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 241
+      ID: 883
       Name: sync/atomic.noCopy
       GoRuntimeType: 946880
       GoKind: 25
       RawFields: []
+    - __kind: BaseType
+      ID: 623
+      Name: syscall.Errno
+      ByteSize: 8
+      GoRuntimeType: 1.194656e+06
+      GoKind: 12
+    - __kind: UnresolvedPointeeType
+      ID: 832
+      Name: text/tabwriter.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 566
+      Name: text/template.ExecError
+      ByteSize: 32
+      GoRuntimeType: 1.514592e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 18 GoInterfaceType error
+    - __kind: BaseType
+      ID: 771
+      Name: time.Duration
+      ByteSize: 8
+      GoRuntimeType: 1.7824e+06
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 641
+      Name: time.Location
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 312
+      Name: time.ParseError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 639
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.224416e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 10 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 14 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 640 PointerType *time.Location
+    - __kind: GoStringHeaderType
+      ID: 233
+      Name: time.fileSizeError
+      ByteSize: 16
+      GoRuntimeType: 761472
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 235 PointerType *time.fileSizeError.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 234 GoStringDataType time.fileSizeError.str
+    - __kind: GoStringDataType
+      ID: 234
+      Name: time.fileSizeError.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -8196,6 +12837,124 @@ Types:
       ByteSize: 8
       GoRuntimeType: 532576
       GoKind: 26
-MaxTypeID: 425
+    - __kind: UnresolvedPointeeType
+      ID: 795
+      Name: vendor/golang.org/x/crypto/sha3.state
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 657
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
+      ByteSize: 80
+      GoRuntimeType: 1.926528e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 658 GoSliceHeaderType []uint8
+        - Name: header
+          Offset: 24
+          Type: 659 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+        - Name: section
+          Offset: 36
+          Type: 660 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+        - Name: off
+          Offset: 40
+          Type: 9 BaseType int
+        - Name: index
+          Offset: 48
+          Type: 9 BaseType int
+        - Name: resHeaderValid
+          Offset: 56
+          Type: 4 BaseType bool
+        - Name: resHeaderOffset
+          Offset: 64
+          Type: 9 BaseType int
+        - Name: resHeaderType
+          Offset: 72
+          Type: 661 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+        - Name: resHeaderLength
+          Offset: 74
+          Type: 7 BaseType uint16
+    - __kind: BaseType
+      ID: 661
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Type
+      ByteSize: 2
+      GoRuntimeType: 953120
+      GoKind: 9
+    - __kind: StructureType
+      ID: 659
+      Name: vendor/golang.org/x/net/dns/dnsmessage.header
+      ByteSize: 12
+      GoRuntimeType: 1.792896e+06
+      GoKind: 25
+      RawFields:
+        - Name: id
+          Offset: 0
+          Type: 7 BaseType uint16
+        - Name: bits
+          Offset: 2
+          Type: 7 BaseType uint16
+        - Name: questions
+          Offset: 4
+          Type: 7 BaseType uint16
+        - Name: answers
+          Offset: 6
+          Type: 7 BaseType uint16
+        - Name: authorities
+          Offset: 8
+          Type: 7 BaseType uint16
+        - Name: additionals
+          Offset: 10
+          Type: 7 BaseType uint16
+    - __kind: UnresolvedPointeeType
+      ID: 398
+      Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 660
+      Name: vendor/golang.org/x/net/dns/dnsmessage.section
+      ByteSize: 1
+      GoRuntimeType: 536224
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 824
+      Name: vendor/golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 382
+      Name: vendor/golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.24464e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 18 GoInterfaceType error
+    - __kind: BaseType
+      ID: 274
+      Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 765408
+      GoKind: 2
+    - __kind: StructureType
+      ID: 545
+      Name: vendor/golang.org/x/net/idna.labelError
+      ByteSize: 32
+      GoRuntimeType: 1.510368e+06
+      GoKind: 25
+      RawFields:
+        - Name: label
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: code_
+          Offset: 16
+          Type: 11 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 499
+      Name: vendor/golang.org/x/net/idna.runeError
+      ByteSize: 4
+      GoRuntimeType: 951968
+      GoKind: 5
+MaxTypeID: 1071
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -3383,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 238
+      ID: 250
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 239 PointerType *main.deepSlice3
+      Pointee: 251 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 257
+      ID: 271
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 258 PointerType *main.deepSlice8
+      Pointee: 272 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 263
+      ID: 277
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 264 PointerType *main.deepSlice9
+      Pointee: 278 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3404,7 +3404,7 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 305
+      ID: 246
       Name: '**main.t'
       ByteSize: 8
       Pointee: 159 PointerType *main.t
@@ -3421,20 +3421,20 @@ Types:
       ByteSize: 8
       Pointee: 183 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 242
+      ID: 254
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 253 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 261
+      ID: 275
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 274 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 267
+      ID: 281
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 280 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 181
       Name: '*[]*string.array'
@@ -3451,15 +3451,15 @@ Types:
       ByteSize: 8
       Pointee: 228 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 270
+      ID: 284
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 269 GoSliceDataType []interface {}.array
+      Pointee: 283 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 309
+      ID: 265
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 308 GoSliceDataType []main.structWithMap.array
+      Pointee: 264 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 225
       Name: '*[]main.structWithNoStrings.array'
@@ -3518,30 +3518,30 @@ Types:
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 246
+      ID: 258
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 247 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 259 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 274
+      ID: 288
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 275 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 289 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 283
+      ID: 297
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 284 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 298 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 96 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 292
+      ID: 306
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 293 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 307 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*bucket<int,uint8>'
@@ -3624,30 +3624,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 244
+      ID: 256
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 245 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 257 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 272
+      ID: 286
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 273 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 287 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 281
+      ID: 295
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 282 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 296 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 93
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 94 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 290
+      ID: 304
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 291 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 305 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 130
       Name: '*hash<int,uint8>'
@@ -3733,12 +3733,12 @@ Types:
       GoKind: 22
       Pointee: 189 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 249
+      ID: 261
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356032
       GoKind: 22
-      Pointee: 250 UnresolvedPointeeType main.deepMap3
+      Pointee: 262 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -3747,19 +3747,19 @@ Types:
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 277
+      ID: 291
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 355712
       GoKind: 22
-      Pointee: 278 StructureType main.deepMap8
+      Pointee: 292 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 286
+      ID: 300
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355648
       GoKind: 22
-      Pointee: 287 StructureType main.deepMap9
+      Pointee: 301 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3782,19 +3782,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 252
+      ID: 266
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356288
       GoKind: 22
-      Pointee: 253 StructureType main.deepPtr8
+      Pointee: 267 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 254
+      ID: 268
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 255 StructureType main.deepPtr9
+      Pointee: 269 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3803,12 +3803,12 @@ Types:
       GoKind: 22
       Pointee: 182 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 239
+      ID: 251
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357184
       GoKind: 22
-      Pointee: 240 UnresolvedPointeeType main.deepSlice3
+      Pointee: 252 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3817,19 +3817,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 258
+      ID: 272
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 356864
       GoKind: 22
-      Pointee: 259 StructureType main.deepSlice8
+      Pointee: 273 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 264
+      ID: 278
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 265 StructureType main.deepSlice9
+      Pointee: 279 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 177
       Name: '*main.emptyStruct'
@@ -3898,10 +3898,10 @@ Types:
       GoKind: 22
       Pointee: 160 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 307
+      ID: 248
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 306 GoSliceDataType main.t.array
+      Pointee: 247 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 171
       Name: '*main.threeStringStruct'
@@ -5951,7 +5951,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 237
+      ID: 249
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446720
@@ -5959,21 +5959,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 238 PointerType **main.deepSlice3
+          Type: 250 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 241 GoSliceDataType []*main.deepSlice3.array
+      Data: 253 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 253
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 239 PointerType *main.deepSlice3
+      Element: 251 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 256
+      ID: 270
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446400
@@ -5981,21 +5981,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 257 PointerType **main.deepSlice8
+          Type: 271 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 260 GoSliceDataType []*main.deepSlice8.array
+      Data: 274 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 274
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 258 PointerType *main.deepSlice8
+      Element: 272 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 262
+      ID: 276
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446336
@@ -6003,19 +6003,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 263 PointerType **main.deepSlice9
+          Type: 277 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 266 GoSliceDataType []*main.deepSlice9.array
+      Data: 280 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 280
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 264 PointerType *main.deepSlice9
+      Element: 278 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6107,30 +6107,30 @@ Types:
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 263
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 247 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 259 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 293
       Name: '[]bucket<int,*main.deepMap8>.array'
       ByteSize: 2048
-      Element: 275 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 289 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 302
       Name: '[]bucket<int,*main.deepMap9>.array'
       ByteSize: 2048
-      Element: 284 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 298 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 192
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 96 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 309
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
-      Element: 293 GoHMapBucketType bucket<int,interface {}>
+      Element: 307 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
       ID: 211
       Name: '[]bucket<int,uint8>.array'
@@ -6167,7 +6167,7 @@ Types:
       ByteSize: 2048
       Element: 138 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 268
+      ID: 282
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454400
@@ -6182,9 +6182,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 269 GoSliceDataType []interface {}.array
+      Data: 283 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 283
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
@@ -6246,9 +6246,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 308 GoSliceDataType []main.structWithMap.array
+      Data: 264 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 308
+      ID: 264
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 91 StructureType main.structWithMap
@@ -6347,26 +6347,26 @@ Types:
       HasCount: true
       Element: 188 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 248
+      ID: 260
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 249 PointerType *main.deepMap3
+      Element: 261 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 276
+      ID: 290
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 277 PointerType *main.deepMap8
+      Element: 291 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 285
+      ID: 299
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 286 PointerType *main.deepMap9
+      Element: 300 PointerType *main.deepMap9
     - __kind: ArrayType
       ID: 201
       Name: '[]val<[2]int>'
@@ -6403,7 +6403,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 294
+      ID: 308
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
@@ -6532,7 +6532,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 188 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 247
+      ID: 259
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
@@ -6544,14 +6544,14 @@ Types:
           Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 248 ArrayType []val<*main.deepMap3>
+          Type: 260 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 246 PointerType *bucket<int,*main.deepMap3>
+          Type: 258 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 249 PointerType *main.deepMap3
+      ValueType: 261 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 275
+      ID: 289
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
@@ -6563,14 +6563,14 @@ Types:
           Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 276 ArrayType []val<*main.deepMap8>
+          Type: 290 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 274 PointerType *bucket<int,*main.deepMap8>
+          Type: 288 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 277 PointerType *main.deepMap8
+      ValueType: 291 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 284
+      ID: 298
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
@@ -6582,12 +6582,12 @@ Types:
           Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 285 ArrayType []val<*main.deepMap9>
+          Type: 299 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 283 PointerType *bucket<int,*main.deepMap9>
+          Type: 297 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 286 PointerType *main.deepMap9
+      ValueType: 300 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 96
       Name: bucket<int,int>
@@ -6608,7 +6608,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 293
+      ID: 307
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
@@ -6620,10 +6620,10 @@ Types:
           Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 294 ArrayType []val<interface {}>
+          Type: 308 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 292 PointerType *bucket<int,interface {}>
+          Type: 306 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -6983,7 +6983,7 @@ Types:
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
       BucketsType: 190 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 245
+      ID: 257
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -7004,20 +7004,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 246 PointerType *bucket<int,*main.deepMap3>
+          Type: 258 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 246 PointerType *bucket<int,*main.deepMap3>
+          Type: 258 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 247 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 251 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 259 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 263 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 273
+      ID: 287
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -7038,20 +7038,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 274 PointerType *bucket<int,*main.deepMap8>
+          Type: 288 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 274 PointerType *bucket<int,*main.deepMap8>
+          Type: 288 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 275 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 279 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 289 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 293 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 282
+      ID: 296
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -7072,18 +7072,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 283 PointerType *bucket<int,*main.deepMap9>
+          Type: 297 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 283 PointerType *bucket<int,*main.deepMap9>
+          Type: 297 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 284 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 288 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 298 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 302 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 94
       Name: hash<int,int>
@@ -7119,7 +7119,7 @@ Types:
       BucketType: 96 GoHMapBucketType bucket<int,int>
       BucketsType: 192 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 291
+      ID: 305
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -7140,18 +7140,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 292 PointerType *bucket<int,interface {}>
+          Type: 306 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 292 PointerType *bucket<int,interface {}>
+          Type: 306 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 293 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 295 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 307 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 309 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 131
       Name: hash<int,uint8>
@@ -7511,9 +7511,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 243 GoMapType map[int]*main.deepMap3
+          Type: 255 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 250
+      ID: 262
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7525,9 +7525,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 271 GoMapType map[int]*main.deepMap8
+          Type: 285 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 278
+      ID: 292
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.09872e+06
@@ -7535,9 +7535,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 280 GoMapType map[int]*main.deepMap9
+          Type: 294 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 287
+      ID: 301
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.098592e+06
@@ -7545,7 +7545,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 289 GoMapType map[int]interface {}
+          Type: 303 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7579,9 +7579,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 252 PointerType *main.deepPtr8
+          Type: 266 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 253
+      ID: 267
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.099872e+06
@@ -7589,9 +7589,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 254 PointerType *main.deepPtr9
+          Type: 268 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 255
+      ID: 269
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.099744e+06
@@ -7619,9 +7619,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 237 GoSliceHeaderType []*main.deepSlice3
+          Type: 249 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 240
+      ID: 252
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7633,9 +7633,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 256 GoSliceHeaderType []*main.deepSlice8
+          Type: 270 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 259
+      ID: 273
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.101024e+06
@@ -7643,9 +7643,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 262 GoSliceHeaderType []*main.deepSlice9
+          Type: 276 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 265
+      ID: 279
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.100896e+06
@@ -7653,7 +7653,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 268 GoSliceHeaderType []interface {}
+          Type: 282 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 176
       Name: main.emptyStruct
@@ -7671,16 +7671,16 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 296 StructureType sync.Mutex
+          Type: 237 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 297 StructureType sync.Once
+          Type: 238 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 300 StructureType sync.WaitGroup
+          Type: 241 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 304 StructureType sync/atomic.Int32
+          Type: 245 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
@@ -7820,16 +7820,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 305 PointerType **main.t
+          Type: 246 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 306 GoSliceDataType main.t.array
+      Data: 247 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 306
+      ID: 247
       Name: main.t.array
       ByteSize: 2048
       Element: 159 PointerType *main.t
@@ -7889,26 +7889,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 243
+      ID: 255
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879584
       GoKind: 21
-      HeaderType: 245 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 257 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 271
+      ID: 285
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879104
       GoKind: 21
-      HeaderType: 273 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 287 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 280
+      ID: 294
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879008
       GoKind: 21
-      HeaderType: 282 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 296 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 92
       Name: map[int]int
@@ -7917,12 +7917,12 @@ Types:
       GoKind: 21
       HeaderType: 94 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 289
+      ID: 303
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 878912
       GoKind: 21
-      HeaderType: 291 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 305 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 129
       Name: map[int]uint8
@@ -7995,7 +7995,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 296
+      ID: 237
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.280768e+06
@@ -8008,7 +8008,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 297
+      ID: 238
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.281888e+06
@@ -8016,12 +8016,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 298 StructureType sync/atomic.Uint32
+          Type: 239 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 296 StructureType sync.Mutex
+          Type: 237 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 300
+      ID: 241
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.420736e+06
@@ -8029,21 +8029,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 301 StructureType sync.noCopy
+          Type: 242 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 302 StructureType sync/atomic.Uint64
+          Type: 243 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 301
+      ID: 242
       Name: sync.noCopy
       GoRuntimeType: 946528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 304
+      ID: 245
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282208e+06
@@ -8051,12 +8051,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 299 StructureType sync/atomic.noCopy
+          Type: 240 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 298
+      ID: 239
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.282368e+06
@@ -8064,12 +8064,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 299 StructureType sync/atomic.noCopy
+          Type: 240 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 302
+      ID: 243
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.42112e+06
@@ -8077,21 +8077,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 299 StructureType sync/atomic.noCopy
+          Type: 240 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 303 StructureType sync/atomic.align64
+          Type: 244 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 303
+      ID: 244
       Name: sync/atomic.align64
       GoRuntimeType: 946720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 299
+      ID: 240
       Name: sync/atomic.noCopy
       GoRuntimeType: 946624
       GoKind: 25

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 406 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x89015c", Frameless: true}]
+        - ID: 98
+          Type: 408 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x8901ac", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 362 EventRootType Probe[main.testAny]
+          Type: 363 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88db2c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 364 EventRootType Probe[main.testAnyPtr]
+          Type: 365 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88dbac", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 324 EventRootType Probe[main.testArrayOfArrays]
+          Type: 325 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 326 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 327 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -78,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 371 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x88e1b0", Frameless: true}]
+        - ID: 63
+          Type: 373 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x88e200", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 325 EventRootType Probe[main.testArrayOfStrings]
+          Type: 326 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 344 EventRootType Probe[main.testBigStruct]
+          Type: 345 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c890", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 313 EventRootType Probe[main.testBoolArray]
+          Type: 314 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 310 EventRootType Probe[main.testByteArray]
+          Type: 311 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c230", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 387 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x88f760", Frameless: true}]
+        - ID: 79
+          Type: 389 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x88f7b0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -162,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 385 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x88f4e0", Frameless: true}]
+        - ID: 77
+          Type: 387 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x88f530", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -176,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 395 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x88fa00", Frameless: true}]
+        - ID: 87
+          Type: 397 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x88fa50", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 349 EventRootType Probe[main.testDeepMap1]
+          Type: 350 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cc70", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 350 EventRootType Probe[main.testDeepMap7]
+          Type: 351 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88cc80", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 345 EventRootType Probe[main.testDeepPtr1]
+          Type: 346 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c960", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 346 EventRootType Probe[main.testDeepPtr7]
+          Type: 347 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c970", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 347 EventRootType Probe[main.testDeepSlice1]
+          Type: 348 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb10", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 348 EventRootType Probe[main.testDeepSlice7]
+          Type: 349 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb20", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -292,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 397 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x88fe00", Frameless: true}]
+        - ID: 89
+          Type: 399 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x88fe50", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -306,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 400 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x88fe30", Frameless: true}]
+        - ID: 92
+          Type: 402 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x88fe80", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -320,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 414 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x890240", Frameless: true}]
+        - ID: 106
+          Type: 416 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x890290", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 416 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x890550", Frameless: true}]
+        - ID: 108
+          Type: 418 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x8905a0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 417 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x890560", Frameless: true}]
+        - ID: 109
+          Type: 419 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x8905b0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 363 EventRootType Probe[main.testError]
+          Type: 364 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88db90", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 354 EventRootType Probe[main.testEsotericHeap]
+          Type: 355 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d12c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 353 EventRootType Probe[main.testEsotericStack]
+          Type: 354 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d03c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 359 EventRootType Probe[main.testFrameless]
+          Type: 360 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88d860", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 360 EventRootType Probe[main.testFramelessArray]
+          Type: 361 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88d870", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 355 EventRootType Probe[main.testInlinedBA]
+          Type: 356 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d56c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 356 EventRootType Probe[main.testInlinedBB]
+          Type: 357 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d5fc", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 357 EventRootType Probe[main.testInlinedBBA]
+          Type: 358 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d6cc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 419 EventRootType Probe[main.testInlinedBBB]
+        - ID: 111
+          Type: 421 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d658", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 358 EventRootType Probe[main.testInlinedBC]
+          Type: 359 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d74c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 420 EventRootType Probe[main.testInlinedBCA]
+        - ID: 112
+          Type: 422 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d75c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 421 EventRootType Probe[main.testInlinedBCB]
+        - ID: 113
+          Type: 423 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88d810", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 418 EventRootType Probe[main.testInlinedPrint]
+        - ID: 110
+          Type: 420 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d3cc"
               Frameless: true
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 422 EventRootType Probe[main.testInlinedSq]
+        - ID: 114
+          Type: 424 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88d864", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 114
-          Type: 423 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 115
+          Type: 425 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88d894"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 316 EventRootType Probe[main.testInt16Array]
+          Type: 317 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 317 EventRootType Probe[main.testInt32Array]
+          Type: 318 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 318 EventRootType Probe[main.testInt64Array]
+          Type: 319 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 315 EventRootType Probe[main.testInt8Array]
+          Type: 316 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 314 EventRootType Probe[main.testIntArray]
+          Type: 315 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 361 EventRootType Probe[main.testInterface]
+          Type: 362 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88db10", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -671,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 389 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x88f910", Frameless: true}]
+        - ID: 81
+          Type: 391 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x88f960", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -685,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 369 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x88e190", Frameless: true}]
+        - ID: 61
+          Type: 371 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x88e1e0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -699,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 375 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x88e1f0", Frameless: true}]
+        - ID: 67
+          Type: 377 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x88e240", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -713,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 373 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x88e1d0", Frameless: true}]
+        - ID: 65
+          Type: 375 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x88e220", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -727,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 384 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e280", Frameless: true}]
+        - ID: 76
+          Type: 386 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e2d0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -741,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 383 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x88e270", Frameless: true}]
+        - ID: 75
+          Type: 385 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x88e2c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -755,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 374 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88e1e0", Frameless: true}]
+        - ID: 66
+          Type: 376 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88e230", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -769,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 382 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e260", Frameless: true}]
+        - ID: 74
+          Type: 384 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e2b0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -783,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 381 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x88e250", Frameless: true}]
+        - ID: 73
+          Type: 383 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x88e2a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -797,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 367 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x88e170", Frameless: true}]
+        - ID: 59
+          Type: 369 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x88e1c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -811,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 368 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x88e180", Frameless: true}]
+        - ID: 60
+          Type: 370 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x88e1d0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -825,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 366 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x88e160", Frameless: true}]
+        - ID: 58
+          Type: 368 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x88e1b0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -839,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 376 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x88e200", Frameless: true}]
+        - ID: 68
+          Type: 378 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x88e250", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -853,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 379 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x88e230", Frameless: true}]
+        - ID: 71
+          Type: 381 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x88e280", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -867,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 380 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x88e240", Frameless: true}]
+        - ID: 72
+          Type: 382 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x88e290", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -881,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 377 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x88e210", Frameless: true}]
+        - ID: 69
+          Type: 379 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x88e260", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -895,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 378 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x88e220", Frameless: true}]
+        - ID: 70
+          Type: 380 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x88e270", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -909,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 412 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x890220", Frameless: true}]
+        - ID: 104
+          Type: 414 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x890270", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -923,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 386 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x88f5c0", Frameless: true}]
+        - ID: 78
+          Type: 388 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x88f610", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -937,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 394 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x88f9e0", Frameless: true}]
+        - ID: 86
+          Type: 396 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x88fa30", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -951,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 404 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x88fe70", Frameless: true}]
+        - ID: 96
+          Type: 406 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x88fec0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -965,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 401 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x88fe40", Frameless: true}]
+        - ID: 93
+          Type: 403 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x88fe90", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -979,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 403 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x88fe60", Frameless: true}]
+        - ID: 95
+          Type: 405 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x88feb0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -993,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 411 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x890210", Frameless: true}]
+        - ID: 103
+          Type: 413 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x890260", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1007,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 390 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x88f920", Frameless: true}]
+        - ID: 82
+          Type: 392 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x88f970", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1021,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 372 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x88e1c0", Frameless: true}]
+        - ID: 64
+          Type: 374 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x88e210", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1035,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 388 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x88f900", Frameless: true}]
+        - ID: 80
+          Type: 390 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x88f950", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 311 EventRootType Probe[main.testRuneArray]
+          Type: 312 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 330 EventRootType Probe[main.testSingleBool]
+          Type: 331 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 328 EventRootType Probe[main.testSingleByte]
+          Type: 329 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c690", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 341 EventRootType Probe[main.testSingleFloat32]
+          Type: 342 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 342 EventRootType Probe[main.testSingleFloat64]
+          Type: 343 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 331 EventRootType Probe[main.testSingleInt]
+          Type: 332 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 333 EventRootType Probe[main.testSingleInt16]
+          Type: 334 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 334 EventRootType Probe[main.testSingleInt32]
+          Type: 335 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 335 EventRootType Probe[main.testSingleInt64]
+          Type: 336 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 332 EventRootType Probe[main.testSingleInt8]
+          Type: 333 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 329 EventRootType Probe[main.testSingleRune]
+          Type: 330 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6a0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1203,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 407 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x8901c0", Frameless: true}]
+        - ID: 99
+          Type: 409 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x890210", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 336 EventRootType Probe[main.testSingleUint]
+          Type: 337 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 338 EventRootType Probe[main.testSingleUint16]
+          Type: 339 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 339 EventRootType Probe[main.testSingleUint32]
+          Type: 340 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 340 EventRootType Probe[main.testSingleUint64]
+          Type: 341 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 337 EventRootType Probe[main.testSingleUint8]
+          Type: 338 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1287,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 398 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x88fe10", Frameless: true}]
+        - ID: 90
+          Type: 400 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x88fe60", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1301,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 370 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x88e1a0", Frameless: true}]
+        - ID: 62
+          Type: 372 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x88e1f0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 312 EventRootType Probe[main.testStringArray]
+          Type: 313 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1329,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 393 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x88f9c0", Frameless: true}]
+        - ID: 85
+          Type: 395 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x88fa10", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1343,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 402 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x88fe50", Frameless: true}]
+        - ID: 94
+          Type: 404 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x88fea0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 351 EventRootType Probe[main.testStringType1]
+          Type: 352 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 352 EventRootType Probe[main.testStringType2]
+          Type: 353 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 415 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x890450", Frameless: true}]
+        - ID: 107
+          Type: 417 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x8904a0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1405,11 +1405,28 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 399 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x88fe20", Frameless: true}]
+        - ID: 91
+          Type: 401 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x88fe70", Frameless: true}]
+          Condition: null
+    - id: testStructWithAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithAny}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 56}
+      events:
+        - ID: 56
+          Type: 366 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x88dc10", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1419,11 +1436,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 365 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x88e150", Frameless: true}]
+        - ID: 57
+          Type: 367 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x88e1a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1433,11 +1450,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 408 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x8901d0", Frameless: true}]
+        - ID: 100
+          Type: 410 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x890220", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1447,11 +1464,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 409 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x8901e0", Frameless: true}]
+        - ID: 101
+          Type: 411 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x890230", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1461,11 +1478,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 410 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x890200", Frameless: true}]
+        - ID: 102
+          Type: 412 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x890250", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1478,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 343 EventRootType Probe[main.testTypeAlias]
+          Type: 344 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1492,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 321 EventRootType Probe[main.testUint16Array]
+          Type: 322 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1506,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 322 EventRootType Probe[main.testUint32Array]
+          Type: 323 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1520,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 323 EventRootType Probe[main.testUint64Array]
+          Type: 324 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1534,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 320 EventRootType Probe[main.testUint8Array]
+          Type: 321 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1548,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 319 EventRootType Probe[main.testUintArray]
+          Type: 320 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1559,11 +1576,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 392 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x88f950", Frameless: true}]
+        - ID: 84
+          Type: 394 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x88f9a0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1573,11 +1590,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 396 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x88fdf0", Frameless: true}]
+        - ID: 88
+          Type: 398 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x88fe40", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1587,11 +1604,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 413 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x890230", Frameless: true}]
+        - ID: 105
+          Type: 415 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x890280", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1601,11 +1618,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 391 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x88f930", Frameless: true}]
+        - ID: 83
+          Type: 393 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x88f980", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1618,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 327 EventRootType Probe[main.testVeryLargeArray]
+          Type: 328 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1629,11 +1646,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 405 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x88fe80", Frameless: true}]
+        - ID: 97
+          Type: 407 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x88fed0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2442,308 +2459,324 @@ Subprograms:
           IsParameter: true
           IsReturn: true
     - ID: 56
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88e150..0x88e160]
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0x88dc10..0x88dc20]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 91 StructureType main.structWithMap
+          Type: 91 StructureType main.structWithAny
           Locations:
-            - Range: 0x88e150..0x88e160
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88dc10..0x88dc20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88e160..0x88e170]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 97 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x88e160..0x88e170
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x88e170..0x88e180]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 102 GoMapType map[string]int
-          Locations:
-            - Range: 0x88e170..0x88e180
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x88e180..0x88e190]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 107 GoMapType map[string][]string
-          Locations:
-            - Range: 0x88e180..0x88e190
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x88e190..0x88e1a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 112 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x88e190..0x88e1a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testSmallMap
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0x88e1a0..0x88e1b0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 102 GoMapType map[string]int
+        - Name: s
+          Type: 92 StructureType main.structWithMap
           Locations:
             - Range: 0x88e1a0..0x88e1b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testArrayOfMaps
+    - ID: 58
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x88e1b0..0x88e1c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 117 ArrayType [2]map[string]int
+          Type: 98 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x88e1b0..0x88e1c0
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testPointerToMap
+    - ID: 59
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x88e1c0..0x88e1d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 PointerType *map[string]int
+          Type: 103 GoMapType map[string]int
           Locations:
             - Range: 0x88e1c0..0x88e1d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapIntToInt
+    - ID: 60
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x88e1d0..0x88e1e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 92 GoMapType map[int]int
+          Type: 108 GoMapType map[string][]string
           Locations:
             - Range: 0x88e1d0..0x88e1e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapMassive
+    - ID: 61
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x88e1e0..0x88e1f0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 119 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 113 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x88e1e0..0x88e1f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapEmbeddedMaps
+    - ID: 62
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0x88e1f0..0x88e200]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 119 GoMapType map[string][]main.structWithMap
+          Type: 103 GoMapType map[string]int
           Locations:
             - Range: 0x88e1f0..0x88e200
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithLinkedList
+    - ID: 63
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x88e200..0x88e210]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 124 GoMapType map[bool]main.node
+          Type: 118 ArrayType [2]map[string]int
           Locations:
             - Range: 0x88e200..0x88e210
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValue
+    - ID: 64
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0x88e210..0x88e220]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 129 GoMapType map[int]uint8
+          Type: 119 PointerType *map[string]int
           Locations:
             - Range: 0x88e210..0x88e220
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallValueMassive
+    - ID: 65
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x88e220..0x88e230]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 129 GoMapType map[int]uint8
+        - Name: m
+          Type: 93 GoMapType map[int]int
           Locations:
             - Range: 0x88e220..0x88e230
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 66
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x88e230..0x88e240]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 134 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88e230..0x88e240
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 67
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x88e240..0x88e250]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 134 GoMapType map[uint8]uint8
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88e240..0x88e250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeySmallValue
+    - ID: 68
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x88e250..0x88e260]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 134 GoMapType map[uint8]uint8
+          Type: 125 GoMapType map[bool]main.node
           Locations:
             - Range: 0x88e250..0x88e260
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 69
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x88e260..0x88e270]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 139 GoMapType map[uint8][4]int
+          Type: 130 GoMapType map[int]uint8
           Locations:
             - Range: 0x88e260..0x88e270
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeySmallValue
+    - ID: 70
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x88e270..0x88e280]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 144 GoMapType map[[4]int]uint8
+        - Name: redactMyEntries
+          Type: 130 GoMapType map[int]uint8
           Locations:
             - Range: 0x88e270..0x88e280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x88e280..0x88e290]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[[4]int][4]int
+          Type: 135 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88e280..0x88e290
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 72
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x88e290..0x88e2a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 135 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88e290..0x88e2a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x88e2a0..0x88e2b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 135 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88e2a0..0x88e2b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x88e2b0..0x88e2c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 140 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x88e2b0..0x88e2c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x88e2c0..0x88e2d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x88e2c0..0x88e2d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 76
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x88e2d0..0x88e2e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 150 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x88e2d0..0x88e2e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 77
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x88f4e0..0x88f4f0]
+      OutOfLinePCRanges: [0x88f530..0x88f540]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f4e0..0x88f4f0
+            - Range: 0x88f530..0x88f540
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f4e0..0x88f4f0
+            - Range: 0x88f530..0x88f540
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88f4e0..0x88f4f0
+            - Range: 0x88f530..0x88f540
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x88f5c0..0x88f5d0]
+      OutOfLinePCRanges: [0x88f610..0x88f620]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88f5c0..0x88f5d0
+            - Range: 0x88f610..0x88f620
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f5c0..0x88f5d0
+            - Range: 0x88f610..0x88f620
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88f5c0..0x88f5d0
+            - Range: 0x88f610..0x88f620
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88f5c0..0x88f5d0
+            - Range: 0x88f610..0x88f620
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f5c0..0x88f5d0
+            - Range: 0x88f610..0x88f620
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2751,39 +2784,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testChannel
-      OutOfLinePCRanges: [0x88f760..0x88f770]
+      OutOfLinePCRanges: [0x88f7b0..0x88f7c0]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 154 GoChannelType chan bool
+          Type: 155 GoChannelType chan bool
           Locations:
-            - Range: 0x88f760..0x88f770
+            - Range: 0x88f7b0..0x88f7c0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x88f900..0x88f910]
+      OutOfLinePCRanges: [0x88f950..0x88f960]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 PointerType *main.structWithTwoValues
+          Type: 156 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x88f900..0x88f910
+            - Range: 0x88f950..0x88f960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x88f910..0x88f920]
+      OutOfLinePCRanges: [0x88f960..0x88f970]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 157 StructureType main.node
+          Type: 158 StructureType main.node
           Locations:
-            - Range: 0x88f910..0x88f920
+            - Range: 0x88f960..0x88f970
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2791,112 +2824,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x88f920..0x88f930]
+      OutOfLinePCRanges: [0x88f970..0x88f980]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 158 PointerType *main.node
+          Type: 159 PointerType *main.node
           Locations:
-            - Range: 0x88f920..0x88f930
+            - Range: 0x88f970..0x88f980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x88f930..0x88f940]
+      OutOfLinePCRanges: [0x88f980..0x88f990]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x88f930..0x88f940
+            - Range: 0x88f980..0x88f990
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x88f950..0x88f960]
+      OutOfLinePCRanges: [0x88f9a0..0x88f9b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x88f950..0x88f960
+            - Range: 0x88f9a0..0x88f9b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x88f9c0..0x88f9d0]
+      OutOfLinePCRanges: [0x88fa10..0x88fa20]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x88f9c0..0x88f9d0
+            - Range: 0x88fa10..0x88fa20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x88f9e0..0x88f9f0]
+      OutOfLinePCRanges: [0x88fa30..0x88fa40]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x88f9e0..0x88f9f0
+            - Range: 0x88fa30..0x88fa40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88f9e0..0x88f9f0
+            - Range: 0x88fa30..0x88fa40
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testCycle
-      OutOfLinePCRanges: [0x88fa00..0x88fa10]
+      OutOfLinePCRanges: [0x88fa50..0x88fa60]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 159 PointerType *main.t
+          Type: 160 PointerType *main.t
           Locations:
-            - Range: 0x88fa00..0x88fa10
+            - Range: 0x88fa50..0x88fa60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x88fdf0..0x88fe00]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 161 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x88fdf0..0x88fe00
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 88
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x88fe00..0x88fe10]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x88fe40..0x88fe50]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 161 GoSliceHeaderType []uint
+          Type: 162 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88fe00..0x88fe10
+            - Range: 0x88fe40..0x88fe50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2907,105 +2922,12 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x88fe10..0x88fe20]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 162 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x88fe10..0x88fe20
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 90
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x88fe20..0x88fe30]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 164 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x88fe20..0x88fe30
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88fe20..0x88fe30
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 91
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x88fe30..0x88fe40]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 164 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x88fe30..0x88fe40
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88fe30..0x88fe40
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x88fe40..0x88fe50]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 164 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x88fe40..0x88fe50
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88fe40..0x88fe50
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 93
-      Name: main.testStringSlice
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x88fe50..0x88fe60]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 167 GoSliceHeaderType []string
+        - Name: u
+          Type: 162 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88fe50..0x88fe60
               Pieces:
@@ -3017,22 +2939,133 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSliceWithOtherParams
+    - ID: 90
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x88fe60..0x88fe70]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 163 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x88fe60..0x88fe70
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x88fe70..0x88fe80]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 165 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88fe70..0x88fe80
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88fe70..0x88fe80
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x88fe80..0x88fe90]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 165 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88fe80..0x88fe90
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88fe80..0x88fe90
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x88fe90..0x88fea0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 165 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88fe90..0x88fea0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88fe90..0x88fea0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x88fea0..0x88feb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 168 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x88fea0..0x88feb0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x88feb0..0x88fec0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x88fe60..0x88fe70
+            - Range: 0x88feb0..0x88fec0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 168 GoSliceHeaderType []bool
+          Type: 169 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x88fe60..0x88fe70
+            - Range: 0x88feb0..0x88fec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3045,37 +3078,19 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88fe60..0x88fe70
+            - Range: 0x88feb0..0x88fec0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 95
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x88fe70..0x88fe80]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 169 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x88fe70..0x88fe80
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 96
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x88fe80..0x88fe90]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x88fec0..0x88fed0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []uint
+          Type: 170 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x88fe80..0x88fe90
+            - Range: 0x88fec0..0x88fed0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3086,119 +3101,51 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 97
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x88fed0..0x88fee0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 162 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x88fed0..0x88fee0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0x890150..0x8901c0]
+      OutOfLinePCRanges: [0x8901a0..0x890210]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x890150..0x8901c0, Pieces: []}]
+          Locations: [{Range: 0x8901a0..0x890210, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0x8901c0..0x8901d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x8901c0..0x8901d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x8901d0..0x8901e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x8901d0..0x8901e0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: y
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x8901d0..0x8901e0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: z
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x8901d0..0x8901e0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x8901e0..0x890200]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 170 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0x8901e0..0x890200
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 101
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x890200..0x890210]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 171 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x890200..0x890210
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 102
-      Name: main.testOneStringInStructPointer
+      Name: main.testSingleString
       OutOfLinePCRanges: [0x890210..0x890220]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 172 PointerType *main.oneStringStruct
+        - Name: x
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x890210..0x890220
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
-      Name: main.testMassiveString
+    - ID: 100
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x890220..0x890230]
       InlinePCRanges: []
       Variables:
@@ -3213,15 +3160,85 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: y
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x890220..0x890230
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x890220..0x890230
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 101
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0x890230..0x890250]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 171 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0x890230..0x890250
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 102
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x890250..0x890260]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 172 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0x890250..0x890260
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x890260..0x890270]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 173 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0x890260..0x890270
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 104
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x890230..0x890240]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x890270..0x890280]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890230..0x890240
+            - Range: 0x890270..0x890280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3230,14 +3247,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x890240..0x890250]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x890280..0x890290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890240..0x890250
+            - Range: 0x890280..0x890290
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3246,14 +3263,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 106
-      Name: main.testStruct
-      OutOfLinePCRanges: [0x890450..0x890470]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x890290..0x8902a0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 174 StructureType main.aStruct
+          Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890450..0x890470
+            - Range: 0x890290..0x8902a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 107
+      Name: main.testStruct
+      OutOfLinePCRanges: [0x8904a0..0x8904c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 175 StructureType main.aStruct
+          Locations:
+            - Range: 0x8904a0..0x8904c0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3271,29 +3304,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x890550..0x890560]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 176 StructureType main.emptyStruct
-          Locations: [{Range: 0x890550..0x890560, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 108
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x890560..0x890570]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0x8905a0..0x8905b0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 177 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0x890560..0x890570
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 177 StructureType main.emptyStruct
+          Locations: [{Range: 0x8905a0..0x8905b0, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 109
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0x8905b0..0x8905c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 178 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0x8905b0..0x8905c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 110
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88d3c0..0x88d430]
       InlinePCRanges:
@@ -3323,28 +3356,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d658..0x88d690]
           RootRanges: [0x88d5f0..0x88d6c0]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d75c..0x88d7a0]
           RootRanges: [0x88d740..0x88d860]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d810..0x88d848]
           RootRanges: [0x88d740..0x88d860]
       Variables: []
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3358,7 +3391,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 115
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3383,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 250
+      ID: 251
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 251 PointerType *main.deepSlice3
+      Pointee: 252 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 271
+      ID: 272
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 272 PointerType *main.deepSlice8
+      Pointee: 273 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 277
+      ID: 278
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 278 PointerType *main.deepSlice9
+      Pointee: 279 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3404,458 +3437,458 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 246
+      ID: 247
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 159 PointerType *main.t
+      Pointee: 160 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 490336
+      GoRuntimeType: 490432
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 184
+      ID: 185
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 184 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 254
+      ID: 255
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 254 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 275
+      ID: 276
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 275 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 281
+      ID: 282
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 281 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*string.array
+      Pointee: 181 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 223
+      ID: 224
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType [][]uint.array
+      Pointee: 223 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 229
+      ID: 230
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 228 GoSliceDataType []bool.array
+      Pointee: 229 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 284
+      ID: 285
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType []interface {}.array
+      Pointee: 284 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 265
+      ID: 266
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []main.structWithMap.array
+      Pointee: 265 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 225
+      ID: 226
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 225 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 227
+      ID: 228
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []string.array
+      Pointee: 227 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 163
+      ID: 164
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 161 GoSliceHeaderType []uint
+      Pointee: 162 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 221
+      ID: 222
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType []uint.array
+      Pointee: 221 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 231
+      ID: 232
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType []uint16.array
+      Pointee: 231 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 363456
+      GoRuntimeType: 363552
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 152
+      ID: 153
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 153 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 154 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 147
+      ID: 148
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 148 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 149 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 115
+      ID: 116
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 117 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 127
+      ID: 128
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 128 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 129 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '*bucket<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 258
+      ID: 259
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 259 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 260 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 288
+      ID: 289
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 289 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 290 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 297
+      ID: 298
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 298 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 299 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 95
+      ID: 96
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 96 GoHMapBucketType bucket<int,int>
+      Pointee: 97 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 306
+      ID: 307
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 307 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 308 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
-      ID: 132
+      ID: 133
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 133 GoHMapBucketType bucket<int,uint8>
+      Pointee: 134 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 122
+      ID: 123
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 110
+      ID: 111
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 111 GoHMapBucketType bucket<string,[]string>
+      Pointee: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 105
+      ID: 106
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 106 GoHMapBucketType bucket<string,int>
+      Pointee: 107 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 100
+      ID: 101
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 101 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 102 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 142
+      ID: 143
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 143 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 144 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 137
+      ID: 138
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 138 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 362368
+      GoRuntimeType: 362464
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 363328
+      GoRuntimeType: 363424
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 363392
+      GoRuntimeType: 363488
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 151 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 152 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 146 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 147 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 114 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 115 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 126 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 127 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*hash<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 256
+      ID: 257
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 257 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 258 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 286
+      ID: 287
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 287 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 288 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 295
+      ID: 296
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 296 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 297 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 94 GoHMapHeaderType hash<int,int>
+      Pointee: 95 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 305 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 306 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 131 GoHMapHeaderType hash<int,uint8>
+      Pointee: 132 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 121 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 109 GoHMapHeaderType hash<string,[]string>
+      Pointee: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 104 GoHMapHeaderType hash<string,int>
+      Pointee: 105 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 99 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 141 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 142 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 136 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
       ID: 28
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 363008
+      GoRuntimeType: 363104
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 362624
+      GoRuntimeType: 362720
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 362752
+      GoRuntimeType: 362848
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 362880
+      GoRuntimeType: 362976
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 362496
+      GoRuntimeType: 362592
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
       ID: 90
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 363584
+      GoRuntimeType: 363680
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 188
+      ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 356096
+      GoRuntimeType: 356192
       GoKind: 22
-      Pointee: 189 StructureType main.deepMap2
+      Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 261
+      ID: 262
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 356032
+      GoRuntimeType: 356128
       GoKind: 22
-      Pointee: 262 UnresolvedPointeeType main.deepMap3
+      Pointee: 263 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 355776
+      GoRuntimeType: 355872
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 291
+      ID: 292
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 355712
+      GoRuntimeType: 355808
       GoKind: 22
-      Pointee: 292 StructureType main.deepMap8
+      Pointee: 293 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 300
+      ID: 301
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 355648
+      GoRuntimeType: 355744
       GoKind: 22
-      Pointee: 301 StructureType main.deepMap9
+      Pointee: 302 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 356672
+      GoRuntimeType: 356768
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 232
+      ID: 233
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 356608
+      GoRuntimeType: 356704
       GoKind: 22
-      Pointee: 233 UnresolvedPointeeType main.deepPtr3
+      Pointee: 234 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 356352
+      GoRuntimeType: 356448
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 266
+      ID: 267
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 356288
+      GoRuntimeType: 356384
       GoKind: 22
-      Pointee: 267 StructureType main.deepPtr8
+      Pointee: 268 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 268
+      ID: 269
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 356224
+      GoRuntimeType: 356320
       GoKind: 22
-      Pointee: 269 StructureType main.deepPtr9
+      Pointee: 270 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 357248
+      GoRuntimeType: 357344
       GoKind: 22
-      Pointee: 182 StructureType main.deepSlice2
+      Pointee: 183 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 251
+      ID: 252
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 357184
+      GoRuntimeType: 357280
       GoKind: 22
-      Pointee: 252 UnresolvedPointeeType main.deepSlice3
+      Pointee: 253 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 356928
+      GoRuntimeType: 357024
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 272
+      ID: 273
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 356864
+      GoRuntimeType: 356960
       GoKind: 22
-      Pointee: 273 StructureType main.deepSlice8
+      Pointee: 274 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 278
+      ID: 279
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 356800
+      GoRuntimeType: 356896
       GoKind: 22
-      Pointee: 279 StructureType main.deepSlice9
+      Pointee: 280 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 177
+      ID: 178
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 176 StructureType main.emptyStruct
+      Pointee: 177 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 86
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 357376
+      GoRuntimeType: 357472
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 158
+      ID: 159
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 357440
+      GoRuntimeType: 357536
       GoKind: 22
-      Pointee: 157 StructureType main.node
+      Pointee: 158 StructureType main.node
     - __kind: PointerType
-      ID: 172
+      ID: 173
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 173 StructureType main.oneStringStruct
+      Pointee: 174 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
@@ -3863,123 +3896,123 @@ Types:
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 235
+      ID: 236
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 234 GoStringDataType main.stringType1.str
+      Pointee: 235 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 236 UnresolvedPointeeType main.stringType2
+      Pointee: 237 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 205
+      ID: 206
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 355584
+      GoRuntimeType: 355680
       GoKind: 22
-      Pointee: 91 StructureType main.structWithMap
+      Pointee: 92 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 165
+      ID: 166
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 166 StructureType main.structWithNoStrings
+      Pointee: 167 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 155
+      ID: 156
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 156 StructureType main.structWithTwoValues
+      Pointee: 157 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 159
+      ID: 160
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 160 GoSliceHeaderType main.t
+      Pointee: 161 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 248
+      ID: 249
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType main.t.array
+      Pointee: 248 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 171
+      ID: 172
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 170 StructureType main.threeStringStruct
+      Pointee: 171 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 102 GoMapType map[string]int
+      Pointee: 103 GoMapType map[string]int
     - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 366336
+      GoRuntimeType: 366432
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 362432
+      GoRuntimeType: 362528
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 179
+      ID: 180
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 178 GoStringDataType string.str
+      Pointee: 179 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 363072
+      GoRuntimeType: 363168
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 362688
+      GoRuntimeType: 362784
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 362816
+      GoRuntimeType: 362912
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 29
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 362944
+      GoRuntimeType: 363040
       GoKind: 22
       Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 362560
+      GoRuntimeType: 362656
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 363136
+      GoRuntimeType: 363232
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 406
+      ID: 408
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 364
+      ID: 365
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3994,7 +4027,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 363
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4009,7 +4042,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
+      ID: 327
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4024,7 +4057,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 324
+      ID: 325
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4039,7 +4072,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 371
+      ID: 373
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4047,14 +4080,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 117 ArrayType [2]map[string]int
+            Type: 118 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 326
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4069,7 +4102,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 344
+      ID: 345
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4084,7 +4117,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 313
+      ID: 314
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4099,7 +4132,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 310
+      ID: 311
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4114,7 +4147,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 387
+      ID: 389
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4122,14 +4155,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 154 GoChannelType chan bool
+            Type: 155 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: c}
+                  Variable: {subprogram: 79, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 385
+      ID: 387
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4140,7 +4173,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: w}
+                  Variable: {subprogram: 77, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4149,7 +4182,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: x}
+                  Variable: {subprogram: 77, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4158,11 +4191,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: y}
+                  Variable: {subprogram: 77, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 395
+      ID: 397
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4170,14 +4203,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 159 PointerType *main.t
+            Type: 160 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: t}
+                  Variable: {subprogram: 87, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 349
+      ID: 350
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4192,7 +4225,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 351
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4207,7 +4240,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 346
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4222,7 +4255,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 347
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4237,7 +4270,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 348
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4252,7 +4285,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 348
+      ID: 349
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4267,7 +4300,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 400
+      ID: 402
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4275,10 +4308,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []main.structWithNoStrings
+            Type: 165 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4287,11 +4320,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 397
+      ID: 399
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4299,14 +4332,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []uint
+            Type: 162 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 414
+      ID: 416
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4317,11 +4350,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 417
+      ID: 419
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4329,14 +4362,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 177 PointerType *main.emptyStruct
+            Type: 178 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 109, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 416
+      ID: 418
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4344,14 +4377,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 176 StructureType main.emptyStruct
+            Type: 177 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 363
+      ID: 364
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4366,7 +4399,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 355
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4381,7 +4414,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 354
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4396,7 +4429,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 360
+      ID: 361
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4411,7 +4444,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 359
+      ID: 360
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4426,7 +4459,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 355
+      ID: 356
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4441,7 +4474,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 357
+      ID: 358
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4456,10 +4489,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 419
+      ID: 421
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 356
+      ID: 357
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4483,16 +4516,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 420
+      ID: 422
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 421
+      ID: 423
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 358
+      ID: 359
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 418
+      ID: 420
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4503,11 +4536,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 424
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4518,11 +4551,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: x}
+                  Variable: {subprogram: 114, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 423
+      ID: 425
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4533,11 +4566,11 @@ Types:
             Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: a}
+                  Variable: {subprogram: 115, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 316
+      ID: 317
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4552,7 +4585,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 317
+      ID: 318
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4567,7 +4600,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 318
+      ID: 319
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4582,7 +4615,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 316
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4597,7 +4630,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 314
+      ID: 315
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4612,7 +4645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 361
+      ID: 362
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4627,7 +4660,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 389
+      ID: 391
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4635,14 +4668,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 157 StructureType main.node
+            Type: 158 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 369
+      ID: 371
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4650,14 +4683,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 112 GoMapType map[[4]string][2]int
+            Type: 113 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 377
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4665,14 +4698,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 119 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 373
+      ID: 375
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4680,14 +4713,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 92 GoMapType map[int]int
+            Type: 93 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 384
+      ID: 386
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4695,14 +4728,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 149 GoMapType map[[4]int][4]int
+            Type: 150 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 383
+      ID: 385
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4710,14 +4743,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 144 GoMapType map[[4]int]uint8
+            Type: 145 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 376
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4725,14 +4758,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 119 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 384
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4740,14 +4773,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 139 GoMapType map[uint8][4]int
+            Type: 140 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 383
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4755,14 +4788,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 GoMapType map[uint8]uint8
+            Type: 135 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 369
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4770,14 +4803,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 102 GoMapType map[string]int
+            Type: 103 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 368
+      ID: 370
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4785,14 +4818,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 107 GoMapType map[string][]string
+            Type: 108 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 368
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4800,14 +4833,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 97 GoMapType map[string]main.nestedStruct
+            Type: 98 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 376
+      ID: 378
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4815,14 +4848,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 124 GoMapType map[bool]main.node
+            Type: 125 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 382
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4830,14 +4863,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 GoMapType map[uint8]uint8
+            Type: 135 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 379
+      ID: 381
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4845,14 +4878,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 GoMapType map[uint8]uint8
+            Type: 135 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 380
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4860,14 +4893,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 129 GoMapType map[int]uint8
+            Type: 130 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 377
+      ID: 379
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4875,14 +4908,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 129 GoMapType map[int]uint8
+            Type: 130 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 412
+      ID: 414
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4893,11 +4926,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 386
+      ID: 388
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4908,7 +4941,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4917,7 +4950,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: b}
+                  Variable: {subprogram: 78, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4926,7 +4959,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: c}
+                  Variable: {subprogram: 78, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4935,7 +4968,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 3, name: d}
+                  Variable: {subprogram: 78, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4944,11 +4977,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 4, name: e}
+                  Variable: {subprogram: 78, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 394
+      ID: 396
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4959,7 +4992,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4968,11 +5001,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: a}
+                  Variable: {subprogram: 86, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 401
+      ID: 403
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4980,10 +5013,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []main.structWithNoStrings
+            Type: 165 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4992,11 +5025,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 403
+      ID: 405
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5007,16 +5040,16 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: a}
+                  Variable: {subprogram: 95, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 168 GoSliceHeaderType []bool
+            Type: 169 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: s}
+                  Variable: {subprogram: 95, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5025,11 +5058,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 2, name: x}
+                  Variable: {subprogram: 95, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 404
+      ID: 406
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5037,14 +5070,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 169 GoSliceHeaderType []uint16
+            Type: 170 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 411
+      ID: 413
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5052,14 +5085,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 172 PointerType *main.oneStringStruct
+            Type: 173 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: a}
+                  Variable: {subprogram: 103, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 390
+      ID: 392
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5067,14 +5100,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 158 PointerType *main.node
+            Type: 159 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 374
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5082,14 +5115,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 PointerType *map[string]int
+            Type: 119 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 388
+      ID: 390
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5097,14 +5130,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 PointerType *main.structWithTwoValues
+            Type: 156 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 312
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5119,7 +5152,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 331
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5134,7 +5167,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 328
+      ID: 329
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5149,7 +5182,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 341
+      ID: 342
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5164,7 +5197,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 342
+      ID: 343
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5179,7 +5212,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 334
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5194,7 +5227,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 334
+      ID: 335
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5209,7 +5242,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 335
+      ID: 336
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5224,7 +5257,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 333
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5239,7 +5272,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 331
+      ID: 332
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5254,7 +5287,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 330
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5269,7 +5302,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 407
+      ID: 409
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5280,11 +5313,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 338
+      ID: 339
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5299,7 +5332,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 339
+      ID: 340
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5314,7 +5347,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 340
+      ID: 341
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5329,7 +5362,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 338
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5344,7 +5377,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 336
+      ID: 337
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5359,7 +5392,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 398
+      ID: 400
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5367,14 +5400,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType [][]uint
+            Type: 163 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: u}
+                  Variable: {subprogram: 90, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 370
+      ID: 372
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5382,14 +5415,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 102 GoMapType map[string]int
+            Type: 103 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 313
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5404,7 +5437,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 393
+      ID: 395
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5415,11 +5448,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 402
+      ID: 404
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5427,14 +5460,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 167 GoSliceHeaderType []string
+            Type: 168 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: s}
+                  Variable: {subprogram: 94, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 351
+      ID: 352
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5449,7 +5482,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 353
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5464,7 +5497,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 399
+      ID: 401
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5472,10 +5505,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []main.structWithNoStrings
+            Type: 165 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5484,11 +5517,26 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 366
+      Name: Probe[main.testStructWithAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 91 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 367
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5496,14 +5544,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 91 StructureType main.structWithMap
+            Type: 92 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 415
+      ID: 417
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5511,14 +5559,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 174 StructureType main.aStruct
+            Type: 175 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 410
+      ID: 412
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5526,14 +5574,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 171 PointerType *main.threeStringStruct
+            Type: 172 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 409
+      ID: 411
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5541,14 +5589,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 StructureType main.threeStringStruct
+            Type: 171 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 408
+      ID: 410
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5559,7 +5607,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5568,7 +5616,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: y}
+                  Variable: {subprogram: 100, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5577,11 +5625,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: z}
+                  Variable: {subprogram: 100, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 343
+      ID: 344
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5596,7 +5644,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 321
+      ID: 322
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5611,7 +5659,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 322
+      ID: 323
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5626,7 +5674,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 324
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5641,7 +5689,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 321
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5656,7 +5704,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 319
+      ID: 320
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5671,7 +5719,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 392
+      ID: 394
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5682,11 +5730,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 396
+      ID: 398
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5694,14 +5742,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []uint
+            Type: 162 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 413
+      ID: 415
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5712,11 +5760,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 391
+      ID: 393
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5727,11 +5775,11 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 328
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5746,7 +5794,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 405
+      ID: 407
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5754,10 +5802,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []uint
+            Type: 162 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: xs}
+                  Variable: {subprogram: 97, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5796,7 +5844,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 622880
+      GoRuntimeType: 622976
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5813,7 +5861,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 624032
+      GoRuntimeType: 624128
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5835,18 +5883,18 @@ Types:
       HasCount: true
       Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 117
+      ID: 118
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 102 GoMapType map[string]int
+      Element: 103 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 624128
+      GoRuntimeType: 624224
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5879,7 +5927,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 624224
+      GoRuntimeType: 624320
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5888,25 +5936,25 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 623936
+      GoRuntimeType: 624032
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 215
+      ID: 216
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 622496
+      GoRuntimeType: 622592
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 200
+      ID: 201
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 622784
+      GoRuntimeType: 622880
       GoKind: 17
       Count: 4
       HasCount: true
@@ -5920,10 +5968,10 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 185
+      ID: 186
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 619808
+      GoRuntimeType: 619904
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5932,7 +5980,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 446784
+      GoRuntimeType: 446880
       GoKind: 23
       RawFields:
         - Name: array
@@ -5944,83 +5992,83 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 183 GoSliceDataType []*main.deepSlice2.array
+      Data: 184 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 184
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 249
+      ID: 250
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 446720
+      GoRuntimeType: 446816
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 250 PointerType **main.deepSlice3
+          Type: 251 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 253 GoSliceDataType []*main.deepSlice3.array
+      Data: 254 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 254
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 251 PointerType *main.deepSlice3
+      Element: 252 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 270
+      ID: 271
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 446400
+      GoRuntimeType: 446496
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 271 PointerType **main.deepSlice8
+          Type: 272 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 274 GoSliceDataType []*main.deepSlice8.array
+      Data: 275 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 275
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 272 PointerType *main.deepSlice8
+      Element: 273 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 276
+      ID: 277
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 446336
+      GoRuntimeType: 446432
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 277 PointerType **main.deepSlice9
+          Type: 278 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 280 GoSliceDataType []*main.deepSlice9.array
+      Data: 281 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 281
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 278 PointerType *main.deepSlice9
+      Element: 279 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 447552
+      GoRuntimeType: 447648
       GoKind: 23
       RawFields:
         - Name: array
@@ -6032,38 +6080,38 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 180 GoSliceDataType []*string.array
+      Data: 181 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 181
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 163
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *[]uint
+          Type: 164 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 222 GoSliceDataType [][]uint.array
+      Data: 223 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 223
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 161 GoSliceHeaderType []uint
+      Element: 162 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 169
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 454080
+      GoRuntimeType: 454176
       GoKind: 23
       RawFields:
         - Name: array
@@ -6075,102 +6123,102 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 228 GoSliceDataType []bool.array
+      Data: 229 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 229
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 220
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 153 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 154 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 219
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 148 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 149 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 203
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 117 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 210
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 128 GoHMapBucketType bucket<bool,main.node>
+      Element: 129 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]bucket<int,*main.deepMap2>.array'
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 264
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 259 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 260 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 294
       Name: '[]bucket<int,*main.deepMap8>.array'
       ByteSize: 2048
-      Element: 289 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 290 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 303
       Name: '[]bucket<int,*main.deepMap9>.array'
       ByteSize: 2048
-      Element: 298 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 299 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 193
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 96 GoHMapBucketType bucket<int,int>
+      Element: 97 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 309
+      ID: 310
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
-      Element: 307 GoHMapBucketType bucket<int,interface {}>
+      Element: 308 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 212
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 133 GoHMapBucketType bucket<int,uint8>
+      Element: 134 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 207
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 199
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 111 GoHMapBucketType bucket<string,[]string>
+      Element: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 197
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 106 GoHMapBucketType bucket<string,int>
+      Element: 107 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 196
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 101 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 102 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 217
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 143 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 144 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 214
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 138 GoHMapBucketType bucket<uint8,uint8>
+      Element: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 282
+      ID: 283
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 454400
+      GoRuntimeType: 454496
       GoKind: 23
       RawFields:
         - Name: array
@@ -6182,102 +6230,102 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 283 GoSliceDataType []interface {}.array
+      Data: 284 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 217
+      ID: 218
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 215 ArrayType [4]int
+      Element: 216 ArrayType [4]int
     - __kind: ArrayType
-      ID: 199
+      ID: 200
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 200 ArrayType [4]string
+      Element: 201 ArrayType [4]string
     - __kind: ArrayType
-      ID: 207
+      ID: 208
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 186
+      ID: 187
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 193
+      ID: 194
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 212
+      ID: 213
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 204
+      ID: 205
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 447040
+      GoRuntimeType: 447136
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *main.structWithMap
+          Type: 206 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 264 GoSliceDataType []main.structWithMap.array
+      Data: 265 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 265
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 91 StructureType main.structWithMap
+      Element: 92 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 165
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *main.structWithNoStrings
+          Type: 166 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 224 GoSliceDataType []main.structWithNoStrings.array
+      Data: 225 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 225
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 166 StructureType main.structWithNoStrings
+      Element: 167 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 168
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 454208
+      GoRuntimeType: 454304
       GoKind: 23
       RawFields:
         - Name: array
@@ -6289,17 +6337,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 226 GoSliceDataType []string.array
+      Data: 227 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 227
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 162
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 453696
+      GoRuntimeType: 453792
       GoKind: 23
       RawFields:
         - Name: array
@@ -6311,17 +6359,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 220 GoSliceDataType []uint.array
+      Data: 221 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 221
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 12 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 170
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 453056
+      GoRuntimeType: 453152
       GoKind: 23
       RawFields:
         - Name: array
@@ -6333,98 +6381,98 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 230 GoSliceDataType []uint16.array
+      Data: 231 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 231
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 187
+      ID: 188
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 188 PointerType *main.deepMap2
+      Element: 189 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 260
+      ID: 261
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 261 PointerType *main.deepMap3
+      Element: 262 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 290
+      ID: 291
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 291 PointerType *main.deepMap8
+      Element: 292 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 299
+      ID: 300
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 300 PointerType *main.deepMap9
+      Element: 301 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 201
+      ID: 202
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 214
+      ID: 215
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 215 ArrayType [4]int
+      Element: 216 ArrayType [4]int
     - __kind: ArrayType
-      ID: 203
+      ID: 204
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 204 GoSliceHeaderType []main.structWithMap
+      Element: 205 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 197
+      ID: 198
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 167 GoSliceHeaderType []string
+      Element: 168 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 191
+      ID: 192
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 308
+      ID: 309
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 194
+      ID: 195
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 175 StructureType main.nestedStruct
+      Element: 176 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 208
+      ID: 209
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 157 StructureType main.node
+      Element: 158 StructureType main.node
     - __kind: ArrayType
-      ID: 210
+      ID: 211
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -6434,84 +6482,84 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 532256
+      GoRuntimeType: 532352
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 153
+      ID: 154
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 217 ArrayType []key<[4]int>
+          Type: 218 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 214 ArrayType []val<[4]int>
+          Type: 215 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 152 PointerType *bucket<[4]int,[4]int>
-      KeyType: 215 ArrayType [4]int
-      ValueType: 215 ArrayType [4]int
+          Type: 153 PointerType *bucket<[4]int,[4]int>
+      KeyType: 216 ArrayType [4]int
+      ValueType: 216 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 148
+      ID: 149
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 217 ArrayType []key<[4]int>
+          Type: 218 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 210 ArrayType []val<uint8>
+          Type: 211 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 147 PointerType *bucket<[4]int,uint8>
-      KeyType: 215 ArrayType [4]int
+          Type: 148 PointerType *bucket<[4]int,uint8>
+      KeyType: 216 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 116
+      ID: 117
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 199 ArrayType []key<[4]string>
+          Type: 200 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 201 ArrayType []val<[2]int>
+          Type: 202 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 115 PointerType *bucket<[4]string,[2]int>
-      KeyType: 200 ArrayType [4]string
+          Type: 116 PointerType *bucket<[4]string,[2]int>
+      KeyType: 201 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 128
+      ID: 129
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 207 ArrayType []key<bool>
+          Type: 208 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 208 ArrayType []val<main.node>
+          Type: 209 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 127 PointerType *bucket<bool,main.node>
+          Type: 128 PointerType *bucket<bool,main.node>
       KeyType: 4 BaseType bool
-      ValueType: 157 StructureType main.node
+      ValueType: 158 StructureType main.node
     - __kind: GoHMapBucketType
       ID: 72
       Name: bucket<int,*main.deepMap2>
@@ -6519,273 +6567,273 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 187 ArrayType []val<*main.deepMap2>
+          Type: 188 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 71 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 188 PointerType *main.deepMap2
+      ValueType: 189 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 259
+      ID: 260
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 260 ArrayType []val<*main.deepMap3>
+          Type: 261 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 258 PointerType *bucket<int,*main.deepMap3>
+          Type: 259 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 261 PointerType *main.deepMap3
+      ValueType: 262 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 289
+      ID: 290
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 290 ArrayType []val<*main.deepMap8>
+          Type: 291 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 288 PointerType *bucket<int,*main.deepMap8>
+          Type: 289 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 291 PointerType *main.deepMap8
+      ValueType: 292 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 298
+      ID: 299
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 299 ArrayType []val<*main.deepMap9>
+          Type: 300 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 297 PointerType *bucket<int,*main.deepMap9>
+          Type: 298 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 300 PointerType *main.deepMap9
+      ValueType: 301 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
-      ID: 96
+      ID: 97
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 191 ArrayType []val<int>
+          Type: 192 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 95 PointerType *bucket<int,int>
+          Type: 96 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 307
+      ID: 308
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 308 ArrayType []val<interface {}>
+          Type: 309 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 306 PointerType *bucket<int,interface {}>
+          Type: 307 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 133
+      ID: 134
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<int>
+          Type: 187 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 210 ArrayType []val<uint8>
+          Type: 211 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 132 PointerType *bucket<int,uint8>
+          Type: 133 PointerType *bucket<int,uint8>
       KeyType: 9 BaseType int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 123
+      ID: 124
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 193 ArrayType []key<string>
+          Type: 194 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 203 ArrayType []val<[]main.structWithMap>
+          Type: 204 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 122 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 204 GoSliceHeaderType []main.structWithMap
+      ValueType: 205 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 111
+      ID: 112
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 193 ArrayType []key<string>
+          Type: 194 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 197 ArrayType []val<[]string>
+          Type: 198 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 110 PointerType *bucket<string,[]string>
+          Type: 111 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 167 GoSliceHeaderType []string
+      ValueType: 168 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 106
+      ID: 107
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 193 ArrayType []key<string>
+          Type: 194 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 191 ArrayType []val<int>
+          Type: 192 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 105 PointerType *bucket<string,int>
+          Type: 106 PointerType *bucket<string,int>
       KeyType: 11 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 101
+      ID: 102
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 193 ArrayType []key<string>
+          Type: 194 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 194 ArrayType []val<main.nestedStruct>
+          Type: 195 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 100 PointerType *bucket<string,main.nestedStruct>
+          Type: 101 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 175 StructureType main.nestedStruct
+      ValueType: 176 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 143
+      ID: 144
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 212 ArrayType []key<uint8>
+          Type: 213 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 214 ArrayType []val<[4]int>
+          Type: 215 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 142 PointerType *bucket<uint8,[4]int>
+          Type: 143 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 215 ArrayType [4]int
+      ValueType: 216 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 138
+      ID: 139
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 186 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 212 ArrayType []key<uint8>
+          Type: 213 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 210 ArrayType []val<uint8>
+          Type: 211 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 137 PointerType *bucket<uint8,uint8>
+          Type: 138 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 154
+      ID: 155
       Name: chan bool
-      GoRuntimeType: 543520
+      GoRuntimeType: 543616
       GoKind: 18
     - __kind: GoChannelType
       ID: 82
       Name: chan struct {}
-      GoRuntimeType: 542432
+      GoRuntimeType: 542528
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 532064
+      GoRuntimeType: 532160
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 532000
+      GoRuntimeType: 532096
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 983872
+      GoRuntimeType: 983968
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6798,22 +6846,22 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 532128
+      GoRuntimeType: 532224
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 532192
+      GoRuntimeType: 532288
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 85
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 445120
+      GoRuntimeType: 445216
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 151
+      ID: 152
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -6834,20 +6882,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 152 PointerType *bucket<[4]int,[4]int>
+          Type: 153 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 152 PointerType *bucket<[4]int,[4]int>
+          Type: 153 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 153 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 219 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketType: 154 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 220 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 146
+      ID: 147
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -6868,20 +6916,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 147 PointerType *bucket<[4]int,uint8>
+          Type: 148 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 147 PointerType *bucket<[4]int,uint8>
+          Type: 148 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 148 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 218 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketType: 149 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 219 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 114
+      ID: 115
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -6902,20 +6950,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 115 PointerType *bucket<[4]string,[2]int>
+          Type: 116 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 115 PointerType *bucket<[4]string,[2]int>
+          Type: 116 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 116 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 202 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketType: 117 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 203 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 126
+      ID: 127
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -6936,18 +6984,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 127 PointerType *bucket<bool,main.node>
+          Type: 128 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 127 PointerType *bucket<bool,main.node>
+          Type: 128 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 128 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 209 GoSliceDataType []bucket<bool,main.node>.array
+      BucketType: 129 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 210 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 70
       Name: hash<int,*main.deepMap2>
@@ -6981,9 +7029,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 190 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 191 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 257
+      ID: 258
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -7004,20 +7052,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 258 PointerType *bucket<int,*main.deepMap3>
+          Type: 259 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 258 PointerType *bucket<int,*main.deepMap3>
+          Type: 259 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 259 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 263 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 260 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 264 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 287
+      ID: 288
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -7038,20 +7086,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 288 PointerType *bucket<int,*main.deepMap8>
+          Type: 289 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 288 PointerType *bucket<int,*main.deepMap8>
+          Type: 289 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 289 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 293 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 290 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 294 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 296
+      ID: 297
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -7072,20 +7120,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 297 PointerType *bucket<int,*main.deepMap9>
+          Type: 298 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 297 PointerType *bucket<int,*main.deepMap9>
+          Type: 298 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 298 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 302 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 299 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 303 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
-      ID: 94
+      ID: 95
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -7106,20 +7154,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 95 PointerType *bucket<int,int>
+          Type: 96 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 95 PointerType *bucket<int,int>
+          Type: 96 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 96 GoHMapBucketType bucket<int,int>
-      BucketsType: 192 GoSliceDataType []bucket<int,int>.array
+      BucketType: 97 GoHMapBucketType bucket<int,int>
+      BucketsType: 193 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 305
+      ID: 306
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -7140,20 +7188,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 306 PointerType *bucket<int,interface {}>
+          Type: 307 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 306 PointerType *bucket<int,interface {}>
+          Type: 307 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 307 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 309 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 308 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 310 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 131
+      ID: 132
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -7174,20 +7222,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 132 PointerType *bucket<int,uint8>
+          Type: 133 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 132 PointerType *bucket<int,uint8>
+          Type: 133 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 133 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 211 GoSliceDataType []bucket<int,uint8>.array
+      BucketType: 134 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 212 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 121
+      ID: 122
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -7208,20 +7256,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 122 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 122 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 206 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketType: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 207 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 109
+      ID: 110
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -7242,20 +7290,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 110 PointerType *bucket<string,[]string>
+          Type: 111 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 110 PointerType *bucket<string,[]string>
+          Type: 111 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 111 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 198 GoSliceDataType []bucket<string,[]string>.array
+      BucketType: 112 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 199 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 104
+      ID: 105
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -7276,20 +7324,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 105 PointerType *bucket<string,int>
+          Type: 106 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 105 PointerType *bucket<string,int>
+          Type: 106 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 106 GoHMapBucketType bucket<string,int>
-      BucketsType: 196 GoSliceDataType []bucket<string,int>.array
+      BucketType: 107 GoHMapBucketType bucket<string,int>
+      BucketsType: 197 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 99
+      ID: 100
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -7310,20 +7358,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 100 PointerType *bucket<string,main.nestedStruct>
+          Type: 101 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 100 PointerType *bucket<string,main.nestedStruct>
+          Type: 101 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 101 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 195 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketType: 102 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 196 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 141
+      ID: 142
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -7344,20 +7392,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 142 PointerType *bucket<uint8,[4]int>
+          Type: 143 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 142 PointerType *bucket<uint8,[4]int>
+          Type: 143 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 143 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 216 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketType: 144 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 217 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 136
+      ID: 137
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -7378,53 +7426,53 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 137 PointerType *bucket<uint8,uint8>
+          Type: 138 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 137 PointerType *bucket<uint8,uint8>
+          Type: 138 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 138 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 213 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketType: 139 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 214 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 531808
+      GoRuntimeType: 531904
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 531424
+      GoRuntimeType: 531520
       GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 531552
+      GoRuntimeType: 531648
       GoKind: 5
     - __kind: BaseType
       ID: 14
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 531680
+      GoRuntimeType: 531776
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 531296
+      GoRuntimeType: 531392
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 83
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 777440
+      GoRuntimeType: 777536
       GoKind: 20
       RawFields:
         - Name: _type
@@ -7437,7 +7485,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 979776
+      GoRuntimeType: 979872
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7447,7 +7495,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 174
+      ID: 175
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -7463,12 +7511,12 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 175 StructureType main.nestedStruct
+          Type: 176 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 89
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 979392
+      GoRuntimeType: 979488
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7496,61 +7544,61 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.099616e+06
+      GoRuntimeType: 1.09984e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 189
+      ID: 190
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.099488e+06
+      GoRuntimeType: 1.099712e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 255 GoMapType map[int]*main.deepMap3
+          Type: 256 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 262
+      ID: 263
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
       ID: 76
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.098848e+06
+      GoRuntimeType: 1.099072e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 285 GoMapType map[int]*main.deepMap8
+          Type: 286 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 292
+      ID: 293
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.09872e+06
+      GoRuntimeType: 1.098944e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 294 GoMapType map[int]*main.deepMap9
+          Type: 295 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 301
+      ID: 302
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.098592e+06
+      GoRuntimeType: 1.098816e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 303 GoMapType map[int]interface {}
+          Type: 304 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.100768e+06
+      GoRuntimeType: 1.100992e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7560,41 +7608,41 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.10064e+06
+      GoRuntimeType: 1.100864e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 232 PointerType *main.deepPtr3
+          Type: 233 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 233
+      ID: 234
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.1e+06
+      GoRuntimeType: 1.100224e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 266 PointerType *main.deepPtr8
+          Type: 267 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 267
+      ID: 268
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.099872e+06
+      GoRuntimeType: 1.100096e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 268 PointerType *main.deepPtr9
+          Type: 269 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 269
+      ID: 270
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.099744e+06
+      GoRuntimeType: 1.099968e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7604,58 +7652,58 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.10192e+06
+      GoRuntimeType: 1.102144e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 182
+      ID: 183
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.101792e+06
+      GoRuntimeType: 1.102016e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 249 GoSliceHeaderType []*main.deepSlice3
+          Type: 250 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 252
+      ID: 253
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.101152e+06
+      GoRuntimeType: 1.101376e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 270 GoSliceHeaderType []*main.deepSlice8
+          Type: 271 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 273
+      ID: 274
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.101024e+06
+      GoRuntimeType: 1.101248e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 276 GoSliceHeaderType []*main.deepSlice9
+          Type: 277 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 279
+      ID: 280
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.100896e+06
+      GoRuntimeType: 1.10112e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 282 GoSliceHeaderType []interface {}
+          Type: 283 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 176
+      ID: 177
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7663,7 +7711,7 @@ Types:
       ID: 87
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.703968e+06
+      GoRuntimeType: 1.704192e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7671,21 +7719,21 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 237 StructureType sync.Mutex
+          Type: 238 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 238 StructureType sync.Once
+          Type: 239 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 241 StructureType sync.WaitGroup
+          Type: 242 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 245 StructureType sync/atomic.Int32
+          Type: 246 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.830432e+06
+      GoRuntimeType: 1.830656e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7710,10 +7758,10 @@ Types:
           Offset: 56
           Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 175
+      ID: 176
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.279488e+06
+      GoRuntimeType: 1.279712e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7723,10 +7771,10 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 157
+      ID: 158
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.279328e+06
+      GoRuntimeType: 1.279552e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7734,9 +7782,9 @@ Types:
           Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 158 PointerType *main.node
+          Type: 159 PointerType *main.node
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7748,7 +7796,7 @@ Types:
       ID: 84
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 979520
+      GoRuntimeType: 979616
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7765,31 +7813,41 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 235 PointerType *main.stringType1.str
+          Type: 236 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 234 GoStringDataType main.stringType1.str
+      Data: 235 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 234
+      ID: 235
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 236
+      ID: 237
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
       ID: 91
+      Name: main.structWithAny
+      ByteSize: 16
+      GoRuntimeType: 1.09856e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 83 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 92
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.098464e+06
+      GoRuntimeType: 1.098688e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 92 GoMapType map[int]int
+          Type: 93 GoMapType map[int]int
     - __kind: StructureType
-      ID: 166
+      ID: 167
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7801,7 +7859,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 156
+      ID: 157
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7813,28 +7871,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 161
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 246 PointerType **main.t
+          Type: 247 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType main.t.array
+      Data: 248 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 248
       Name: main.t.array
       ByteSize: 2048
-      Element: 159 PointerType *main.t
+      Element: 160 PointerType *main.t
     - __kind: StructureType
-      ID: 170
+      ID: 171
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7854,124 +7912,124 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 149
+      ID: 150
       Name: map[[4]int][4]int
-      ByteSize: 8
-      GoRuntimeType: 879776
-      GoKind: 21
-      HeaderType: 151 GoHMapHeaderType hash<[4]int,[4]int>
-    - __kind: GoMapType
-      ID: 144
-      Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 879872
       GoKind: 21
-      HeaderType: 146 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 152 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 112
-      Name: map[[4]string][2]int
+      ID: 145
+      Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 879968
       GoKind: 21
-      HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 147 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 124
-      Name: map[bool]main.node
+      ID: 113
+      Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 880064
       GoKind: 21
-      HeaderType: 126 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 115 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: GoMapType
+      ID: 125
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 880160
+      GoKind: 21
+      HeaderType: 127 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 879680
+      GoRuntimeType: 879776
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 255
+      ID: 256
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 879584
+      GoRuntimeType: 879680
       GoKind: 21
-      HeaderType: 257 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 258 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 285
+      ID: 286
       Name: map[int]*main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 879200
+      GoKind: 21
+      HeaderType: 288 GoHMapHeaderType hash<int,*main.deepMap8>
+    - __kind: GoMapType
+      ID: 295
+      Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879104
       GoKind: 21
-      HeaderType: 287 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 297 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 294
-      Name: map[int]*main.deepMap9
+      ID: 93
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 878048
+      GoKind: 21
+      HeaderType: 95 GoHMapHeaderType hash<int,int>
+    - __kind: GoMapType
+      ID: 304
+      Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879008
       GoKind: 21
-      HeaderType: 296 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 306 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
-      ID: 92
-      Name: map[int]int
-      ByteSize: 8
-      GoRuntimeType: 877952
-      GoKind: 21
-      HeaderType: 94 GoHMapHeaderType hash<int,int>
-    - __kind: GoMapType
-      ID: 303
-      Name: map[int]interface {}
-      ByteSize: 8
-      GoRuntimeType: 878912
-      GoKind: 21
-      HeaderType: 305 GoHMapHeaderType hash<int,interface {}>
-    - __kind: GoMapType
-      ID: 129
+      ID: 130
       Name: map[int]uint8
-      ByteSize: 8
-      GoRuntimeType: 880160
-      GoKind: 21
-      HeaderType: 131 GoHMapHeaderType hash<int,uint8>
-    - __kind: GoMapType
-      ID: 119
-      Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 880256
       GoKind: 21
-      HeaderType: 121 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 132 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 107
-      Name: map[string][]string
+      ID: 120
+      Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 880352
       GoKind: 21
-      HeaderType: 109 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 102
-      Name: map[string]int
+      ID: 108
+      Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 880448
       GoKind: 21
-      HeaderType: 104 GoHMapHeaderType hash<string,int>
+      HeaderType: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 97
-      Name: map[string]main.nestedStruct
+      ID: 103
+      Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 880544
       GoKind: 21
-      HeaderType: 99 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 105 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 139
-      Name: map[uint8][4]int
+      ID: 98
+      Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 880640
       GoKind: 21
-      HeaderType: 141 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 134
-      Name: map[uint8]uint8
+      ID: 140
+      Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 880736
       GoKind: 21
-      HeaderType: 136 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 142 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: GoMapType
+      ID: 135
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 880832
+      GoKind: 21
+      HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: UnresolvedPointeeType
       ID: 74
       Name: runtime.mapextra
@@ -7980,25 +8038,25 @@ Types:
       ID: 11
       Name: string
       ByteSize: 16
-      GoRuntimeType: 531232
+      GoRuntimeType: 531328
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 179 PointerType *string.str
+          Type: 180 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 178 GoStringDataType string.str
+      Data: 179 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 178
+      ID: 179
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 237
+      ID: 238
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.280768e+06
+      GoRuntimeType: 1.280992e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -8008,136 +8066,136 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 238
+      ID: 239
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.281888e+06
+      GoRuntimeType: 1.282112e+06
       GoKind: 25
       RawFields:
         - Name: done
           Offset: 0
-          Type: 239 StructureType sync/atomic.Uint32
+          Type: 240 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 237 StructureType sync.Mutex
+          Type: 238 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 241
+      ID: 242
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.420736e+06
+      GoRuntimeType: 1.42096e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 242 StructureType sync.noCopy
+          Type: 243 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 243 StructureType sync/atomic.Uint64
+          Type: 244 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 242
+      ID: 243
       Name: sync.noCopy
-      GoRuntimeType: 946528
+      GoRuntimeType: 946624
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 245
+      ID: 246
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.282208e+06
+      GoRuntimeType: 1.282432e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 240 StructureType sync/atomic.noCopy
+          Type: 241 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 239
+      ID: 240
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.282368e+06
+      GoRuntimeType: 1.282592e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 240 StructureType sync/atomic.noCopy
+          Type: 241 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 243
+      ID: 244
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.42112e+06
+      GoRuntimeType: 1.421344e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 240 StructureType sync/atomic.noCopy
+          Type: 241 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 244 StructureType sync/atomic.align64
+          Type: 245 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 244
+      ID: 245
       Name: sync/atomic.align64
-      GoRuntimeType: 946720
+      GoRuntimeType: 946816
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 240
+      ID: 241
       Name: sync/atomic.noCopy
-      GoRuntimeType: 946624
+      GoRuntimeType: 946720
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 12
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 531872
+      GoRuntimeType: 531968
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 531488
+      GoRuntimeType: 531584
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 531616
+      GoRuntimeType: 531712
       GoKind: 10
     - __kind: BaseType
       ID: 10
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 531744
+      GoRuntimeType: 531840
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 531360
+      GoRuntimeType: 531456
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 531936
+      GoRuntimeType: 532032
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 532320
+      GoRuntimeType: 532416
       GoKind: 26
-MaxTypeID: 423
+MaxTypeID: 425
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -3445,7 +3445,7 @@ Types:
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 490432
+      GoRuntimeType: 490592
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
@@ -3522,7 +3522,7 @@ Types:
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 363552
+      GoRuntimeType: 363712
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -3614,21 +3614,21 @@ Types:
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 362464
+      GoRuntimeType: 362624
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 363424
+      GoRuntimeType: 363584
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 363488
+      GoRuntimeType: 363648
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
@@ -3720,147 +3720,147 @@ Types:
       ID: 28
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 363104
+      GoRuntimeType: 363264
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 362720
+      GoRuntimeType: 362880
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 362848
+      GoRuntimeType: 363008
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 362976
+      GoRuntimeType: 363136
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 362592
+      GoRuntimeType: 362752
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
       ID: 90
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 363680
+      GoRuntimeType: 363840
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 356192
+      GoRuntimeType: 356352
       GoKind: 22
       Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
       ID: 262
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 356128
+      GoRuntimeType: 356288
       GoKind: 22
       Pointee: 263 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 355872
+      GoRuntimeType: 356032
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
       ID: 292
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 355808
+      GoRuntimeType: 355968
       GoKind: 22
       Pointee: 293 StructureType main.deepMap8
     - __kind: PointerType
       ID: 301
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 355744
+      GoRuntimeType: 355904
       GoKind: 22
       Pointee: 302 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 356768
+      GoRuntimeType: 356928
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 233
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 356704
+      GoRuntimeType: 356864
       GoKind: 22
       Pointee: 234 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 356448
+      GoRuntimeType: 356608
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 267
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 356384
+      GoRuntimeType: 356544
       GoKind: 22
       Pointee: 268 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 269
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 356320
+      GoRuntimeType: 356480
       GoKind: 22
       Pointee: 270 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 357344
+      GoRuntimeType: 357504
       GoKind: 22
       Pointee: 183 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 252
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 357280
+      GoRuntimeType: 357440
       GoKind: 22
       Pointee: 253 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 357024
+      GoRuntimeType: 357184
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 273
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 356960
+      GoRuntimeType: 357120
       GoKind: 22
       Pointee: 274 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 279
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 356896
+      GoRuntimeType: 357056
       GoKind: 22
       Pointee: 280 StructureType main.deepSlice9
     - __kind: PointerType
@@ -3873,14 +3873,14 @@ Types:
       ID: 86
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 357472
+      GoRuntimeType: 357632
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 159
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 357536
+      GoRuntimeType: 357696
       GoKind: 22
       Pointee: 158 StructureType main.node
     - __kind: PointerType
@@ -3910,7 +3910,7 @@ Types:
       ID: 206
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 355680
+      GoRuntimeType: 355840
       GoKind: 22
       Pointee: 92 StructureType main.structWithMap
     - __kind: PointerType
@@ -3951,14 +3951,14 @@ Types:
       ID: 73
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 366432
+      GoRuntimeType: 366592
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 362528
+      GoRuntimeType: 362688
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
@@ -3970,42 +3970,42 @@ Types:
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 363168
+      GoRuntimeType: 363328
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 362784
+      GoRuntimeType: 362944
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 362912
+      GoRuntimeType: 363072
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 29
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 363040
+      GoRuntimeType: 363200
       GoKind: 22
       Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 362656
+      GoRuntimeType: 362816
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 363232
+      GoRuntimeType: 363392
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -5844,7 +5844,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 622976
+      GoRuntimeType: 623136
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5861,7 +5861,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 624128
+      GoRuntimeType: 624288
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5894,7 +5894,7 @@ Types:
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 624224
+      GoRuntimeType: 624384
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5927,7 +5927,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 624320
+      GoRuntimeType: 624480
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5936,7 +5936,7 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 624032
+      GoRuntimeType: 624192
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5945,7 +5945,7 @@ Types:
       ID: 216
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 622592
+      GoRuntimeType: 622752
       GoKind: 17
       Count: 4
       HasCount: true
@@ -5954,7 +5954,7 @@ Types:
       ID: 201
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 622880
+      GoRuntimeType: 623040
       GoKind: 17
       Count: 4
       HasCount: true
@@ -5971,7 +5971,7 @@ Types:
       ID: 186
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 619904
+      GoRuntimeType: 620064
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5980,7 +5980,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 446880
+      GoRuntimeType: 447040
       GoKind: 23
       RawFields:
         - Name: array
@@ -6002,7 +6002,7 @@ Types:
       ID: 250
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 446816
+      GoRuntimeType: 446976
       GoKind: 23
       RawFields:
         - Name: array
@@ -6024,7 +6024,7 @@ Types:
       ID: 271
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 446496
+      GoRuntimeType: 446656
       GoKind: 23
       RawFields:
         - Name: array
@@ -6046,7 +6046,7 @@ Types:
       ID: 277
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 446432
+      GoRuntimeType: 446592
       GoKind: 23
       RawFields:
         - Name: array
@@ -6068,7 +6068,7 @@ Types:
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 447648
+      GoRuntimeType: 447808
       GoKind: 23
       RawFields:
         - Name: array
@@ -6111,7 +6111,7 @@ Types:
       ID: 169
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 454176
+      GoRuntimeType: 454336
       GoKind: 23
       RawFields:
         - Name: array
@@ -6218,7 +6218,7 @@ Types:
       ID: 283
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 454496
+      GoRuntimeType: 454656
       GoKind: 23
       RawFields:
         - Name: array
@@ -6282,7 +6282,7 @@ Types:
       ID: 205
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 447136
+      GoRuntimeType: 447296
       GoKind: 23
       RawFields:
         - Name: array
@@ -6325,7 +6325,7 @@ Types:
       ID: 168
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 454304
+      GoRuntimeType: 454464
       GoKind: 23
       RawFields:
         - Name: array
@@ -6347,7 +6347,7 @@ Types:
       ID: 162
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 453792
+      GoRuntimeType: 453952
       GoKind: 23
       RawFields:
         - Name: array
@@ -6369,7 +6369,7 @@ Types:
       ID: 170
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 453152
+      GoRuntimeType: 453312
       GoKind: 23
       RawFields:
         - Name: array
@@ -6482,7 +6482,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 532352
+      GoRuntimeType: 532512
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 154
@@ -6810,30 +6810,30 @@ Types:
     - __kind: GoChannelType
       ID: 155
       Name: chan bool
-      GoRuntimeType: 543616
+      GoRuntimeType: 543776
       GoKind: 18
     - __kind: GoChannelType
       ID: 82
       Name: chan struct {}
-      GoRuntimeType: 542528
+      GoRuntimeType: 542688
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 532160
+      GoRuntimeType: 532320
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 532096
+      GoRuntimeType: 532256
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 983968
+      GoRuntimeType: 984128
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6846,19 +6846,19 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 532224
+      GoRuntimeType: 532384
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 532288
+      GoRuntimeType: 532448
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 85
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 445216
+      GoRuntimeType: 445376
       GoKind: 19
     - __kind: GoHMapHeaderType
       ID: 152
@@ -7442,37 +7442,37 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 531904
+      GoRuntimeType: 532064
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 531520
+      GoRuntimeType: 531680
       GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 531648
+      GoRuntimeType: 531808
       GoKind: 5
     - __kind: BaseType
       ID: 14
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 531776
+      GoRuntimeType: 531936
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 531392
+      GoRuntimeType: 531552
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 83
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 777536
+      GoRuntimeType: 777696
       GoKind: 20
       RawFields:
         - Name: _type
@@ -7485,7 +7485,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 979872
+      GoRuntimeType: 980032
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7516,7 +7516,7 @@ Types:
       ID: 89
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 979488
+      GoRuntimeType: 979648
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7544,7 +7544,7 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.09984e+06
+      GoRuntimeType: 1.100256e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7554,7 +7554,7 @@ Types:
       ID: 190
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.099712e+06
+      GoRuntimeType: 1.100128e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7568,7 +7568,7 @@ Types:
       ID: 76
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.099072e+06
+      GoRuntimeType: 1.099488e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7578,7 +7578,7 @@ Types:
       ID: 293
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.098944e+06
+      GoRuntimeType: 1.09936e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7588,7 +7588,7 @@ Types:
       ID: 302
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.098816e+06
+      GoRuntimeType: 1.099232e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7598,7 +7598,7 @@ Types:
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.100992e+06
+      GoRuntimeType: 1.101408e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7608,7 +7608,7 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.100864e+06
+      GoRuntimeType: 1.10128e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7622,7 +7622,7 @@ Types:
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.100224e+06
+      GoRuntimeType: 1.10064e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7632,7 +7632,7 @@ Types:
       ID: 268
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.100096e+06
+      GoRuntimeType: 1.100512e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7642,7 +7642,7 @@ Types:
       ID: 270
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.099968e+06
+      GoRuntimeType: 1.100384e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7652,7 +7652,7 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.102144e+06
+      GoRuntimeType: 1.10256e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7662,7 +7662,7 @@ Types:
       ID: 183
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.102016e+06
+      GoRuntimeType: 1.102432e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7676,7 +7676,7 @@ Types:
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.101376e+06
+      GoRuntimeType: 1.101792e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7686,7 +7686,7 @@ Types:
       ID: 274
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.101248e+06
+      GoRuntimeType: 1.101664e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7696,7 +7696,7 @@ Types:
       ID: 280
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.10112e+06
+      GoRuntimeType: 1.101536e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7711,7 +7711,7 @@ Types:
       ID: 87
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.704192e+06
+      GoRuntimeType: 1.704608e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7733,7 +7733,7 @@ Types:
       ID: 81
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.830656e+06
+      GoRuntimeType: 1.831072e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7761,7 +7761,7 @@ Types:
       ID: 176
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.279712e+06
+      GoRuntimeType: 1.280128e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7774,7 +7774,7 @@ Types:
       ID: 158
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.279552e+06
+      GoRuntimeType: 1.279968e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7796,7 +7796,7 @@ Types:
       ID: 84
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 979616
+      GoRuntimeType: 979776
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7830,7 +7830,7 @@ Types:
       ID: 91
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.09856e+06
+      GoRuntimeType: 1.098976e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7840,7 +7840,7 @@ Types:
       ID: 92
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.098688e+06
+      GoRuntimeType: 1.099104e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -7915,119 +7915,119 @@ Types:
       ID: 150
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 879872
+      GoRuntimeType: 880032
       GoKind: 21
       HeaderType: 152 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
       ID: 145
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 879968
+      GoRuntimeType: 880128
       GoKind: 21
       HeaderType: 147 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
       ID: 113
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 880064
+      GoRuntimeType: 880224
       GoKind: 21
       HeaderType: 115 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
       ID: 125
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 880160
+      GoRuntimeType: 880320
       GoKind: 21
       HeaderType: 127 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 879776
+      GoRuntimeType: 879936
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 256
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 879680
+      GoRuntimeType: 879840
       GoKind: 21
       HeaderType: 258 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 286
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 879200
+      GoRuntimeType: 879360
       GoKind: 21
       HeaderType: 288 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 295
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 879104
+      GoRuntimeType: 879264
       GoKind: 21
       HeaderType: 297 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 93
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 878048
+      GoRuntimeType: 878208
       GoKind: 21
       HeaderType: 95 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
       ID: 304
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 879008
+      GoRuntimeType: 879168
       GoKind: 21
       HeaderType: 306 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 130
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 880256
+      GoRuntimeType: 880416
       GoKind: 21
       HeaderType: 132 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
       ID: 120
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 880352
+      GoRuntimeType: 880512
       GoKind: 21
       HeaderType: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 108
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 880448
+      GoRuntimeType: 880608
       GoKind: 21
       HeaderType: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
       ID: 103
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 880544
+      GoRuntimeType: 880704
       GoKind: 21
       HeaderType: 105 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 98
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 880640
+      GoRuntimeType: 880800
       GoKind: 21
       HeaderType: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 140
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 880736
+      GoRuntimeType: 880896
       GoKind: 21
       HeaderType: 142 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
       ID: 135
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 880832
+      GoRuntimeType: 880992
       GoKind: 21
       HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: UnresolvedPointeeType
@@ -8038,7 +8038,7 @@ Types:
       ID: 11
       Name: string
       ByteSize: 16
-      GoRuntimeType: 531328
+      GoRuntimeType: 531488
       GoKind: 24
       RawFields:
         - Name: str
@@ -8056,7 +8056,7 @@ Types:
       ID: 238
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.280992e+06
+      GoRuntimeType: 1.281408e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -8069,7 +8069,7 @@ Types:
       ID: 239
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.282112e+06
+      GoRuntimeType: 1.282528e+06
       GoKind: 25
       RawFields:
         - Name: done
@@ -8082,7 +8082,7 @@ Types:
       ID: 242
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.42096e+06
+      GoRuntimeType: 1.421376e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -8097,14 +8097,14 @@ Types:
     - __kind: StructureType
       ID: 243
       Name: sync.noCopy
-      GoRuntimeType: 946624
+      GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 246
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.282432e+06
+      GoRuntimeType: 1.282848e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8117,7 +8117,7 @@ Types:
       ID: 240
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.282592e+06
+      GoRuntimeType: 1.283008e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8130,7 +8130,7 @@ Types:
       ID: 244
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.421344e+06
+      GoRuntimeType: 1.42176e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8145,56 +8145,56 @@ Types:
     - __kind: StructureType
       ID: 245
       Name: sync/atomic.align64
-      GoRuntimeType: 946816
+      GoRuntimeType: 946976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 241
       Name: sync/atomic.noCopy
-      GoRuntimeType: 946720
+      GoRuntimeType: 946880
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 12
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 531968
+      GoRuntimeType: 532128
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 531584
+      GoRuntimeType: 531744
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 531712
+      GoRuntimeType: 531872
       GoKind: 10
     - __kind: BaseType
       ID: 10
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 531840
+      GoRuntimeType: 532000
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 531456
+      GoRuntimeType: 531616
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 532032
+      GoRuntimeType: 532192
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 532416
+      GoRuntimeType: 532576
       GoKind: 26
 MaxTypeID: 425
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 405 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x89000c", Frameless: true}]
+        - ID: 97
+          Type: 406 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x89015c", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -26,7 +26,21 @@ Probes:
       events:
         - ID: 53
           Type: 362 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x88db7c", Frameless: true}]
+          InjectionPoints: [{PC: "0x88db2c", Frameless: true}]
+          Condition: null
+    - id: testAnyPtr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAnyPtr}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 55}
+      events:
+        - ID: 55
+          Type: 364 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x88dbac", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -64,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 370 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x88e060", Frameless: true}]
+        - ID: 62
+          Type: 371 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x88e1b0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 386 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x88f610", Frameless: true}]
+        - ID: 78
+          Type: 387 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x88f760", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 384 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x88f390", Frameless: true}]
+        - ID: 76
+          Type: 385 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x88f4e0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 394 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x88f8b0", Frameless: true}]
+        - ID: 86
+          Type: 395 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x88fa00", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -278,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 396 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x88fcb0", Frameless: true}]
+        - ID: 88
+          Type: 397 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x88fe00", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 399 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x88fce0", Frameless: true}]
+        - ID: 91
+          Type: 400 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x88fe30", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -306,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 413 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x8900f0", Frameless: true}]
+        - ID: 105
+          Type: 414 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x890240", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -320,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 415 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x890400", Frameless: true}]
+        - ID: 107
+          Type: 416 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x890550", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -333,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 416 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x890410", Frameless: true}]
+        - ID: 108
+          Type: 417 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x890560", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -351,7 +365,7 @@ Probes:
       events:
         - ID: 54
           Type: 363 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x88dbe0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88db90", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -459,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 418 EventRootType Probe[main.testInlinedBBB]
+        - ID: 110
+          Type: 419 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d658", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -487,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 419 EventRootType Probe[main.testInlinedBCA]
+        - ID: 111
+          Type: 420 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d75c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -501,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 420 EventRootType Probe[main.testInlinedBCB]
+        - ID: 112
+          Type: 421 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88d810", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -516,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 417 EventRootType Probe[main.testInlinedPrint]
+        - ID: 109
+          Type: 418 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d3cc"
               Frameless: true
@@ -540,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 421 EventRootType Probe[main.testInlinedSq]
+        - ID: 113
+          Type: 422 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88d864", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -555,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 422 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 114
+          Type: 423 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88d894"
               Frameless: false
@@ -647,7 +661,7 @@ Probes:
       events:
         - ID: 52
           Type: 361 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x88db1c", Frameless: true}]
+          InjectionPoints: [{PC: "0x88db10", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -657,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 388 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x88f7c0", Frameless: true}]
+        - ID: 80
+          Type: 389 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x88f910", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -671,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 368 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x88e040", Frameless: true}]
+        - ID: 60
+          Type: 369 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x88e190", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -685,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 374 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x88e0a0", Frameless: true}]
+        - ID: 66
+          Type: 375 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x88e1f0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -699,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 372 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x88e080", Frameless: true}]
+        - ID: 64
+          Type: 373 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x88e1d0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -713,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 383 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e130", Frameless: true}]
+        - ID: 75
+          Type: 384 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e280", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -727,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 382 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x88e120", Frameless: true}]
+        - ID: 74
+          Type: 383 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x88e270", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -741,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 373 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88e090", Frameless: true}]
+        - ID: 65
+          Type: 374 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88e1e0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -755,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 381 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e110", Frameless: true}]
+        - ID: 73
+          Type: 382 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e260", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -769,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 380 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x88e100", Frameless: true}]
+        - ID: 72
+          Type: 381 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x88e250", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -783,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 366 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x88e020", Frameless: true}]
+        - ID: 58
+          Type: 367 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x88e170", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -797,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 367 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x88e030", Frameless: true}]
+        - ID: 59
+          Type: 368 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x88e180", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -811,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 365 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x88e010", Frameless: true}]
+        - ID: 57
+          Type: 366 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x88e160", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -825,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 375 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x88e0b0", Frameless: true}]
+        - ID: 67
+          Type: 376 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x88e200", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -839,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 378 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x88e0e0", Frameless: true}]
+        - ID: 70
+          Type: 379 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x88e230", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -853,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 379 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x88e0f0", Frameless: true}]
+        - ID: 71
+          Type: 380 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x88e240", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -867,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 376 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x88e0c0", Frameless: true}]
+        - ID: 68
+          Type: 377 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x88e210", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -881,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 377 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x88e0d0", Frameless: true}]
+        - ID: 69
+          Type: 378 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x88e220", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -895,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 411 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x8900d0", Frameless: true}]
+        - ID: 103
+          Type: 412 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x890220", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -909,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 385 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x88f470", Frameless: true}]
+        - ID: 77
+          Type: 386 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x88f5c0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -923,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 393 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x88f890", Frameless: true}]
+        - ID: 85
+          Type: 394 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x88f9e0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -937,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 403 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
+        - ID: 95
+          Type: 404 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x88fe70", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -951,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 400 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x88fcf0", Frameless: true}]
+        - ID: 92
+          Type: 401 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x88fe40", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -965,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 402 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x88fd10", Frameless: true}]
+        - ID: 94
+          Type: 403 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x88fe60", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -979,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 410 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x8900c0", Frameless: true}]
+        - ID: 102
+          Type: 411 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x890210", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -993,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 389 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x88f7d0", Frameless: true}]
+        - ID: 81
+          Type: 390 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x88f920", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1007,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 371 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x88e070", Frameless: true}]
+        - ID: 63
+          Type: 372 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x88e1c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1021,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 387 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x88f7b0", Frameless: true}]
+        - ID: 79
+          Type: 388 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x88f900", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1189,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 406 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x890070", Frameless: true}]
+        - ID: 98
+          Type: 407 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x8901c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1273,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 397 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x88fcc0", Frameless: true}]
+        - ID: 89
+          Type: 398 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x88fe10", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1287,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 369 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x88e050", Frameless: true}]
+        - ID: 61
+          Type: 370 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x88e1a0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1315,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 392 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x88f870", Frameless: true}]
+        - ID: 84
+          Type: 393 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x88f9c0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1329,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 401 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x88fd00", Frameless: true}]
+        - ID: 93
+          Type: 402 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x88fe50", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1377,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 414 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x890300", Frameless: true}]
+        - ID: 106
+          Type: 415 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x890450", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1391,11 +1405,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 398 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x88fcd0", Frameless: true}]
+        - ID: 90
+          Type: 399 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x88fe20", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1405,11 +1419,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 55
-          Type: 364 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x88e000", Frameless: true}]
+        - ID: 56
+          Type: 365 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x88e150", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1419,11 +1433,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 407 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x890080", Frameless: true}]
+        - ID: 99
+          Type: 408 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x8901d0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1433,11 +1447,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 408 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x890090", Frameless: true}]
+        - ID: 100
+          Type: 409 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x8901e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1447,11 +1461,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 409 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x8900b0", Frameless: true}]
+        - ID: 101
+          Type: 410 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x890200", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1545,11 +1559,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 391 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x88f800", Frameless: true}]
+        - ID: 83
+          Type: 392 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x88f950", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1559,11 +1573,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 395 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x88fca0", Frameless: true}]
+        - ID: 87
+          Type: 396 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x88fdf0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1573,11 +1587,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 412 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x8900e0", Frameless: true}]
+        - ID: 104
+          Type: 413 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x890230", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1587,11 +1601,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 390 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x88f7e0", Frameless: true}]
+        - ID: 82
+          Type: 391 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x88f930", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1615,11 +1629,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 404 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
+        - ID: 96
+          Type: 405 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x88fe80", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2353,46 +2367,35 @@ Subprograms:
           IsReturn: true
     - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0x88db10..0x88db70]
+      OutOfLinePCRanges: [0x88db10..0x88db20]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 89 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x88db10..0x88db38
+            - Range: 0x88db10..0x88db20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88db38..0x88db3c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-        - Name: ~r0
-          Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88db10..0x88db70, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
     - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0x88db70..0x88dbe0]
+      OutOfLinePCRanges: [0x88db20..0x88db90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 83 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x88db70..0x88dba0
+            - Range: 0x88db20..0x88db50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88dba0..0x88dba4
+            - Range: 0x88db50..0x88db54
               Pieces:
                 - Size: 8
                   Op: null
@@ -2402,18 +2405,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88db70..0x88dbe0, Pieces: []}]
+          Locations: [{Range: 0x88db20..0x88db90, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0x88dbe0..0x88dbf0]
+      OutOfLinePCRanges: [0x88db90..0x88dba0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88dbe0..0x88dbf0
+            - Range: 0x88db90..0x88dba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2422,308 +2425,325 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 55
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88e000..0x88e010]
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0x88dba0..0x88dc10]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 90 StructureType main.structWithMap
+        - Name: a
+          Type: 90 PointerType *interface {}
           Locations:
-            - Range: 0x88e000..0x88e010
+            - Range: 0x88dba0..0x88dbd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: ~r0
+          Type: 11 GoStringHeaderType string
+          Locations: [{Range: 0x88dba0..0x88dc10, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 56
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88e010..0x88e020]
+      Name: main.testStructWithMap
+      OutOfLinePCRanges: [0x88e150..0x88e160]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 96 GoMapType map[string]main.nestedStruct
+        - Name: s
+          Type: 91 StructureType main.structWithMap
           Locations:
-            - Range: 0x88e010..0x88e020
+            - Range: 0x88e150..0x88e160
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x88e020..0x88e030]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0x88e160..0x88e170]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 101 GoMapType map[string]int
+          Type: 97 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x88e020..0x88e030
+            - Range: 0x88e160..0x88e170
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x88e030..0x88e040]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x88e170..0x88e180]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 106 GoMapType map[string][]string
+          Type: 102 GoMapType map[string]int
           Locations:
-            - Range: 0x88e030..0x88e040
+            - Range: 0x88e170..0x88e180
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x88e040..0x88e050]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x88e180..0x88e190]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 111 GoMapType map[[4]string][2]int
+          Type: 107 GoMapType map[string][]string
           Locations:
-            - Range: 0x88e040..0x88e050
+            - Range: 0x88e180..0x88e190
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x88e050..0x88e060]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x88e190..0x88e1a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 101 GoMapType map[string]int
+          Type: 112 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x88e050..0x88e060
+            - Range: 0x88e190..0x88e1a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x88e060..0x88e070]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x88e1a0..0x88e1b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 116 ArrayType [2]map[string]int
+          Type: 102 GoMapType map[string]int
           Locations:
-            - Range: 0x88e060..0x88e070
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x88e070..0x88e080]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 117 PointerType *map[string]int
-          Locations:
-            - Range: 0x88e070..0x88e080
+            - Range: 0x88e1a0..0x88e1b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x88e080..0x88e090]
+    - ID: 62
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x88e1b0..0x88e1c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 91 GoMapType map[int]int
+          Type: 117 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x88e080..0x88e090
+            - Range: 0x88e1b0..0x88e1c0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 63
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x88e1c0..0x88e1d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 118 PointerType *map[string]int
+          Locations:
+            - Range: 0x88e1c0..0x88e1d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x88e090..0x88e0a0]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x88e1d0..0x88e1e0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 118 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 92 GoMapType map[int]int
           Locations:
-            - Range: 0x88e090..0x88e0a0
+            - Range: 0x88e1d0..0x88e1e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x88e0a0..0x88e0b0]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x88e1e0..0x88e1f0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 118 GoMapType map[string][]main.structWithMap
+        - Name: redactMyEntries
+          Type: 119 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x88e0a0..0x88e0b0
+            - Range: 0x88e1e0..0x88e1f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x88e0b0..0x88e0c0]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x88e1f0..0x88e200]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 123 GoMapType map[bool]main.node
+          Type: 119 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x88e0b0..0x88e0c0
+            - Range: 0x88e1f0..0x88e200
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x88e0c0..0x88e0d0]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x88e200..0x88e210]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 128 GoMapType map[int]uint8
+          Type: 124 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x88e0c0..0x88e0d0
+            - Range: 0x88e200..0x88e210
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 68
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x88e0d0..0x88e0e0]
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x88e210..0x88e220]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 128 GoMapType map[int]uint8
+        - Name: m
+          Type: 129 GoMapType map[int]uint8
           Locations:
-            - Range: 0x88e0d0..0x88e0e0
+            - Range: 0x88e210..0x88e220
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 69
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x88e0e0..0x88e0f0]
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x88e220..0x88e230]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 133 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 129 GoMapType map[int]uint8
           Locations:
-            - Range: 0x88e0e0..0x88e0f0
+            - Range: 0x88e220..0x88e230
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 70
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x88e0f0..0x88e100]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x88e230..0x88e240]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[uint8]uint8
+          Type: 134 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x88e0f0..0x88e100
+            - Range: 0x88e230..0x88e240
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 71
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x88e100..0x88e110]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x88e240..0x88e250]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[uint8]uint8
+          Type: 134 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x88e100..0x88e110
+            - Range: 0x88e240..0x88e250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x88e110..0x88e120]
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x88e250..0x88e260]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 138 GoMapType map[uint8][4]int
+          Type: 134 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x88e110..0x88e120
+            - Range: 0x88e250..0x88e260
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x88e120..0x88e130]
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x88e260..0x88e270]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 143 GoMapType map[[4]int]uint8
+          Type: 139 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x88e120..0x88e130
+            - Range: 0x88e260..0x88e270
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x88e130..0x88e140]
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x88e270..0x88e280]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 148 GoMapType map[[4]int][4]int
+          Type: 144 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x88e130..0x88e140
+            - Range: 0x88e270..0x88e280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 75
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x88e280..0x88e290]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 149 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x88e280..0x88e290
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 76
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x88f390..0x88f3a0]
+      OutOfLinePCRanges: [0x88f4e0..0x88f4f0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f390..0x88f3a0
+            - Range: 0x88f4e0..0x88f4f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f390..0x88f3a0
+            - Range: 0x88f4e0..0x88f4f0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88f390..0x88f3a0
+            - Range: 0x88f4e0..0x88f4f0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x88f470..0x88f480]
+      OutOfLinePCRanges: [0x88f5c0..0x88f5d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88f470..0x88f480
+            - Range: 0x88f5c0..0x88f5d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f470..0x88f480
+            - Range: 0x88f5c0..0x88f5d0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88f470..0x88f480
+            - Range: 0x88f5c0..0x88f5d0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88f470..0x88f480
+            - Range: 0x88f5c0..0x88f5d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f470..0x88f480
+            - Range: 0x88f5c0..0x88f5d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2731,39 +2751,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testChannel
-      OutOfLinePCRanges: [0x88f610..0x88f620]
+      OutOfLinePCRanges: [0x88f760..0x88f770]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 153 GoChannelType chan bool
+          Type: 154 GoChannelType chan bool
           Locations:
-            - Range: 0x88f610..0x88f620
+            - Range: 0x88f760..0x88f770
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x88f7b0..0x88f7c0]
+      OutOfLinePCRanges: [0x88f900..0x88f910]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 154 PointerType *main.structWithTwoValues
+          Type: 155 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x88f7b0..0x88f7c0
+            - Range: 0x88f900..0x88f910
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x88f7c0..0x88f7d0]
+      OutOfLinePCRanges: [0x88f910..0x88f920]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 156 StructureType main.node
+          Type: 157 StructureType main.node
           Locations:
-            - Range: 0x88f7c0..0x88f7d0
+            - Range: 0x88f910..0x88f920
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2771,112 +2791,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x88f7d0..0x88f7e0]
+      OutOfLinePCRanges: [0x88f920..0x88f930]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 157 PointerType *main.node
+          Type: 158 PointerType *main.node
           Locations:
-            - Range: 0x88f7d0..0x88f7e0
+            - Range: 0x88f920..0x88f930
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x88f7e0..0x88f7f0]
+      OutOfLinePCRanges: [0x88f930..0x88f940]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x88f7e0..0x88f7f0
+            - Range: 0x88f930..0x88f940
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x88f800..0x88f810]
+      OutOfLinePCRanges: [0x88f950..0x88f960]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x88f800..0x88f810
+            - Range: 0x88f950..0x88f960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x88f870..0x88f880]
+      OutOfLinePCRanges: [0x88f9c0..0x88f9d0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x88f870..0x88f880
+            - Range: 0x88f9c0..0x88f9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x88f890..0x88f8a0]
+      OutOfLinePCRanges: [0x88f9e0..0x88f9f0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x88f890..0x88f8a0
+            - Range: 0x88f9e0..0x88f9f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88f890..0x88f8a0
+            - Range: 0x88f9e0..0x88f9f0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testCycle
-      OutOfLinePCRanges: [0x88f8b0..0x88f8c0]
+      OutOfLinePCRanges: [0x88fa00..0x88fa10]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 158 PointerType *main.t
+          Type: 159 PointerType *main.t
           Locations:
-            - Range: 0x88f8b0..0x88f8c0
+            - Range: 0x88fa00..0x88fa10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x88fca0..0x88fcb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 160 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x88fca0..0x88fcb0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 87
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x88fcb0..0x88fcc0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x88fdf0..0x88fe00]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 160 GoSliceHeaderType []uint
+          Type: 161 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88fcb0..0x88fcc0
+            - Range: 0x88fdf0..0x88fe00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2887,14 +2889,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x88fcc0..0x88fcd0]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x88fe00..0x88fe10]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 161 GoSliceHeaderType [][]uint
+          Type: 161 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88fcc0..0x88fcd0
+            - Range: 0x88fe00..0x88fe10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2905,14 +2907,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x88fcd0..0x88fce0]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x88fe10..0x88fe20]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 162 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x88fcd0..0x88fce0
+            - Range: 0x88fe10..0x88fe20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2920,24 +2922,17 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88fcd0..0x88fce0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 90
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x88fce0..0x88fcf0]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x88fe20..0x88fe30]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Type: 164 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x88fce0..0x88fcf0
+            - Range: 0x88fe20..0x88fe30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2950,19 +2945,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88fce0..0x88fcf0
+            - Range: 0x88fe20..0x88fe30
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 91
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x88fcf0..0x88fd00]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x88fe30..0x88fe40]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Type: 164 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x88fcf0..0x88fd00
+            - Range: 0x88fe30..0x88fe40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2975,19 +2970,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88fcf0..0x88fd00
+            - Range: 0x88fe30..0x88fe40
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0x88fd00..0x88fd10]
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x88fe40..0x88fe50]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 166 GoSliceHeaderType []string
+        - Name: xs
+          Type: 164 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x88fd00..0x88fd10
+            - Range: 0x88fe40..0x88fe50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2997,22 +2992,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88fe40..0x88fe50
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 93
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x88fe50..0x88fe60]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 167 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x88fe50..0x88fe60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x88fd10..0x88fd20]
+      OutOfLinePCRanges: [0x88fe60..0x88fe70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x88fd10..0x88fd20
+            - Range: 0x88fe60..0x88fe70
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 167 GoSliceHeaderType []bool
+          Type: 168 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x88fd10..0x88fd20
+            - Range: 0x88fe60..0x88fe70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3025,37 +3045,19 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88fd10..0x88fd20
+            - Range: 0x88fe60..0x88fe70
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x88fd20..0x88fd30]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 168 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x88fd20..0x88fd30
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 95
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x88fd30..0x88fd40]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x88fe70..0x88fe80]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 160 GoSliceHeaderType []uint
+          Type: 169 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x88fd30..0x88fd40
+            - Range: 0x88fe70..0x88fe80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3066,24 +3068,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 96
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x88fe80..0x88fe90]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x88fe80..0x88fe90
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 97
       Name: main.stackC
-      OutOfLinePCRanges: [0x890000..0x890070]
+      OutOfLinePCRanges: [0x890150..0x8901c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x890000..0x890070, Pieces: []}]
+          Locations: [{Range: 0x890150..0x8901c0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x890070..0x890080]
+      OutOfLinePCRanges: [0x8901c0..0x8901d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890070..0x890080
+            - Range: 0x8901c0..0x8901d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3091,15 +3111,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x890080..0x890090]
+      OutOfLinePCRanges: [0x8901d0..0x8901e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890080..0x890090
+            - Range: 0x8901d0..0x8901e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3110,7 +3130,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890080..0x890090
+            - Range: 0x8901d0..0x8901e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3121,7 +3141,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890080..0x890090
+            - Range: 0x8901d0..0x8901e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3129,15 +3149,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 100
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x890090..0x8900b0]
+      OutOfLinePCRanges: [0x8901e0..0x890200]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 169 StructureType main.threeStringStruct
+          Type: 170 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x890090..0x8900b0
+            - Range: 0x8901e0..0x890200
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3153,55 +3173,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x8900b0..0x8900c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 170 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x8900b0..0x8900c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 101
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x8900c0..0x8900d0]
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x890200..0x890210]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 171 PointerType *main.oneStringStruct
+          Type: 171 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x8900c0..0x8900d0
+            - Range: 0x890200..0x890210
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x8900d0..0x8900e0]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x890210..0x890220]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
+        - Name: a
+          Type: 172 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x8900d0..0x8900e0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890210..0x890220
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x8900e0..0x8900f0]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x890220..0x890230]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8900e0..0x8900f0
+            - Range: 0x890220..0x890230
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3210,14 +3214,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 104
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x8900f0..0x890100]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x890230..0x890240]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8900f0..0x890100
+            - Range: 0x890230..0x890240
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3226,14 +3230,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testStruct
-      OutOfLinePCRanges: [0x890300..0x890320]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x890240..0x890250]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 173 StructureType main.aStruct
+          Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890300..0x890320
+            - Range: 0x890240..0x890250
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 106
+      Name: main.testStruct
+      OutOfLinePCRanges: [0x890450..0x890470]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 174 StructureType main.aStruct
+          Locations:
+            - Range: 0x890450..0x890470
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3251,29 +3271,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 106
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x890400..0x890410]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 175 StructureType main.emptyStruct
-          Locations: [{Range: 0x890400..0x890410, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 107
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x890410..0x890420]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0x890550..0x890560]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 176 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0x890410..0x890420
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 176 StructureType main.emptyStruct
+          Locations: [{Range: 0x890550..0x890560, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0x890560..0x890570]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 177 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0x890560..0x890570
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88d3c0..0x88d430]
       InlinePCRanges:
@@ -3303,28 +3323,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 110
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d658..0x88d690]
           RootRanges: [0x88d5f0..0x88d6c0]
       Variables: []
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d75c..0x88d7a0]
           RootRanges: [0x88d740..0x88d860]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d810..0x88d848]
           RootRanges: [0x88d740..0x88d860]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3338,7 +3358,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3363,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 237
+      ID: 238
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 238 PointerType *main.deepSlice3
+      Pointee: 239 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 256
+      ID: 257
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 257 PointerType *main.deepSlice8
+      Pointee: 258 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 262
+      ID: 263
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 263 PointerType *main.deepSlice9
+      Pointee: 264 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3387,7 +3407,7 @@ Types:
       ID: 305
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 158 PointerType *main.t
+      Pointee: 159 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3396,40 +3416,40 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 183
+      ID: 184
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 183 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 241
+      ID: 242
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 241 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 260
+      ID: 261
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 260 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 266
+      ID: 267
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 266 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 180
+      ID: 181
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*string.array
+      Pointee: 180 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 222
+      ID: 223
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType [][]uint.array
+      Pointee: 222 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 228
+      ID: 229
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []bool.array
+      Pointee: 228 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 270
       Name: '*[]interface {}.array'
@@ -3441,30 +3461,30 @@ Types:
       ByteSize: 8
       Pointee: 308 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 224
+      ID: 225
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 223 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 224 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 226
+      ID: 227
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType []string.array
+      Pointee: 226 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 162
+      ID: 163
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 160 GoSliceHeaderType []uint
+      Pointee: 161 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 220
+      ID: 221
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []uint.array
+      Pointee: 220 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 230
+      ID: 231
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType []uint16.array
+      Pointee: 230 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3473,35 +3493,35 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 151
+      ID: 152
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 152 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 153 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 146
+      ID: 147
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 147 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 148 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 114
+      ID: 115
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 115 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 116 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 126
+      ID: 127
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 127 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 128 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '*bucket<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 245
+      ID: 246
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 246 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 247 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
       ID: 274
       Name: '*bucket<int,*main.deepMap8>'
@@ -3513,50 +3533,50 @@ Types:
       ByteSize: 8
       Pointee: 284 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 94
+      ID: 95
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 95 GoHMapBucketType bucket<int,int>
+      Pointee: 96 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
       ID: 292
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
       Pointee: 293 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
-      ID: 131
+      ID: 132
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 132 GoHMapBucketType bucket<int,uint8>
+      Pointee: 133 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 122
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 109
+      ID: 110
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 110 GoHMapBucketType bucket<string,[]string>
+      Pointee: 111 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 104
+      ID: 105
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 105 GoHMapBucketType bucket<string,int>
+      Pointee: 106 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 99
+      ID: 100
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 100 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 101 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 141
+      ID: 142
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 142 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 143 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 136
+      ID: 137
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 138 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -3579,35 +3599,35 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 149
+      ID: 150
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 150 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 151 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 144
+      ID: 145
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 145 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 146 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 112
+      ID: 113
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 113 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 114 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 124
+      ID: 125
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 125 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 126 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*hash<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 243
+      ID: 244
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 244 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 245 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
       ID: 272
       Name: '*hash<int,*main.deepMap8>'
@@ -3619,50 +3639,50 @@ Types:
       ByteSize: 8
       Pointee: 282 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 92
+      ID: 93
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 93 GoHMapHeaderType hash<int,int>
+      Pointee: 94 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
       ID: 290
       Name: '*hash<int,interface {}>'
       ByteSize: 8
       Pointee: 291 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
-      ID: 129
+      ID: 130
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 130 GoHMapHeaderType hash<int,uint8>
+      Pointee: 131 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 120
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 120 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 121 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 107
+      ID: 108
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 108 GoHMapHeaderType hash<string,[]string>
+      Pointee: 109 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 103
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 103 GoHMapHeaderType hash<string,int>
+      Pointee: 104 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 97
+      ID: 98
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 98 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 99 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 139
+      ID: 140
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 140 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 141 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 134
+      ID: 135
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 136 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -3699,26 +3719,26 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 268
+      ID: 90
       Name: '*interface {}'
       ByteSize: 8
       GoRuntimeType: 363584
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 187
+      ID: 188
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 356096
       GoKind: 22
-      Pointee: 188 StructureType main.deepMap2
+      Pointee: 189 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 248
+      ID: 249
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356032
       GoKind: 22
-      Pointee: 249 UnresolvedPointeeType main.deepMap3
+      Pointee: 250 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -3748,12 +3768,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 231
+      ID: 232
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356608
       GoKind: 22
-      Pointee: 232 UnresolvedPointeeType main.deepPtr3
+      Pointee: 233 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3762,33 +3782,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 251
+      ID: 252
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356288
       GoKind: 22
-      Pointee: 252 StructureType main.deepPtr8
+      Pointee: 253 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 253
+      ID: 254
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 254 StructureType main.deepPtr9
+      Pointee: 255 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 357248
       GoKind: 22
-      Pointee: 181 StructureType main.deepSlice2
+      Pointee: 182 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 238
+      ID: 239
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357184
       GoKind: 22
-      Pointee: 239 UnresolvedPointeeType main.deepSlice3
+      Pointee: 240 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3797,25 +3817,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 257
+      ID: 258
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 356864
       GoKind: 22
-      Pointee: 258 StructureType main.deepSlice8
+      Pointee: 259 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 263
+      ID: 264
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 264 StructureType main.deepSlice9
+      Pointee: 265 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 176
+      ID: 177
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 175 StructureType main.emptyStruct
+      Pointee: 176 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 86
       Name: '*main.esotericHeap'
@@ -3824,18 +3844,18 @@ Types:
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 157
+      ID: 158
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 357440
       GoKind: 22
-      Pointee: 156 StructureType main.node
+      Pointee: 157 StructureType main.node
     - __kind: PointerType
-      ID: 171
+      ID: 172
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 172 StructureType main.oneStringStruct
+      Pointee: 173 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
@@ -3843,57 +3863,57 @@ Types:
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 234
+      ID: 235
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 233 GoStringDataType main.stringType1.str
+      Pointee: 234 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 235 UnresolvedPointeeType main.stringType2
+      Pointee: 236 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 204
+      ID: 205
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 355584
       GoKind: 22
-      Pointee: 90 StructureType main.structWithMap
+      Pointee: 91 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 164
+      ID: 165
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 165 StructureType main.structWithNoStrings
+      Pointee: 166 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 154
+      ID: 155
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 155 StructureType main.structWithTwoValues
+      Pointee: 156 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 158
+      ID: 159
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 159 GoSliceHeaderType main.t
+      Pointee: 160 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 307
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 306 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 170
+      ID: 171
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 169 StructureType main.threeStringStruct
+      Pointee: 170 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 117
+      ID: 118
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 101 GoMapType map[string]int
+      Pointee: 102 GoMapType map[string]int
     - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
@@ -3909,10 +3929,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 178
+      ID: 179
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 177 GoStringDataType string.str
+      Pointee: 178 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -3956,8 +3976,23 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 405
+      ID: 406
       Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 364
+      Name: Probe[main.testAnyPtr]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 90 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 362
       Name: Probe[main.testAny]
@@ -4004,7 +4039,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 370
+      ID: 371
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4012,10 +4047,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 ArrayType [2]map[string]int
+            Type: 117 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4079,7 +4114,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 386
+      ID: 387
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4087,14 +4122,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 153 GoChannelType chan bool
+            Type: 154 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: c}
+                  Variable: {subprogram: 78, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 384
+      ID: 385
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4105,7 +4140,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: w}
+                  Variable: {subprogram: 76, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4114,7 +4149,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 1, name: x}
+                  Variable: {subprogram: 76, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4123,11 +4158,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 2, name: y}
+                  Variable: {subprogram: 76, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 394
+      ID: 395
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4135,10 +4170,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 158 PointerType *main.t
+            Type: 159 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: t}
+                  Variable: {subprogram: 86, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4232,7 +4267,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 399
+      ID: 400
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4240,10 +4275,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 163 GoSliceHeaderType []main.structWithNoStrings
+            Type: 164 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4252,11 +4287,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 396
+      ID: 397
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4264,14 +4299,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType []uint
+            Type: 161 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 413
+      ID: 414
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4282,11 +4317,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 416
+      ID: 417
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4294,14 +4329,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 176 PointerType *main.emptyStruct
+            Type: 177 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 415
+      ID: 416
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4309,10 +4344,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 StructureType main.emptyStruct
+            Type: 176 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: e}
+                  Variable: {subprogram: 107, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -4421,7 +4456,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 418
+      ID: 419
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 356
@@ -4448,16 +4483,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 419
+      ID: 420
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 420
+      ID: 421
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 358
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 417
+      ID: 418
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4468,11 +4503,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 421
+      ID: 422
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4483,11 +4518,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: x}
+                  Variable: {subprogram: 113, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 423
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4498,7 +4533,7 @@ Types:
             Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4592,7 +4627,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 388
+      ID: 389
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4600,14 +4635,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 156 StructureType main.node
+            Type: 157 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 368
+      ID: 369
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4615,14 +4650,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 111 GoMapType map[[4]string][2]int
+            Type: 112 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 375
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4630,14 +4665,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 GoMapType map[string][]main.structWithMap
+            Type: 119 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 373
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4645,14 +4680,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 91 GoMapType map[int]int
+            Type: 92 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 383
+      ID: 384
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4660,14 +4695,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 148 GoMapType map[[4]int][4]int
+            Type: 149 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 383
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4675,14 +4710,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 143 GoMapType map[[4]int]uint8
+            Type: 144 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 373
+      ID: 374
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4690,14 +4725,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 118 GoMapType map[string][]main.structWithMap
+            Type: 119 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 382
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4705,14 +4740,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 138 GoMapType map[uint8][4]int
+            Type: 139 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 381
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4720,14 +4755,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[uint8]uint8
+            Type: 134 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 367
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4735,14 +4770,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 101 GoMapType map[string]int
+            Type: 102 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 368
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4750,14 +4785,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[string][]string
+            Type: 107 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 366
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4765,14 +4800,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 96 GoMapType map[string]main.nestedStruct
+            Type: 97 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 376
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4780,14 +4815,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 123 GoMapType map[bool]main.node
+            Type: 124 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 379
+      ID: 380
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4795,14 +4830,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[uint8]uint8
+            Type: 134 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 379
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4810,14 +4845,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[uint8]uint8
+            Type: 134 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 377
+      ID: 378
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4825,14 +4860,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 128 GoMapType map[int]uint8
+            Type: 129 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 376
+      ID: 377
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4840,14 +4875,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 128 GoMapType map[int]uint8
+            Type: 129 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 411
+      ID: 412
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4858,11 +4893,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 385
+      ID: 386
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4873,7 +4908,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4882,7 +4917,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: b}
+                  Variable: {subprogram: 77, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4891,7 +4926,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: c}
+                  Variable: {subprogram: 77, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4900,7 +4935,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 3, name: d}
+                  Variable: {subprogram: 77, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4909,11 +4944,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 4, name: e}
+                  Variable: {subprogram: 77, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 393
+      ID: 394
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4924,7 +4959,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4933,11 +4968,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: a}
+                  Variable: {subprogram: 85, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 400
+      ID: 401
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4945,10 +4980,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 163 GoSliceHeaderType []main.structWithNoStrings
+            Type: 164 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4957,11 +4992,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 402
+      ID: 403
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4972,16 +5007,16 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 94, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 167 GoSliceHeaderType []bool
+            Type: 168 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: s}
+                  Variable: {subprogram: 94, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -4990,11 +5025,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 2, name: x}
+                  Variable: {subprogram: 94, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 403
+      ID: 404
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5002,14 +5037,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 168 GoSliceHeaderType []uint16
+            Type: 169 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 410
+      ID: 411
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5017,14 +5052,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 171 PointerType *main.oneStringStruct
+            Type: 172 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 389
+      ID: 390
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5032,14 +5067,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 157 PointerType *main.node
+            Type: 158 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 371
+      ID: 372
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5047,14 +5082,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 117 PointerType *map[string]int
+            Type: 118 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 387
+      ID: 388
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5062,10 +5097,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 154 PointerType *main.structWithTwoValues
+            Type: 155 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5234,7 +5269,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 406
+      ID: 407
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5245,7 +5280,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5324,7 +5359,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 397
+      ID: 398
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5332,14 +5367,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType [][]uint
+            Type: 162 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 369
+      ID: 370
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5347,10 +5382,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 101 GoMapType map[string]int
+            Type: 102 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5369,7 +5404,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 392
+      ID: 393
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5380,11 +5415,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 401
+      ID: 402
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5392,10 +5427,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 166 GoSliceHeaderType []string
+            Type: 167 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: s}
+                  Variable: {subprogram: 93, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5429,7 +5464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 398
+      ID: 399
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5437,10 +5472,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 163 GoSliceHeaderType []main.structWithNoStrings
+            Type: 164 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5449,11 +5484,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 365
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5461,14 +5496,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 90 StructureType main.structWithMap
+            Type: 91 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: s}
+                  Variable: {subprogram: 56, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 414
+      ID: 415
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5476,14 +5511,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 173 StructureType main.aStruct
+            Type: 174 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 409
+      ID: 410
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5491,14 +5526,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.threeStringStruct
+            Type: 171 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 408
+      ID: 409
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5506,14 +5541,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 StructureType main.threeStringStruct
+            Type: 170 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 407
+      ID: 408
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5524,7 +5559,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5533,7 +5568,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: y}
+                  Variable: {subprogram: 99, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5542,7 +5577,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: z}
+                  Variable: {subprogram: 99, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5636,7 +5671,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 391
+      ID: 392
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5647,11 +5682,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 395
+      ID: 396
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5659,14 +5694,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType []uint
+            Type: 161 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 412
+      ID: 413
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5677,11 +5712,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 390
+      ID: 391
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5692,7 +5727,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5711,7 +5746,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 404
+      ID: 405
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5719,10 +5754,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType []uint
+            Type: 161 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5800,13 +5835,13 @@ Types:
       HasCount: true
       Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 116
+      ID: 117
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 101 GoMapType map[string]int
+      Element: 102 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -5859,7 +5894,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 214
+      ID: 215
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 622496
@@ -5868,7 +5903,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 199
+      ID: 200
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 622784
@@ -5885,7 +5920,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 184
+      ID: 185
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 619808
@@ -5909,14 +5944,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 182 GoSliceDataType []*main.deepSlice2.array
+      Data: 183 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 183
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 236
+      ID: 237
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446720
@@ -5924,21 +5959,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 237 PointerType **main.deepSlice3
+          Type: 238 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 240 GoSliceDataType []*main.deepSlice3.array
+      Data: 241 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 241
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 238 PointerType *main.deepSlice3
+      Element: 239 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 255
+      ID: 256
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446400
@@ -5946,21 +5981,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 256 PointerType **main.deepSlice8
+          Type: 257 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 259 GoSliceDataType []*main.deepSlice8.array
+      Data: 260 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 260
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 257 PointerType *main.deepSlice8
+      Element: 258 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 261
+      ID: 262
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446336
@@ -5968,19 +6003,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 262 PointerType **main.deepSlice9
+          Type: 263 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 265 GoSliceDataType []*main.deepSlice9.array
+      Data: 266 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 266
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 263 PointerType *main.deepSlice9
+      Element: 264 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -5997,35 +6032,35 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 179 GoSliceDataType []*string.array
+      Data: 180 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 180
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 162
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *[]uint
+          Type: 163 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 221 GoSliceDataType [][]uint.array
+      Data: 222 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 222
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 160 GoSliceHeaderType []uint
+      Element: 161 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 168
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 454080
@@ -6040,42 +6075,42 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 227 GoSliceDataType []bool.array
+      Data: 228 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 228
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 219
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 152 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 153 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 218
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 147 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 148 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 202
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 115 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 116 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 209
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 127 GoHMapBucketType bucket<bool,main.node>
+      Element: 128 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 190
       Name: '[]bucket<int,*main.deepMap2>.array'
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 246 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 247 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 279
       Name: '[]bucket<int,*main.deepMap8>.array'
@@ -6087,52 +6122,52 @@ Types:
       ByteSize: 2048
       Element: 284 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 95 GoHMapBucketType bucket<int,int>
+      Element: 96 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
       ID: 295
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
       Element: 293 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 211
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 132 GoHMapBucketType bucket<int,uint8>
+      Element: 133 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 206
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 198
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 110 GoHMapBucketType bucket<string,[]string>
+      Element: 111 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 196
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 105 GoHMapBucketType bucket<string,int>
+      Element: 106 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 195
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 100 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 101 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 142 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 143 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 213
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<uint8,uint8>
+      Element: 138 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 267
+      ID: 268
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454400
@@ -6140,7 +6175,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 268 PointerType *interface {}
+          Type: 90 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -6154,49 +6189,49 @@ Types:
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 216
+      ID: 217
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 214 ArrayType [4]int
+      Element: 215 ArrayType [4]int
     - __kind: ArrayType
-      ID: 198
+      ID: 199
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 199 ArrayType [4]string
+      Element: 200 ArrayType [4]string
     - __kind: ArrayType
-      ID: 206
+      ID: 207
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 185
+      ID: 186
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 192
+      ID: 193
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 211
+      ID: 212
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 203
+      ID: 204
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 447040
@@ -6204,7 +6239,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 204 PointerType *main.structWithMap
+          Type: 205 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -6216,30 +6251,30 @@ Types:
       ID: 308
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 90 StructureType main.structWithMap
+      Element: 91 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 164
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 164 PointerType *main.structWithNoStrings
+          Type: 165 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 223 GoSliceDataType []main.structWithNoStrings.array
+      Data: 224 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 165 StructureType main.structWithNoStrings
+      Element: 166 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 454208
@@ -6254,14 +6289,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 225 GoSliceDataType []string.array
+      Data: 226 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 226
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 161
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 453696
@@ -6276,14 +6311,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []uint.array
+      Data: 220 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 220
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 12 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 169
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 453056
@@ -6298,26 +6333,26 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []uint16.array
+      Data: 230 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 230
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 186
+      ID: 187
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 187 PointerType *main.deepMap2
+      Element: 188 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 247
+      ID: 248
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 248 PointerType *main.deepMap3
+      Element: 249 PointerType *main.deepMap3
     - __kind: ArrayType
       ID: 276
       Name: '[]val<*main.deepMap8>'
@@ -6333,35 +6368,35 @@ Types:
       HasCount: true
       Element: 286 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 200
+      ID: 201
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 213
+      ID: 214
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 214 ArrayType [4]int
+      Element: 215 ArrayType [4]int
     - __kind: ArrayType
-      ID: 202
+      ID: 203
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 203 GoSliceHeaderType []main.structWithMap
+      Element: 204 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 196
+      ID: 197
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 166 GoSliceHeaderType []string
+      Element: 167 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 190
+      ID: 191
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
@@ -6375,21 +6410,21 @@ Types:
       HasCount: true
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 193
+      ID: 194
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 174 StructureType main.nestedStruct
+      Element: 175 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 207
+      ID: 208
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 156 StructureType main.node
+      Element: 157 StructureType main.node
     - __kind: ArrayType
-      ID: 209
+      ID: 210
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -6402,81 +6437,81 @@ Types:
       GoRuntimeType: 532256
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 152
+      ID: 153
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 216 ArrayType []key<[4]int>
+          Type: 217 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 213 ArrayType []val<[4]int>
+          Type: 214 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 151 PointerType *bucket<[4]int,[4]int>
-      KeyType: 214 ArrayType [4]int
-      ValueType: 214 ArrayType [4]int
+          Type: 152 PointerType *bucket<[4]int,[4]int>
+      KeyType: 215 ArrayType [4]int
+      ValueType: 215 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 147
+      ID: 148
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 216 ArrayType []key<[4]int>
+          Type: 217 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 209 ArrayType []val<uint8>
+          Type: 210 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 146 PointerType *bucket<[4]int,uint8>
-      KeyType: 214 ArrayType [4]int
+          Type: 147 PointerType *bucket<[4]int,uint8>
+      KeyType: 215 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 115
+      ID: 116
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<[4]string>
+          Type: 199 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 200 ArrayType []val<[2]int>
+          Type: 201 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 114 PointerType *bucket<[4]string,[2]int>
-      KeyType: 199 ArrayType [4]string
+          Type: 115 PointerType *bucket<[4]string,[2]int>
+      KeyType: 200 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 127
+      ID: 128
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 206 ArrayType []key<bool>
+          Type: 207 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 207 ArrayType []val<main.node>
+          Type: 208 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 126 PointerType *bucket<bool,main.node>
+          Type: 127 PointerType *bucket<bool,main.node>
       KeyType: 4 BaseType bool
-      ValueType: 156 StructureType main.node
+      ValueType: 157 StructureType main.node
     - __kind: GoHMapBucketType
       ID: 72
       Name: bucket<int,*main.deepMap2>
@@ -6484,37 +6519,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 186 ArrayType []val<*main.deepMap2>
+          Type: 187 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 71 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 187 PointerType *main.deepMap2
+      ValueType: 188 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 246
+      ID: 247
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 247 ArrayType []val<*main.deepMap3>
+          Type: 248 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 245 PointerType *bucket<int,*main.deepMap3>
+          Type: 246 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 248 PointerType *main.deepMap3
+      ValueType: 249 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
       ID: 275
       Name: bucket<int,*main.deepMap8>
@@ -6522,10 +6557,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 276 ArrayType []val<*main.deepMap8>
@@ -6541,10 +6576,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 285 ArrayType []val<*main.deepMap9>
@@ -6554,22 +6589,22 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 286 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
-      ID: 95
+      ID: 96
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 190 ArrayType []val<int>
+          Type: 191 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 94 PointerType *bucket<int,int>
+          Type: 95 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
@@ -6579,10 +6614,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 294 ArrayType []val<interface {}>
@@ -6592,140 +6627,140 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 132
+      ID: 133
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<int>
+          Type: 186 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 209 ArrayType []val<uint8>
+          Type: 210 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 131 PointerType *bucket<int,uint8>
+          Type: 132 PointerType *bucket<int,uint8>
       KeyType: 9 BaseType int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 122
+      ID: 123
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 193 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 202 ArrayType []val<[]main.structWithMap>
+          Type: 203 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 121 PointerType *bucket<string,[]main.structWithMap>
+          Type: 122 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 203 GoSliceHeaderType []main.structWithMap
+      ValueType: 204 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 110
+      ID: 111
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 193 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 196 ArrayType []val<[]string>
+          Type: 197 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 109 PointerType *bucket<string,[]string>
+          Type: 110 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 166 GoSliceHeaderType []string
+      ValueType: 167 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 105
+      ID: 106
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 193 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 190 ArrayType []val<int>
+          Type: 191 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 104 PointerType *bucket<string,int>
+          Type: 105 PointerType *bucket<string,int>
       KeyType: 11 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 100
+      ID: 101
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 193 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 193 ArrayType []val<main.nestedStruct>
+          Type: 194 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 99 PointerType *bucket<string,main.nestedStruct>
+          Type: 100 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 174 StructureType main.nestedStruct
+      ValueType: 175 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 142
+      ID: 143
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 211 ArrayType []key<uint8>
+          Type: 212 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 213 ArrayType []val<[4]int>
+          Type: 214 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 141 PointerType *bucket<uint8,[4]int>
+          Type: 142 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 214 ArrayType [4]int
+      ValueType: 215 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 137
+      ID: 138
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 185 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 211 ArrayType []key<uint8>
+          Type: 212 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 209 ArrayType []val<uint8>
+          Type: 210 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 136 PointerType *bucket<uint8,uint8>
+          Type: 137 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 153
+      ID: 154
       Name: chan bool
       GoRuntimeType: 543520
       GoKind: 18
@@ -6778,7 +6813,7 @@ Types:
       GoRuntimeType: 445120
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 150
+      ID: 151
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -6799,20 +6834,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 151 PointerType *bucket<[4]int,[4]int>
+          Type: 152 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 151 PointerType *bucket<[4]int,[4]int>
+          Type: 152 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 152 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 218 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketType: 153 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 219 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 145
+      ID: 146
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -6833,20 +6868,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 146 PointerType *bucket<[4]int,uint8>
+          Type: 147 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 146 PointerType *bucket<[4]int,uint8>
+          Type: 147 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 147 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 217 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketType: 148 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 218 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 113
+      ID: 114
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -6867,20 +6902,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 114 PointerType *bucket<[4]string,[2]int>
+          Type: 115 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 114 PointerType *bucket<[4]string,[2]int>
+          Type: 115 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 115 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 201 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketType: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 202 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 125
+      ID: 126
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -6901,18 +6936,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 126 PointerType *bucket<bool,main.node>
+          Type: 127 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 126 PointerType *bucket<bool,main.node>
+          Type: 127 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 127 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 208 GoSliceDataType []bucket<bool,main.node>.array
+      BucketType: 128 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 209 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 70
       Name: hash<int,*main.deepMap2>
@@ -6946,9 +6981,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 189 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 190 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 244
+      ID: 245
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -6969,18 +7004,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 245 PointerType *bucket<int,*main.deepMap3>
+          Type: 246 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 245 PointerType *bucket<int,*main.deepMap3>
+          Type: 246 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 246 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 250 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 247 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 251 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
       ID: 273
       Name: hash<int,*main.deepMap8>
@@ -7050,7 +7085,7 @@ Types:
       BucketType: 284 GoHMapBucketType bucket<int,*main.deepMap9>
       BucketsType: 288 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
-      ID: 93
+      ID: 94
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -7071,18 +7106,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 94 PointerType *bucket<int,int>
+          Type: 95 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 94 PointerType *bucket<int,int>
+          Type: 95 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 95 GoHMapBucketType bucket<int,int>
-      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
+      BucketType: 96 GoHMapBucketType bucket<int,int>
+      BucketsType: 192 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
       ID: 291
       Name: hash<int,interface {}>
@@ -7118,7 +7153,7 @@ Types:
       BucketType: 293 GoHMapBucketType bucket<int,interface {}>
       BucketsType: 295 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 130
+      ID: 131
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -7139,20 +7174,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 131 PointerType *bucket<int,uint8>
+          Type: 132 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 131 PointerType *bucket<int,uint8>
+          Type: 132 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 132 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 210 GoSliceDataType []bucket<int,uint8>.array
+      BucketType: 133 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 211 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 120
+      ID: 121
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -7173,20 +7208,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 121 PointerType *bucket<string,[]main.structWithMap>
+          Type: 122 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 121 PointerType *bucket<string,[]main.structWithMap>
+          Type: 122 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 205 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketType: 123 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 206 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 108
+      ID: 109
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -7207,20 +7242,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 109 PointerType *bucket<string,[]string>
+          Type: 110 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 109 PointerType *bucket<string,[]string>
+          Type: 110 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 110 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 197 GoSliceDataType []bucket<string,[]string>.array
+      BucketType: 111 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 198 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 103
+      ID: 104
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -7241,20 +7276,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 104 PointerType *bucket<string,int>
+          Type: 105 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 104 PointerType *bucket<string,int>
+          Type: 105 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 105 GoHMapBucketType bucket<string,int>
-      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
+      BucketType: 106 GoHMapBucketType bucket<string,int>
+      BucketsType: 196 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 98
+      ID: 99
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -7275,20 +7310,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 99 PointerType *bucket<string,main.nestedStruct>
+          Type: 100 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 99 PointerType *bucket<string,main.nestedStruct>
+          Type: 100 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 100 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketType: 101 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 195 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 140
+      ID: 141
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -7309,20 +7344,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 141 PointerType *bucket<uint8,[4]int>
+          Type: 142 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 141 PointerType *bucket<uint8,[4]int>
+          Type: 142 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 142 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 215 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketType: 143 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 216 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 135
+      ID: 136
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -7343,18 +7378,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 136 PointerType *bucket<uint8,uint8>
+          Type: 137 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 136 PointerType *bucket<uint8,uint8>
+          Type: 137 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 212 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketType: 138 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 213 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -7412,7 +7447,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -7428,7 +7463,7 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 174 StructureType main.nestedStruct
+          Type: 175 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 89
       Name: main.behavior
@@ -7468,7 +7503,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 188
+      ID: 189
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.099488e+06
@@ -7476,9 +7511,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 242 GoMapType map[int]*main.deepMap3
+          Type: 243 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 249
+      ID: 250
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7530,9 +7565,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 231 PointerType *main.deepPtr3
+          Type: 232 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 232
+      ID: 233
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7544,9 +7579,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 251 PointerType *main.deepPtr8
+          Type: 252 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 252
+      ID: 253
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.099872e+06
@@ -7554,9 +7589,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 253 PointerType *main.deepPtr9
+          Type: 254 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 254
+      ID: 255
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.099744e+06
@@ -7576,7 +7611,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 181
+      ID: 182
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.101792e+06
@@ -7584,9 +7619,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 236 GoSliceHeaderType []*main.deepSlice3
+          Type: 237 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 239
+      ID: 240
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7598,9 +7633,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 255 GoSliceHeaderType []*main.deepSlice8
+          Type: 256 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 258
+      ID: 259
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.101024e+06
@@ -7608,9 +7643,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 261 GoSliceHeaderType []*main.deepSlice9
+          Type: 262 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 264
+      ID: 265
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.100896e+06
@@ -7618,9 +7653,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 267 GoSliceHeaderType []interface {}
+          Type: 268 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 175
+      ID: 176
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7675,7 +7710,7 @@ Types:
           Offset: 56
           Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 174
+      ID: 175
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.279488e+06
@@ -7688,7 +7723,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 156
+      ID: 157
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.279328e+06
@@ -7699,9 +7734,9 @@ Types:
           Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 157 PointerType *main.node
+          Type: 158 PointerType *main.node
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7730,21 +7765,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 234 PointerType *main.stringType1.str
+          Type: 235 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 233 GoStringDataType main.stringType1.str
+      Data: 234 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 233
+      ID: 234
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 235
+      ID: 236
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
-      ID: 90
+      ID: 91
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.098464e+06
@@ -7752,9 +7787,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 91 GoMapType map[int]int
+          Type: 92 GoMapType map[int]int
     - __kind: StructureType
-      ID: 165
+      ID: 166
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7766,7 +7801,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 155
+      ID: 156
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7778,7 +7813,7 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: main.t
       ByteSize: 24
       GoKind: 23
@@ -7797,9 +7832,9 @@ Types:
       ID: 306
       Name: main.t.array
       ByteSize: 2048
-      Element: 158 PointerType *main.t
+      Element: 159 PointerType *main.t
     - __kind: StructureType
-      ID: 169
+      ID: 170
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7819,33 +7854,33 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 148
+      ID: 149
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 879776
       GoKind: 21
-      HeaderType: 150 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 151 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 143
+      ID: 144
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 879872
       GoKind: 21
-      HeaderType: 145 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 146 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 111
+      ID: 112
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 879968
       GoKind: 21
-      HeaderType: 113 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 123
+      ID: 124
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 880064
       GoKind: 21
-      HeaderType: 125 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 126 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
@@ -7854,12 +7889,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 242
+      ID: 243
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879584
       GoKind: 21
-      HeaderType: 244 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 245 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 271
       Name: map[int]*main.deepMap8
@@ -7875,12 +7910,12 @@ Types:
       GoKind: 21
       HeaderType: 282 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 91
+      ID: 92
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 877952
       GoKind: 21
-      HeaderType: 93 GoHMapHeaderType hash<int,int>
+      HeaderType: 94 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
       ID: 289
       Name: map[int]interface {}
@@ -7889,54 +7924,54 @@ Types:
       GoKind: 21
       HeaderType: 291 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
-      ID: 128
+      ID: 129
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 880160
       GoKind: 21
-      HeaderType: 130 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 131 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 118
+      ID: 119
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 880256
       GoKind: 21
-      HeaderType: 120 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 121 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 106
+      ID: 107
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 880352
       GoKind: 21
-      HeaderType: 108 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 109 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 101
+      ID: 102
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 880448
       GoKind: 21
-      HeaderType: 103 GoHMapHeaderType hash<string,int>
+      HeaderType: 104 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 96
+      ID: 97
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 880544
       GoKind: 21
-      HeaderType: 98 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 99 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 138
+      ID: 139
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 880640
       GoKind: 21
-      HeaderType: 140 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 141 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 133
+      ID: 134
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 880736
       GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 136 GoHMapHeaderType hash<uint8,uint8>
     - __kind: UnresolvedPointeeType
       ID: 74
       Name: runtime.mapextra
@@ -7950,13 +7985,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 178 PointerType *string.str
+          Type: 179 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 177 GoStringDataType string.str
+      Data: 178 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 177
+      ID: 178
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -8103,6 +8138,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 532320
       GoKind: 26
-MaxTypeID: 422
+MaxTypeID: 423
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 503 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84d77c", Frameless: true}]
+        - ID: 97
+          Type: 504 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x84d8dc", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -26,7 +26,21 @@ Probes:
       events:
         - ID: 53
           Type: 460 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x84b26c", Frameless: true}]
+          InjectionPoints: [{PC: "0x84b22c", Frameless: true}]
+          Condition: null
+    - id: testAnyPtr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAnyPtr}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 55}
+      events:
+        - ID: 55
+          Type: 462 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x84b2ac", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -64,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 468 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x84b750", Frameless: true}]
+        - ID: 62
+          Type: 469 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x84b8b0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 484 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84cda0", Frameless: true}]
+        - ID: 78
+          Type: 485 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x84cf00", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 482 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x84cb20", Frameless: true}]
+        - ID: 76
+          Type: 483 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x84cc80", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 492 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84d040", Frameless: true}]
+        - ID: 86
+          Type: 493 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x84d1a0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -278,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 494 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84d420", Frameless: true}]
+        - ID: 88
+          Type: 495 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84d580", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 497 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84d450", Frameless: true}]
+        - ID: 91
+          Type: 498 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -306,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 511 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84d860", Frameless: true}]
+        - ID: 105
+          Type: 512 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x84d9c0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -320,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 513 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84db70", Frameless: true}]
+        - ID: 107
+          Type: 514 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x84dcd0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -333,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 514 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x84db80", Frameless: true}]
+        - ID: 108
+          Type: 515 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x84dce0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -351,7 +365,7 @@ Probes:
       events:
         - ID: 54
           Type: 461 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x84b2d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84b290", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -459,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 516 EventRootType Probe[main.testInlinedBBB]
+        - ID: 110
+          Type: 517 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84ad78", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -487,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 517 EventRootType Probe[main.testInlinedBCA]
+        - ID: 111
+          Type: 518 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84ae6c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -501,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 518 EventRootType Probe[main.testInlinedBCB]
+        - ID: 112
+          Type: 519 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84af20", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -516,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 515 EventRootType Probe[main.testInlinedPrint]
+        - ID: 109
+          Type: 516 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84aaec"
               Frameless: true
@@ -540,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 519 EventRootType Probe[main.testInlinedSq]
+        - ID: 113
+          Type: 520 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84af74", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -555,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 520 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 114
+          Type: 521 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84afa4"
               Frameless: false
@@ -647,7 +661,7 @@ Probes:
       events:
         - ID: 52
           Type: 459 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x84b21c", Frameless: true}]
+          InjectionPoints: [{PC: "0x84b210", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -657,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 486 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84cf50", Frameless: true}]
+        - ID: 80
+          Type: 487 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x84d0b0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -671,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 466 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x84b730", Frameless: true}]
+        - ID: 60
+          Type: 467 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x84b890", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -685,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 472 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x84b790", Frameless: true}]
+        - ID: 66
+          Type: 473 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x84b8f0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -699,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 470 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x84b770", Frameless: true}]
+        - ID: 64
+          Type: 471 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x84b8d0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -713,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 481 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x84b820", Frameless: true}]
+        - ID: 75
+          Type: 482 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x84b980", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -727,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 480 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x84b810", Frameless: true}]
+        - ID: 74
+          Type: 481 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x84b970", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -741,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 471 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84b780", Frameless: true}]
+        - ID: 65
+          Type: 472 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84b8e0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -755,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 479 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x84b800", Frameless: true}]
+        - ID: 73
+          Type: 480 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x84b960", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -769,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 478 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x84b7f0", Frameless: true}]
+        - ID: 72
+          Type: 479 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x84b950", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -783,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 464 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x84b710", Frameless: true}]
+        - ID: 58
+          Type: 465 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x84b870", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -797,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 465 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x84b720", Frameless: true}]
+        - ID: 59
+          Type: 466 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x84b880", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -811,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 463 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x84b700", Frameless: true}]
+        - ID: 57
+          Type: 464 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x84b860", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -825,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 473 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x84b7a0", Frameless: true}]
+        - ID: 67
+          Type: 474 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x84b900", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -839,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 476 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x84b7d0", Frameless: true}]
+        - ID: 70
+          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x84b930", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -853,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x84b7e0", Frameless: true}]
+        - ID: 71
+          Type: 478 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x84b940", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -867,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 474 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x84b7b0", Frameless: true}]
+        - ID: 68
+          Type: 475 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x84b910", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -881,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 475 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x84b7c0", Frameless: true}]
+        - ID: 69
+          Type: 476 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x84b920", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -895,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 509 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84d840", Frameless: true}]
+        - ID: 103
+          Type: 510 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84d9a0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -909,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 483 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x84cc00", Frameless: true}]
+        - ID: 77
+          Type: 484 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x84cd60", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -923,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 491 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84d020", Frameless: true}]
+        - ID: 85
+          Type: 492 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x84d180", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -937,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 501 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84d490", Frameless: true}]
+        - ID: 95
+          Type: 502 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -951,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 498 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84d460", Frameless: true}]
+        - ID: 92
+          Type: 499 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -965,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 500 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84d480", Frameless: true}]
+        - ID: 94
+          Type: 501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -979,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 508 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84d830", Frameless: true}]
+        - ID: 102
+          Type: 509 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x84d990", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -993,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 487 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84cf60", Frameless: true}]
+        - ID: 81
+          Type: 488 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x84d0c0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1007,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 469 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x84b760", Frameless: true}]
+        - ID: 63
+          Type: 470 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x84b8c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1021,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 485 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84cf40", Frameless: true}]
+        - ID: 79
+          Type: 486 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x84d0a0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1189,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 504 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84d7e0", Frameless: true}]
+        - ID: 98
+          Type: 505 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x84d940", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1273,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 495 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84d430", Frameless: true}]
+        - ID: 89
+          Type: 496 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84d590", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1287,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 467 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x84b740", Frameless: true}]
+        - ID: 61
+          Type: 468 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x84b8a0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1315,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 490 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84d000", Frameless: true}]
+        - ID: 84
+          Type: 491 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x84d160", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1329,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 499 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84d470", Frameless: true}]
+        - ID: 93
+          Type: 500 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1377,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 512 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84da70", Frameless: true}]
+        - ID: 106
+          Type: 513 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x84dbd0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1391,11 +1405,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 496 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84d440", Frameless: true}]
+        - ID: 90
+          Type: 497 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84d5a0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1405,11 +1419,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 55
-          Type: 462 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x84b6f0", Frameless: true}]
+        - ID: 56
+          Type: 463 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x84b850", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1419,11 +1433,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 505 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84d7f0", Frameless: true}]
+        - ID: 99
+          Type: 506 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x84d950", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1433,11 +1447,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 506 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84d800", Frameless: true}]
+        - ID: 100
+          Type: 507 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84d960", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1447,11 +1461,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 507 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84d820", Frameless: true}]
+        - ID: 101
+          Type: 508 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84d980", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1545,11 +1559,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 489 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84cf90", Frameless: true}]
+        - ID: 83
+          Type: 490 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x84d0f0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1559,11 +1573,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 493 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84d410", Frameless: true}]
+        - ID: 87
+          Type: 494 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84d570", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1573,11 +1587,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 510 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84d850", Frameless: true}]
+        - ID: 104
+          Type: 511 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x84d9b0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1587,11 +1601,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 488 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84cf70", Frameless: true}]
+        - ID: 82
+          Type: 489 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x84d0d0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1615,11 +1629,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 502 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84d4a0", Frameless: true}]
+        - ID: 96
+          Type: 503 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84d600", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2353,46 +2367,35 @@ Subprograms:
           IsReturn: true
     - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84b210..0x84b260]
+      OutOfLinePCRanges: [0x84b210..0x84b220]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 87 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84b210..0x84b238
+            - Range: 0x84b210..0x84b220
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84b238..0x84b23c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84b210..0x84b260, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
     - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0x84b260..0x84b2d0]
+      OutOfLinePCRanges: [0x84b220..0x84b290]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 81 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84b260..0x84b290
+            - Range: 0x84b220..0x84b250
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84b290..0x84b294
+            - Range: 0x84b250..0x84b254
               Pieces:
                 - Size: 8
                   Op: null
@@ -2402,18 +2405,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84b260..0x84b2d0, Pieces: []}]
+          Locations: [{Range: 0x84b220..0x84b290, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0x84b2d0..0x84b2e0]
+      OutOfLinePCRanges: [0x84b290..0x84b2a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84b2d0..0x84b2e0
+            - Range: 0x84b290..0x84b2a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2422,308 +2425,325 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 55
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84b6f0..0x84b700]
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0x84b2a0..0x84b310]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 88 StructureType main.structWithMap
+        - Name: a
+          Type: 88 PointerType *interface {}
           Locations:
-            - Range: 0x84b6f0..0x84b700
+            - Range: 0x84b2a0..0x84b2d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations: [{Range: 0x84b2a0..0x84b310, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 56
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84b700..0x84b710]
+      Name: main.testStructWithMap
+      OutOfLinePCRanges: [0x84b850..0x84b860]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 94 GoMapType map[string]main.nestedStruct
+        - Name: s
+          Type: 89 StructureType main.structWithMap
           Locations:
-            - Range: 0x84b700..0x84b710
+            - Range: 0x84b850..0x84b860
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84b710..0x84b720]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0x84b860..0x84b870]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 95 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x84b710..0x84b720
+            - Range: 0x84b860..0x84b870
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84b720..0x84b730]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x84b870..0x84b880]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 104 GoMapType map[string][]string
+          Type: 100 GoMapType map[string]int
           Locations:
-            - Range: 0x84b720..0x84b730
+            - Range: 0x84b870..0x84b880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84b730..0x84b740]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x84b880..0x84b890]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 109 GoMapType map[[4]string][2]int
+          Type: 105 GoMapType map[string][]string
           Locations:
-            - Range: 0x84b730..0x84b740
+            - Range: 0x84b880..0x84b890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84b740..0x84b750]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x84b890..0x84b8a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 110 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x84b740..0x84b750
+            - Range: 0x84b890..0x84b8a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84b750..0x84b760]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x84b8a0..0x84b8b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 114 ArrayType [2]map[string]int
+          Type: 100 GoMapType map[string]int
           Locations:
-            - Range: 0x84b750..0x84b760
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84b760..0x84b770]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 115 PointerType *map[string]int
-          Locations:
-            - Range: 0x84b760..0x84b770
+            - Range: 0x84b8a0..0x84b8b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84b770..0x84b780]
+    - ID: 62
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x84b8b0..0x84b8c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 89 GoMapType map[int]int
+          Type: 115 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x84b770..0x84b780
+            - Range: 0x84b8b0..0x84b8c0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 63
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x84b8c0..0x84b8d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 PointerType *map[string]int
+          Locations:
+            - Range: 0x84b8c0..0x84b8d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84b780..0x84b790]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x84b8d0..0x84b8e0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 116 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 90 GoMapType map[int]int
           Locations:
-            - Range: 0x84b780..0x84b790
+            - Range: 0x84b8d0..0x84b8e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84b790..0x84b7a0]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x84b8e0..0x84b8f0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 116 GoMapType map[string][]main.structWithMap
+        - Name: redactMyEntries
+          Type: 117 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84b790..0x84b7a0
+            - Range: 0x84b8e0..0x84b8f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84b7a0..0x84b7b0]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x84b8f0..0x84b900]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 121 GoMapType map[bool]main.node
+          Type: 117 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84b7a0..0x84b7b0
+            - Range: 0x84b8f0..0x84b900
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84b7b0..0x84b7c0]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x84b900..0x84b910]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 126 GoMapType map[int]uint8
+          Type: 122 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x84b7b0..0x84b7c0
+            - Range: 0x84b900..0x84b910
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 68
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x84b7c0..0x84b7d0]
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x84b910..0x84b920]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 126 GoMapType map[int]uint8
+        - Name: m
+          Type: 127 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84b7c0..0x84b7d0
+            - Range: 0x84b910..0x84b920
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 69
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x84b7d0..0x84b7e0]
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x84b920..0x84b930]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 127 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84b7d0..0x84b7e0
+            - Range: 0x84b920..0x84b930
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 70
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x84b7e0..0x84b7f0]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x84b930..0x84b940]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 132 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84b7e0..0x84b7f0
+            - Range: 0x84b930..0x84b940
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 71
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x84b7f0..0x84b800]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x84b940..0x84b950]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 132 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84b7f0..0x84b800
+            - Range: 0x84b940..0x84b950
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x84b800..0x84b810]
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84b950..0x84b960]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 GoMapType map[uint8][4]int
+          Type: 132 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84b800..0x84b810
+            - Range: 0x84b950..0x84b960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x84b810..0x84b820]
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x84b960..0x84b970]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 141 GoMapType map[[4]int]uint8
+          Type: 137 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x84b810..0x84b820
+            - Range: 0x84b960..0x84b970
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x84b820..0x84b830]
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x84b970..0x84b980]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[[4]int][4]int
+          Type: 142 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x84b820..0x84b830
+            - Range: 0x84b970..0x84b980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 75
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x84b980..0x84b990]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 147 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x84b980..0x84b990
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 76
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84cb20..0x84cb30]
+      OutOfLinePCRanges: [0x84cc80..0x84cc90]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84cb20..0x84cb30
+            - Range: 0x84cc80..0x84cc90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84cb20..0x84cb30
+            - Range: 0x84cc80..0x84cc90
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84cb20..0x84cb30
+            - Range: 0x84cc80..0x84cc90
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84cc00..0x84cc10]
+      OutOfLinePCRanges: [0x84cd60..0x84cd70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84cc00..0x84cc10
+            - Range: 0x84cd60..0x84cd70
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84cc00..0x84cc10
+            - Range: 0x84cd60..0x84cd70
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84cc00..0x84cc10
+            - Range: 0x84cd60..0x84cd70
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84cc00..0x84cc10
+            - Range: 0x84cd60..0x84cd70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cc00..0x84cc10
+            - Range: 0x84cd60..0x84cd70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2731,39 +2751,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84cda0..0x84cdb0]
+      OutOfLinePCRanges: [0x84cf00..0x84cf10]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 151 GoChannelType chan bool
+          Type: 152 GoChannelType chan bool
           Locations:
-            - Range: 0x84cda0..0x84cdb0
+            - Range: 0x84cf00..0x84cf10
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84cf40..0x84cf50]
+      OutOfLinePCRanges: [0x84d0a0..0x84d0b0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 152 PointerType *main.structWithTwoValues
+          Type: 153 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84cf40..0x84cf50
+            - Range: 0x84d0a0..0x84d0b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84cf50..0x84cf60]
+      OutOfLinePCRanges: [0x84d0b0..0x84d0c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 154 StructureType main.node
+          Type: 155 StructureType main.node
           Locations:
-            - Range: 0x84cf50..0x84cf60
+            - Range: 0x84d0b0..0x84d0c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2771,112 +2791,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84cf60..0x84cf70]
+      OutOfLinePCRanges: [0x84d0c0..0x84d0d0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 PointerType *main.node
+          Type: 156 PointerType *main.node
           Locations:
-            - Range: 0x84cf60..0x84cf70
+            - Range: 0x84d0c0..0x84d0d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84cf70..0x84cf80]
+      OutOfLinePCRanges: [0x84d0d0..0x84d0e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84cf70..0x84cf80
+            - Range: 0x84d0d0..0x84d0e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84cf90..0x84cfa0]
+      OutOfLinePCRanges: [0x84d0f0..0x84d100]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x84cf90..0x84cfa0
+            - Range: 0x84d0f0..0x84d100
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84d000..0x84d010]
+      OutOfLinePCRanges: [0x84d160..0x84d170]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x84d000..0x84d010
+            - Range: 0x84d160..0x84d170
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84d020..0x84d030]
+      OutOfLinePCRanges: [0x84d180..0x84d190]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x84d020..0x84d030
+            - Range: 0x84d180..0x84d190
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d020..0x84d030
+            - Range: 0x84d180..0x84d190
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84d040..0x84d050]
+      OutOfLinePCRanges: [0x84d1a0..0x84d1b0]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 156 PointerType *main.t
+          Type: 157 PointerType *main.t
           Locations:
-            - Range: 0x84d040..0x84d050
+            - Range: 0x84d1a0..0x84d1b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84d410..0x84d420]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 158 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84d410..0x84d420
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 87
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84d420..0x84d430]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84d570..0x84d580]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 158 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84d420..0x84d430
+            - Range: 0x84d570..0x84d580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2887,14 +2889,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84d430..0x84d440]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x84d580..0x84d590]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType [][]uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84d430..0x84d440
+            - Range: 0x84d580..0x84d590
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2905,14 +2907,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84d440..0x84d450]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x84d590..0x84d5a0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 160 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x84d440..0x84d450
+            - Range: 0x84d590..0x84d5a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2920,24 +2922,17 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84d440..0x84d450
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 90
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84d450..0x84d460]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84d5a0..0x84d5b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84d450..0x84d460
+            - Range: 0x84d5a0..0x84d5b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2950,19 +2945,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d450..0x84d460
+            - Range: 0x84d5a0..0x84d5b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 91
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84d460..0x84d470]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84d5b0..0x84d5c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84d460..0x84d470
+            - Range: 0x84d5b0..0x84d5c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2975,19 +2970,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d460..0x84d470
+            - Range: 0x84d5b0..0x84d5c0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84d470..0x84d480]
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84d5c0..0x84d5d0]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 164 GoSliceHeaderType []string
+        - Name: xs
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84d470..0x84d480
+            - Range: 0x84d5c0..0x84d5d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2997,22 +2992,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d5c0..0x84d5d0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 93
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 165 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x84d5d0..0x84d5e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84d480..0x84d490]
+      OutOfLinePCRanges: [0x84d5e0..0x84d5f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84d480..0x84d490
+            - Range: 0x84d5e0..0x84d5f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 165 GoSliceHeaderType []bool
+          Type: 166 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84d480..0x84d490
+            - Range: 0x84d5e0..0x84d5f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3025,37 +3045,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d480..0x84d490
+            - Range: 0x84d5e0..0x84d5f0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84d490..0x84d4a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 166 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x84d490..0x84d4a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 95
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84d4a0..0x84d4b0]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x84d5f0..0x84d600]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 158 GoSliceHeaderType []uint
+          Type: 167 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84d4a0..0x84d4b0
+            - Range: 0x84d5f0..0x84d600
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3066,24 +3068,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 96
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x84d600..0x84d610]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 159 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x84d600..0x84d610
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 97
       Name: main.stackC
-      OutOfLinePCRanges: [0x84d770..0x84d7e0]
+      OutOfLinePCRanges: [0x84d8d0..0x84d940]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84d770..0x84d7e0, Pieces: []}]
+          Locations: [{Range: 0x84d8d0..0x84d940, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84d7e0..0x84d7f0]
+      OutOfLinePCRanges: [0x84d940..0x84d950]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d7e0..0x84d7f0
+            - Range: 0x84d940..0x84d950
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3091,15 +3111,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84d7f0..0x84d800]
+      OutOfLinePCRanges: [0x84d950..0x84d960]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d7f0..0x84d800
+            - Range: 0x84d950..0x84d960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3110,7 +3130,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d7f0..0x84d800
+            - Range: 0x84d950..0x84d960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3121,7 +3141,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d7f0..0x84d800
+            - Range: 0x84d950..0x84d960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3129,15 +3149,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 100
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84d800..0x84d820]
+      OutOfLinePCRanges: [0x84d960..0x84d980]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 167 StructureType main.threeStringStruct
+          Type: 168 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84d800..0x84d820
+            - Range: 0x84d960..0x84d980
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3153,55 +3173,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84d820..0x84d830]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x84d820..0x84d830
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 101
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84d830..0x84d840]
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x84d980..0x84d990]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 169 PointerType *main.oneStringStruct
+          Type: 169 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84d830..0x84d840
+            - Range: 0x84d980..0x84d990
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84d840..0x84d850]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x84d990..0x84d9a0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 170 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84d840..0x84d850
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84d990..0x84d9a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84d850..0x84d860]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x84d9a0..0x84d9b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d850..0x84d860
+            - Range: 0x84d9a0..0x84d9b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3210,14 +3214,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 104
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84d860..0x84d870]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x84d9b0..0x84d9c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d860..0x84d870
+            - Range: 0x84d9b0..0x84d9c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3226,14 +3230,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testStruct
-      OutOfLinePCRanges: [0x84da70..0x84da90]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x84d9c0..0x84d9d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 171 StructureType main.aStruct
+          Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84da70..0x84da90
+            - Range: 0x84d9c0..0x84d9d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 106
+      Name: main.testStruct
+      OutOfLinePCRanges: [0x84dbd0..0x84dbf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 172 StructureType main.aStruct
+          Locations:
+            - Range: 0x84dbd0..0x84dbf0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3251,29 +3271,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 106
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84db70..0x84db80]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 173 StructureType main.emptyStruct
-          Locations: [{Range: 0x84db70..0x84db80, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 107
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x84db80..0x84db90]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0x84dcd0..0x84dce0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 174 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0x84db80..0x84db90
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 174 StructureType main.emptyStruct
+          Locations: [{Range: 0x84dcd0..0x84dce0, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0x84dce0..0x84dcf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 175 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0x84dce0..0x84dcf0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84aae0..0x84ab50]
       InlinePCRanges:
@@ -3303,28 +3323,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 110
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84ad78..0x84adb0]
           RootRanges: [0x84ad10..0x84add0]
       Variables: []
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84ae6c..0x84aeb0]
           RootRanges: [0x84ae50..0x84af70]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84af20..0x84af58]
           RootRanges: [0x84ae50..0x84af70]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3338,7 +3358,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3363,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 310
+      ID: 311
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 311 PointerType *main.deepSlice3
+      Pointee: 312 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 335
+      ID: 336
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 336 PointerType *main.deepSlice8
+      Pointee: 337 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 341
+      ID: 342
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 342 PointerType *main.deepSlice9
+      Pointee: 343 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3387,7 +3407,7 @@ Types:
       ID: 403
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 156 PointerType *main.t
+      Pointee: 157 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3396,35 +3416,35 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 149
+      ID: 150
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<[4]int,[4]int>
+      Pointee: 151 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 144
+      ID: 145
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 145 PointerType *table<[4]int,uint8>
+      Pointee: 146 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 112
+      ID: 113
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 113 PointerType *table<[4]string,[2]int>
+      Pointee: 114 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 124
+      ID: 125
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 125 PointerType *table<bool,main.node>
+      Pointee: 126 PointerType *table<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 318
+      ID: 319
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 319 PointerType *table<int,*main.deepMap3>
+      Pointee: 320 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 353
       Name: '**table<int,*main.deepMap8>'
@@ -3436,85 +3456,85 @@ Types:
       ByteSize: 8
       Pointee: 369 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 92
+      ID: 93
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 93 PointerType *table<int,int>
+      Pointee: 94 PointerType *table<int,int>
     - __kind: PointerType
       ID: 383
       Name: '**table<int,interface {}>'
       ByteSize: 8
       Pointee: 384 PointerType *table<int,interface {}>
     - __kind: PointerType
-      ID: 129
+      ID: 130
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 130 PointerType *table<int,uint8>
+      Pointee: 131 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 120
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 120 PointerType *table<string,[]main.structWithMap>
+      Pointee: 121 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 107
+      ID: 108
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 108 PointerType *table<string,[]string>
+      Pointee: 109 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 103
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 103 PointerType *table<string,int>
+      Pointee: 104 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 97
+      ID: 98
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 98 PointerType *table<string,main.nestedStruct>
+      Pointee: 99 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 139
+      ID: 140
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<uint8,[4]int>
+      Pointee: 141 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 134
+      ID: 135
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 135 PointerType *table<uint8,uint8>
+      Pointee: 136 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 314
+      ID: 315
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 313 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 314 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 339
+      ID: 340
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 338 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 339 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 345
+      ID: 346
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 344 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 345 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 178
+      ID: 179
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []*string.array
+      Pointee: 178 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 295
+      ID: 296
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType [][]uint.array
+      Pointee: 295 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 301
+      ID: 302
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []bool.array
+      Pointee: 301 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 349
       Name: '*[]interface {}.array'
@@ -3526,30 +3546,30 @@ Types:
       ByteSize: 8
       Pointee: 406 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 297
+      ID: 298
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 297 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 299
+      ID: 300
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []string.array
+      Pointee: 299 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 160
+      ID: 161
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 158 GoSliceHeaderType []uint
+      Pointee: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 293
+      ID: 294
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []uint.array
+      Pointee: 293 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 303
+      ID: 304
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []uint16.array
+      Pointee: 303 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3614,26 +3634,26 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 347
+      ID: 88
       Name: '*interface {}'
       ByteSize: 8
       GoRuntimeType: 390304
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 188
+      ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 382880
       GoKind: 22
-      Pointee: 189 StructureType main.deepMap2
+      Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 326
+      ID: 327
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 382816
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType main.deepMap3
+      Pointee: 328 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3663,12 +3683,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383392
       GoKind: 22
-      Pointee: 305 UnresolvedPointeeType main.deepPtr3
+      Pointee: 306 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3677,33 +3697,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 330
+      ID: 331
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383072
       GoKind: 22
-      Pointee: 331 StructureType main.deepPtr8
+      Pointee: 332 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 332
+      ID: 333
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383008
       GoKind: 22
-      Pointee: 333 StructureType main.deepPtr9
+      Pointee: 334 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 384032
       GoKind: 22
-      Pointee: 179 StructureType main.deepSlice2
+      Pointee: 180 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 311
+      ID: 312
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 383968
       GoKind: 22
-      Pointee: 312 UnresolvedPointeeType main.deepSlice3
+      Pointee: 313 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3712,25 +3732,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 336
+      ID: 337
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 383648
       GoKind: 22
-      Pointee: 337 StructureType main.deepSlice8
+      Pointee: 338 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 342
+      ID: 343
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383584
       GoKind: 22
-      Pointee: 343 StructureType main.deepSlice9
+      Pointee: 344 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 174
+      ID: 175
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 173 StructureType main.emptyStruct
+      Pointee: 174 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
@@ -3739,18 +3759,18 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 155
+      ID: 156
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 384224
       GoKind: 22
-      Pointee: 154 StructureType main.node
+      Pointee: 155 StructureType main.node
     - __kind: PointerType
-      ID: 169
+      ID: 170
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 170 StructureType main.oneStringStruct
+      Pointee: 171 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -3758,81 +3778,81 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 307
+      ID: 308
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType main.stringType1.str
+      Pointee: 307 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 308 UnresolvedPointeeType main.stringType2
+      Pointee: 309 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 240
+      ID: 241
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382368
       GoKind: 22
-      Pointee: 88 StructureType main.structWithMap
+      Pointee: 89 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 162
+      ID: 163
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 163 StructureType main.structWithNoStrings
+      Pointee: 164 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 152
+      ID: 153
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 153 StructureType main.structWithTwoValues
+      Pointee: 154 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 156
+      ID: 157
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 GoSliceHeaderType main.t
+      Pointee: 158 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 405
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 404 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 168
+      ID: 169
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 167 StructureType main.threeStringStruct
+      Pointee: 168 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 147
+      ID: 148
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 149 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 142
+      ID: 143
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 143 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 144 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 110
+      ID: 111
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 111 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 112 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 122
+      ID: 123
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 123 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 124 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 316
+      ID: 317
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 317 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 351
       Name: '*map<int,*main.deepMap8>'
@@ -3844,86 +3864,86 @@ Types:
       ByteSize: 8
       Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 90
+      ID: 91
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 91 GoSwissMapHeaderType map<int,int>
+      Pointee: 92 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
       ID: 381
       Name: '*map<int,interface {}>'
       ByteSize: 8
       Pointee: 382 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
-      ID: 127
+      ID: 128
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 128 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 129 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 117
+      ID: 118
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 105
+      ID: 106
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 106 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 107 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 100
+      ID: 101
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 101 GoSwissMapHeaderType map<string,int>
+      Pointee: 102 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 95
+      ID: 96
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 137
+      ID: 138
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 139 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 132
+      ID: 133
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 133 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 134 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 115
+      ID: 116
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 GoMapType map[string]int
+      Pointee: 100 GoMapType map[string]int
     - __kind: PointerType
-      ID: 286
+      ID: 287
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 287 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 278
+      ID: 279
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 279 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 226
+      ID: 227
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 227 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 245
+      ID: 246
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 246 StructureType noalg.map.group[bool]main.node
+      Pointee: 247 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 184
+      ID: 185
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 322
+      ID: 323
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 323 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 357
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -3935,50 +3955,50 @@ Types:
       ByteSize: 8
       Pointee: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 194
+      ID: 195
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 195 StructureType noalg.map.group[int]int
+      Pointee: 196 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 387
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 388 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 253
+      ID: 254
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 254 StructureType noalg.map.group[int]uint8
+      Pointee: 255 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 235
+      ID: 236
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 236 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 218
+      ID: 219
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 219 StructureType noalg.map.group[string][]string
+      Pointee: 220 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 210
+      ID: 211
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 211 StructureType noalg.map.group[string]int
+      Pointee: 212 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 202
+      ID: 203
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 269
+      ID: 270
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 270 StructureType noalg.map.group[uint8][4]int
+      Pointee: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 261
+      ID: 262
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 262 StructureType noalg.map.group[uint8]uint8
+      Pointee: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3987,40 +4007,40 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 176
+      ID: 177
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 175 GoStringDataType string.str
+      Pointee: 176 GoStringDataType string.str
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 284 StructureType table<[4]int,[4]int>
+      Pointee: 285 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 276 StructureType table<[4]int,uint8>
+      Pointee: 277 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 224 StructureType table<[4]string,[2]int>
+      Pointee: 225 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 243 StructureType table<bool,main.node>
+      Pointee: 244 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 182 StructureType table<int,*main.deepMap2>
+      Pointee: 183 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 319
+      ID: 320
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 320 StructureType table<int,*main.deepMap3>
+      Pointee: 321 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 354
       Name: '*table<int,*main.deepMap8>'
@@ -4032,50 +4052,50 @@ Types:
       ByteSize: 8
       Pointee: 370 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 192 StructureType table<int,int>
+      Pointee: 193 StructureType table<int,int>
     - __kind: PointerType
       ID: 384
       Name: '*table<int,interface {}>'
       ByteSize: 8
       Pointee: 385 StructureType table<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 251 StructureType table<int,uint8>
+      Pointee: 252 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 233 StructureType table<string,[]main.structWithMap>
+      Pointee: 234 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 216 StructureType table<string,[]string>
+      Pointee: 217 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 208 StructureType table<string,int>
+      Pointee: 209 StructureType table<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 200 StructureType table<string,main.nestedStruct>
+      Pointee: 201 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 267 StructureType table<uint8,[4]int>
+      Pointee: 268 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 259 StructureType table<uint8,uint8>
+      Pointee: 260 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4119,8 +4139,23 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 503
+      ID: 504
       Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 462
+      Name: Probe[main.testAnyPtr]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 88 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 460
       Name: Probe[main.testAny]
@@ -4167,7 +4202,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 468
+      ID: 469
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4175,10 +4210,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 114 ArrayType [2]map[string]int
+            Type: 115 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4242,7 +4277,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 484
+      ID: 485
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4250,14 +4285,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 151 GoChannelType chan bool
+            Type: 152 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: c}
+                  Variable: {subprogram: 78, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 482
+      ID: 483
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4268,7 +4303,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: w}
+                  Variable: {subprogram: 76, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4277,7 +4312,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 1, name: x}
+                  Variable: {subprogram: 76, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4286,11 +4321,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 2, name: y}
+                  Variable: {subprogram: 76, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 492
+      ID: 493
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4298,10 +4333,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.t
+            Type: 157 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: t}
+                  Variable: {subprogram: 86, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4395,7 +4430,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 498
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4403,10 +4438,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4415,11 +4450,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 494
+      ID: 495
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4427,14 +4462,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 512
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4445,11 +4480,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 514
+      ID: 515
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4457,14 +4492,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 174 PointerType *main.emptyStruct
+            Type: 175 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 513
+      ID: 514
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4472,10 +4507,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 173 StructureType main.emptyStruct
+            Type: 174 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: e}
+                  Variable: {subprogram: 107, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -4584,7 +4619,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 516
+      ID: 517
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 454
@@ -4611,16 +4646,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 517
+      ID: 518
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 518
+      ID: 519
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 456
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 515
+      ID: 516
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4631,11 +4666,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 519
+      ID: 520
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4646,11 +4681,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: x}
+                  Variable: {subprogram: 113, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 521
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4661,7 +4696,7 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4755,7 +4790,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 486
+      ID: 487
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4763,14 +4798,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 154 StructureType main.node
+            Type: 155 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 466
+      ID: 467
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4778,14 +4813,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 109 GoMapType map[[4]string][2]int
+            Type: 110 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 473
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4793,14 +4828,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 GoMapType map[string][]main.structWithMap
+            Type: 117 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 470
+      ID: 471
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4808,14 +4843,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 89 GoMapType map[int]int
+            Type: 90 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 482
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4823,14 +4858,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[[4]int][4]int
+            Type: 147 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 481
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4838,14 +4873,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 141 GoMapType map[[4]int]uint8
+            Type: 142 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 471
+      ID: 472
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4853,14 +4888,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 116 GoMapType map[string][]main.structWithMap
+            Type: 117 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 480
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4868,14 +4903,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[uint8][4]int
+            Type: 137 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 479
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4883,14 +4918,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 465
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4898,14 +4933,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 465
+      ID: 466
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4913,14 +4948,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 104 GoMapType map[string][]string
+            Type: 105 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 463
+      ID: 464
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4928,14 +4963,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[string]main.nestedStruct
+            Type: 95 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 474
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4943,14 +4978,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[bool]main.node
+            Type: 122 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 478
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4958,14 +4993,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 477
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4973,14 +5008,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 476
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4988,14 +5023,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 126 GoMapType map[int]uint8
+            Type: 127 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 475
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5003,14 +5038,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 126 GoMapType map[int]uint8
+            Type: 127 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 509
+      ID: 510
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5021,11 +5056,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 483
+      ID: 484
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5036,7 +5071,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -5045,7 +5080,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: b}
+                  Variable: {subprogram: 77, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -5054,7 +5089,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: c}
+                  Variable: {subprogram: 77, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -5063,7 +5098,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 3, name: d}
+                  Variable: {subprogram: 77, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -5072,11 +5107,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 4, name: e}
+                  Variable: {subprogram: 77, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 491
+      ID: 492
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5087,7 +5122,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -5096,11 +5131,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: a}
+                  Variable: {subprogram: 85, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 499
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5108,10 +5143,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5120,11 +5155,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 501
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5135,16 +5170,16 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 94, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 165 GoSliceHeaderType []bool
+            Type: 166 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: s}
+                  Variable: {subprogram: 94, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5153,11 +5188,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 2, name: x}
+                  Variable: {subprogram: 94, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 502
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5165,14 +5200,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 166 GoSliceHeaderType []uint16
+            Type: 167 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 508
+      ID: 509
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5180,14 +5215,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.oneStringStruct
+            Type: 170 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 487
+      ID: 488
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5195,14 +5230,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 PointerType *main.node
+            Type: 156 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 469
+      ID: 470
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5210,14 +5245,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 PointerType *map[string]int
+            Type: 116 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 485
+      ID: 486
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5225,10 +5260,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 152 PointerType *main.structWithTwoValues
+            Type: 153 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5397,7 +5432,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 504
+      ID: 505
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5408,7 +5443,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5487,7 +5522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 495
+      ID: 496
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5495,14 +5530,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType [][]uint
+            Type: 160 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 467
+      ID: 468
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5510,10 +5545,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5532,7 +5567,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 490
+      ID: 491
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5543,11 +5578,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 500
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5555,10 +5590,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []string
+            Type: 165 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: s}
+                  Variable: {subprogram: 93, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5592,7 +5627,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 497
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5600,10 +5635,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5612,11 +5647,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 462
+      ID: 463
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5624,14 +5659,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 88 StructureType main.structWithMap
+            Type: 89 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: s}
+                  Variable: {subprogram: 56, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 512
+      ID: 513
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5639,14 +5674,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 171 StructureType main.aStruct
+            Type: 172 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 507
+      ID: 508
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5654,14 +5689,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 PointerType *main.threeStringStruct
+            Type: 169 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 506
+      ID: 507
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5669,14 +5704,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 167 StructureType main.threeStringStruct
+            Type: 168 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 505
+      ID: 506
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5687,7 +5722,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5696,7 +5731,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: y}
+                  Variable: {subprogram: 99, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5705,7 +5740,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: z}
+                  Variable: {subprogram: 99, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5799,7 +5834,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 490
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5810,11 +5845,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 493
+      ID: 494
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5822,14 +5857,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 510
+      ID: 511
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5840,11 +5875,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 488
+      ID: 489
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5855,7 +5890,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5874,7 +5909,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 502
+      ID: 503
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5882,10 +5917,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5963,13 +5998,13 @@ Types:
       HasCount: true
       Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 114
+      ID: 115
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 99 GoMapType map[string]int
+      Element: 100 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -6022,7 +6057,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 273
+      ID: 274
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 678656
@@ -6031,7 +6066,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 230
+      ID: 231
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 678944
@@ -6063,14 +6098,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 180 GoSliceDataType []*main.deepSlice2.array
+      Data: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 181
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 309
+      ID: 310
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474528
@@ -6078,21 +6113,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 310 PointerType **main.deepSlice3
+          Type: 311 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 313 GoSliceDataType []*main.deepSlice3.array
+      Data: 314 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 313
+      ID: 314
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 311 PointerType *main.deepSlice3
+      Element: 312 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 334
+      ID: 335
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474208
@@ -6100,21 +6135,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 335 PointerType **main.deepSlice8
+          Type: 336 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 338 GoSliceDataType []*main.deepSlice8.array
+      Data: 339 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 338
+      ID: 339
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 336 PointerType *main.deepSlice8
+      Element: 337 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 340
+      ID: 341
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474144
@@ -6122,19 +6157,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 341 PointerType **main.deepSlice9
+          Type: 342 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 344 GoSliceDataType []*main.deepSlice9.array
+      Data: 345 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 345
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 342 PointerType *main.deepSlice9
+      Element: 343 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6151,42 +6186,42 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 177 GoSliceDataType []*string.array
+      Data: 178 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 178
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 291
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<[4]int,[4]int>
+      Element: 151 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 283
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 145 PointerType *table<[4]int,uint8>
+      Element: 146 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 232
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 113 PointerType *table<[4]string,[2]int>
+      Element: 114 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 250
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 125 PointerType *table<bool,main.node>
+      Element: 126 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 329
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 319 PointerType *table<int,*main.deepMap3>
+      Element: 320 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 363
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -6198,73 +6233,73 @@ Types:
       ByteSize: 8192
       Element: 369 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 199
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 93 PointerType *table<int,int>
+      Element: 94 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 391
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
       Element: 384 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 258
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 130 PointerType *table<int,uint8>
+      Element: 131 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 242
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 120 PointerType *table<string,[]main.structWithMap>
+      Element: 121 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 223
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 108 PointerType *table<string,[]string>
+      Element: 109 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 215
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 103 PointerType *table<string,int>
+      Element: 104 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 207
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 98 PointerType *table<string,main.nestedStruct>
+      Element: 99 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 275
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 140 PointerType *table<uint8,[4]int>
+      Element: 141 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 266
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 135 PointerType *table<uint8,uint8>
+      Element: 136 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 160 PointerType *[]uint
+          Type: 161 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 294 GoSliceDataType [][]uint.array
+      Data: 295 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 295
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 158 GoSliceHeaderType []uint
+      Element: 159 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 166
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 483488
@@ -6279,14 +6314,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 300 GoSliceDataType []bool.array
+      Data: 301 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 301
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 346
+      ID: 347
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 483808
@@ -6294,7 +6329,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 347 PointerType *interface {}
+          Type: 88 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -6308,7 +6343,7 @@ Types:
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 239
+      ID: 240
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 474848
@@ -6316,7 +6351,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 240 PointerType *main.structWithMap
+          Type: 241 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -6328,58 +6363,58 @@ Types:
       ID: 406
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 88 StructureType main.structWithMap
+      Element: 89 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 162
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *main.structWithNoStrings
+          Type: 163 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 296 GoSliceDataType []main.structWithNoStrings.array
+      Data: 297 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 297
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 163 StructureType main.structWithNoStrings
+      Element: 164 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 292
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 287 StructureType noalg.map.group[[4]int][4]int
+      Element: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 279 StructureType noalg.map.group[[4]int]uint8
+      Element: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 233
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 227 StructureType noalg.map.group[[4]string][2]int
+      Element: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 246 StructureType noalg.map.group[bool]main.node
+      Element: 247 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 330
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 323 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 364
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -6391,52 +6426,52 @@ Types:
       ByteSize: 2048
       Element: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 195 StructureType noalg.map.group[int]int
+      Element: 196 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 392
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
       Element: 388 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 259
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 254 StructureType noalg.map.group[int]uint8
+      Element: 255 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 243
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 236 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 219 StructureType noalg.map.group[string][]string
+      Element: 220 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 211 StructureType noalg.map.group[string]int
+      Element: 212 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 208
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 203 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 276
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 270 StructureType noalg.map.group[uint8][4]int
+      Element: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 267
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 262 StructureType noalg.map.group[uint8]uint8
+      Element: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 165
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 483616
@@ -6451,14 +6486,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 298 GoSliceDataType []string.array
+      Data: 299 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 299
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 159
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 483104
@@ -6473,14 +6508,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType []uint.array
+      Data: 293 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 293
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 482464
@@ -6495,9 +6530,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 302 GoSliceDataType []uint16.array
+      Data: 303 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 303
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -6508,7 +6543,7 @@ Types:
       GoRuntimeType: 580928
       GoKind: 1
     - __kind: GoChannelType
-      ID: 151
+      ID: 152
       Name: chan bool
       GoRuntimeType: 592256
       GoKind: 18
@@ -6561,89 +6596,89 @@ Types:
       GoRuntimeType: 472800
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 285
+      ID: 286
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 286 PointerType *noalg.map.group[[4]int][4]int
+          Type: 287 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 287 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 291 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 292 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 277
+      ID: 278
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 278 PointerType *noalg.map.group[[4]int]uint8
+          Type: 279 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 279 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 283 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 284 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 225
+      ID: 226
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 226 PointerType *noalg.map.group[[4]string][2]int
+          Type: 227 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 227 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 233 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 244
+      ID: 245
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 245 PointerType *noalg.map.group[bool]main.node
+          Type: 246 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 246 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 250 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 247 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 184
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 185 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 191 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 321
+      ID: 322
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 322 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 323 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 323 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 329 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 356
       Name: groupReference<int,*main.deepMap8>
@@ -6673,19 +6708,19 @@ Types:
       GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 193
+      ID: 194
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 194 PointerType *noalg.map.group[int]int
+          Type: 195 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 195 StructureType noalg.map.group[int]int
-      GroupSliceType: 199 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 196 StructureType noalg.map.group[int]int
+      GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 386
       Name: groupReference<int,interface {}>
@@ -6701,103 +6736,103 @@ Types:
       GroupType: 388 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 392 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 252
+      ID: 253
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 253 PointerType *noalg.map.group[int]uint8
+          Type: 254 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 254 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 255 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 234
+      ID: 235
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 235 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 236 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 236 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 217
+      ID: 218
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 218 PointerType *noalg.map.group[string][]string
+          Type: 219 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 219 StructureType noalg.map.group[string][]string
-      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 220 StructureType noalg.map.group[string][]string
+      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 209
+      ID: 210
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 210 PointerType *noalg.map.group[string]int
+          Type: 211 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 211 StructureType noalg.map.group[string]int
-      GroupSliceType: 215 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 212 StructureType noalg.map.group[string]int
+      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 202
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 203 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 207 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 268
+      ID: 269
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 269 PointerType *noalg.map.group[uint8][4]int
+          Type: 270 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 270 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 275 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 271 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 276 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 260
+      ID: 261
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 261 PointerType *noalg.map.group[uint8]uint8
+          Type: 262 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 262 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 266 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 263 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6868,7 +6903,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6884,7 +6919,7 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 172 StructureType main.nestedStruct
+          Type: 173 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
@@ -6924,7 +6959,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 189
+      ID: 190
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.18096e+06
@@ -6932,9 +6967,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 315 GoMapType map[int]*main.deepMap3
+          Type: 316 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 328
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -6986,9 +7021,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 304 PointerType *main.deepPtr3
+          Type: 305 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 305
+      ID: 306
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7000,9 +7035,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 330 PointerType *main.deepPtr8
+          Type: 331 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 331
+      ID: 332
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.181344e+06
@@ -7010,9 +7045,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 332 PointerType *main.deepPtr9
+          Type: 333 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 333
+      ID: 334
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.181216e+06
@@ -7032,7 +7067,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 179
+      ID: 180
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.183264e+06
@@ -7040,9 +7075,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 309 GoSliceHeaderType []*main.deepSlice3
+          Type: 310 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 312
+      ID: 313
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7054,9 +7089,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 334 GoSliceHeaderType []*main.deepSlice8
+          Type: 335 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 337
+      ID: 338
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.182496e+06
@@ -7064,9 +7099,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 340 GoSliceHeaderType []*main.deepSlice9
+          Type: 341 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 343
+      ID: 344
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.182368e+06
@@ -7074,9 +7109,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 346 GoSliceHeaderType []interface {}
+          Type: 347 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7131,7 +7166,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.456256e+06
@@ -7144,7 +7179,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 154
+      ID: 155
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.456096e+06
@@ -7155,9 +7190,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 155 PointerType *main.node
+          Type: 156 PointerType *main.node
     - __kind: StructureType
-      ID: 170
+      ID: 171
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7186,21 +7221,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *main.stringType1.str
+          Type: 308 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 306 GoStringDataType main.stringType1.str
+      Data: 307 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 307
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 308
+      ID: 309
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
-      ID: 88
+      ID: 89
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.179936e+06
@@ -7208,9 +7243,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 89 GoMapType map[int]int
+          Type: 90 GoMapType map[int]int
     - __kind: StructureType
-      ID: 163
+      ID: 164
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7222,7 +7257,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 153
+      ID: 154
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7234,7 +7269,7 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 157
+      ID: 158
       Name: main.t
       ByteSize: 24
       GoKind: 23
@@ -7253,9 +7288,9 @@ Types:
       ID: 404
       Name: main.t.array
       ByteSize: 2048
-      Element: 156 PointerType *main.t
+      Element: 157 PointerType *main.t
     - __kind: StructureType
-      ID: 167
+      ID: 168
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7275,7 +7310,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 149
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7288,7 +7323,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<[4]int,[4]int>
+          Type: 150 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7304,10 +7339,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 290 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 287 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 291 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 143
+      ID: 144
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7320,7 +7355,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 144 PointerType **table<[4]int,uint8>
+          Type: 145 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7336,10 +7371,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 282 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 279 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 283 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 111
+      ID: 112
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -7352,7 +7387,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 112 PointerType **table<[4]string,[2]int>
+          Type: 113 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7368,10 +7403,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 227 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 232 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 123
+      ID: 124
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -7384,7 +7419,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 124 PointerType **table<bool,main.node>
+          Type: 125 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7400,8 +7435,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 249 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 246 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 250 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 247 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -7432,10 +7467,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 190 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 185 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 317
+      ID: 318
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7448,7 +7483,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 318 PointerType **table<int,*main.deepMap3>
+          Type: 319 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7464,8 +7499,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 328 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 323 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 352
       Name: map<int,*main.deepMap8>
@@ -7531,7 +7566,7 @@ Types:
       TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap9>.array
       GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
-      ID: 91
+      ID: 92
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -7544,7 +7579,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 92 PointerType **table<int,int>
+          Type: 93 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7560,8 +7595,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 198 GoSliceDataType []*table<int,int>.array
-      GroupType: 195 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
+      GroupType: 196 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 382
       Name: map<int,interface {}>
@@ -7595,7 +7630,7 @@ Types:
       TablePtrSliceType: 391 GoSliceDataType []*table<int,interface {}>.array
       GroupType: 388 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 128
+      ID: 129
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7608,7 +7643,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 129 PointerType **table<int,uint8>
+          Type: 130 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7624,10 +7659,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 254 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 258 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 255 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 118
+      ID: 119
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -7640,7 +7675,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 119 PointerType **table<string,[]main.structWithMap>
+          Type: 120 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7656,10 +7691,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 241 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 236 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 106
+      ID: 107
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -7672,7 +7707,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 107 PointerType **table<string,[]string>
+          Type: 108 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7688,10 +7723,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 222 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 219 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 223 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 220 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 101
+      ID: 102
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -7704,7 +7739,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 102 PointerType **table<string,int>
+          Type: 103 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7720,10 +7755,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 214 GoSliceDataType []*table<string,int>.array
-      GroupType: 211 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 215 GoSliceDataType []*table<string,int>.array
+      GroupType: 212 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 96
+      ID: 97
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -7736,7 +7771,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 97 PointerType **table<string,main.nestedStruct>
+          Type: 98 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7752,10 +7787,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 206 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 203 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 207 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 139
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7768,7 +7803,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<uint8,[4]int>
+          Type: 140 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7784,10 +7819,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 274 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 270 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 275 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 133
+      ID: 134
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7800,7 +7835,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 134 PointerType **table<uint8,uint8>
+          Type: 135 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7816,36 +7851,36 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 265 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 262 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 266 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 146
+      ID: 147
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.124e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 149 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 141
+      ID: 142
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.124128e+06
       GoKind: 21
-      HeaderType: 143 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 144 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 109
+      ID: 110
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.124256e+06
       GoKind: 21
-      HeaderType: 111 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 112 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 121
+      ID: 122
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.124384e+06
       GoKind: 21
-      HeaderType: 123 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 124 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
@@ -7854,12 +7889,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 315
+      ID: 316
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.123744e+06
       GoKind: 21
-      HeaderType: 317 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 350
       Name: map[int]*main.deepMap8
@@ -7875,12 +7910,12 @@ Types:
       GoKind: 21
       HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 89
+      ID: 90
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.122464e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<int,int>
+      HeaderType: 92 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 380
       Name: map[int]interface {}
@@ -7889,108 +7924,108 @@ Types:
       GoKind: 21
       HeaderType: 382 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
-      ID: 126
+      ID: 127
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.124512e+06
       GoKind: 21
-      HeaderType: 128 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 129 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 116
+      ID: 117
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.12464e+06
       GoKind: 21
-      HeaderType: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 104
+      ID: 105
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.124768e+06
       GoKind: 21
-      HeaderType: 106 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 107 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 99
+      ID: 100
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.124896e+06
       GoKind: 21
-      HeaderType: 101 GoSwissMapHeaderType map<string,int>
+      HeaderType: 102 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 94
+      ID: 95
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.125024e+06
       GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 136
+      ID: 137
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.125152e+06
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 139 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 131
+      ID: 132
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.12528e+06
       GoKind: 21
-      HeaderType: 133 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 134 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 288
+      ID: 289
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 678752
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 289 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 290 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 280
+      ID: 281
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 678848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 281 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 282 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 228
+      ID: 229
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 679136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 229 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 230 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 247
+      ID: 248
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 679232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 248 StructureType noalg.struct { key bool; elem main.node }
+      Element: 249 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 186
+      ID: 187
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 678080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 187 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 324
+      ID: 325
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 677984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 325 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 359
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -8010,14 +8045,14 @@ Types:
       HasCount: true
       Element: 375 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 196
+      ID: 197
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 676160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 197 StructureType noalg.struct { key int; elem int }
+      Element: 198 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 389
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -8028,70 +8063,70 @@ Types:
       HasCount: true
       Element: 390 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 255
+      ID: 256
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 679328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 256 StructureType noalg.struct { key int; elem uint8 }
+      Element: 257 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 237
+      ID: 238
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 679424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 238 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 239 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 220
+      ID: 221
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 679520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 221 StructureType noalg.struct { key string; elem []string }
+      Element: 222 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 212
+      ID: 213
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 679616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem int }
+      Element: 214 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 204
+      ID: 205
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 679712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 205 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 206 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 271
+      ID: 272
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 679808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 272 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 273 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 263
+      ID: 264
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 679904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 264 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 265 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 287
+      ID: 288
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.28944e+06
@@ -8102,9 +8137,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 288 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 289 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 279
+      ID: 280
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.289696e+06
@@ -8115,9 +8150,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 280 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 281 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 227
+      ID: 228
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.289952e+06
@@ -8128,9 +8163,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 228 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 229 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 246
+      ID: 247
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.290208e+06
@@ -8141,9 +8176,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 247 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 248 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 185
+      ID: 186
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.289184e+06
@@ -8154,9 +8189,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 186 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 323
+      ID: 324
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.288928e+06
@@ -8167,7 +8202,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 324 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 358
       Name: noalg.map.group[int]*main.deepMap8
@@ -8195,7 +8230,7 @@ Types:
           Offset: 8
           Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 195
+      ID: 196
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.286368e+06
@@ -8206,7 +8241,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 196 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 197 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 388
       Name: noalg.map.group[int]interface {}
@@ -8221,7 +8256,7 @@ Types:
           Offset: 8
           Type: 389 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 254
+      ID: 255
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.290464e+06
@@ -8232,9 +8267,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 255 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 256 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 236
+      ID: 237
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.29072e+06
@@ -8245,9 +8280,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 237 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 238 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 219
+      ID: 220
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290976e+06
@@ -8258,9 +8293,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 220 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 211
+      ID: 212
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.291232e+06
@@ -8271,9 +8306,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 213 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 203
+      ID: 204
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.291488e+06
@@ -8284,9 +8319,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 204 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 205 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 270
+      ID: 271
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.291744e+06
@@ -8297,9 +8332,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 271 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 272 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 262
+      ID: 263
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.292e+06
@@ -8310,9 +8345,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 263 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 264 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 289
+      ID: 290
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.289312e+06
@@ -8320,12 +8355,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
     - __kind: StructureType
-      ID: 281
+      ID: 282
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.289568e+06
@@ -8333,12 +8368,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 229
+      ID: 230
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.289824e+06
@@ -8346,12 +8381,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 230 ArrayType [4]string
+          Type: 231 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 248
+      ID: 249
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.29008e+06
@@ -8362,9 +8397,9 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 154 StructureType main.node
+          Type: 155 StructureType main.node
     - __kind: StructureType
-      ID: 187
+      ID: 188
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.289056e+06
@@ -8375,9 +8410,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 188 PointerType *main.deepMap2
+          Type: 189 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 325
+      ID: 326
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.2888e+06
@@ -8388,7 +8423,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 326 PointerType *main.deepMap3
+          Type: 327 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 360
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -8416,7 +8451,7 @@ Types:
           Offset: 8
           Type: 376 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 197
+      ID: 198
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.28624e+06
@@ -8442,7 +8477,7 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 256
+      ID: 257
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.290336e+06
@@ -8455,7 +8490,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 238
+      ID: 239
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.290592e+06
@@ -8466,9 +8501,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 239 GoSliceHeaderType []main.structWithMap
+          Type: 240 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 221
+      ID: 222
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290848e+06
@@ -8479,9 +8514,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 164 GoSliceHeaderType []string
+          Type: 165 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 213
+      ID: 214
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.291104e+06
@@ -8494,7 +8529,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 205
+      ID: 206
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.29136e+06
@@ -8505,9 +8540,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 172 StructureType main.nestedStruct
+          Type: 173 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 272
+      ID: 273
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.291616e+06
@@ -8518,9 +8553,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
     - __kind: StructureType
-      ID: 264
+      ID: 265
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.291872e+06
@@ -8541,13 +8576,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 176 PointerType *string.str
+          Type: 177 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 175 GoStringDataType string.str
+      Data: 176 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 175
+      ID: 176
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -8656,7 +8691,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 284
+      ID: 285
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -8678,9 +8713,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 285 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 286 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 276
+      ID: 277
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8702,9 +8737,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 277 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 278 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 224
+      ID: 225
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -8726,9 +8761,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 225 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 226 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 243
+      ID: 244
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -8750,9 +8785,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 244 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 245 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 182
+      ID: 183
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -8774,9 +8809,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 320
+      ID: 321
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8798,7 +8833,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 321 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 355
       Name: table<int,*main.deepMap8>
@@ -8848,7 +8883,7 @@ Types:
           Offset: 16
           Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 192
+      ID: 193
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -8870,7 +8905,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 193 GoSwissMapGroupsType groupReference<int,int>
+          Type: 194 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 385
       Name: table<int,interface {}>
@@ -8896,7 +8931,7 @@ Types:
           Offset: 16
           Type: 386 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 251
+      ID: 252
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8918,9 +8953,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 252 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 253 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 233
+      ID: 234
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -8942,9 +8977,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 234 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 235 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 216
+      ID: 217
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -8966,9 +9001,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 217 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 218 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 208
+      ID: 209
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -8990,9 +9025,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 209 GoSwissMapGroupsType groupReference<string,int>
+          Type: 210 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 200
+      ID: 201
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -9014,9 +9049,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 202 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 267
+      ID: 268
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -9038,9 +9073,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 268 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 269 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 259
+      ID: 260
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9062,7 +9097,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 260 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 261 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -9105,6 +9140,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580992
       GoKind: 26
-MaxTypeID: 520
+MaxTypeID: 521
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x131d360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 506 EventRootType Probe[main.stackC]
+          Type: 1169 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84d92c", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 461 EventRootType Probe[main.testAny]
+          Type: 1124 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b22c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 463 EventRootType Probe[main.testAnyPtr]
+          Type: 1126 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b2ac", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 423 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1086 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 425 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1088 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 471 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1134 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84b900", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 424 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1087 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 443 EventRootType Probe[main.testBigStruct]
+          Type: 1106 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849fd0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 412 EventRootType Probe[main.testBoolArray]
+          Type: 1075 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 409 EventRootType Probe[main.testByteArray]
+          Type: 1072 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849970", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 487 EventRootType Probe[main.testChannel]
+          Type: 1150 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84cf50", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 485 EventRootType Probe[main.testCombinedByte]
+          Type: 1148 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84ccd0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 495 EventRootType Probe[main.testCycle]
+          Type: 1158 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d1f0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 448 EventRootType Probe[main.testDeepMap1]
+          Type: 1111 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3b0", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 449 EventRootType Probe[main.testDeepMap7]
+          Type: 1112 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3c0", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 444 EventRootType Probe[main.testDeepPtr1]
+          Type: 1107 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0a0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 445 EventRootType Probe[main.testDeepPtr7]
+          Type: 1108 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0b0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 446 EventRootType Probe[main.testDeepSlice1]
+          Type: 1109 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a250", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 447 EventRootType Probe[main.testDeepSlice7]
+          Type: 1110 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a260", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 497 EventRootType Probe[main.testEmptySlice]
+          Type: 1160 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 500 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1163 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84d600", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 514 EventRootType Probe[main.testEmptyString]
+          Type: 1177 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84da10", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -337,7 +337,7 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - ID: 108
-          Type: 516 EventRootType Probe[main.testEmptyStruct]
+          Type: 1179 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x84dd20", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -350,7 +350,7 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - ID: 109
-          Type: 517 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1180 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x84dd30", Frameless: true}]
           Condition: null
     - id: testError
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 462 EventRootType Probe[main.testError]
+          Type: 1125 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b290", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 453 EventRootType Probe[main.testEsotericHeap]
+          Type: 1116 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84a84c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 452 EventRootType Probe[main.testEsotericStack]
+          Type: 1115 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a77c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 458 EventRootType Probe[main.testFrameless]
+          Type: 1121 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84af70", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 459 EventRootType Probe[main.testFramelessArray]
+          Type: 1122 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84af80", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 454 EventRootType Probe[main.testInlinedBA]
+          Type: 1117 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84ac8c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 455 EventRootType Probe[main.testInlinedBB]
+          Type: 1118 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84ad1c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 456 EventRootType Probe[main.testInlinedBBA]
+          Type: 1119 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84addc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -476,7 +476,7 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - ID: 111
-          Type: 519 EventRootType Probe[main.testInlinedBBB]
+          Type: 1182 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84ad78", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 457 EventRootType Probe[main.testInlinedBC]
+          Type: 1120 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84ae5c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -504,7 +504,7 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - ID: 112
-          Type: 520 EventRootType Probe[main.testInlinedBCA]
+          Type: 1183 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84ae6c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -518,7 +518,7 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - ID: 113
-          Type: 521 EventRootType Probe[main.testInlinedBCB]
+          Type: 1184 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84af20", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - ID: 110
-          Type: 518 EventRootType Probe[main.testInlinedPrint]
+          Type: 1181 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84aaec"
               Frameless: true
@@ -557,7 +557,7 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - ID: 114
-          Type: 522 EventRootType Probe[main.testInlinedSq]
+          Type: 1185 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84af74", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -572,7 +572,7 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - ID: 115
-          Type: 523 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1186 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84afa4"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 415 EventRootType Probe[main.testInt16Array]
+          Type: 1078 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 416 EventRootType Probe[main.testInt32Array]
+          Type: 1079 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 417 EventRootType Probe[main.testInt64Array]
+          Type: 1080 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 414 EventRootType Probe[main.testInt8Array]
+          Type: 1077 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 413 EventRootType Probe[main.testIntArray]
+          Type: 1076 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 460 EventRootType Probe[main.testInterface]
+          Type: 1123 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b210", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 489 EventRootType Probe[main.testLinkedList]
+          Type: 1152 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d100", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 469 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1132 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84b8e0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 475 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1138 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84b940", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 473 EventRootType Probe[main.testMapIntToInt]
+          Type: 1136 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84b920", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 484 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1147 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84b9d0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 483 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1146 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84b9c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 474 EventRootType Probe[main.testMapMassive]
+          Type: 1137 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84b930", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 482 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1145 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84b9b0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 481 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1144 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84b9a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 467 EventRootType Probe[main.testMapStringToInt]
+          Type: 1130 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84b8c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 468 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1131 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84b8d0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 466 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1129 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84b8b0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 476 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1139 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84b950", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 479 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1142 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84b980", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 480 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1143 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84b990", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 477 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1140 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84b960", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 478 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1141 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84b970", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 512 EventRootType Probe[main.testMassiveString]
+          Type: 1175 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84d9f0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 486 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1149 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84cdb0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 494 EventRootType Probe[main.testNilPointer]
+          Type: 1157 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d1d0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 504 EventRootType Probe[main.testNilSlice]
+          Type: 1167 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84d640", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 501 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1164 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84d610", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 503 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1166 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84d630", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 511 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1174 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84d9e0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 490 EventRootType Probe[main.testPointerLoop]
+          Type: 1153 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d110", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 472 EventRootType Probe[main.testPointerToMap]
+          Type: 1135 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84b910", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 488 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1151 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d0f0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 410 EventRootType Probe[main.testRuneArray]
+          Type: 1073 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 429 EventRootType Probe[main.testSingleBool]
+          Type: 1092 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 427 EventRootType Probe[main.testSingleByte]
+          Type: 1090 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849dd0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 440 EventRootType Probe[main.testSingleFloat32]
+          Type: 1103 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 441 EventRootType Probe[main.testSingleFloat64]
+          Type: 1104 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 430 EventRootType Probe[main.testSingleInt]
+          Type: 1093 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 432 EventRootType Probe[main.testSingleInt16]
+          Type: 1095 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 433 EventRootType Probe[main.testSingleInt32]
+          Type: 1096 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 434 EventRootType Probe[main.testSingleInt64]
+          Type: 1097 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 431 EventRootType Probe[main.testSingleInt8]
+          Type: 1094 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 428 EventRootType Probe[main.testSingleRune]
+          Type: 1091 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849de0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 507 EventRootType Probe[main.testSingleString]
+          Type: 1170 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84d990", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 435 EventRootType Probe[main.testSingleUint]
+          Type: 1098 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 437 EventRootType Probe[main.testSingleUint16]
+          Type: 1100 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 438 EventRootType Probe[main.testSingleUint32]
+          Type: 1101 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 439 EventRootType Probe[main.testSingleUint64]
+          Type: 1102 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 436 EventRootType Probe[main.testSingleUint8]
+          Type: 1099 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 498 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1161 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 470 EventRootType Probe[main.testSmallMap]
+          Type: 1133 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84b8f0", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 411 EventRootType Probe[main.testStringArray]
+          Type: 1074 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 493 EventRootType Probe[main.testStringPointer]
+          Type: 1156 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d1b0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 502 EventRootType Probe[main.testStringSlice]
+          Type: 1165 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84d620", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 450 EventRootType Probe[main.testStringType1]
+          Type: 1113 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 451 EventRootType Probe[main.testStringType2]
+          Type: 1114 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1394,7 +1394,7 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - ID: 107
-          Type: 515 EventRootType Probe[main.testStruct]
+          Type: 1178 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x84dc20", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 499 EventRootType Probe[main.testStructSlice]
+          Type: 1162 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,7 +1425,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 464 EventRootType Probe[main.testStructWithAny]
+          Type: 1127 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x84b310", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1439,7 +1439,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 465 EventRootType Probe[main.testStructWithMap]
+          Type: 1128 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84b8a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1453,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 508 EventRootType Probe[main.testThreeStrings]
+          Type: 1171 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84d9a0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1467,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 509 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1172 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84d9b0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1481,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 510 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1173 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84d9d0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 442 EventRootType Probe[main.testTypeAlias]
+          Type: 1105 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 420 EventRootType Probe[main.testUint16Array]
+          Type: 1083 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 421 EventRootType Probe[main.testUint32Array]
+          Type: 1084 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 422 EventRootType Probe[main.testUint64Array]
+          Type: 1085 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 419 EventRootType Probe[main.testUint8Array]
+          Type: 1082 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 418 EventRootType Probe[main.testUintArray]
+          Type: 1081 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1579,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 492 EventRootType Probe[main.testUintPointer]
+          Type: 1155 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d140", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1593,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 496 EventRootType Probe[main.testUintSlice]
+          Type: 1159 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1607,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 513 EventRootType Probe[main.testUnitializedString]
+          Type: 1176 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84da00", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1621,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 491 EventRootType Probe[main.testUnsafePointer]
+          Type: 1154 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d120", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 426 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1089 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1649,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 505 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1168 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84d650", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3416,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 325
+      ID: 988
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 326 PointerType *main.deepSlice3
+      Pointee: 989 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 352
+      ID: 1015
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 353 PointerType *main.deepSlice8
+      Pointee: 1016 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 358
+      ID: 1021
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 359 PointerType *main.deepSlice9
+      Pointee: 1022 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3437,7 +3437,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 321
+      ID: 984
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3474,30 +3474,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 333
+      ID: 996
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 334 PointerType *table<int,*main.deepMap3>
+      Pointee: 997 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 369
+      ID: 1032
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 370 PointerType *table<int,*main.deepMap8>
+      Pointee: 1033 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 384
+      ID: 1047
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 385 PointerType *table<int,*main.deepMap9>
+      Pointee: 1048 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 399
+      ID: 1062
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 400 PointerType *table<int,interface {}>
+      Pointee: 1063 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '**table<int,uint8>'
@@ -3513,6 +3513,11 @@ Types:
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
+    - __kind: PointerType
+      ID: 727
+      Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 728 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3539,20 +3544,20 @@ Types:
       ByteSize: 8
       Pointee: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 329
+      ID: 992
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 328 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 991 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 356
+      ID: 1019
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 355 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1018 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 362
+      ID: 1025
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 361 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1024 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 180
       Name: '*[]*string.array'
@@ -3569,15 +3574,20 @@ Types:
       ByteSize: 8
       Pointee: 302 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 365
+      ID: 767
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 766 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 1028
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 364 GoSliceDataType []interface {}.array
+      Pointee: 1027 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 346
+      ID: 1009
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 345 GoSliceDataType []main.structWithMap.array
+      Pointee: 1008 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 299
       Name: '*[]main.structWithNoStrings.array'
@@ -3604,6 +3614,72 @@ Types:
       ByteSize: 8
       Pointee: 304 GoSliceDataType []uint16.array
     - __kind: PointerType
+      ID: 765
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 764 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 897
+      Name: '*archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.976128e+06
+      GoKind: 22
+      Pointee: 898 UnresolvedPointeeType archive/tar.Writer
+    - __kind: PointerType
+      ID: 535
+      Name: '*archive/tar.headerError'
+      ByteSize: 8
+      GoRuntimeType: 925920
+      GoKind: 22
+      Pointee: 536 GoSliceHeaderType archive/tar.headerError
+    - __kind: PointerType
+      ID: 538
+      Name: '*archive/tar.headerError.array'
+      ByteSize: 8
+      Pointee: 537 GoSliceDataType archive/tar.headerError.array
+    - __kind: PointerType
+      ID: 832
+      Name: '*archive/tar.regFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.430016e+06
+      GoKind: 22
+      Pointee: 833 UnresolvedPointeeType archive/tar.regFileWriter
+    - __kind: PointerType
+      ID: 780
+      Name: '*archive/zip.countWriter'
+      ByteSize: 8
+      GoRuntimeType: 926112
+      GoKind: 22
+      Pointee: 781 UnresolvedPointeeType archive/zip.countWriter
+    - __kind: PointerType
+      ID: 782
+      Name: '*archive/zip.dirWriter'
+      ByteSize: 8
+      GoRuntimeType: 926208
+      GoKind: 22
+      Pointee: 783 StructureType archive/zip.dirWriter
+    - __kind: PointerType
+      ID: 880
+      Name: '*archive/zip.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.895808e+06
+      GoKind: 22
+      Pointee: 881 UnresolvedPointeeType archive/zip.fileWriter
+    - __kind: PointerType
+      ID: 808
+      Name: '*archive/zip.nopCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.052544e+06
+      GoKind: 22
+      Pointee: 809 StructureType archive/zip.nopCloser
+    - __kind: PointerType
+      ID: 810
+      Name: '*archive/zip.pooledFlateWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.0528e+06
+      GoKind: 22
+      Pointee: 811 UnresolvedPointeeType archive/zip.pooledFlateWriter
+    - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
@@ -3611,12 +3687,442 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
+      ID: 855
+      Name: '*bufio.Reader'
+      ByteSize: 8
+      GoRuntimeType: 2.164256e+06
+      GoKind: 22
+      Pointee: 856 UnresolvedPointeeType bufio.Reader
+    - __kind: PointerType
+      ID: 884
+      Name: '*bufio.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.94032e+06
+      GoKind: 22
+      Pointee: 885 UnresolvedPointeeType bufio.Writer
+    - __kind: PointerType
+      ID: 935
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.261536e+06
+      GoKind: 22
+      Pointee: 936 UnresolvedPointeeType bytes.Buffer
+    - __kind: PointerType
+      ID: 447
+      Name: '*compress/flate.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 908544
+      GoKind: 22
+      Pointee: 339 BaseType compress/flate.CorruptInputError
+    - __kind: PointerType
+      ID: 448
+      Name: '*compress/flate.InternalError'
+      ByteSize: 8
+      GoRuntimeType: 908640
+      GoKind: 22
+      Pointee: 340 GoStringHeaderType compress/flate.InternalError
+    - __kind: PointerType
+      ID: 342
+      Name: '*compress/flate.InternalError.str'
+      ByteSize: 8
+      Pointee: 341 GoStringDataType compress/flate.InternalError.str
+    - __kind: PointerType
+      ID: 830
+      Name: '*compress/flate.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.419456e+06
+      GoKind: 22
+      Pointee: 831 UnresolvedPointeeType compress/flate.Writer
+    - __kind: PointerType
+      ID: 776
+      Name: '*compress/flate.dictWriter'
+      ByteSize: 8
+      GoRuntimeType: 908736
+      GoKind: 22
+      Pointee: 777 UnresolvedPointeeType compress/flate.dictWriter
+    - __kind: PointerType
+      ID: 852
+      Name: '*compress/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.717792e+06
+      GoKind: 22
+      Pointee: 853 UnresolvedPointeeType compress/gzip.Writer
+    - __kind: PointerType
+      ID: 679
+      Name: '*context.deadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.198752e+06
+      GoKind: 22
+      Pointee: 680 StructureType context.deadlineExceededError
+    - __kind: PointerType
+      ID: 527
+      Name: '*crypto/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 920544
+      GoKind: 22
+      Pointee: 353 BaseType crypto/aes.KeySizeError
+    - __kind: PointerType
+      ID: 528
+      Name: '*crypto/des.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 920736
+      GoKind: 22
+      Pointee: 354 BaseType crypto/des.KeySizeError
+    - __kind: PointerType
+      ID: 529
+      Name: '*crypto/internal/fips140/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 921024
+      GoKind: 22
+      Pointee: 355 BaseType crypto/internal/fips140/aes.KeySizeError
+    - __kind: PointerType
+      ID: 842
+      Name: '*crypto/internal/fips140/hmac.HMAC'
+      ByteSize: 8
+      GoRuntimeType: 1.560096e+06
+      GoKind: 22
+      Pointee: 843 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+    - __kind: PointerType
+      ID: 876
+      Name: '*crypto/internal/fips140/sha256.Digest'
+      ByteSize: 8
+      GoRuntimeType: 1.854464e+06
+      GoKind: 22
+      Pointee: 877 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+    - __kind: PointerType
+      ID: 908
+      Name: '*crypto/internal/fips140/sha3.Digest'
+      ByteSize: 8
+      GoRuntimeType: 2.111584e+06
+      GoKind: 22
+      Pointee: 909 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+    - __kind: PointerType
+      ID: 882
+      Name: '*crypto/internal/fips140/sha3.SHAKE'
+      ByteSize: 8
+      GoRuntimeType: 1.89632e+06
+      GoKind: 22
+      Pointee: 883 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+    - __kind: PointerType
+      ID: 878
+      Name: '*crypto/internal/fips140/sha512.Digest'
+      ByteSize: 8
+      GoRuntimeType: 1.854912e+06
+      GoKind: 22
+      Pointee: 879 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+    - __kind: PointerType
+      ID: 874
+      Name: '*crypto/md5.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.847296e+06
+      GoKind: 22
+      Pointee: 875 UnresolvedPointeeType crypto/md5.digest
+    - __kind: PointerType
+      ID: 530
+      Name: '*crypto/rc4.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 921312
+      GoKind: 22
+      Pointee: 356 BaseType crypto/rc4.KeySizeError
+    - __kind: PointerType
+      ID: 892
+      Name: '*crypto/sha1.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.945696e+06
+      GoKind: 22
+      Pointee: 893 UnresolvedPointeeType crypto/sha1.digest
+    - __kind: PointerType
+      ID: 864
+      Name: '*crypto/sha3.SHA3'
+      ByteSize: 8
+      GoRuntimeType: 1.80128e+06
+      GoKind: 22
+      Pointee: 865 UnresolvedPointeeType crypto/sha3.SHA3
+    - __kind: PointerType
+      ID: 453
+      Name: '*crypto/tls.AlertError'
+      ByteSize: 8
+      GoRuntimeType: 910176
+      GoKind: 22
+      Pointee: 343 BaseType crypto/tls.AlertError
+    - __kind: PointerType
+      ID: 619
+      Name: '*crypto/tls.CertificateVerificationError'
+      ByteSize: 8
+      GoRuntimeType: 1.041152e+06
+      GoKind: 22
+      Pointee: 620 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+    - __kind: PointerType
+      ID: 961
+      Name: '*crypto/tls.Conn'
+      ByteSize: 8
+      GoRuntimeType: 2.373408e+06
+      GoKind: 22
+      Pointee: 962 UnresolvedPointeeType crypto/tls.Conn
+    - __kind: PointerType
+      ID: 451
+      Name: '*crypto/tls.ECHRejectionError'
+      ByteSize: 8
+      GoRuntimeType: 909984
+      GoKind: 22
+      Pointee: 452 UnresolvedPointeeType crypto/tls.ECHRejectionError
+    - __kind: PointerType
+      ID: 449
+      Name: '*crypto/tls.RecordHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 909888
+      GoKind: 22
+      Pointee: 450 StructureType crypto/tls.RecordHeaderError
+    - __kind: PointerType
+      ID: 618
+      Name: '*crypto/tls.alert'
+      ByteSize: 8
+      GoRuntimeType: 1.039488e+06
+      GoKind: 22
+      Pointee: 575 BaseType crypto/tls.alert
+    - __kind: PointerType
+      ID: 840
+      Name: '*crypto/tls.cthWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.553056e+06
+      GoKind: 22
+      Pointee: 841 UnresolvedPointeeType crypto/tls.cthWrapper
+    - __kind: PointerType
+      ID: 847
+      Name: '*crypto/tls.finishedHash'
+      ByteSize: 8
+      GoRuntimeType: 1.635488e+06
+      GoKind: 22
+      Pointee: 848 UnresolvedPointeeType crypto/tls.finishedHash
+    - __kind: PointerType
+      ID: 714
+      Name: '*crypto/tls.permanentError'
+      ByteSize: 8
+      GoRuntimeType: 1.419776e+06
+      GoKind: 22
+      Pointee: 715 UnresolvedPointeeType crypto/tls.permanentError
+    - __kind: PointerType
+      ID: 729
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.034176e+06
+      GoKind: 22
+      Pointee: 730 UnresolvedPointeeType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 523
+      Name: '*crypto/x509.CertificateInvalidError'
+      ByteSize: 8
+      GoRuntimeType: 919584
+      GoKind: 22
+      Pointee: 524 StructureType crypto/x509.CertificateInvalidError
+    - __kind: PointerType
+      ID: 517
+      Name: '*crypto/x509.ConstraintViolationError'
+      ByteSize: 8
+      GoRuntimeType: 919104
+      GoKind: 22
+      Pointee: 518 StructureType crypto/x509.ConstraintViolationError
+    - __kind: PointerType
+      ID: 519
+      Name: '*crypto/x509.HostnameError'
+      ByteSize: 8
+      GoRuntimeType: 919200
+      GoKind: 22
+      Pointee: 520 StructureType crypto/x509.HostnameError
+    - __kind: PointerType
+      ID: 516
+      Name: '*crypto/x509.InsecureAlgorithmError'
+      ByteSize: 8
+      GoRuntimeType: 919008
+      GoKind: 22
+      Pointee: 352 BaseType crypto/x509.InsecureAlgorithmError
+    - __kind: PointerType
+      ID: 624
+      Name: '*crypto/x509.SystemRootsError'
+      ByteSize: 8
+      GoRuntimeType: 1.046912e+06
+      GoKind: 22
+      Pointee: 625 StructureType crypto/x509.SystemRootsError
+    - __kind: PointerType
+      ID: 525
+      Name: '*crypto/x509.UnhandledCriticalExtension'
+      ByteSize: 8
+      GoRuntimeType: 919680
+      GoKind: 22
+      Pointee: 526 StructureType crypto/x509.UnhandledCriticalExtension
+    - __kind: PointerType
+      ID: 521
+      Name: '*crypto/x509.UnknownAuthorityError'
+      ByteSize: 8
+      GoRuntimeType: 919488
+      GoKind: 22
+      Pointee: 522 StructureType crypto/x509.UnknownAuthorityError
+    - __kind: PointerType
+      ID: 539
+      Name: '*encoding/asn1.StructuralError'
+      ByteSize: 8
+      GoRuntimeType: 926400
+      GoKind: 22
+      Pointee: 540 StructureType encoding/asn1.StructuralError
+    - __kind: PointerType
+      ID: 543
+      Name: '*encoding/asn1.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 926592
+      GoKind: 22
+      Pointee: 544 StructureType encoding/asn1.SyntaxError
+    - __kind: PointerType
+      ID: 541
+      Name: '*encoding/asn1.invalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 926496
+      GoKind: 22
+      Pointee: 542 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+    - __kind: PointerType
+      ID: 437
+      Name: '*encoding/base64.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 906624
+      GoKind: 22
+      Pointee: 337 BaseType encoding/base64.CorruptInputError
+    - __kind: PointerType
+      ID: 798
+      Name: '*encoding/base64.encoder'
+      ByteSize: 8
+      GoRuntimeType: 1.036672e+06
+      GoKind: 22
+      Pointee: 799 UnresolvedPointeeType encoding/base64.encoder
+    - __kind: PointerType
+      ID: 440
+      Name: '*encoding/hex.InvalidByteError'
+      ByteSize: 8
+      GoRuntimeType: 907488
+      GoKind: 22
+      Pointee: 338 BaseType encoding/hex.InvalidByteError
+    - __kind: PointerType
+      ID: 408
+      Name: '*encoding/json.InvalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 901344
+      GoKind: 22
+      Pointee: 409 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+    - __kind: PointerType
+      ID: 610
+      Name: '*encoding/json.MarshalerError'
+      ByteSize: 8
+      GoRuntimeType: 1.03296e+06
+      GoKind: 22
+      Pointee: 611 UnresolvedPointeeType encoding/json.MarshalerError
+    - __kind: PointerType
+      ID: 400
+      Name: '*encoding/json.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 900960
+      GoKind: 22
+      Pointee: 401 UnresolvedPointeeType encoding/json.SyntaxError
+    - __kind: PointerType
+      ID: 406
+      Name: '*encoding/json.UnmarshalTypeError'
+      ByteSize: 8
+      GoRuntimeType: 901248
+      GoKind: 22
+      Pointee: 407 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+    - __kind: PointerType
+      ID: 404
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 901152
+      GoKind: 22
+      Pointee: 405 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 402
+      Name: '*encoding/json.UnsupportedValueError'
+      ByteSize: 8
+      GoRuntimeType: 901056
+      GoKind: 22
+      Pointee: 403 UnresolvedPointeeType encoding/json.UnsupportedValueError
+    - __kind: PointerType
+      ID: 941
+      Name: '*encoding/json.encodeState'
+      ByteSize: 8
+      GoRuntimeType: 2.28656e+06
+      GoKind: 22
+      Pointee: 942 UnresolvedPointeeType encoding/json.encodeState
+    - __kind: PointerType
+      ID: 410
+      Name: '*encoding/json.jsonError'
+      ByteSize: 8
+      GoRuntimeType: 901728
+      GoKind: 22
+      Pointee: 411 StructureType encoding/json.jsonError
+    - __kind: PointerType
+      ID: 806
+      Name: '*encoding/pem.lineBreaker'
+      ByteSize: 8
+      GoRuntimeType: 1.049472e+06
+      GoKind: 22
+      Pointee: 807 UnresolvedPointeeType encoding/pem.lineBreaker
+    - __kind: PointerType
+      ID: 511
+      Name: '*encoding/xml.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 918048
+      GoKind: 22
+      Pointee: 512 UnresolvedPointeeType encoding/xml.SyntaxError
+    - __kind: PointerType
+      ID: 509
+      Name: '*encoding/xml.TagPathError'
+      ByteSize: 8
+      GoRuntimeType: 917952
+      GoKind: 22
+      Pointee: 510 UnresolvedPointeeType encoding/xml.TagPathError
+    - __kind: PointerType
+      ID: 513
+      Name: '*encoding/xml.UnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 918144
+      GoKind: 22
+      Pointee: 349 GoStringHeaderType encoding/xml.UnmarshalError
+    - __kind: PointerType
+      ID: 351
+      Name: '*encoding/xml.UnmarshalError.str'
+      ByteSize: 8
+      Pointee: 350 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: PointerType
+      ID: 514
+      Name: '*encoding/xml.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 918240
+      GoKind: 22
+      Pointee: 515 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 919
+      Name: '*encoding/xml.printer'
+      ByteSize: 8
+      GoRuntimeType: 2.150016e+06
+      GoKind: 22
+      Pointee: 920 UnresolvedPointeeType encoding/xml.printer
+    - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 389344
       GoKind: 22
       Pointee: 14 GoInterfaceType error
+    - __kind: PointerType
+      ID: 378
+      Name: '*errors.errorString'
+      ByteSize: 8
+      GoRuntimeType: 891648
+      GoKind: 22
+      Pointee: 379 UnresolvedPointeeType errors.errorString
+    - __kind: PointerType
+      ID: 577
+      Name: '*errors.joinError'
+      ByteSize: 8
+      GoRuntimeType: 1.017856e+06
+      GoKind: 22
+      Pointee: 578 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -3631,6 +4137,814 @@ Types:
       GoRuntimeType: 390368
       GoKind: 22
       Pointee: 18 BaseType float64
+    - __kind: PointerType
+      ID: 929
+      Name: '*fmt.pp'
+      ByteSize: 8
+      GoRuntimeType: 2.253856e+06
+      GoKind: 22
+      Pointee: 930 UnresolvedPointeeType fmt.pp
+    - __kind: PointerType
+      ID: 579
+      Name: '*fmt.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.019648e+06
+      GoKind: 22
+      Pointee: 580 UnresolvedPointeeType fmt.wrapError
+    - __kind: PointerType
+      ID: 581
+      Name: '*fmt.wrapErrors'
+      ByteSize: 8
+      GoRuntimeType: 1.019776e+06
+      GoKind: 22
+      Pointee: 582 UnresolvedPointeeType fmt.wrapErrors
+    - __kind: PointerType
+      ID: 438
+      Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 907008
+      GoKind: 22
+      Pointee: 439 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+    - __kind: PointerType
+      ID: 419
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 904128
+      GoKind: 22
+      Pointee: 420 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+    - __kind: PointerType
+      ID: 421
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 904224
+      GoKind: 22
+      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+    - __kind: PointerType
+      ID: 742
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
+      ByteSize: 8
+      GoRuntimeType: 903936
+      GoKind: 22
+      Pointee: 743 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+    - __kind: PointerType
+      ID: 425
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
+      ByteSize: 8
+      GoRuntimeType: 904512
+      GoKind: 22
+      Pointee: 426 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+    - __kind: PointerType
+      ID: 744
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
+      ByteSize: 8
+      GoRuntimeType: 904032
+      GoKind: 22
+      Pointee: 745 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+    - __kind: PointerType
+      ID: 423
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
+      ByteSize: 8
+      GoRuntimeType: 904320
+      GoKind: 22
+      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+    - __kind: PointerType
+      ID: 333
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
+      ByteSize: 8
+      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: PointerType
+      ID: 418
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
+      ByteSize: 8
+      GoRuntimeType: 903840
+      GoKind: 22
+      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+    - __kind: PointerType
+      ID: 330
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
+      ByteSize: 8
+      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: PointerType
+      ID: 424
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
+      ByteSize: 8
+      GoRuntimeType: 904416
+      GoKind: 22
+      Pointee: 334 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+    - __kind: PointerType
+      ID: 336
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
+      ByteSize: 8
+      Pointee: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: PointerType
+      ID: 820
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.204256e+06
+      GoKind: 22
+      Pointee: 821 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+    - __kind: PointerType
+      ID: 905
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.049184e+06
+      GoKind: 22
+      Pointee: 906 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+    - __kind: PointerType
+      ID: 533
+      Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
+      ByteSize: 8
+      GoRuntimeType: 924864
+      GoKind: 22
+      Pointee: 534 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+    - __kind: PointerType
+      ID: 688
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
+      ByteSize: 8
+      GoRuntimeType: 1.20784e+06
+      GoKind: 22
+      Pointee: 689 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+    - __kind: PointerType
+      ID: 937
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
+      ByteSize: 8
+      GoRuntimeType: 2.263584e+06
+      GoKind: 22
+      Pointee: 938 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+    - __kind: PointerType
+      ID: 460
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
+      ByteSize: 8
+      GoRuntimeType: 913536
+      GoKind: 22
+      Pointee: 461 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+    - __kind: PointerType
+      ID: 467
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
+      ByteSize: 8
+      GoRuntimeType: 914592
+      GoKind: 22
+      Pointee: 468 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+    - __kind: PointerType
+      ID: 462
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
+      ByteSize: 8
+      GoRuntimeType: 914304
+      GoKind: 22
+      Pointee: 348 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+    - __kind: PointerType
+      ID: 465
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
+      ByteSize: 8
+      GoRuntimeType: 914496
+      GoKind: 22
+      Pointee: 466 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+    - __kind: PointerType
+      ID: 463
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
+      ByteSize: 8
+      GoRuntimeType: 914400
+      GoKind: 22
+      Pointee: 464 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+    - __kind: PointerType
+      ID: 483
+      Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
+      ByteSize: 8
+      GoRuntimeType: 916512
+      GoKind: 22
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+    - __kind: PointerType
+      ID: 487
+      Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
+      ByteSize: 8
+      GoRuntimeType: 916704
+      GoKind: 22
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+    - __kind: PointerType
+      ID: 485
+      Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
+      ByteSize: 8
+      GoRuntimeType: 916608
+      GoKind: 22
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+    - __kind: PointerType
+      ID: 481
+      Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
+      ByteSize: 8
+      GoRuntimeType: 916416
+      GoKind: 22
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+    - __kind: PointerType
+      ID: 769
+      Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 8
+      Pointee: 768 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: PointerType
+      ID: 495
+      Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
+      ByteSize: 8
+      GoRuntimeType: 917088
+      GoKind: 22
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+    - __kind: PointerType
+      ID: 489
+      Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
+      ByteSize: 8
+      GoRuntimeType: 916800
+      GoKind: 22
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+    - __kind: PointerType
+      ID: 493
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
+      ByteSize: 8
+      GoRuntimeType: 916992
+      GoKind: 22
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+    - __kind: PointerType
+      ID: 491
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
+      ByteSize: 8
+      GoRuntimeType: 916896
+      GoKind: 22
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+    - __kind: PointerType
+      ID: 497
+      Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
+      ByteSize: 8
+      GoRuntimeType: 917184
+      GoKind: 22
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+    - __kind: PointerType
+      ID: 503
+      Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
+      ByteSize: 8
+      GoRuntimeType: 917472
+      GoKind: 22
+      Pointee: 504 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+    - __kind: PointerType
+      ID: 505
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
+      ByteSize: 8
+      GoRuntimeType: 917568
+      GoKind: 22
+      Pointee: 506 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+    - __kind: PointerType
+      ID: 501
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
+      ByteSize: 8
+      GoRuntimeType: 917376
+      GoKind: 22
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+    - __kind: PointerType
+      ID: 499
+      Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
+      ByteSize: 8
+      GoRuntimeType: 917280
+      GoKind: 22
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+    - __kind: PointerType
+      ID: 507
+      Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
+      ByteSize: 8
+      GoRuntimeType: 917760
+      GoKind: 22
+      Pointee: 508 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+    - __kind: PointerType
+      ID: 427
+      Name: '*github.com/cihub/seelog.baseError'
+      ByteSize: 8
+      GoRuntimeType: 905664
+      GoKind: 22
+      Pointee: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: PointerType
+      ID: 858
+      Name: '*github.com/cihub/seelog.bufferedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.793888e+06
+      GoKind: 22
+      Pointee: 859 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+    - __kind: PointerType
+      ID: 429
+      Name: '*github.com/cihub/seelog.cannotOpenFileError'
+      ByteSize: 8
+      GoRuntimeType: 905760
+      GoKind: 22
+      Pointee: 430 StructureType github.com/cihub/seelog.cannotOpenFileError
+    - __kind: PointerType
+      ID: 838
+      Name: '*github.com/cihub/seelog.connWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.551936e+06
+      GoKind: 22
+      Pointee: 839 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+    - __kind: PointerType
+      ID: 794
+      Name: '*github.com/cihub/seelog.consoleWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.035648e+06
+      GoKind: 22
+      Pointee: 795 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+    - __kind: PointerType
+      ID: 828
+      Name: '*github.com/cihub/seelog.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.417536e+06
+      GoKind: 22
+      Pointee: 829 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+    - __kind: PointerType
+      ID: 433
+      Name: '*github.com/cihub/seelog.missingArgumentError'
+      ByteSize: 8
+      GoRuntimeType: 905952
+      GoKind: 22
+      Pointee: 434 StructureType github.com/cihub/seelog.missingArgumentError
+    - __kind: PointerType
+      ID: 895
+      Name: '*github.com/cihub/seelog.rollingFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.966048e+06
+      GoKind: 22
+      Pointee: 896 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+    - __kind: PointerType
+      ID: 912
+      Name: '*github.com/cihub/seelog.rollingFileWriterSize'
+      ByteSize: 8
+      GoRuntimeType: 2.123168e+06
+      GoKind: 22
+      Pointee: 907 StructureType github.com/cihub/seelog.rollingFileWriterSize
+    - __kind: PointerType
+      ID: 911
+      Name: '*github.com/cihub/seelog.rollingFileWriterTime'
+      ByteSize: 8
+      GoRuntimeType: 2.122784e+06
+      GoKind: 22
+      Pointee: 910 StructureType github.com/cihub/seelog.rollingFileWriterTime
+    - __kind: PointerType
+      ID: 796
+      Name: '*github.com/cihub/seelog.smtpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.035776e+06
+      GoKind: 22
+      Pointee: 797 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+    - __kind: PointerType
+      ID: 431
+      Name: '*github.com/cihub/seelog.unexpectedAttributeError'
+      ByteSize: 8
+      GoRuntimeType: 905856
+      GoKind: 22
+      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedAttributeError
+    - __kind: PointerType
+      ID: 435
+      Name: '*github.com/cihub/seelog.unexpectedChildElementError'
+      ByteSize: 8
+      GoRuntimeType: 906048
+      GoKind: 22
+      Pointee: 436 StructureType github.com/cihub/seelog.unexpectedChildElementError
+    - __kind: PointerType
+      ID: 860
+      Name: '*github.com/cihub/seelog/archive/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.79568e+06
+      GoKind: 22
+      Pointee: 861 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+    - __kind: PointerType
+      ID: 901
+      Name: '*github.com/cihub/seelog/archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.002784e+06
+      GoKind: 22
+      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+    - __kind: PointerType
+      ID: 903
+      Name: '*github.com/cihub/seelog/archive/zip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.033856e+06
+      GoKind: 22
+      Pointee: 904 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+    - __kind: PointerType
+      ID: 719
+      Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
+      ByteSize: 8
+      GoRuntimeType: 1.432416e+06
+      GoKind: 22
+      Pointee: 720 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+    - __kind: PointerType
+      ID: 632
+      Name: '*github.com/go-viper/mapstructure/v2.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.060992e+06
+      GoKind: 22
+      Pointee: 633 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+    - __kind: PointerType
+      ID: 630
+      Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.060864e+06
+      GoKind: 22
+      Pointee: 631 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+    - __kind: PointerType
+      ID: 634
+      Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.06496e+06
+      GoKind: 22
+      Pointee: 635 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 636
+      Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
+      ByteSize: 8
+      GoRuntimeType: 1.065088e+06
+      GoKind: 22
+      Pointee: 637 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+    - __kind: PointerType
+      ID: 849
+      Name: '*github.com/gogo/protobuf/proto.textWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.66256e+06
+      GoKind: 22
+      Pointee: 850 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+    - __kind: PointerType
+      ID: 626
+      Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.047552e+06
+      GoKind: 22
+      Pointee: 627 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 441
+      Name: '*github.com/google/uuid.invalidLengthError'
+      ByteSize: 8
+      GoRuntimeType: 907680
+      GoKind: 22
+      Pointee: 442 StructureType github.com/google/uuid.invalidLengthError
+    - __kind: PointerType
+      ID: 953
+      Name: '*github.com/json-iterator/go.Stream'
+      ByteSize: 8
+      GoRuntimeType: 2.349632e+06
+      GoKind: 22
+      Pointee: 954 UnresolvedPointeeType github.com/json-iterator/go.Stream
+    - __kind: PointerType
+      ID: 690
+      Name: '*github.com/pkg/errors.fundamental'
+      ByteSize: 8
+      GoRuntimeType: 1.216288e+06
+      GoKind: 22
+      Pointee: 691 UnresolvedPointeeType github.com/pkg/errors.fundamental
+    - __kind: PointerType
+      ID: 663
+      Name: '*github.com/tinylib/msgp/msgp.ArrayError'
+      ByteSize: 8
+      GoRuntimeType: 1.19504e+06
+      GoKind: 22
+      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.ArrayError
+    - __kind: PointerType
+      ID: 657
+      Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
+      ByteSize: 8
+      GoRuntimeType: 1.194656e+06
+      GoKind: 22
+      Pointee: 658 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+    - __kind: PointerType
+      ID: 596
+      Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.026944e+06
+      GoKind: 22
+      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+    - __kind: PointerType
+      ID: 669
+      Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.195424e+06
+      GoKind: 22
+      Pointee: 670 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+    - __kind: PointerType
+      ID: 595
+      Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.026816e+06
+      GoKind: 22
+      Pointee: 574 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+    - __kind: PointerType
+      ID: 661
+      Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
+      ByteSize: 8
+      GoRuntimeType: 1.194912e+06
+      GoKind: 22
+      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+    - __kind: PointerType
+      ID: 659
+      Name: '*github.com/tinylib/msgp/msgp.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.194784e+06
+      GoKind: 22
+      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.TypeError
+    - __kind: PointerType
+      ID: 667
+      Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
+      ByteSize: 8
+      GoRuntimeType: 1.195296e+06
+      GoKind: 22
+      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+    - __kind: PointerType
+      ID: 665
+      Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.195168e+06
+      GoKind: 22
+      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+    - __kind: PointerType
+      ID: 957
+      Name: '*github.com/tinylib/msgp/msgp.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.36144e+06
+      GoKind: 22
+      Pointee: 958 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+    - __kind: PointerType
+      ID: 673
+      Name: '*github.com/tinylib/msgp/msgp.errFatal'
+      ByteSize: 8
+      GoRuntimeType: 1.195808e+06
+      GoKind: 22
+      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.errFatal
+    - __kind: PointerType
+      ID: 600
+      Name: '*github.com/tinylib/msgp/msgp.errRecursion'
+      ByteSize: 8
+      GoRuntimeType: 1.0272e+06
+      GoKind: 22
+      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.errRecursion
+    - __kind: PointerType
+      ID: 598
+      Name: '*github.com/tinylib/msgp/msgp.errShort'
+      ByteSize: 8
+      GoRuntimeType: 1.027072e+06
+      GoKind: 22
+      Pointee: 599 StructureType github.com/tinylib/msgp/msgp.errShort
+    - __kind: PointerType
+      ID: 671
+      Name: '*github.com/tinylib/msgp/msgp.errWrapped'
+      ByteSize: 8
+      GoRuntimeType: 1.19568e+06
+      GoKind: 22
+      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.errWrapped
+    - __kind: PointerType
+      ID: 555
+      Name: '*go.opentelemetry.io/otel/trace.errorConst'
+      ByteSize: 8
+      GoRuntimeType: 939360
+      GoKind: 22
+      Pointee: 361 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+    - __kind: PointerType
+      ID: 363
+      Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
+      ByteSize: 8
+      Pointee: 362 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: PointerType
+      ID: 732
+      Name: '*go.uber.org/multierr.multiError'
+      ByteSize: 8
+      GoRuntimeType: 1.661024e+06
+      GoKind: 22
+      Pointee: 733 UnresolvedPointeeType go.uber.org/multierr.multiError
+    - __kind: PointerType
+      ID: 640
+      Name: '*go.uber.org/zap.errArrayElem'
+      ByteSize: 8
+      GoRuntimeType: 1.079808e+06
+      GoKind: 22
+      Pointee: 641 StructureType go.uber.org/zap.errArrayElem
+    - __kind: PointerType
+      ID: 826
+      Name: '*go.uber.org/zap.nopCloserSink'
+      ByteSize: 8
+      GoRuntimeType: 1.25584e+06
+      GoKind: 22
+      Pointee: 827 StructureType go.uber.org/zap.nopCloserSink
+    - __kind: PointerType
+      ID: 917
+      Name: '*go.uber.org/zap/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.138144e+06
+      GoKind: 22
+      Pointee: 918 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+    - __kind: PointerType
+      ID: 812
+      Name: '*go.uber.org/zap/zapcore.writerWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.082112e+06
+      GoKind: 22
+      Pointee: 813 StructureType go.uber.org/zap/zapcore.writerWrapper
+    - __kind: PointerType
+      ID: 556
+      Name: '*golang.org/x/net/http2.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 940608
+      GoKind: 22
+      Pointee: 364 BaseType golang.org/x/net/http2.ConnectionError
+    - __kind: PointerType
+      ID: 698
+      Name: '*golang.org/x/net/http2.StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.257504e+06
+      GoKind: 22
+      Pointee: 699 StructureType golang.org/x/net/http2.StreamError
+    - __kind: PointerType
+      ID: 559
+      Name: '*golang.org/x/net/http2.connError'
+      ByteSize: 8
+      GoRuntimeType: 940896
+      GoKind: 22
+      Pointee: 560 StructureType golang.org/x/net/http2.connError
+    - __kind: PointerType
+      ID: 558
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 940800
+      GoKind: 22
+      Pointee: 368 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 370
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 369 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 562
+      Name: '*golang.org/x/net/http2.headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 941088
+      GoKind: 22
+      Pointee: 374 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+    - __kind: PointerType
+      ID: 376
+      Name: '*golang.org/x/net/http2.headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 375 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: PointerType
+      ID: 561
+      Name: '*golang.org/x/net/http2.headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 940992
+      GoKind: 22
+      Pointee: 371 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+    - __kind: PointerType
+      ID: 373
+      Name: '*golang.org/x/net/http2.headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 372 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: PointerType
+      ID: 557
+      Name: '*golang.org/x/net/http2.pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 940704
+      GoKind: 22
+      Pointee: 365 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+    - __kind: PointerType
+      ID: 367
+      Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 366 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 915
+      Name: '*golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.136224e+06
+      GoKind: 22
+      Pointee: 916 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 563
+      Name: '*golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 941184
+      GoKind: 22
+      Pointee: 564 StructureType golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 565
+      Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 941280
+      GoKind: 22
+      Pointee: 377 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 551
+      Name: '*google.golang.org/grpc.dropError'
+      ByteSize: 8
+      GoRuntimeType: 934560
+      GoKind: 22
+      Pointee: 552 StructureType google.golang.org/grpc.dropError
+    - __kind: PointerType
+      ID: 696
+      Name: '*google.golang.org/grpc/internal/status.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.25456e+06
+      GoKind: 22
+      Pointee: 697 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+    - __kind: PointerType
+      ID: 721
+      Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 1.439776e+06
+      GoKind: 22
+      Pointee: 722 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+    - __kind: PointerType
+      ID: 553
+      Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
+      ByteSize: 8
+      GoRuntimeType: 937632
+      GoKind: 22
+      Pointee: 554 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+    - __kind: PointerType
+      ID: 866
+      Name: '*google.golang.org/grpc/internal/transport.bufConn'
+      ByteSize: 8
+      GoRuntimeType: 1.801728e+06
+      GoKind: 22
+      Pointee: 867 StructureType google.golang.org/grpc/internal/transport.bufConn
+    - __kind: PointerType
+      ID: 824
+      Name: '*google.golang.org/grpc/internal/transport.bufWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.251104e+06
+      GoKind: 22
+      Pointee: 825 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+    - __kind: PointerType
+      ID: 638
+      Name: '*google.golang.org/grpc/internal/transport.ioError'
+      ByteSize: 8
+      GoRuntimeType: 1.074048e+06
+      GoKind: 22
+      Pointee: 639 StructureType google.golang.org/grpc/internal/transport.ioError
+    - __kind: PointerType
+      ID: 784
+      Name: '*google.golang.org/grpc/mem.writer'
+      ByteSize: 8
+      GoRuntimeType: 937728
+      GoKind: 22
+      Pointee: 785 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+    - __kind: PointerType
+      ID: 531
+      Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
+      ByteSize: 8
+      GoRuntimeType: 922752
+      GoKind: 22
+      Pointee: 532 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+    - __kind: PointerType
+      ID: 628
+      Name: '*google.golang.org/protobuf/internal/errors.prefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.05088e+06
+      GoKind: 22
+      Pointee: 629 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+    - __kind: PointerType
+      ID: 694
+      Name: '*google.golang.org/protobuf/internal/errors.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.22256e+06
+      GoKind: 22
+      Pointee: 695 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+    - __kind: PointerType
+      ID: 692
+      Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
+      ByteSize: 8
+      GoRuntimeType: 1.222304e+06
+      GoKind: 22
+      Pointee: 693 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+    - __kind: PointerType
+      ID: 545
+      Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
+      ByteSize: 8
+      GoRuntimeType: 927456
+      GoKind: 22
+      Pointee: 546 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+    - __kind: PointerType
+      ID: 547
+      Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
+      ByteSize: 8
+      GoRuntimeType: 927552
+      GoKind: 22
+      Pointee: 548 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+    - __kind: PointerType
+      ID: 475
+      Name: '*gopkg.in/yaml%2ev3.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 914976
+      GoKind: 22
+      Pointee: 476 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+    - __kind: PointerType
+      ID: 872
+      Name: '*hash/crc32.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.842368e+06
+      GoKind: 22
+      Pointee: 873 UnresolvedPointeeType hash/crc32.digest
+    - __kind: PointerType
+      ID: 566
+      Name: '*html/template.Error'
+      ByteSize: 8
+      GoRuntimeType: 942048
+      GoKind: 22
+      Pointee: 567 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -3674,6 +4988,90 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
+      ID: 445
+      Name: '*internal/bisect.parseError'
+      ByteSize: 8
+      GoRuntimeType: 908256
+      GoKind: 22
+      Pointee: 446 UnresolvedPointeeType internal/bisect.parseError
+    - __kind: PointerType
+      ID: 443
+      Name: '*internal/chacha8rand.errUnmarshalChaCha8'
+      ByteSize: 8
+      GoRuntimeType: 908160
+      GoKind: 22
+      Pointee: 444 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+    - __kind: PointerType
+      ID: 770
+      Name: '*internal/godebug.runtimeStderr'
+      ByteSize: 8
+      GoRuntimeType: 896160
+      GoKind: 22
+      Pointee: 771 UnresolvedPointeeType internal/godebug.runtimeStderr
+    - __kind: PointerType
+      ID: 655
+      Name: '*internal/poll.DeadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.193888e+06
+      GoKind: 22
+      Pointee: 656 UnresolvedPointeeType internal/poll.DeadlineExceededError
+    - __kind: PointerType
+      ID: 959
+      Name: '*internal/poll.FD'
+      ByteSize: 8
+      GoRuntimeType: 2.367072e+06
+      GoKind: 22
+      Pointee: 960 UnresolvedPointeeType internal/poll.FD
+    - __kind: PointerType
+      ID: 653
+      Name: '*internal/poll.errNetClosing'
+      ByteSize: 8
+      GoRuntimeType: 1.19376e+06
+      GoKind: 22
+      Pointee: 654 StructureType internal/poll.errNetClosing
+    - __kind: PointerType
+      ID: 380
+      Name: '*internal/reflectlite.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 895392
+      GoKind: 22
+      Pointee: 381 UnresolvedPointeeType internal/reflectlite.ValueError
+    - __kind: PointerType
+      ID: 816
+      Name: '*io.PipeWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.185312e+06
+      GoKind: 22
+      Pointee: 817 UnresolvedPointeeType io.PipeWriter
+    - __kind: PointerType
+      ID: 814
+      Name: '*io.discard'
+      ByteSize: 8
+      GoRuntimeType: 1.184928e+06
+      GoKind: 22
+      Pointee: 815 StructureType io.discard
+    - __kind: PointerType
+      ID: 788
+      Name: '*io.multiWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.018112e+06
+      GoKind: 22
+      Pointee: 789 UnresolvedPointeeType io.multiWriter
+    - __kind: PointerType
+      ID: 651
+      Name: '*io/fs.PathError'
+      ByteSize: 8
+      GoRuntimeType: 1.193504e+06
+      GoKind: 22
+      Pointee: 652 UnresolvedPointeeType io/fs.PathError
+    - __kind: PointerType
+      ID: 862
+      Name: '*log/slog/internal/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 1.795904e+06
+      GoKind: 22
+      Pointee: 863 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+    - __kind: PointerType
       ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
@@ -3681,12 +5079,12 @@ Types:
       GoKind: 22
       Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 341
+      ID: 1004
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383072
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType main.deepMap3
+      Pointee: 1005 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3695,19 +5093,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 377
+      ID: 1040
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 382752
       GoKind: 22
-      Pointee: 378 StructureType main.deepMap8
+      Pointee: 1041 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 392
+      ID: 1055
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382688
       GoKind: 22
-      Pointee: 393 StructureType main.deepMap9
+      Pointee: 1056 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3716,12 +5114,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 306
+      ID: 963
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383648
       GoKind: 22
-      Pointee: 307 UnresolvedPointeeType main.deepPtr3
+      Pointee: 964 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3730,19 +5128,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 347
+      ID: 1010
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383328
       GoKind: 22
-      Pointee: 348 StructureType main.deepPtr8
+      Pointee: 1011 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 349
+      ID: 1012
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383264
       GoKind: 22
-      Pointee: 350 StructureType main.deepPtr9
+      Pointee: 1013 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3751,12 +5149,12 @@ Types:
       GoKind: 22
       Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 326
+      ID: 989
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384224
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType main.deepSlice3
+      Pointee: 990 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3765,19 +5163,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 353
+      ID: 1016
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 383904
       GoKind: 22
-      Pointee: 354 StructureType main.deepSlice8
+      Pointee: 1017 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 359
+      ID: 1022
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383840
       GoKind: 22
-      Pointee: 360 StructureType main.deepSlice9
+      Pointee: 1023 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 176
       Name: '*main.emptyStruct'
@@ -3792,6 +5190,13 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
+      ID: 980
+      Name: '*main.firstBehavior'
+      ByteSize: 8
+      GoRuntimeType: 891360
+      GoKind: 22
+      Pointee: 981 StructureType main.firstBehavior
+    - __kind: PointerType
       ID: 157
       Name: '*main.node'
       ByteSize: 8
@@ -3805,22 +5210,36 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
+      ID: 982
+      Name: '*main.secondBehavior'
+      ByteSize: 8
+      GoRuntimeType: 891456
+      GoKind: 22
+      Pointee: 983 StructureType main.secondBehavior
+    - __kind: PointerType
+      ID: 968
+      Name: '*main.somethingImpl'
+      ByteSize: 8
+      GoRuntimeType: 891552
+      GoKind: 22
+      Pointee: 969 UnresolvedPointeeType main.somethingImpl
+    - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
       ByteSize: 8
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 309
+      ID: 966
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType main.stringType1.str
+      Pointee: 965 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 310 UnresolvedPointeeType main.stringType2
+      Pointee: 967 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 242
       Name: '*main.structWithMap'
@@ -3846,10 +5265,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 323
+      ID: 986
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 322 GoSliceDataType main.t.array
+      Pointee: 985 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -3882,30 +5301,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 331
+      ID: 994
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 995 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 367
+      ID: 1030
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1031 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 382
+      ID: 1045
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1046 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 397
+      ID: 1060
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 398 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1061 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 129
       Name: '*map<int,uint8>'
@@ -3921,6 +5340,11 @@ Types:
       Name: '*map<string,[]string>'
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 725
+      Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 726 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -3948,6 +5372,452 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
+      ID: 479
+      Name: '*math/big.ErrNaN'
+      ByteSize: 8
+      GoRuntimeType: 915840
+      GoKind: 22
+      Pointee: 480 StructureType math/big.ErrNaN
+    - __kind: PointerType
+      ID: 778
+      Name: '*mime/multipart.writerOnly·1'
+      ByteSize: 8
+      GoRuntimeType: 910656
+      GoKind: 22
+      Pointee: 779 StructureType mime/multipart.writerOnly·1
+    - __kind: PointerType
+      ID: 682
+      Name: '*net.AddrError'
+      ByteSize: 8
+      GoRuntimeType: 1.20208e+06
+      GoKind: 22
+      Pointee: 683 UnresolvedPointeeType net.AddrError
+    - __kind: PointerType
+      ID: 708
+      Name: '*net.DNSError'
+      ByteSize: 8
+      GoRuntimeType: 1.415776e+06
+      GoKind: 22
+      Pointee: 709 UnresolvedPointeeType net.DNSError
+    - __kind: PointerType
+      ID: 923
+      Name: '*net.IPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.224192e+06
+      GoKind: 22
+      Pointee: 924 UnresolvedPointeeType net.IPConn
+    - __kind: PointerType
+      ID: 706
+      Name: '*net.OpError'
+      ByteSize: 8
+      GoRuntimeType: 1.415456e+06
+      GoKind: 22
+      Pointee: 707 UnresolvedPointeeType net.OpError
+    - __kind: PointerType
+      ID: 684
+      Name: '*net.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.202208e+06
+      GoKind: 22
+      Pointee: 685 UnresolvedPointeeType net.ParseError
+    - __kind: PointerType
+      ID: 933
+      Name: '*net.TCPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.25488e+06
+      GoKind: 22
+      Pointee: 934 UnresolvedPointeeType net.TCPConn
+    - __kind: PointerType
+      ID: 943
+      Name: '*net.UDPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.299872e+06
+      GoKind: 22
+      Pointee: 944 UnresolvedPointeeType net.UDPConn
+    - __kind: PointerType
+      ID: 931
+      Name: '*net.UnixConn'
+      ByteSize: 8
+      GoRuntimeType: 2.254368e+06
+      GoKind: 22
+      Pointee: 932 UnresolvedPointeeType net.UnixConn
+    - __kind: PointerType
+      ID: 681
+      Name: '*net.UnknownNetworkError'
+      ByteSize: 8
+      GoRuntimeType: 1.201312e+06
+      GoKind: 22
+      Pointee: 644 GoStringHeaderType net.UnknownNetworkError
+    - __kind: PointerType
+      ID: 646
+      Name: '*net.UnknownNetworkError.str'
+      ByteSize: 8
+      Pointee: 645 GoStringDataType net.UnknownNetworkError.str
+    - __kind: PointerType
+      ID: 612
+      Name: '*net.canceledError'
+      ByteSize: 8
+      GoRuntimeType: 1.033856e+06
+      GoKind: 22
+      Pointee: 613 StructureType net.canceledError
+    - __kind: PointerType
+      ID: 899
+      Name: '*net.conn'
+      ByteSize: 8
+      GoRuntimeType: 1.999904e+06
+      GoKind: 22
+      Pointee: 900 UnresolvedPointeeType net.conn
+    - __kind: PointerType
+      ID: 751
+      Name: '*net.dialResult·1'
+      ByteSize: 8
+      GoRuntimeType: 1.837664e+06
+      GoKind: 22
+      Pointee: 752 StructureType net.dialResult·1
+    - __kind: PointerType
+      ID: 945
+      Name: '*net.netFD'
+      ByteSize: 8
+      GoRuntimeType: 2.304128e+06
+      GoKind: 22
+      Pointee: 946 UnresolvedPointeeType net.netFD
+    - __kind: PointerType
+      ID: 412
+      Name: '*net.notFoundError'
+      ByteSize: 8
+      GoRuntimeType: 902688
+      GoKind: 22
+      Pointee: 413 UnresolvedPointeeType net.notFoundError
+    - __kind: PointerType
+      ID: 414
+      Name: '*net.result·2'
+      ByteSize: 8
+      GoRuntimeType: 903360
+      GoKind: 22
+      Pointee: 415 StructureType net.result·2
+    - __kind: PointerType
+      ID: 927
+      Name: '*net.tcpConnWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.240416e+06
+      GoKind: 22
+      Pointee: 928 StructureType net.tcpConnWithoutReadFrom
+    - __kind: PointerType
+      ID: 925
+      Name: '*net.tcpConnWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.239936e+06
+      GoKind: 22
+      Pointee: 926 StructureType net.tcpConnWithoutWriteTo
+    - __kind: PointerType
+      ID: 686
+      Name: '*net.temporaryError'
+      ByteSize: 8
+      GoRuntimeType: 1.202848e+06
+      GoKind: 22
+      Pointee: 687 UnresolvedPointeeType net.temporaryError
+    - __kind: PointerType
+      ID: 710
+      Name: '*net.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.415936e+06
+      GoKind: 22
+      Pointee: 711 UnresolvedPointeeType net.timeoutError
+    - __kind: PointerType
+      ID: 602
+      Name: '*net/http.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 1.029632e+06
+      GoKind: 22
+      Pointee: 603 UnresolvedPointeeType net/http.ProtocolError
+    - __kind: PointerType
+      ID: 772
+      Name: '*net/http.bufioFlushWriter'
+      ByteSize: 8
+      GoRuntimeType: 898464
+      GoKind: 22
+      Pointee: 773 StructureType net/http.bufioFlushWriter
+    - __kind: PointerType
+      ID: 389
+      Name: '*net/http.http2ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 899136
+      GoKind: 22
+      Pointee: 309 BaseType net/http.http2ConnectionError
+    - __kind: PointerType
+      ID: 390
+      Name: '*net/http.http2GoAwayError'
+      ByteSize: 8
+      GoRuntimeType: 899232
+      GoKind: 22
+      Pointee: 391 StructureType net/http.http2GoAwayError
+    - __kind: PointerType
+      ID: 702
+      Name: '*net/http.http2StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.411616e+06
+      GoKind: 22
+      Pointee: 703 StructureType net/http.http2StreamError
+    - __kind: PointerType
+      ID: 394
+      Name: '*net/http.http2connError'
+      ByteSize: 8
+      GoRuntimeType: 899808
+      GoKind: 22
+      Pointee: 395 StructureType net/http.http2connError
+    - __kind: PointerType
+      ID: 834
+      Name: '*net/http.http2dataBuffer'
+      ByteSize: 8
+      GoRuntimeType: 1.548416e+06
+      GoKind: 22
+      Pointee: 835 UnresolvedPointeeType net/http.http2dataBuffer
+    - __kind: PointerType
+      ID: 393
+      Name: '*net/http.http2duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 899712
+      GoKind: 22
+      Pointee: 313 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 315
+      Name: '*net/http.http2duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 397
+      Name: '*net/http.http2headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 900000
+      GoKind: 22
+      Pointee: 319 GoStringHeaderType net/http.http2headerFieldNameError
+    - __kind: PointerType
+      ID: 321
+      Name: '*net/http.http2headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 320 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: PointerType
+      ID: 396
+      Name: '*net/http.http2headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 899904
+      GoKind: 22
+      Pointee: 316 GoStringHeaderType net/http.http2headerFieldValueError
+    - __kind: PointerType
+      ID: 318
+      Name: '*net/http.http2headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 317 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: PointerType
+      ID: 677
+      Name: '*net/http.http2httpError'
+      ByteSize: 8
+      GoRuntimeType: 1.197856e+06
+      GoKind: 22
+      Pointee: 678 UnresolvedPointeeType net/http.http2httpError
+    - __kind: PointerType
+      ID: 608
+      Name: '*net/http.http2noCachedConnError'
+      ByteSize: 8
+      GoRuntimeType: 1.030272e+06
+      GoKind: 22
+      Pointee: 609 StructureType net/http.http2noCachedConnError
+    - __kind: PointerType
+      ID: 888
+      Name: '*net/http.http2pipe'
+      ByteSize: 8
+      GoRuntimeType: 1.942368e+06
+      GoKind: 22
+      Pointee: 889 UnresolvedPointeeType net/http.http2pipe
+    - __kind: PointerType
+      ID: 392
+      Name: '*net/http.http2pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 899616
+      GoKind: 22
+      Pointee: 310 GoStringHeaderType net/http.http2pseudoHeaderError
+    - __kind: PointerType
+      ID: 312
+      Name: '*net/http.http2pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 774
+      Name: '*net/http.http2stickyErrWriter'
+      ByteSize: 8
+      GoRuntimeType: 900096
+      GoKind: 22
+      Pointee: 775 StructureType net/http.http2stickyErrWriter
+    - __kind: PointerType
+      ID: 604
+      Name: '*net/http.nothingWrittenError'
+      ByteSize: 8
+      GoRuntimeType: 1.029888e+06
+      GoKind: 22
+      Pointee: 605 StructureType net/http.nothingWrittenError
+    - __kind: PointerType
+      ID: 836
+      Name: '*net/http.persistConn'
+      ByteSize: 8
+      GoRuntimeType: 2.165504e+06
+      GoKind: 22
+      Pointee: 837 UnresolvedPointeeType net/http.persistConn
+    - __kind: PointerType
+      ID: 792
+      Name: '*net/http.persistConnWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.02976e+06
+      GoKind: 22
+      Pointee: 793 StructureType net/http.persistConnWriter
+    - __kind: PointerType
+      ID: 818
+      Name: '*net/http.readWriteCloserBody'
+      ByteSize: 8
+      GoRuntimeType: 1.19696e+06
+      GoKind: 22
+      Pointee: 819 StructureType net/http.readWriteCloserBody
+    - __kind: PointerType
+      ID: 398
+      Name: '*net/http.requestBodyReadError'
+      ByteSize: 8
+      GoRuntimeType: 900192
+      GoKind: 22
+      Pointee: 399 StructureType net/http.requestBodyReadError
+    - __kind: PointerType
+      ID: 704
+      Name: '*net/http.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.412736e+06
+      GoKind: 22
+      Pointee: 705 UnresolvedPointeeType net/http.timeoutError
+    - __kind: PointerType
+      ID: 675
+      Name: '*net/http.tlsHandshakeTimeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.197728e+06
+      GoKind: 22
+      Pointee: 676 StructureType net/http.tlsHandshakeTimeoutError
+    - __kind: PointerType
+      ID: 606
+      Name: '*net/http.transportReadFromServerError'
+      ByteSize: 8
+      GoRuntimeType: 1.030016e+06
+      GoKind: 22
+      Pointee: 607 StructureType net/http.transportReadFromServerError
+    - __kind: PointerType
+      ID: 870
+      Name: '*net/http.unencryptedNetConnInTLSConn'
+      ByteSize: 8
+      GoRuntimeType: 1.834304e+06
+      GoKind: 22
+      Pointee: 871 StructureType net/http.unencryptedNetConnInTLSConn
+    - __kind: PointerType
+      ID: 387
+      Name: '*net/http.unsupportedTEError'
+      ByteSize: 8
+      GoRuntimeType: 898368
+      GoKind: 22
+      Pointee: 388 UnresolvedPointeeType net/http.unsupportedTEError
+    - __kind: PointerType
+      ID: 890
+      Name: '*net/http/internal.FlushAfterChunkWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.943904e+06
+      GoKind: 22
+      Pointee: 891 StructureType net/http/internal.FlushAfterChunkWriter
+    - __kind: PointerType
+      ID: 802
+      Name: '*net/http/internal.chunkedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.042304e+06
+      GoKind: 22
+      Pointee: 803 UnresolvedPointeeType net/http/internal.chunkedWriter
+    - __kind: PointerType
+      ID: 471
+      Name: '*net/netip.parseAddrError'
+      ByteSize: 8
+      GoRuntimeType: 914784
+      GoKind: 22
+      Pointee: 472 StructureType net/netip.parseAddrError
+    - __kind: PointerType
+      ID: 469
+      Name: '*net/netip.parsePrefixError'
+      ByteSize: 8
+      GoRuntimeType: 914688
+      GoKind: 22
+      Pointee: 470 StructureType net/netip.parsePrefixError
+    - __kind: PointerType
+      ID: 844
+      Name: '*net/smtp.Client'
+      ByteSize: 8
+      GoRuntimeType: 2.110176e+06
+      GoKind: 22
+      Pointee: 845 UnresolvedPointeeType net/smtp.Client
+    - __kind: PointerType
+      ID: 804
+      Name: '*net/smtp.dataCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.047168e+06
+      GoKind: 22
+      Pointee: 805 StructureType net/smtp.dataCloser
+    - __kind: PointerType
+      ID: 455
+      Name: '*net/textproto.Error'
+      ByteSize: 8
+      GoRuntimeType: 910848
+      GoKind: 22
+      Pointee: 456 UnresolvedPointeeType net/textproto.Error
+    - __kind: PointerType
+      ID: 454
+      Name: '*net/textproto.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 910752
+      GoKind: 22
+      Pointee: 344 GoStringHeaderType net/textproto.ProtocolError
+    - __kind: PointerType
+      ID: 346
+      Name: '*net/textproto.ProtocolError.str'
+      ByteSize: 8
+      Pointee: 345 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: PointerType
+      ID: 800
+      Name: '*net/textproto.dotWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.041536e+06
+      GoKind: 22
+      Pointee: 801 UnresolvedPointeeType net/textproto.dotWriter
+    - __kind: PointerType
+      ID: 712
+      Name: '*net/url.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.416256e+06
+      GoKind: 22
+      Pointee: 713 UnresolvedPointeeType net/url.Error
+    - __kind: PointerType
+      ID: 416
+      Name: '*net/url.EscapeError'
+      ByteSize: 8
+      GoRuntimeType: 903456
+      GoKind: 22
+      Pointee: 322 GoStringHeaderType net/url.EscapeError
+    - __kind: PointerType
+      ID: 324
+      Name: '*net/url.EscapeError.str'
+      ByteSize: 8
+      Pointee: 323 GoStringDataType net/url.EscapeError.str
+    - __kind: PointerType
+      ID: 417
+      Name: '*net/url.InvalidHostError'
+      ByteSize: 8
+      GoRuntimeType: 903552
+      GoKind: 22
+      Pointee: 325 GoStringHeaderType net/url.InvalidHostError
+    - __kind: PointerType
+      ID: 327
+      Name: '*net/url.InvalidHostError.str'
+      ByteSize: 8
+      Pointee: 326 GoStringDataType net/url.InvalidHostError.str
+    - __kind: PointerType
       ID: 288
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
@@ -3973,30 +5843,30 @@ Types:
       ByteSize: 8
       Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 337
+      ID: 1000
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 338 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1001 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 373
+      ID: 1036
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 374 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1037 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 388
+      ID: 1051
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 389 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1052 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 196
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 197 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 403
+      ID: 1066
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 404 StructureType noalg.map.group[int]interface {}
+      Pointee: 1067 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 255
       Name: '*noalg.map.group[int]uint8'
@@ -4012,6 +5882,11 @@ Types:
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
       Pointee: 221 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 758
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 212
       Name: '*noalg.map.group[string]int'
@@ -4033,6 +5908,161 @@ Types:
       ByteSize: 8
       Pointee: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
+      ID: 951
+      Name: '*os.File'
+      ByteSize: 8
+      GoRuntimeType: 2.342784e+06
+      GoKind: 22
+      Pointee: 952 UnresolvedPointeeType os.File
+    - __kind: PointerType
+      ID: 583
+      Name: '*os.LinkError'
+      ByteSize: 8
+      GoRuntimeType: 1.020928e+06
+      GoKind: 22
+      Pointee: 584 UnresolvedPointeeType os.LinkError
+    - __kind: PointerType
+      ID: 647
+      Name: '*os.SyscallError'
+      ByteSize: 8
+      GoRuntimeType: 1.186848e+06
+      GoKind: 22
+      Pointee: 648 UnresolvedPointeeType os.SyscallError
+    - __kind: PointerType
+      ID: 949
+      Name: '*os.fileWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.339104e+06
+      GoKind: 22
+      Pointee: 950 StructureType os.fileWithoutReadFrom
+    - __kind: PointerType
+      ID: 947
+      Name: '*os.fileWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.338368e+06
+      GoKind: 22
+      Pointee: 948 StructureType os.fileWithoutWriteTo
+    - __kind: PointerType
+      ID: 614
+      Name: '*os/exec.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.038208e+06
+      GoKind: 22
+      Pointee: 615 UnresolvedPointeeType os/exec.Error
+    - __kind: PointerType
+      ID: 754
+      Name: '*os/exec.ExitError'
+      ByteSize: 8
+      GoRuntimeType: 2.080032e+06
+      GoKind: 22
+      Pointee: 755 UnresolvedPointeeType os/exec.ExitError
+    - __kind: PointerType
+      ID: 822
+      Name: '*os/exec.prefixSuffixSaver'
+      ByteSize: 8
+      GoRuntimeType: 1.20912e+06
+      GoKind: 22
+      Pointee: 823 UnresolvedPointeeType os/exec.prefixSuffixSaver
+    - __kind: PointerType
+      ID: 616
+      Name: '*os/exec.wrappedError'
+      ByteSize: 8
+      GoRuntimeType: 1.038336e+06
+      GoKind: 22
+      Pointee: 617 StructureType os/exec.wrappedError
+    - __kind: PointerType
+      ID: 550
+      Name: '*os/user.UnknownGroupIdError'
+      ByteSize: 8
+      GoRuntimeType: 932640
+      GoKind: 22
+      Pointee: 358 GoStringHeaderType os/user.UnknownGroupIdError
+    - __kind: PointerType
+      ID: 360
+      Name: '*os/user.UnknownGroupIdError.str'
+      ByteSize: 8
+      Pointee: 359 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: PointerType
+      ID: 549
+      Name: '*os/user.UnknownUserIdError'
+      ByteSize: 8
+      GoRuntimeType: 932544
+      GoKind: 22
+      Pointee: 357 BaseType os/user.UnknownUserIdError
+    - __kind: PointerType
+      ID: 382
+      Name: '*reflect.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 896064
+      GoKind: 22
+      Pointee: 383 UnresolvedPointeeType reflect.ValueError
+    - __kind: PointerType
+      ID: 477
+      Name: '*regexp/syntax.Error'
+      ByteSize: 8
+      GoRuntimeType: 915456
+      GoKind: 22
+      Pointee: 478 UnresolvedPointeeType regexp/syntax.Error
+    - __kind: PointerType
+      ID: 587
+      Name: '*runtime.PanicNilError'
+      ByteSize: 8
+      GoRuntimeType: 1.022464e+06
+      GoKind: 22
+      Pointee: 588 UnresolvedPointeeType runtime.PanicNilError
+    - __kind: PointerType
+      ID: 591
+      Name: '*runtime.TypeAssertionError'
+      ByteSize: 8
+      GoRuntimeType: 1.024256e+06
+      GoKind: 22
+      Pointee: 592 UnresolvedPointeeType runtime.TypeAssertionError
+    - __kind: PointerType
+      ID: 589
+      Name: '*runtime.boundsError'
+      ByteSize: 8
+      GoRuntimeType: 1.022592e+06
+      GoKind: 22
+      Pointee: 590 StructureType runtime.boundsError
+    - __kind: PointerType
+      ID: 649
+      Name: '*runtime.errorAddressString'
+      ByteSize: 8
+      GoRuntimeType: 1.192224e+06
+      GoKind: 22
+      Pointee: 650 StructureType runtime.errorAddressString
+    - __kind: PointerType
+      ID: 585
+      Name: '*runtime.errorString'
+      ByteSize: 8
+      GoRuntimeType: 1.02208e+06
+      GoKind: 22
+      Pointee: 568 GoStringHeaderType runtime.errorString
+    - __kind: PointerType
+      ID: 570
+      Name: '*runtime.errorString.str'
+      ByteSize: 8
+      Pointee: 569 GoStringDataType runtime.errorString.str
+    - __kind: PointerType
+      ID: 586
+      Name: '*runtime.plainError'
+      ByteSize: 8
+      GoRuntimeType: 1.022208e+06
+      GoKind: 22
+      Pointee: 571 GoStringHeaderType runtime.plainError
+    - __kind: PointerType
+      ID: 573
+      Name: '*runtime.plainError.str'
+      ByteSize: 8
+      Pointee: 572 GoStringDataType runtime.plainError.str
+    - __kind: PointerType
+      ID: 593
+      Name: '*strconv.NumError'
+      ByteSize: 8
+      GoRuntimeType: 1.024512e+06
+      GoKind: 22
+      Pointee: 594 UnresolvedPointeeType strconv.NumError
+    - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
@@ -4044,6 +6074,34 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 177 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 886
+      Name: '*strings.Builder'
+      ByteSize: 8
+      GoRuntimeType: 1.941088e+06
+      GoKind: 22
+      Pointee: 887 UnresolvedPointeeType strings.Builder
+    - __kind: PointerType
+      ID: 790
+      Name: '*strings.appendSliceWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.02464e+06
+      GoKind: 22
+      Pointee: 791 UnresolvedPointeeType strings.appendSliceWriter
+    - __kind: PointerType
+      ID: 786
+      Name: '*struct { io.Writer }'
+      ByteSize: 8
+      GoRuntimeType: 965440
+      GoKind: 22
+      Pointee: 787 StructureType struct { io.Writer }
+    - __kind: PointerType
+      ID: 701
+      Name: '*syscall.Errno'
+      ByteSize: 8
+      GoRuntimeType: 1.410976e+06
+      GoKind: 22
+      Pointee: 700 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
@@ -4070,30 +6128,30 @@ Types:
       ByteSize: 8
       Pointee: 184 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 334
+      ID: 997
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 335 StructureType table<int,*main.deepMap3>
+      Pointee: 998 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 370
+      ID: 1033
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 371 StructureType table<int,*main.deepMap8>
+      Pointee: 1034 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 385
+      ID: 1048
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 386 StructureType table<int,*main.deepMap9>
+      Pointee: 1049 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 194 StructureType table<int,int>
     - __kind: PointerType
-      ID: 400
+      ID: 1063
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 401 StructureType table<int,interface {}>
+      Pointee: 1064 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*table<int,uint8>'
@@ -4109,6 +6167,11 @@ Types:
       Name: '*table<string,[]string>'
       ByteSize: 8
       Pointee: 218 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 728
+      Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 756 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
@@ -4129,6 +6192,46 @@ Types:
       Name: '*table<uint8,uint8>'
       ByteSize: 8
       Pointee: 261 StructureType table<uint8,uint8>
+    - __kind: PointerType
+      ID: 921
+      Name: '*text/tabwriter.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.1504e+06
+      GoKind: 22
+      Pointee: 922 UnresolvedPointeeType text/tabwriter.Writer
+    - __kind: PointerType
+      ID: 642
+      Name: '*text/template.ExecError'
+      ByteSize: 8
+      GoRuntimeType: 1.083648e+06
+      GoKind: 22
+      Pointee: 643 StructureType text/template.ExecError
+    - __kind: PointerType
+      ID: 717
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.61648e+06
+      GoKind: 22
+      Pointee: 718 UnresolvedPointeeType time.Location
+    - __kind: PointerType
+      ID: 385
+      Name: '*time.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 896928
+      GoKind: 22
+      Pointee: 386 UnresolvedPointeeType time.ParseError
+    - __kind: PointerType
+      ID: 384
+      Name: '*time.fileSizeError'
+      ByteSize: 8
+      GoRuntimeType: 896832
+      GoKind: 22
+      Pointee: 306 GoStringHeaderType time.fileSizeError
+    - __kind: PointerType
+      ID: 308
+      Name: '*time.fileSizeError.str'
+      ByteSize: 8
+      Pointee: 307 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4171,11 +6274,53 @@ Types:
       GoRuntimeType: 390112
       GoKind: 22
       Pointee: 1 BaseType uintptr
+    - __kind: PointerType
+      ID: 473
+      Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
+      ByteSize: 8
+      GoRuntimeType: 914880
+      GoKind: 22
+      Pointee: 474 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+    - __kind: PointerType
+      ID: 913
+      Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.125856e+06
+      GoKind: 22
+      Pointee: 914 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 457
+      Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 911040
+      GoKind: 22
+      Pointee: 458 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 459
+      Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 911136
+      GoKind: 22
+      Pointee: 347 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 621
+      Name: '*vendor/golang.org/x/net/idna.labelError'
+      ByteSize: 8
+      GoRuntimeType: 1.042048e+06
+      GoKind: 22
+      Pointee: 622 StructureType vendor/golang.org/x/net/idna.labelError
+    - __kind: PointerType
+      ID: 623
+      Name: '*vendor/golang.org/x/net/idna.runeError'
+      ByteSize: 8
+      GoRuntimeType: 1.042176e+06
+      GoKind: 22
+      Pointee: 576 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 506
+      ID: 1169
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 463
+      ID: 1126
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4190,7 +6335,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 461
+      ID: 1124
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4205,7 +6350,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 425
+      ID: 1088
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4220,7 +6365,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 423
+      ID: 1086
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4235,7 +6380,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 471
+      ID: 1134
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4250,7 +6395,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 424
+      ID: 1087
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4265,7 +6410,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 443
+      ID: 1106
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4280,7 +6425,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 412
+      ID: 1075
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4295,7 +6440,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 409
+      ID: 1072
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4310,7 +6455,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 487
+      ID: 1150
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4325,7 +6470,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 485
+      ID: 1148
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4358,7 +6503,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 495
+      ID: 1158
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4373,7 +6518,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 448
+      ID: 1111
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4388,7 +6533,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 449
+      ID: 1112
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4403,7 +6548,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 444
+      ID: 1107
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4418,7 +6563,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 445
+      ID: 1108
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4433,7 +6578,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 446
+      ID: 1109
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4448,7 +6593,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 447
+      ID: 1110
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4463,7 +6608,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 1163
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4487,7 +6632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 1160
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4502,7 +6647,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 514
+      ID: 1177
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4517,7 +6662,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 517
+      ID: 1180
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4532,7 +6677,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 516
+      ID: 1179
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4547,7 +6692,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 462
+      ID: 1125
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4562,7 +6707,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 453
+      ID: 1116
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4577,7 +6722,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 452
+      ID: 1115
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4592,7 +6737,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 459
+      ID: 1122
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4607,7 +6752,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 458
+      ID: 1121
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4622,7 +6767,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 454
+      ID: 1117
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4637,7 +6782,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 456
+      ID: 1119
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4652,10 +6797,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 519
+      ID: 1182
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 455
+      ID: 1118
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4679,16 +6824,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 1183
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 521
+      ID: 1184
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 457
+      ID: 1120
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 518
+      ID: 1181
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4703,7 +6848,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 522
+      ID: 1185
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4718,7 +6863,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 523
+      ID: 1186
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4733,7 +6878,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 415
+      ID: 1078
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4748,7 +6893,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 416
+      ID: 1079
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4763,7 +6908,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 417
+      ID: 1080
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4778,7 +6923,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 414
+      ID: 1077
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4793,7 +6938,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 413
+      ID: 1076
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4808,7 +6953,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 460
+      ID: 1123
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4823,7 +6968,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 1152
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4838,7 +6983,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 469
+      ID: 1132
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4853,7 +6998,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 1138
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4868,7 +7013,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 1136
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4883,7 +7028,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 484
+      ID: 1147
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4898,7 +7043,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 483
+      ID: 1146
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4913,7 +7058,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 1137
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4928,7 +7073,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 482
+      ID: 1145
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4943,7 +7088,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 1144
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4958,7 +7103,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 467
+      ID: 1130
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4973,7 +7118,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 468
+      ID: 1131
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4988,7 +7133,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 466
+      ID: 1129
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5003,7 +7148,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 1139
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5018,7 +7163,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 1143
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5033,7 +7178,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 1142
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5048,7 +7193,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 1141
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5063,7 +7208,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 1140
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5078,7 +7223,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 512
+      ID: 1175
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5093,7 +7238,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 486
+      ID: 1149
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5144,7 +7289,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 494
+      ID: 1157
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5168,7 +7313,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 1164
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5192,7 +7337,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 503
+      ID: 1166
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5225,7 +7370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 504
+      ID: 1167
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5240,7 +7385,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 1174
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5255,7 +7400,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 490
+      ID: 1153
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5270,7 +7415,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 1135
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5285,7 +7430,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 488
+      ID: 1151
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5300,7 +7445,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 410
+      ID: 1073
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5315,7 +7460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 429
+      ID: 1092
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5330,7 +7475,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 427
+      ID: 1090
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5345,7 +7490,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 440
+      ID: 1103
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5360,7 +7505,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 441
+      ID: 1104
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5375,7 +7520,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 432
+      ID: 1095
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5390,7 +7535,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 433
+      ID: 1096
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5405,7 +7550,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 434
+      ID: 1097
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5420,7 +7565,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 431
+      ID: 1094
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5435,7 +7580,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 430
+      ID: 1093
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5450,7 +7595,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 428
+      ID: 1091
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5465,7 +7610,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 507
+      ID: 1170
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5480,7 +7625,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 437
+      ID: 1100
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5495,7 +7640,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 438
+      ID: 1101
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5510,7 +7655,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 439
+      ID: 1102
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5525,7 +7670,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 436
+      ID: 1099
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5540,7 +7685,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 435
+      ID: 1098
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5555,7 +7700,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 1161
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5570,7 +7715,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 470
+      ID: 1133
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5585,7 +7730,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 411
+      ID: 1074
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5600,7 +7745,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 493
+      ID: 1156
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5615,7 +7760,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 502
+      ID: 1165
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5630,7 +7775,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 450
+      ID: 1113
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5645,7 +7790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 451
+      ID: 1114
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5660,7 +7805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 1162
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5684,7 +7829,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 1127
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5699,7 +7844,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 465
+      ID: 1128
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5714,7 +7859,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 515
+      ID: 1178
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5729,7 +7874,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 510
+      ID: 1173
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5744,7 +7889,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 509
+      ID: 1172
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5759,7 +7904,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 508
+      ID: 1171
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5792,7 +7937,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 442
+      ID: 1105
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5807,7 +7952,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 420
+      ID: 1083
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5822,7 +7967,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 421
+      ID: 1084
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5837,7 +7982,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 1085
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5852,7 +7997,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 419
+      ID: 1082
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5867,7 +8012,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 418
+      ID: 1081
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5882,7 +8027,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 492
+      ID: 1155
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5897,7 +8042,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 1159
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5912,7 +8057,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 513
+      ID: 1176
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5927,7 +8072,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 491
+      ID: 1154
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5942,7 +8087,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 426
+      ID: 1089
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5957,7 +8102,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 505
+      ID: 1168
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6130,6 +8275,15 @@ Types:
       Count: 5
       HasCount: true
       Element: 7 BaseType int
+    - __kind: ArrayType
+      ID: 746
+      Name: '[5]uint8'
+      ByteSize: 5
+      GoRuntimeType: 680448
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*main.deepSlice2'
@@ -6153,7 +8307,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 324
+      ID: 987
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474784
@@ -6161,21 +8315,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 325 PointerType **main.deepSlice3
+          Type: 988 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 328 GoSliceDataType []*main.deepSlice3.array
+      Data: 991 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 991
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 326 PointerType *main.deepSlice3
+      Element: 989 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 351
+      ID: 1014
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474464
@@ -6183,21 +8337,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 352 PointerType **main.deepSlice8
+          Type: 1015 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 355 GoSliceDataType []*main.deepSlice8.array
+      Data: 1018 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 355
+      ID: 1018
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 353 PointerType *main.deepSlice8
+      Element: 1016 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 357
+      ID: 1020
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474400
@@ -6205,19 +8359,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 358 PointerType **main.deepSlice9
+          Type: 1021 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 361 GoSliceDataType []*main.deepSlice9.array
+      Data: 1024 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 1024
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 359 PointerType *main.deepSlice9
+      Element: 1022 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6266,30 +8420,30 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 1006
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 334 PointerType *table<int,*main.deepMap3>
+      Element: 997 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 379
+      ID: 1042
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 370 PointerType *table<int,*main.deepMap8>
+      Element: 1033 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 1057
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 385 PointerType *table<int,*main.deepMap9>
+      Element: 1048 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 1070
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 400 PointerType *table<int,interface {}>
+      Element: 1063 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]*table<int,uint8>.array'
@@ -6305,6 +8459,11 @@ Types:
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 762
+      Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
+      ByteSize: 8192
+      Element: 728 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 216
       Name: '[]*table<string,int>.array'
@@ -6369,7 +8528,29 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 363
+      ID: 741
+      Name: '[]float64'
+      ByteSize: 24
+      GoRuntimeType: 483616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 26 PointerType *float64
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 766 GoSliceDataType []float64.array
+    - __kind: GoSliceDataType
+      ID: 766
+      Name: '[]float64.array'
+      ByteSize: 2048
+      Element: 18 BaseType float64
+    - __kind: GoSliceHeaderType
+      ID: 1026
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484064
@@ -6384,9 +8565,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 364 GoSliceDataType []interface {}.array
+      Data: 1027 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 1027
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
@@ -6406,9 +8587,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 345 GoSliceDataType []main.structWithMap.array
+      Data: 1008 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 1008
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -6459,30 +8640,30 @@ Types:
       ByteSize: 2048
       Element: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 1007
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 338 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1001 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 1043
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 374 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1037 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 1058
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 389 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1052 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 201
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 197 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 408
+      ID: 1071
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 404 StructureType noalg.map.group[int]interface {}
+      Element: 1067 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]noalg.map.group[int]uint8.array'
@@ -6498,6 +8679,11 @@ Types:
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 221 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 763
+      Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 2048
+      Element: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 217
       Name: '[]noalg.map.group[string]int.array'
@@ -6584,12 +8770,104 @@ Types:
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
+    - __kind: GoSliceHeaderType
+      ID: 735
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 482592
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 5 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 764 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 764
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 898
+      Name: archive/tar.Writer
+      ByteSize: 8
+    - __kind: GoSliceHeaderType
+      ID: 536
+      Name: archive/tar.headerError
+      ByteSize: 24
+      GoRuntimeType: 926016
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 22 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 537 GoSliceDataType archive/tar.headerError.array
+    - __kind: GoSliceDataType
+      ID: 537
+      Name: archive/tar.headerError.array
+      ByteSize: 2048
+      Element: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 833
+      Name: archive/tar.regFileWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 781
+      Name: archive/zip.countWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 783
+      Name: archive/zip.dirWriter
+      GoRuntimeType: 1.114784e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 881
+      Name: archive/zip.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 809
+      Name: archive/zip.nopCloser
+      ByteSize: 16
+      GoRuntimeType: 1.558976e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 811
+      Name: archive/zip.pooledFlateWriter
+      ByteSize: 8
     - __kind: BaseType
       ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 581184
       GoKind: 1
+    - __kind: UnresolvedPointeeType
+      ID: 856
+      Name: bufio.Reader
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 885
+      Name: bufio.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 936
+      Name: bytes.Buffer
+      ByteSize: 8
     - __kind: GoChannelType
       ID: 153
       Name: chan bool
@@ -6612,6 +8890,355 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580928
       GoKind: 15
+    - __kind: BaseType
+      ID: 339
+      Name: compress/flate.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 830528
+      GoKind: 6
+    - __kind: GoStringHeaderType
+      ID: 340
+      Name: compress/flate.InternalError
+      ByteSize: 16
+      GoRuntimeType: 830624
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 342 PointerType *compress/flate.InternalError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 341 GoStringDataType compress/flate.InternalError.str
+    - __kind: GoStringDataType
+      ID: 341
+      Name: compress/flate.InternalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 831
+      Name: compress/flate.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 777
+      Name: compress/flate.dictWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 853
+      Name: compress/gzip.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 680
+      Name: context.deadlineExceededError
+      GoRuntimeType: 1.473216e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 353
+      Name: crypto/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 833120
+      GoKind: 2
+    - __kind: BaseType
+      ID: 354
+      Name: crypto/des.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 833216
+      GoKind: 2
+    - __kind: BaseType
+      ID: 355
+      Name: crypto/internal/fips140/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 833312
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 843
+      Name: crypto/internal/fips140/hmac.HMAC
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 877
+      Name: crypto/internal/fips140/sha256.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 909
+      Name: crypto/internal/fips140/sha3.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 883
+      Name: crypto/internal/fips140/sha3.SHAKE
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 879
+      Name: crypto/internal/fips140/sha512.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 875
+      Name: crypto/md5.digest
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 356
+      Name: crypto/rc4.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 833408
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 893
+      Name: crypto/sha1.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 865
+      Name: crypto/sha3.SHA3
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 343
+      Name: crypto/tls.AlertError
+      ByteSize: 1
+      GoRuntimeType: 831104
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 620
+      Name: crypto/tls.CertificateVerificationError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 962
+      Name: crypto/tls.Conn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 452
+      Name: crypto/tls.ECHRejectionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 450
+      Name: crypto/tls.RecordHeaderError
+      ByteSize: 40
+      GoRuntimeType: 1.7224e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: RecordHeader
+          Offset: 16
+          Type: 746 ArrayType [5]uint8
+        - Name: Conn
+          Offset: 24
+          Type: 747 GoInterfaceType net.Conn
+    - __kind: BaseType
+      ID: 575
+      Name: crypto/tls.alert
+      ByteSize: 1
+      GoRuntimeType: 988256
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 841
+      Name: crypto/tls.cthWrapper
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 848
+      Name: crypto/tls.finishedHash
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 715
+      Name: crypto/tls.permanentError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 730
+      Name: crypto/x509.Certificate
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 524
+      Name: crypto/x509.CertificateInvalidError
+      ByteSize: 32
+      GoRuntimeType: 1.72528e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 729 PointerType *crypto/x509.Certificate
+        - Name: Reason
+          Offset: 8
+          Type: 749 BaseType crypto/x509.InvalidReason
+        - Name: Detail
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 518
+      Name: crypto/x509.ConstraintViolationError
+      GoRuntimeType: 1.112352e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 520
+      Name: crypto/x509.HostnameError
+      ByteSize: 24
+      GoRuntimeType: 1.593696e+06
+      GoKind: 25
+      RawFields:
+        - Name: Certificate
+          Offset: 0
+          Type: 729 PointerType *crypto/x509.Certificate
+        - Name: Host
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 352
+      Name: crypto/x509.InsecureAlgorithmError
+      ByteSize: 8
+      GoRuntimeType: 832736
+      GoKind: 2
+    - __kind: BaseType
+      ID: 749
+      Name: crypto/x509.InvalidReason
+      ByteSize: 8
+      GoRuntimeType: 586368
+      GoKind: 2
+    - __kind: StructureType
+      ID: 625
+      Name: crypto/x509.SystemRootsError
+      ByteSize: 16
+      GoRuntimeType: 1.554976e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 526
+      Name: crypto/x509.UnhandledCriticalExtension
+      GoRuntimeType: 1.112608e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 522
+      Name: crypto/x509.UnknownAuthorityError
+      ByteSize: 32
+      GoRuntimeType: 1.725088e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 729 PointerType *crypto/x509.Certificate
+        - Name: hintErr
+          Offset: 8
+          Type: 14 GoInterfaceType error
+        - Name: hintCert
+          Offset: 24
+          Type: 729 PointerType *crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 540
+      Name: encoding/asn1.StructuralError
+      ByteSize: 16
+      GoRuntimeType: 1.430656e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 544
+      Name: encoding/asn1.SyntaxError
+      ByteSize: 16
+      GoRuntimeType: 1.430816e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 542
+      Name: encoding/asn1.invalidUnmarshalError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 337
+      Name: encoding/base64.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 830144
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 799
+      Name: encoding/base64.encoder
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 338
+      Name: encoding/hex.InvalidByteError
+      ByteSize: 1
+      GoRuntimeType: 830336
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 409
+      Name: encoding/json.InvalidUnmarshalError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 611
+      Name: encoding/json.MarshalerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 401
+      Name: encoding/json.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 407
+      Name: encoding/json.UnmarshalTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 405
+      Name: encoding/json.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 403
+      Name: encoding/json.UnsupportedValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 942
+      Name: encoding/json.encodeState
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 411
+      Name: encoding/json.jsonError
+      ByteSize: 16
+      GoRuntimeType: 1.414496e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 807
+      Name: encoding/pem.lineBreaker
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 512
+      Name: encoding/xml.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 510
+      Name: encoding/xml.TagPathError
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 349
+      Name: encoding/xml.UnmarshalError
+      ByteSize: 16
+      GoRuntimeType: 832640
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 351 PointerType *encoding/xml.UnmarshalError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 350 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: GoStringDataType
+      ID: 350
+      Name: encoding/xml.UnmarshalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 515
+      Name: encoding/xml.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 920
+      Name: encoding/xml.printer
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 14
       Name: error
@@ -6625,6 +9252,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 379
+      Name: errors.errorString
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 578
+      Name: errors.joinError
+      ByteSize: 8
     - __kind: BaseType
       ID: 17
       Name: float32
@@ -6637,12 +9272,1062 @@ Types:
       ByteSize: 8
       GoRuntimeType: 581120
       GoKind: 14
+    - __kind: UnresolvedPointeeType
+      ID: 930
+      Name: fmt.pp
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 580
+      Name: fmt.wrapError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 582
+      Name: fmt.wrapErrors
+      ByteSize: 8
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
       GoRuntimeType: 473056
       GoKind: 19
+    - __kind: UnresolvedPointeeType
+      ID: 439
+      Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 420
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      ByteSize: 216
+      GoRuntimeType: 1.721248e+06
+      GoKind: 25
+      RawFields:
+        - Name: Metric
+          Offset: 0
+          Type: 739 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+        - Name: ChannelSize
+          Offset: 192
+          Type: 7 BaseType int
+        - Name: Msg
+          Offset: 200
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 422
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 743
+      Name: github.com/DataDog/datadog-go/v5/statsd.Event
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 426
+      Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      GoRuntimeType: 1.10864e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 745
+      Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 331
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      ByteSize: 16
+      GoRuntimeType: 829568
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: GoStringDataType
+      ID: 332
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 739
+      Name: github.com/DataDog/datadog-go/v5/statsd.metric
+      ByteSize: 192
+      GoRuntimeType: 2.210208e+06
+      GoKind: 25
+      RawFields:
+        - Name: metricType
+          Offset: 0
+          Type: 740 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+        - Name: namespace
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+        - Name: globalTags
+          Offset: 24
+          Type: 166 GoSliceHeaderType []string
+        - Name: name
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fvalue
+          Offset: 64
+          Type: 18 BaseType float64
+        - Name: fvalues
+          Offset: 72
+          Type: 741 GoSliceHeaderType []float64
+        - Name: ivalue
+          Offset: 96
+          Type: 13 BaseType int64
+        - Name: svalue
+          Offset: 104
+          Type: 9 GoStringHeaderType string
+        - Name: evalue
+          Offset: 120
+          Type: 742 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+        - Name: scvalue
+          Offset: 128
+          Type: 744 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+        - Name: tags
+          Offset: 136
+          Type: 166 GoSliceHeaderType []string
+        - Name: stags
+          Offset: 160
+          Type: 9 GoStringHeaderType string
+        - Name: rate
+          Offset: 176
+          Type: 18 BaseType float64
+        - Name: timestamp
+          Offset: 184
+          Type: 13 BaseType int64
+    - __kind: BaseType
+      ID: 740
+      Name: github.com/DataDog/datadog-go/v5/statsd.metricType
+      ByteSize: 8
+      GoRuntimeType: 582976
+      GoKind: 2
+    - __kind: GoStringHeaderType
+      ID: 328
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      ByteSize: 16
+      GoRuntimeType: 829472
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: GoStringDataType
+      ID: 329
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 334
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      ByteSize: 16
+      GoRuntimeType: 829664
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 336 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: GoStringDataType
+      ID: 335
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 821
+      Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 906
+      Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 534
+      Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 689
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 938
+      Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 461
+      Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 468
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      GoRuntimeType: 1.111584e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 348
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      ByteSize: 8
+      GoRuntimeType: 831776
+      GoKind: 2
+    - __kind: StructureType
+      ID: 466
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      GoRuntimeType: 1.111456e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 464
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      ByteSize: 32
+      GoRuntimeType: 1.591776e+06
+      GoKind: 25
+      RawFields:
+        - Name: OS
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Arch
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 484
+      Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      ByteSize: 32
+      GoRuntimeType: 1.592576e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 488
+      Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      ByteSize: 32
+      GoRuntimeType: 1.724512e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Size
+          Offset: 16
+          Type: 13 BaseType int64
+        - Name: MaxSize
+          Offset: 24
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 486
+      Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      ByteSize: 16
+      GoRuntimeType: 1.424256e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 482
+      Name: github.com/DataDog/go-tuf/client.ErrNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.423936e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 724
+      Name: github.com/DataDog/go-tuf/data.Hashes
+      ByteSize: 8
+      GoRuntimeType: 1.494336e+06
+      GoKind: 21
+      HeaderType: 726 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+    - __kind: GoSliceHeaderType
+      ID: 748
+      Name: github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 24
+      GoRuntimeType: 1.045632e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 5 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 768 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: GoSliceDataType
+      ID: 768
+      Name: github.com/DataDog/go-tuf/data.HexBytes.array
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: StructureType
+      ID: 496
+      Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      ByteSize: 16
+      GoRuntimeType: 1.592896e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 724 GoMapType github.com/DataDog/go-tuf/data.Hashes
+        - Name: Actual
+          Offset: 8
+          Type: 724 GoMapType github.com/DataDog/go-tuf/data.Hashes
+    - __kind: StructureType
+      ID: 490
+      Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      ByteSize: 16
+      GoRuntimeType: 1.424416e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 494
+      Name: github.com/DataDog/go-tuf/util.ErrWrongHash
+      ByteSize: 64
+      GoRuntimeType: 1.724704e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Expected
+          Offset: 16
+          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+        - Name: Actual
+          Offset: 40
+          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: StructureType
+      ID: 492
+      Name: github.com/DataDog/go-tuf/util.ErrWrongLength
+      ByteSize: 16
+      GoRuntimeType: 1.592736e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Actual
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 498
+      Name: github.com/DataDog/go-tuf/verify.ErrExpired
+      ByteSize: 24
+      GoRuntimeType: 1.424576e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expired
+          Offset: 0
+          Type: 716 StructureType time.Time
+    - __kind: StructureType
+      ID: 504
+      Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
+      ByteSize: 16
+      GoRuntimeType: 1.593216e+06
+      GoKind: 25
+      RawFields:
+        - Name: Actual
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Current
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 506
+      Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
+      ByteSize: 16
+      GoRuntimeType: 1.424896e+06
+      GoKind: 25
+      RawFields:
+        - Name: KeyID
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 502
+      Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      ByteSize: 16
+      GoRuntimeType: 1.593056e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: Actual
+          Offset: 8
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 500
+      Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      ByteSize: 16
+      GoRuntimeType: 1.424736e+06
+      GoKind: 25
+      RawFields:
+        - Name: Role
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 508
+      Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      ByteSize: 16
+      GoRuntimeType: 1.593376e+06
+      GoKind: 25
+      RawFields:
+        - Name: Given
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Expected
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 428
+      Name: github.com/cihub/seelog.baseError
+      ByteSize: 16
+      GoRuntimeType: 1.416736e+06
+      GoKind: 25
+      RawFields:
+        - Name: message
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 859
+      Name: github.com/cihub/seelog.bufferedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 430
+      Name: github.com/cihub/seelog.cannotOpenFileError
+      ByteSize: 16
+      GoRuntimeType: 1.416896e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 839
+      Name: github.com/cihub/seelog.connWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 795
+      Name: github.com/cihub/seelog.consoleWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 829
+      Name: github.com/cihub/seelog.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 434
+      Name: github.com/cihub/seelog.missingArgumentError
+      ByteSize: 16
+      GoRuntimeType: 1.417216e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 896
+      Name: github.com/cihub/seelog.rollingFileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 907
+      Name: github.com/cihub/seelog.rollingFileWriterSize
+      ByteSize: 16
+      GoRuntimeType: 2.098592e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 895 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: maxFileSize
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 910
+      Name: github.com/cihub/seelog.rollingFileWriterTime
+      ByteSize: 40
+      GoRuntimeType: 2.1224e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 895 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: timePattern
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+        - Name: currentTimeFileName
+          Offset: 24
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 797
+      Name: github.com/cihub/seelog.smtpWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 432
+      Name: github.com/cihub/seelog.unexpectedAttributeError
+      ByteSize: 16
+      GoRuntimeType: 1.417056e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: StructureType
+      ID: 436
+      Name: github.com/cihub/seelog.unexpectedChildElementError
+      ByteSize: 16
+      GoRuntimeType: 1.417376e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 428 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 861
+      Name: github.com/cihub/seelog/archive/gzip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 902
+      Name: github.com/cihub/seelog/archive/tar.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 904
+      Name: github.com/cihub/seelog/archive/zip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 720
+      Name: github.com/go-viper/mapstructure/v2.DecodeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 633
+      Name: github.com/go-viper/mapstructure/v2.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 631
+      Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 635
+      Name: github.com/gogo/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 637
+      Name: github.com/gogo/protobuf/proto.invalidUTF8Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 850
+      Name: github.com/gogo/protobuf/proto.textWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 627
+      Name: github.com/golang/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 442
+      Name: github.com/google/uuid.invalidLengthError
+      ByteSize: 8
+      GoRuntimeType: 1.418336e+06
+      GoKind: 25
+      RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
+    - __kind: UnresolvedPointeeType
+      ID: 954
+      Name: github.com/json-iterator/go.Stream
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 691
+      Name: github.com/pkg/errors.fundamental
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 664
+      Name: github.com/tinylib/msgp/msgp.ArrayError
+      ByteSize: 24
+      GoRuntimeType: 1.832512e+06
+      GoKind: 25
+      RawFields:
+        - Name: Wanted
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Got
+          Offset: 4
+          Type: 2 BaseType uint32
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 658
+      Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 597
+      Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
+      ByteSize: 2
+      GoRuntimeType: 1.695296e+06
+      GoKind: 25
+      RawFields:
+        - Name: Got
+          Offset: 0
+          Type: 16 BaseType int8
+        - Name: Want
+          Offset: 1
+          Type: 16 BaseType int8
+    - __kind: StructureType
+      ID: 670
+      Name: github.com/tinylib/msgp/msgp.IntOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.83296e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 574
+      Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
+      ByteSize: 1
+      GoRuntimeType: 985568
+      GoKind: 8
+    - __kind: StructureType
+      ID: 662
+      Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
+      ByteSize: 32
+      GoRuntimeType: 1.832288e+06
+      GoKind: 25
+      RawFields:
+        - Name: Nanos
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: FieldLength
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 750
+      Name: github.com/tinylib/msgp/msgp.Type
+      ByteSize: 1
+      GoRuntimeType: 827744
+      GoKind: 8
+    - __kind: StructureType
+      ID: 660
+      Name: github.com/tinylib/msgp/msgp.TypeError
+      ByteSize: 24
+      GoRuntimeType: 1.832064e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 750 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: Encoded
+          Offset: 1
+          Type: 750 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 668
+      Name: github.com/tinylib/msgp/msgp.UintBelowZero
+      ByteSize: 24
+      GoRuntimeType: 1.746752e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 666
+      Name: github.com/tinylib/msgp/msgp.UintOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.832736e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 958
+      Name: github.com/tinylib/msgp/msgp.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 674
+      Name: github.com/tinylib/msgp/msgp.errFatal
+      ByteSize: 16
+      GoRuntimeType: 1.61744e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctx
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 601
+      Name: github.com/tinylib/msgp/msgp.errRecursion
+      GoRuntimeType: 1.278048e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 599
+      Name: github.com/tinylib/msgp/msgp.errShort
+      GoRuntimeType: 1.27792e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 672
+      Name: github.com/tinylib/msgp/msgp.errWrapped
+      ByteSize: 32
+      GoRuntimeType: 1.746944e+06
+      GoKind: 25
+      RawFields:
+        - Name: cause
+          Offset: 0
+          Type: 14 GoInterfaceType error
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 361
+      Name: go.opentelemetry.io/otel/trace.errorConst
+      ByteSize: 16
+      GoRuntimeType: 835232
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 363 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 362 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: GoStringDataType
+      ID: 362
+      Name: go.opentelemetry.io/otel/trace.errorConst.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 733
+      Name: go.uber.org/multierr.multiError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 641
+      Name: go.uber.org/zap.errArrayElem
+      ByteSize: 16
+      GoRuntimeType: 1.442496e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 827
+      Name: go.uber.org/zap.nopCloserSink
+      ByteSize: 16
+      GoRuntimeType: 1.671392e+06
+      GoKind: 25
+      RawFields:
+        - Name: WriteSyncer
+          Offset: 0
+          Type: 851 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+    - __kind: UnresolvedPointeeType
+      ID: 918
+      Name: go.uber.org/zap/buffer.Buffer
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 851
+      Name: go.uber.org/zap/zapcore.WriteSyncer
+      ByteSize: 16
+      GoRuntimeType: 1.122336e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 813
+      Name: go.uber.org/zap/zapcore.writerWrapper
+      ByteSize: 16
+      GoRuntimeType: 1.563936e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 364
+      Name: golang.org/x/net/http2.ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 835808
+      GoKind: 10
+    - __kind: BaseType
+      ID: 731
+      Name: golang.org/x/net/http2.ErrCode
+      ByteSize: 4
+      GoRuntimeType: 998720
+      GoKind: 10
+    - __kind: StructureType
+      ID: 699
+      Name: golang.org/x/net/http2.StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.871488e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 731 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 560
+      Name: golang.org/x/net/http2.connError
+      ByteSize: 24
+      GoRuntimeType: 1.600416e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 731 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 368
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 836000
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 370 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 369 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 369
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 374
+      Name: golang.org/x/net/http2.headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 836192
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 376 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 375 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 375
+      Name: golang.org/x/net/http2.headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 371
+      Name: golang.org/x/net/http2.headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 836096
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 373 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 372 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 372
+      Name: golang.org/x/net/http2.headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 365
+      Name: golang.org/x/net/http2.pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 835904
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 367 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 366 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 366
+      Name: golang.org/x/net/http2.pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 916
+      Name: golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 564
+      Name: golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.443136e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: BaseType
+      ID: 377
+      Name: golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 836288
+      GoKind: 2
+    - __kind: StructureType
+      ID: 552
+      Name: google.golang.org/grpc.dropError
+      ByteSize: 16
+      GoRuntimeType: 1.438176e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 697
+      Name: google.golang.org/grpc/internal/status.Error
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 722
+      Name: google.golang.org/grpc/internal/transport.ConnectionError
+      ByteSize: 40
+      GoRuntimeType: 1.899392e+06
+      GoKind: 25
+      RawFields:
+        - Name: Desc
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: temp
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: err
+          Offset: 24
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 554
+      Name: google.golang.org/grpc/internal/transport.NewStreamError
+      ByteSize: 24
+      GoRuntimeType: 1.599936e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+        - Name: AllowTransparentRetry
+          Offset: 16
+          Type: 4 BaseType bool
+    - __kind: StructureType
+      ID: 867
+      Name: google.golang.org/grpc/internal/transport.bufConn
+      ByteSize: 32
+      GoRuntimeType: 1.95696e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 747 GoInterfaceType net.Conn
+        - Name: r
+          Offset: 16
+          Type: 894 GoInterfaceType io.Reader
+    - __kind: UnresolvedPointeeType
+      ID: 825
+      Name: google.golang.org/grpc/internal/transport.bufWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 639
+      Name: google.golang.org/grpc/internal/transport.ioError
+      ByteSize: 16
+      GoRuntimeType: 1.561536e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 785
+      Name: google.golang.org/grpc/mem.writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 532
+      Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 629
+      Name: google.golang.org/protobuf/internal/errors.prefixError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 695
+      Name: google.golang.org/protobuf/internal/errors.wrapError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 693
+      Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      GoRuntimeType: 1.504896e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 546
+      Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.431456e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 548
+      Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
+      ByteSize: 16
+      GoRuntimeType: 1.431616e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 476
+      Name: gopkg.in/yaml%2ev3.TypeError
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
       ID: 287
       Name: groupReference<[4]int,[4]int>
@@ -6714,47 +10399,47 @@ Types:
       GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 336
+      ID: 999
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 337 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1000 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 344 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1001 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1007 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 372
+      ID: 1035
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 373 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1036 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 380 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1037 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1043 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 387
+      ID: 1050
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 388 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1051 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 395 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1052 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1058 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 195
       Name: groupReference<int,int>
@@ -6770,19 +10455,19 @@ Types:
       GroupType: 197 StructureType noalg.map.group[int]int
       GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 402
+      ID: 1065
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 403 PointerType *noalg.map.group[int]interface {}
+          Type: 1066 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 404 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 408 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1067 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1071 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 254
       Name: groupReference<int,uint8>
@@ -6825,6 +10510,20 @@ Types:
           Type: 8 BaseType uint64
       GroupType: 221 StructureType noalg.map.group[string][]string
       GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 757
+      Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 758 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 763 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 211
       Name: groupReference<string,int>
@@ -6881,6 +10580,14 @@ Types:
           Type: 8 BaseType uint64
       GroupType: 264 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
+    - __kind: UnresolvedPointeeType
+      ID: 873
+      Name: hash/crc32.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 567
+      Name: html/template.Error
+      ByteSize: 8
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6924,8 +10631,38 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 446
+      Name: internal/bisect.parseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 444
+      Name: internal/chacha8rand.errUnmarshalChaCha8
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 771
+      Name: internal/godebug.runtimeStderr
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 656
+      Name: internal/poll.DeadlineExceededError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 960
+      Name: internal/poll.FD
+      ByteSize: 8
     - __kind: StructureType
-      ID: 313
+      ID: 654
+      Name: internal/poll.errNetClosing
+      GoRuntimeType: 1.470016e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 381
+      Name: internal/reflectlite.ValueError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 972
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.467456e+06
@@ -6937,6 +10674,49 @@ Types:
         - Name: sema
           Offset: 4
           Type: 2 BaseType uint32
+    - __kind: UnresolvedPointeeType
+      ID: 817
+      Name: io.PipeWriter
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 857
+      Name: io.ReadWriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.185056e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 894
+      Name: io.Reader
+      ByteSize: 16
+      GoRuntimeType: 1.01824e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 846
+      Name: io.WriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.104928e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 55
       Name: io.Writer
@@ -6950,6 +10730,24 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 815
+      Name: io.discard
+      GoRuntimeType: 1.457376e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 789
+      Name: io.multiWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 652
+      Name: io/fs.PathError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 863
+      Name: log/slog/internal/buffer.Buffer
+      ByteSize: 8
     - __kind: StructureType
       ID: 173
       Name: main.aStruct
@@ -7015,9 +10813,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 330 GoMapType map[int]*main.deepMap3
+          Type: 993 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 1005
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7029,9 +10827,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 366 GoMapType map[int]*main.deepMap8
+          Type: 1029 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 378
+      ID: 1041
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.180832e+06
@@ -7039,9 +10837,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 381 GoMapType map[int]*main.deepMap9
+          Type: 1044 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 393
+      ID: 1056
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.180704e+06
@@ -7049,7 +10847,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 396 GoMapType map[int]interface {}
+          Type: 1059 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7069,9 +10867,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 306 PointerType *main.deepPtr3
+          Type: 963 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 307
+      ID: 964
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7083,9 +10881,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 347 PointerType *main.deepPtr8
+          Type: 1010 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 348
+      ID: 1011
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.181984e+06
@@ -7093,9 +10891,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 349 PointerType *main.deepPtr9
+          Type: 1012 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 350
+      ID: 1013
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.181856e+06
@@ -7123,9 +10921,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 324 GoSliceHeaderType []*main.deepSlice3
+          Type: 987 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 990
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7137,9 +10935,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 351 GoSliceHeaderType []*main.deepSlice8
+          Type: 1014 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 354
+      ID: 1017
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.183136e+06
@@ -7147,9 +10945,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 357 GoSliceHeaderType []*main.deepSlice9
+          Type: 1020 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 360
+      ID: 1023
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.183008e+06
@@ -7157,7 +10955,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 363 GoSliceHeaderType []interface {}
+          Type: 1026 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 175
       Name: main.emptyStruct
@@ -7175,16 +10973,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 311 StructureType sync.Mutex
+          Type: 970 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 314 StructureType sync.Once
+          Type: 973 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 317 StructureType sync.WaitGroup
+          Type: 976 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 320 StructureType sync/atomic.Int32
+          Type: 979 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -7213,6 +11011,16 @@ Types:
         - Name: foo
           Offset: 56
           Type: 83 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 981
+      Name: main.firstBehavior
+      ByteSize: 16
+      GoRuntimeType: 1.407616e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
       ID: 174
       Name: main.nestedStruct
@@ -7248,6 +11056,13 @@ Types:
         - Name: a
           Offset: 0
           Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 983
+      Name: main.secondBehavior
+      ByteSize: 8
+      GoRuntimeType: 1.407776e+06
+      GoKind: 25
+      RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 82
       Name: main.something
@@ -7261,6 +11076,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 969
+      Name: main.somethingImpl
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 76
       Name: main.stringType1
@@ -7269,17 +11088,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *main.stringType1.str
+          Type: 966 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 308 GoStringDataType main.stringType1.str
+      Data: 965 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 965
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 310
+      ID: 967
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -7334,16 +11153,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 321 PointerType **main.t
+          Type: 984 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 322 GoSliceDataType main.t.array
+      Data: 985 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 322
+      ID: 985
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -7528,7 +11347,7 @@ Types:
       TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 332
+      ID: 995
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7541,7 +11360,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 333 PointerType **table<int,*main.deepMap3>
+          Type: 996 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7557,10 +11376,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 343 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1006 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1001 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 368
+      ID: 1031
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7573,7 +11392,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 369 PointerType **table<int,*main.deepMap8>
+          Type: 1032 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7589,10 +11408,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 379 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1042 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1037 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 383
+      ID: 1046
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7605,7 +11424,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 384 PointerType **table<int,*main.deepMap9>
+          Type: 1047 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7621,8 +11440,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 394 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1057 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1052 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 93
       Name: map<int,int>
@@ -7656,7 +11475,7 @@ Types:
       TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
       GroupType: 197 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 398
+      ID: 1061
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7669,7 +11488,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 399 PointerType **table<int,interface {}>
+          Type: 1062 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7685,8 +11504,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 407 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 404 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1070 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1067 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 130
       Name: map<int,uint8>
@@ -7783,6 +11602,38 @@ Types:
           Type: 8 BaseType uint64
       TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
       GroupType: 221 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 726
+      Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 727 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 762 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -7947,26 +11798,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 330
+      ID: 993
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124e+06
       GoKind: 21
-      HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 995 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 366
+      ID: 1029
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.12336e+06
       GoKind: 21
-      HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1031 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 381
+      ID: 1044
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.123232e+06
       GoKind: 21
-      HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1046 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
@@ -7975,12 +11826,12 @@ Types:
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 396
+      ID: 1059
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.123104e+06
       GoKind: 21
-      HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1061 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
@@ -8030,6 +11881,601 @@ Types:
       GoRuntimeType: 1.125536e+06
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: StructureType
+      ID: 480
+      Name: math/big.ErrNaN
+      ByteSize: 16
+      GoRuntimeType: 1.423616e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 779
+      Name: mime/multipart.writerOnly·1
+      ByteSize: 16
+      GoRuntimeType: 1.420416e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 683
+      Name: net.AddrError
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 747
+      Name: net.Conn
+      ByteSize: 16
+      GoRuntimeType: 1.590496e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 709
+      Name: net.DNSError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 924
+      Name: net.IPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 707
+      Name: net.OpError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 685
+      Name: net.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 934
+      Name: net.TCPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 944
+      Name: net.UDPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 932
+      Name: net.UnixConn
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 644
+      Name: net.UnknownNetworkError
+      ByteSize: 16
+      GoRuntimeType: 1.108256e+06
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 646 PointerType *net.UnknownNetworkError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 645 GoStringDataType net.UnknownNetworkError.str
+    - __kind: GoStringDataType
+      ID: 645
+      Name: net.UnknownNetworkError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 613
+      Name: net.canceledError
+      GoRuntimeType: 1.279072e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 900
+      Name: net.conn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 752
+      Name: net.dialResult·1
+      ByteSize: 40
+      GoRuntimeType: 2.097888e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 747 GoInterfaceType net.Conn
+        - Name: error
+          Offset: 16
+          Type: 14 GoInterfaceType error
+        - Name: primary
+          Offset: 32
+          Type: 4 BaseType bool
+        - Name: done
+          Offset: 33
+          Type: 4 BaseType bool
+    - __kind: UnresolvedPointeeType
+      ID: 946
+      Name: net.netFD
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 940
+      Name: net.noReadFrom
+      GoRuntimeType: 1.108512e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 939
+      Name: net.noWriteTo
+      GoRuntimeType: 1.108384e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 413
+      Name: net.notFoundError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 415
+      Name: net.result·2
+      ByteSize: 112
+      GoRuntimeType: 1.721056e+06
+      GoKind: 25
+      RawFields:
+        - Name: p
+          Offset: 0
+          Type: 734 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+        - Name: server
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: error
+          Offset: 96
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 928
+      Name: net.tcpConnWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.282624e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 940 StructureType net.noReadFrom
+        - Name: TCPConn
+          Offset: 0
+          Type: 933 PointerType *net.TCPConn
+    - __kind: StructureType
+      ID: 926
+      Name: net.tcpConnWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.28208e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 939 StructureType net.noWriteTo
+        - Name: TCPConn
+          Offset: 0
+          Type: 933 PointerType *net.TCPConn
+    - __kind: UnresolvedPointeeType
+      ID: 687
+      Name: net.temporaryError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 711
+      Name: net.timeoutError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 603
+      Name: net/http.ProtocolError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 773
+      Name: net/http.bufioFlushWriter
+      ByteSize: 16
+      GoRuntimeType: 1.411936e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 309
+      Name: net/http.http2ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 828224
+      GoKind: 10
+    - __kind: BaseType
+      ID: 723
+      Name: net/http.http2ErrCode
+      ByteSize: 4
+      GoRuntimeType: 985664
+      GoKind: 10
+    - __kind: StructureType
+      ID: 391
+      Name: net/http.http2GoAwayError
+      ByteSize: 24
+      GoRuntimeType: 1.719328e+06
+      GoKind: 25
+      RawFields:
+        - Name: LastStreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: ErrCode
+          Offset: 4
+          Type: 723 BaseType net/http.http2ErrCode
+        - Name: DebugData
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 703
+      Name: net/http.http2StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.890688e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 723 BaseType net/http.http2ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 395
+      Name: net/http.http2connError
+      ByteSize: 24
+      GoRuntimeType: 1.590016e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 723 BaseType net/http.http2ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 835
+      Name: net/http.http2dataBuffer
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 313
+      Name: net/http.http2duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 828416
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 315 PointerType *net/http.http2duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 314
+      Name: net/http.http2duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 319
+      Name: net/http.http2headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 828608
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 321 PointerType *net/http.http2headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 320 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 320
+      Name: net/http.http2headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 316
+      Name: net/http.http2headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 828512
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 318 PointerType *net/http.http2headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 317 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 317
+      Name: net/http.http2headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 678
+      Name: net/http.http2httpError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 609
+      Name: net/http.http2noCachedConnError
+      GoRuntimeType: 1.278304e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 889
+      Name: net/http.http2pipe
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 310
+      Name: net/http.http2pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 828320
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 312 PointerType *net/http.http2pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 311
+      Name: net/http.http2pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 775
+      Name: net/http.http2stickyErrWriter
+      ByteSize: 48
+      GoRuntimeType: 1.8152e+06
+      GoKind: 25
+      RawFields:
+        - Name: group
+          Offset: 0
+          Type: 868 GoInterfaceType net/http.http2synctestGroupInterface
+        - Name: conn
+          Offset: 16
+          Type: 747 GoInterfaceType net.Conn
+        - Name: timeout
+          Offset: 32
+          Type: 869 BaseType time.Duration
+        - Name: err
+          Offset: 40
+          Type: 33 PointerType *error
+    - __kind: GoInterfaceType
+      ID: 868
+      Name: net/http.http2synctestGroupInterface
+      ByteSize: 16
+      GoRuntimeType: 1.411296e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: ArrayType
+      ID: 854
+      Name: net/http.incomparable
+      GoRuntimeType: 898176
+      GoKind: 17
+      HasCount: true
+      Element: 83 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 605
+      Name: net/http.nothingWrittenError
+      ByteSize: 16
+      GoRuntimeType: 1.549056e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 837
+      Name: net/http.persistConn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 793
+      Name: net/http.persistConnWriter
+      ByteSize: 8
+      GoRuntimeType: 1.548896e+06
+      GoKind: 25
+      RawFields:
+        - Name: pc
+          Offset: 0
+          Type: 836 PointerType *net/http.persistConn
+    - __kind: StructureType
+      ID: 819
+      Name: net/http.readWriteCloserBody
+      ByteSize: 24
+      GoRuntimeType: 1.7912e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 854 ArrayType net/http.incomparable
+        - Name: br
+          Offset: 0
+          Type: 855 PointerType *bufio.Reader
+        - Name: ReadWriteCloser
+          Offset: 8
+          Type: 857 GoInterfaceType io.ReadWriteCloser
+    - __kind: StructureType
+      ID: 399
+      Name: net/http.requestBodyReadError
+      ByteSize: 16
+      GoRuntimeType: 1.412896e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 705
+      Name: net/http.timeoutError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 676
+      Name: net/http.tlsHandshakeTimeoutError
+      GoRuntimeType: 1.472896e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 607
+      Name: net/http.transportReadFromServerError
+      ByteSize: 16
+      GoRuntimeType: 1.549216e+06
+      GoKind: 25
+      RawFields:
+        - Name: err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 871
+      Name: net/http.unencryptedNetConnInTLSConn
+      ByteSize: 32
+      GoRuntimeType: 2.016864e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 747 GoInterfaceType net.Conn
+        - Name: conn
+          Offset: 16
+          Type: 747 GoInterfaceType net.Conn
+    - __kind: UnresolvedPointeeType
+      ID: 388
+      Name: net/http.unsupportedTEError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 891
+      Name: net/http/internal.FlushAfterChunkWriter
+      ByteSize: 8
+      GoRuntimeType: 2.032896e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 884 PointerType *bufio.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 803
+      Name: net/http/internal.chunkedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 472
+      Name: net/netip.parseAddrError
+      ByteSize: 48
+      GoRuntimeType: 1.724128e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: at
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 470
+      Name: net/netip.parsePrefixError
+      ByteSize: 32
+      GoRuntimeType: 1.591936e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 845
+      Name: net/smtp.Client
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 805
+      Name: net/smtp.dataCloser
+      ByteSize: 24
+      GoRuntimeType: 1.593856e+06
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 844 PointerType *net/smtp.Client
+        - Name: WriteCloser
+          Offset: 8
+          Type: 846 GoInterfaceType io.WriteCloser
+    - __kind: UnresolvedPointeeType
+      ID: 456
+      Name: net/textproto.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 344
+      Name: net/textproto.ProtocolError
+      ByteSize: 16
+      GoRuntimeType: 831200
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 346 PointerType *net/textproto.ProtocolError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 345 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: GoStringDataType
+      ID: 345
+      Name: net/textproto.ProtocolError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 801
+      Name: net/textproto.dotWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 713
+      Name: net/url.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 322
+      Name: net/url.EscapeError
+      ByteSize: 16
+      GoRuntimeType: 829184
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 324 PointerType *net/url.EscapeError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 323 GoStringDataType net/url.EscapeError.str
+    - __kind: GoStringDataType
+      ID: 323
+      Name: net/url.EscapeError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 325
+      Name: net/url.InvalidHostError
+      ByteSize: 16
+      GoRuntimeType: 829280
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 327 PointerType *net/url.InvalidHostError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 326 GoStringDataType net/url.InvalidHostError.str
+    - __kind: GoStringDataType
+      ID: 326
+      Name: net/url.InvalidHostError.str
+      ByteSize: 2048
     - __kind: ArrayType
       ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
@@ -8076,32 +12522,32 @@ Types:
       HasCount: true
       Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 339
+      ID: 1002
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 340 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1003 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 375
+      ID: 1038
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 677760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 376 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1039 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 390
+      ID: 1053
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 391 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1054 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 198
       Name: noalg.[8]struct { key int; elem int }
@@ -8112,14 +12558,14 @@ Types:
       HasCount: true
       Element: 199 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 405
+      ID: 1068
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 677568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 406 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1069 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -8147,6 +12593,15 @@ Types:
       Count: 8
       HasCount: true
       Element: 223 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 760
+      Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      ByteSize: 320
+      GoRuntimeType: 754592
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 761 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 214
       Name: noalg.[8]struct { key string; elem int }
@@ -8249,7 +12704,7 @@ Types:
           Offset: 8
           Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 338
+      ID: 1001
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.289568e+06
@@ -8260,9 +12715,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 339 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1002 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 374
+      ID: 1037
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.288288e+06
@@ -8273,9 +12728,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 375 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1038 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 389
+      ID: 1052
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.288032e+06
@@ -8286,7 +12741,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 390 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1053 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 197
       Name: noalg.map.group[int]int
@@ -8301,7 +12756,7 @@ Types:
           Offset: 8
           Type: 198 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 404
+      ID: 1067
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.287776e+06
@@ -8312,7 +12767,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 405 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1068 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 256
       Name: noalg.map.group[int]uint8
@@ -8352,6 +12807,19 @@ Types:
         - Name: slots
           Offset: 8
           Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 759
+      Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 328
+      GoRuntimeType: 1.3528e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 760 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 213
       Name: noalg.map.group[string]int
@@ -8470,7 +12938,7 @@ Types:
           Offset: 8
           Type: 190 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 340
+      ID: 1003
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.28944e+06
@@ -8481,9 +12949,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 341 PointerType *main.deepMap3
+          Type: 1004 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 376
+      ID: 1039
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.28816e+06
@@ -8494,9 +12962,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 377 PointerType *main.deepMap8
+          Type: 1040 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 391
+      ID: 1054
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.287904e+06
@@ -8507,7 +12975,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 392 PointerType *main.deepMap9
+          Type: 1055 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 199
       Name: noalg.struct { key int; elem int }
@@ -8522,7 +12990,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 406
+      ID: 1069
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.287648e+06
@@ -8573,6 +13041,19 @@ Types:
         - Name: elem
           Offset: 16
           Type: 166 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 761
+      Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      ByteSize: 40
+      GoRuntimeType: 1.352672e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 215
       Name: noalg.struct { key string; elem int }
@@ -8625,6 +13106,199 @@ Types:
         - Name: elem
           Offset: 1
           Type: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 952
+      Name: os.File
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 584
+      Name: os.LinkError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 648
+      Name: os.SyscallError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 950
+      Name: os.fileWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.351232e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 956 StructureType os.noReadFrom
+        - Name: File
+          Offset: 0
+          Type: 951 PointerType *os.File
+    - __kind: StructureType
+      ID: 948
+      Name: os.fileWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.350432e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 955 StructureType os.noWriteTo
+        - Name: File
+          Offset: 0
+          Type: 951 PointerType *os.File
+    - __kind: StructureType
+      ID: 956
+      Name: os.noReadFrom
+      GoRuntimeType: 1.105824e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 955
+      Name: os.noWriteTo
+      GoRuntimeType: 1.105696e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 615
+      Name: os/exec.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 755
+      Name: os/exec.ExitError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 823
+      Name: os/exec.prefixSuffixSaver
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 617
+      Name: os/exec.wrappedError
+      ByteSize: 32
+      GoRuntimeType: 1.695872e+06
+      GoKind: 25
+      RawFields:
+        - Name: prefix
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: err
+          Offset: 16
+          Type: 14 GoInterfaceType error
+    - __kind: GoStringHeaderType
+      ID: 358
+      Name: os/user.UnknownGroupIdError
+      ByteSize: 16
+      GoRuntimeType: 834464
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 360 PointerType *os/user.UnknownGroupIdError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 359 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: GoStringDataType
+      ID: 359
+      Name: os/user.UnknownGroupIdError.str
+      ByteSize: 2048
+    - __kind: BaseType
+      ID: 357
+      Name: os/user.UnknownUserIdError
+      ByteSize: 8
+      GoRuntimeType: 834368
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 383
+      Name: reflect.ValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 478
+      Name: regexp/syntax.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 588
+      Name: runtime.PanicNilError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 592
+      Name: runtime.TypeAssertionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 590
+      Name: runtime.boundsError
+      ByteSize: 24
+      GoRuntimeType: 1.879104e+06
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: y
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: signed
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: code
+          Offset: 17
+          Type: 753 BaseType runtime.boundsErrorCode
+    - __kind: BaseType
+      ID: 753
+      Name: runtime.boundsErrorCode
+      ByteSize: 1
+      GoRuntimeType: 581312
+      GoKind: 8
+    - __kind: StructureType
+      ID: 650
+      Name: runtime.errorAddressString
+      ByteSize: 24
+      GoRuntimeType: 1.74368e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: addr
+          Offset: 16
+          Type: 1 BaseType uintptr
+    - __kind: GoStringHeaderType
+      ID: 568
+      Name: runtime.errorString
+      ByteSize: 16
+      GoRuntimeType: 984320
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 570 PointerType *runtime.errorString.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 569 GoStringDataType runtime.errorString.str
+    - __kind: GoStringDataType
+      ID: 569
+      Name: runtime.errorString.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 571
+      Name: runtime.plainError
+      ByteSize: 16
+      GoRuntimeType: 984416
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 573 PointerType *runtime.plainError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 572 GoStringDataType runtime.plainError.str
+    - __kind: GoStringDataType
+      ID: 572
+      Name: runtime.plainError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 594
+      Name: strconv.NumError
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
@@ -8643,8 +13317,26 @@ Types:
       ID: 177
       Name: string.str
       ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 887
+      Name: strings.Builder
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 791
+      Name: strings.appendSliceWriter
+      ByteSize: 8
     - __kind: StructureType
-      ID: 311
+      ID: 787
+      Name: struct { io.Writer }
+      ByteSize: 16
+      GoRuntimeType: 1.449696e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 970
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.458176e+06
@@ -8652,12 +13344,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 971 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 313 StructureType internal/sync.Mutex
+          Type: 972 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 314
+      ID: 973
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.606688e+06
@@ -8665,15 +13357,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 971 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 315 StructureType sync/atomic.Uint32
+          Type: 974 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 311 StructureType sync.Mutex
+          Type: 970 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 317
+      ID: 976
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.60688e+06
@@ -8681,21 +13373,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 971 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 318 StructureType sync/atomic.Uint64
+          Type: 977 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 312
+      ID: 971
       Name: sync.noCopy
       GoRuntimeType: 983264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 320
+      ID: 979
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.459456e+06
@@ -8703,12 +13395,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 975 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 315
+      ID: 974
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.459616e+06
@@ -8716,12 +13408,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 975 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 318
+      ID: 977
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607264e+06
@@ -8729,25 +13421,31 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 975 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 319 StructureType sync/atomic.align64
+          Type: 978 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 319
+      ID: 978
       Name: sync/atomic.align64
       GoRuntimeType: 983456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 316
+      ID: 975
       Name: sync/atomic.noCopy
       GoRuntimeType: 983360
       GoKind: 25
       RawFields: []
+    - __kind: BaseType
+      ID: 700
+      Name: syscall.Errno
+      ByteSize: 8
+      GoRuntimeType: 1.277664e+06
+      GoKind: 12
     - __kind: StructureType
       ID: 286
       Name: table<[4]int,[4]int>
@@ -8869,7 +13567,7 @@ Types:
           Offset: 16
           Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 335
+      ID: 998
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8891,9 +13589,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 336 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 999 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 371
+      ID: 1034
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8915,9 +13613,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 372 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1035 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 386
+      ID: 1049
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8939,7 +13637,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 387 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1050 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 194
       Name: table<int,int>
@@ -8965,7 +13663,7 @@ Types:
           Offset: 16
           Type: 195 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 401
+      ID: 1064
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8987,7 +13685,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 402 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1065 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 253
       Name: table<int,uint8>
@@ -9060,6 +13758,30 @@ Types:
         - Name: groups
           Offset: 16
           Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 756
+      Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 757 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 210
       Name: table<string,int>
@@ -9156,6 +13878,71 @@ Types:
         - Name: groups
           Offset: 16
           Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
+    - __kind: UnresolvedPointeeType
+      ID: 922
+      Name: text/tabwriter.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 643
+      Name: text/template.ExecError
+      ByteSize: 32
+      GoRuntimeType: 1.700288e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 14 GoInterfaceType error
+    - __kind: BaseType
+      ID: 869
+      Name: time.Duration
+      ByteSize: 8
+      GoRuntimeType: 1.905248e+06
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 718
+      Name: time.Location
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 386
+      Name: time.ParseError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 716
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.366112e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 13 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 717 PointerType *time.Location
+    - __kind: GoStringHeaderType
+      ID: 306
+      Name: time.fileSizeError
+      ByteSize: 16
+      GoRuntimeType: 827360
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 308 PointerType *time.fileSizeError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 307 GoStringDataType time.fileSizeError.str
+    - __kind: GoStringDataType
+      ID: 307
+      Name: time.fileSizeError.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -9198,6 +13985,120 @@ Types:
       ByteSize: 8
       GoRuntimeType: 581248
       GoKind: 26
-MaxTypeID: 523
+    - __kind: StructureType
+      ID: 734
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
+      ByteSize: 80
+      GoRuntimeType: 2.054304e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 735 GoSliceHeaderType []uint8
+        - Name: header
+          Offset: 24
+          Type: 736 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+        - Name: section
+          Offset: 36
+          Type: 737 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+        - Name: off
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: index
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: resHeaderValid
+          Offset: 56
+          Type: 4 BaseType bool
+        - Name: resHeaderOffset
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: resHeaderType
+          Offset: 72
+          Type: 738 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+        - Name: resHeaderLength
+          Offset: 74
+          Type: 6 BaseType uint16
+    - __kind: BaseType
+      ID: 738
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Type
+      ByteSize: 2
+      GoRuntimeType: 989888
+      GoKind: 9
+    - __kind: StructureType
+      ID: 736
+      Name: vendor/golang.org/x/net/dns/dnsmessage.header
+      ByteSize: 12
+      GoRuntimeType: 1.916e+06
+      GoKind: 25
+      RawFields:
+        - Name: id
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: bits
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: questions
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: answers
+          Offset: 6
+          Type: 6 BaseType uint16
+        - Name: authorities
+          Offset: 8
+          Type: 6 BaseType uint16
+        - Name: additionals
+          Offset: 10
+          Type: 6 BaseType uint16
+    - __kind: UnresolvedPointeeType
+      ID: 474
+      Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 737
+      Name: vendor/golang.org/x/net/dns/dnsmessage.section
+      ByteSize: 1
+      GoRuntimeType: 584896
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 914
+      Name: vendor/golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 458
+      Name: vendor/golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.420736e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: BaseType
+      ID: 347
+      Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 831296
+      GoKind: 2
+    - __kind: StructureType
+      ID: 622
+      Name: vendor/golang.org/x/net/idna.labelError
+      ByteSize: 32
+      GoRuntimeType: 1.696064e+06
+      GoKind: 25
+      RawFields:
+        - Name: label
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: code_
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 576
+      Name: vendor/golang.org/x/net/idna.runeError
+      ByteSize: 4
+      GoRuntimeType: 988736
+      GoKind: 5
+MaxTypeID: 1186
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x131d360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -3445,7 +3445,7 @@ Types:
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 526112
+      GoRuntimeType: 526272
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
@@ -3607,175 +3607,175 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 390272
+      GoRuntimeType: 390432
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 389184
+      GoRuntimeType: 389344
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 390144
+      GoRuntimeType: 390304
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 390208
+      GoRuntimeType: 390368
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 28
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 389824
+      GoRuntimeType: 389984
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 389440
+      GoRuntimeType: 389600
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 389568
+      GoRuntimeType: 389728
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 389696
+      GoRuntimeType: 389856
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 389312
+      GoRuntimeType: 389472
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
       ID: 88
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 390400
+      GoRuntimeType: 390560
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 382976
+      GoRuntimeType: 383136
       GoKind: 22
       Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
       ID: 341
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 382912
+      GoRuntimeType: 383072
       GoKind: 22
       Pointee: 342 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 382656
+      GoRuntimeType: 382816
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
       ID: 377
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 382592
+      GoRuntimeType: 382752
       GoKind: 22
       Pointee: 378 StructureType main.deepMap8
     - __kind: PointerType
       ID: 392
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 382528
+      GoRuntimeType: 382688
       GoKind: 22
       Pointee: 393 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 383552
+      GoRuntimeType: 383712
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 306
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 383488
+      GoRuntimeType: 383648
       GoKind: 22
       Pointee: 307 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 383232
+      GoRuntimeType: 383392
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 347
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 383168
+      GoRuntimeType: 383328
       GoKind: 22
       Pointee: 348 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 349
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 383104
+      GoRuntimeType: 383264
       GoKind: 22
       Pointee: 350 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 384128
+      GoRuntimeType: 384288
       GoKind: 22
       Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 326
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 384064
+      GoRuntimeType: 384224
       GoKind: 22
       Pointee: 327 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 383808
+      GoRuntimeType: 383968
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 353
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 383744
+      GoRuntimeType: 383904
       GoKind: 22
       Pointee: 354 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 359
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 383680
+      GoRuntimeType: 383840
       GoKind: 22
       Pointee: 360 StructureType main.deepSlice9
     - __kind: PointerType
@@ -3788,14 +3788,14 @@ Types:
       ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 384256
+      GoRuntimeType: 384416
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 384320
+      GoRuntimeType: 384480
       GoKind: 22
       Pointee: 156 StructureType main.node
     - __kind: PointerType
@@ -3825,7 +3825,7 @@ Types:
       ID: 242
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 382464
+      GoRuntimeType: 382624
       GoKind: 22
       Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
@@ -4036,7 +4036,7 @@ Types:
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 389248
+      GoRuntimeType: 389408
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -4133,42 +4133,42 @@ Types:
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 389888
+      GoRuntimeType: 390048
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 389504
+      GoRuntimeType: 389664
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 389632
+      GoRuntimeType: 389792
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 29
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 389760
+      GoRuntimeType: 389920
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 389376
+      GoRuntimeType: 389536
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 389952
+      GoRuntimeType: 390112
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -6007,7 +6007,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 679136
+      GoRuntimeType: 679296
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6024,7 +6024,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 680480
+      GoRuntimeType: 680640
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6057,7 +6057,7 @@ Types:
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 680576
+      GoRuntimeType: 680736
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6090,7 +6090,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 680672
+      GoRuntimeType: 680832
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6099,7 +6099,7 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 680384
+      GoRuntimeType: 680544
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6108,7 +6108,7 @@ Types:
       ID: 275
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 678752
+      GoRuntimeType: 678912
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6117,7 +6117,7 @@ Types:
       ID: 232
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 679040
+      GoRuntimeType: 679200
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6134,7 +6134,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 474688
+      GoRuntimeType: 474848
       GoKind: 23
       RawFields:
         - Name: array
@@ -6156,7 +6156,7 @@ Types:
       ID: 324
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 474624
+      GoRuntimeType: 474784
       GoKind: 23
       RawFields:
         - Name: array
@@ -6178,7 +6178,7 @@ Types:
       ID: 351
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 474304
+      GoRuntimeType: 474464
       GoKind: 23
       RawFields:
         - Name: array
@@ -6200,7 +6200,7 @@ Types:
       ID: 357
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 474240
+      GoRuntimeType: 474400
       GoKind: 23
       RawFields:
         - Name: array
@@ -6222,7 +6222,7 @@ Types:
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 475712
+      GoRuntimeType: 475872
       GoKind: 23
       RawFields:
         - Name: array
@@ -6350,7 +6350,7 @@ Types:
       ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 483584
+      GoRuntimeType: 483744
       GoKind: 23
       RawFields:
         - Name: array
@@ -6372,7 +6372,7 @@ Types:
       ID: 363
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 483904
+      GoRuntimeType: 484064
       GoKind: 23
       RawFields:
         - Name: array
@@ -6394,7 +6394,7 @@ Types:
       ID: 241
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 474944
+      GoRuntimeType: 475104
       GoKind: 23
       RawFields:
         - Name: array
@@ -6522,7 +6522,7 @@ Types:
       ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 483712
+      GoRuntimeType: 483872
       GoKind: 23
       RawFields:
         - Name: array
@@ -6544,7 +6544,7 @@ Types:
       ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 483200
+      GoRuntimeType: 483360
       GoKind: 23
       RawFields:
         - Name: array
@@ -6566,7 +6566,7 @@ Types:
       ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 482560
+      GoRuntimeType: 482720
       GoKind: 23
       RawFields:
         - Name: array
@@ -6588,35 +6588,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 581024
+      GoRuntimeType: 581184
       GoKind: 1
     - __kind: GoChannelType
       ID: 153
       Name: chan bool
-      GoRuntimeType: 592352
+      GoRuntimeType: 592512
       GoKind: 18
     - __kind: GoChannelType
       ID: 80
       Name: chan struct {}
-      GoRuntimeType: 591264
+      GoRuntimeType: 591424
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 580832
+      GoRuntimeType: 580992
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 580768
+      GoRuntimeType: 580928
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.021792e+06
+      GoRuntimeType: 1.021952e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6629,19 +6629,19 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 580896
+      GoRuntimeType: 581056
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 580960
+      GoRuntimeType: 581120
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 472896
+      GoRuntimeType: 473056
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 287
@@ -6885,37 +6885,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 580576
+      GoRuntimeType: 580736
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 580192
+      GoRuntimeType: 580352
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 580320
+      GoRuntimeType: 580480
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 580448
+      GoRuntimeType: 580608
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 580064
+      GoRuntimeType: 580224
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 843808
+      GoRuntimeType: 843968
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6928,7 +6928,7 @@ Types:
       ID: 313
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.46704e+06
+      GoRuntimeType: 1.467456e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6941,7 +6941,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.017824e+06
+      GoRuntimeType: 1.017984e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6972,7 +6972,7 @@ Types:
       ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.01744e+06
+      GoRuntimeType: 1.0176e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7000,7 +7000,7 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.181312e+06
+      GoRuntimeType: 1.181728e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7010,7 +7010,7 @@ Types:
       ID: 191
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.181184e+06
+      GoRuntimeType: 1.1816e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7024,7 +7024,7 @@ Types:
       ID: 74
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.180544e+06
+      GoRuntimeType: 1.18096e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7034,7 +7034,7 @@ Types:
       ID: 378
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.180416e+06
+      GoRuntimeType: 1.180832e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7044,7 +7044,7 @@ Types:
       ID: 393
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.180288e+06
+      GoRuntimeType: 1.180704e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7054,7 +7054,7 @@ Types:
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.182464e+06
+      GoRuntimeType: 1.18288e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7064,7 +7064,7 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.182336e+06
+      GoRuntimeType: 1.182752e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7078,7 +7078,7 @@ Types:
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.181696e+06
+      GoRuntimeType: 1.182112e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7088,7 +7088,7 @@ Types:
       ID: 348
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.181568e+06
+      GoRuntimeType: 1.181984e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7098,7 +7098,7 @@ Types:
       ID: 350
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.18144e+06
+      GoRuntimeType: 1.181856e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7108,7 +7108,7 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.183616e+06
+      GoRuntimeType: 1.184032e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7118,7 +7118,7 @@ Types:
       ID: 181
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.183488e+06
+      GoRuntimeType: 1.183904e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7132,7 +7132,7 @@ Types:
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.182848e+06
+      GoRuntimeType: 1.183264e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7142,7 +7142,7 @@ Types:
       ID: 354
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.18272e+06
+      GoRuntimeType: 1.183136e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7152,7 +7152,7 @@ Types:
       ID: 360
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.182592e+06
+      GoRuntimeType: 1.183008e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7167,7 +7167,7 @@ Types:
       ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.824256e+06
+      GoRuntimeType: 1.824672e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7189,7 +7189,7 @@ Types:
       ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.957856e+06
+      GoRuntimeType: 1.958272e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7217,7 +7217,7 @@ Types:
       ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.45648e+06
+      GoRuntimeType: 1.456896e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7230,7 +7230,7 @@ Types:
       ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.45632e+06
+      GoRuntimeType: 1.456736e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7252,7 +7252,7 @@ Types:
       ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.017568e+06
+      GoRuntimeType: 1.017728e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7286,7 +7286,7 @@ Types:
       ID: 89
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.180032e+06
+      GoRuntimeType: 1.180448e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7296,7 +7296,7 @@ Types:
       ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.18016e+06
+      GoRuntimeType: 1.180576e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -7915,126 +7915,126 @@ Types:
       ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.124096e+06
+      GoRuntimeType: 1.124256e+06
       GoKind: 21
       HeaderType: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.124224e+06
+      GoRuntimeType: 1.124384e+06
       GoKind: 21
       HeaderType: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.124352e+06
+      GoRuntimeType: 1.124512e+06
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.12448e+06
+      GoRuntimeType: 1.12464e+06
       GoKind: 21
       HeaderType: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.123968e+06
+      GoRuntimeType: 1.124128e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 330
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.12384e+06
+      GoRuntimeType: 1.124e+06
       GoKind: 21
       HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 366
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.1232e+06
+      GoRuntimeType: 1.12336e+06
       GoKind: 21
       HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 381
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.123072e+06
+      GoRuntimeType: 1.123232e+06
       GoKind: 21
       HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.12256e+06
+      GoRuntimeType: 1.12272e+06
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 396
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.122944e+06
+      GoRuntimeType: 1.123104e+06
       GoKind: 21
       HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.124608e+06
+      GoRuntimeType: 1.124768e+06
       GoKind: 21
       HeaderType: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.124736e+06
+      GoRuntimeType: 1.124896e+06
       GoKind: 21
       HeaderType: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.124864e+06
+      GoRuntimeType: 1.125024e+06
       GoKind: 21
       HeaderType: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.124992e+06
+      GoRuntimeType: 1.125152e+06
       GoKind: 21
       HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.12512e+06
+      GoRuntimeType: 1.12528e+06
       GoKind: 21
       HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.125248e+06
+      GoRuntimeType: 1.125408e+06
       GoKind: 21
       HeaderType: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.125376e+06
+      GoRuntimeType: 1.125536e+06
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
       ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 678848
+      GoRuntimeType: 679008
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8043,7 +8043,7 @@ Types:
       ID: 282
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 678944
+      GoRuntimeType: 679104
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8052,7 +8052,7 @@ Types:
       ID: 230
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 679232
+      GoRuntimeType: 679392
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8061,7 +8061,7 @@ Types:
       ID: 249
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 679328
+      GoRuntimeType: 679488
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8070,7 +8070,7 @@ Types:
       ID: 188
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 678176
+      GoRuntimeType: 678336
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8079,7 +8079,7 @@ Types:
       ID: 339
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 678080
+      GoRuntimeType: 678240
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8088,7 +8088,7 @@ Types:
       ID: 375
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 677600
+      GoRuntimeType: 677760
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8097,7 +8097,7 @@ Types:
       ID: 390
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 677504
+      GoRuntimeType: 677664
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8106,7 +8106,7 @@ Types:
       ID: 198
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 676256
+      GoRuntimeType: 676416
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8115,7 +8115,7 @@ Types:
       ID: 405
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 677408
+      GoRuntimeType: 677568
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8124,7 +8124,7 @@ Types:
       ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 679424
+      GoRuntimeType: 679584
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8133,7 +8133,7 @@ Types:
       ID: 239
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 679520
+      GoRuntimeType: 679680
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8142,7 +8142,7 @@ Types:
       ID: 222
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 679616
+      GoRuntimeType: 679776
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8151,7 +8151,7 @@ Types:
       ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 679712
+      GoRuntimeType: 679872
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8160,7 +8160,7 @@ Types:
       ID: 206
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 679808
+      GoRuntimeType: 679968
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8169,7 +8169,7 @@ Types:
       ID: 273
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 679904
+      GoRuntimeType: 680064
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8178,7 +8178,7 @@ Types:
       ID: 265
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 680000
+      GoRuntimeType: 680160
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8187,7 +8187,7 @@ Types:
       ID: 289
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.289664e+06
+      GoRuntimeType: 1.29008e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8200,7 +8200,7 @@ Types:
       ID: 281
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.28992e+06
+      GoRuntimeType: 1.290336e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8213,7 +8213,7 @@ Types:
       ID: 229
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.290176e+06
+      GoRuntimeType: 1.290592e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8226,7 +8226,7 @@ Types:
       ID: 248
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.290432e+06
+      GoRuntimeType: 1.290848e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8239,7 +8239,7 @@ Types:
       ID: 187
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.289408e+06
+      GoRuntimeType: 1.289824e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8252,7 +8252,7 @@ Types:
       ID: 338
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.289152e+06
+      GoRuntimeType: 1.289568e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8265,7 +8265,7 @@ Types:
       ID: 374
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.287872e+06
+      GoRuntimeType: 1.288288e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8278,7 +8278,7 @@ Types:
       ID: 389
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.287616e+06
+      GoRuntimeType: 1.288032e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8291,7 +8291,7 @@ Types:
       ID: 197
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.286592e+06
+      GoRuntimeType: 1.287008e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8304,7 +8304,7 @@ Types:
       ID: 404
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.28736e+06
+      GoRuntimeType: 1.287776e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8317,7 +8317,7 @@ Types:
       ID: 256
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.290688e+06
+      GoRuntimeType: 1.291104e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8330,7 +8330,7 @@ Types:
       ID: 238
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.290944e+06
+      GoRuntimeType: 1.29136e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8343,7 +8343,7 @@ Types:
       ID: 221
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.2912e+06
+      GoRuntimeType: 1.291616e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8356,7 +8356,7 @@ Types:
       ID: 213
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.291456e+06
+      GoRuntimeType: 1.291872e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8369,7 +8369,7 @@ Types:
       ID: 205
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.291712e+06
+      GoRuntimeType: 1.292128e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8382,7 +8382,7 @@ Types:
       ID: 272
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.291968e+06
+      GoRuntimeType: 1.292384e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8395,7 +8395,7 @@ Types:
       ID: 264
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.292224e+06
+      GoRuntimeType: 1.29264e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8408,7 +8408,7 @@ Types:
       ID: 291
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.289536e+06
+      GoRuntimeType: 1.289952e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8421,7 +8421,7 @@ Types:
       ID: 283
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.289792e+06
+      GoRuntimeType: 1.290208e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8434,7 +8434,7 @@ Types:
       ID: 231
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.290048e+06
+      GoRuntimeType: 1.290464e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8447,7 +8447,7 @@ Types:
       ID: 250
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.290304e+06
+      GoRuntimeType: 1.29072e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8460,7 +8460,7 @@ Types:
       ID: 189
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.28928e+06
+      GoRuntimeType: 1.289696e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8473,7 +8473,7 @@ Types:
       ID: 340
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.289024e+06
+      GoRuntimeType: 1.28944e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8486,7 +8486,7 @@ Types:
       ID: 376
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.287744e+06
+      GoRuntimeType: 1.28816e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8499,7 +8499,7 @@ Types:
       ID: 391
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.287488e+06
+      GoRuntimeType: 1.287904e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8512,7 +8512,7 @@ Types:
       ID: 199
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.286464e+06
+      GoRuntimeType: 1.28688e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8525,7 +8525,7 @@ Types:
       ID: 406
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.287232e+06
+      GoRuntimeType: 1.287648e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8538,7 +8538,7 @@ Types:
       ID: 258
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.29056e+06
+      GoRuntimeType: 1.290976e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8551,7 +8551,7 @@ Types:
       ID: 240
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.290816e+06
+      GoRuntimeType: 1.291232e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8564,7 +8564,7 @@ Types:
       ID: 223
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.291072e+06
+      GoRuntimeType: 1.291488e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8577,7 +8577,7 @@ Types:
       ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.291328e+06
+      GoRuntimeType: 1.291744e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8590,7 +8590,7 @@ Types:
       ID: 207
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.291584e+06
+      GoRuntimeType: 1.292e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8603,7 +8603,7 @@ Types:
       ID: 274
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.29184e+06
+      GoRuntimeType: 1.292256e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8616,7 +8616,7 @@ Types:
       ID: 266
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.292096e+06
+      GoRuntimeType: 1.292512e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8629,7 +8629,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 580000
+      GoRuntimeType: 580160
       GoKind: 24
       RawFields:
         - Name: str
@@ -8647,7 +8647,7 @@ Types:
       ID: 311
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.45776e+06
+      GoRuntimeType: 1.458176e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8660,7 +8660,7 @@ Types:
       ID: 314
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.606272e+06
+      GoRuntimeType: 1.606688e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8676,7 +8676,7 @@ Types:
       ID: 317
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.606464e+06
+      GoRuntimeType: 1.60688e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -8691,14 +8691,14 @@ Types:
     - __kind: StructureType
       ID: 312
       Name: sync.noCopy
-      GoRuntimeType: 983104
+      GoRuntimeType: 983264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 320
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.45904e+06
+      GoRuntimeType: 1.459456e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8711,7 +8711,7 @@ Types:
       ID: 315
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.4592e+06
+      GoRuntimeType: 1.459616e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8724,7 +8724,7 @@ Types:
       ID: 318
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.606848e+06
+      GoRuntimeType: 1.607264e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8739,13 +8739,13 @@ Types:
     - __kind: StructureType
       ID: 319
       Name: sync/atomic.align64
-      GoRuntimeType: 983296
+      GoRuntimeType: 983456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 316
       Name: sync/atomic.noCopy
-      GoRuntimeType: 983200
+      GoRuntimeType: 983360
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -9160,43 +9160,43 @@ Types:
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 580640
+      GoRuntimeType: 580800
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 580256
+      GoRuntimeType: 580416
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 580384
+      GoRuntimeType: 580544
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 580512
+      GoRuntimeType: 580672
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 580128
+      GoRuntimeType: 580288
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 580704
+      GoRuntimeType: 580864
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 581088
+      GoRuntimeType: 581248
       GoKind: 26
 MaxTypeID: 523
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -3383,20 +3383,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 311
+      ID: 324
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 312 PointerType *main.deepSlice3
+      Pointee: 325 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 336
+      ID: 351
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 337 PointerType *main.deepSlice8
+      Pointee: 352 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 342
+      ID: 357
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 343 PointerType *main.deepSlice9
+      Pointee: 358 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3404,7 +3404,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 403
+      ID: 320
       Name: '**main.t'
       ByteSize: 8
       Pointee: 157 PointerType *main.t
@@ -3441,30 +3441,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 319
+      ID: 332
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 320 PointerType *table<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 353
-      Name: '**table<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 354 PointerType *table<int,*main.deepMap8>
+      Pointee: 333 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 368
+      Name: '**table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 369 PointerType *table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 383
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 369 PointerType *table<int,*main.deepMap9>
+      Pointee: 384 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 93
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 94 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 383
+      ID: 398
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 384 PointerType *table<int,interface {}>
+      Pointee: 399 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 130
       Name: '**table<int,uint8>'
@@ -3506,20 +3506,20 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 315
+      ID: 328
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 314 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 327 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 340
+      ID: 355
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 339 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 354 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 346
+      ID: 361
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 345 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 360 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 179
       Name: '*[]*string.array'
@@ -3536,15 +3536,15 @@ Types:
       ByteSize: 8
       Pointee: 301 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 349
+      ID: 364
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 348 GoSliceDataType []interface {}.array
+      Pointee: 363 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 407
+      ID: 345
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 406 GoSliceDataType []main.structWithMap.array
+      Pointee: 344 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 298
       Name: '*[]main.structWithNoStrings.array'
@@ -3648,12 +3648,12 @@ Types:
       GoKind: 22
       Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 327
+      ID: 340
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 382816
       GoKind: 22
-      Pointee: 328 UnresolvedPointeeType main.deepMap3
+      Pointee: 341 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3662,19 +3662,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 361
+      ID: 376
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 382496
       GoKind: 22
-      Pointee: 362 StructureType main.deepMap8
+      Pointee: 377 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 376
+      ID: 391
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382432
       GoKind: 22
-      Pointee: 377 StructureType main.deepMap9
+      Pointee: 392 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3697,19 +3697,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 331
+      ID: 346
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383072
       GoKind: 22
-      Pointee: 332 StructureType main.deepPtr8
+      Pointee: 347 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 333
+      ID: 348
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383008
       GoKind: 22
-      Pointee: 334 StructureType main.deepPtr9
+      Pointee: 349 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3718,12 +3718,12 @@ Types:
       GoKind: 22
       Pointee: 180 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 312
+      ID: 325
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 383968
       GoKind: 22
-      Pointee: 313 UnresolvedPointeeType main.deepSlice3
+      Pointee: 326 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3732,19 +3732,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 337
+      ID: 352
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 383648
       GoKind: 22
-      Pointee: 338 StructureType main.deepSlice8
+      Pointee: 353 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 343
+      ID: 358
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383584
       GoKind: 22
-      Pointee: 344 StructureType main.deepSlice9
+      Pointee: 359 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 175
       Name: '*main.emptyStruct'
@@ -3813,10 +3813,10 @@ Types:
       GoKind: 22
       Pointee: 158 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 405
+      ID: 322
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 404 GoSliceDataType main.t.array
+      Pointee: 321 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 169
       Name: '*main.threeStringStruct'
@@ -3849,30 +3849,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 317
+      ID: 330
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 351
-      Name: '*map<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 352 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 366
+      Name: '*map<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 381
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 91
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 92 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 381
+      ID: 396
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 382 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 397 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 128
       Name: '*map<int,uint8>'
@@ -3940,30 +3940,30 @@ Types:
       ByteSize: 8
       Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 323
+      ID: 336
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 357
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 358 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 372
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 387
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 195
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 196 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 387
+      ID: 402
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 388 StructureType noalg.map.group[int]interface {}
+      Pointee: 403 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 254
       Name: '*noalg.map.group[int]uint8'
@@ -4037,30 +4037,30 @@ Types:
       ByteSize: 8
       Pointee: 183 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 320
+      ID: 333
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 321 StructureType table<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 354
-      Name: '*table<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 355 StructureType table<int,*main.deepMap8>
+      Pointee: 334 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 369
+      Name: '*table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 370 StructureType table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 384
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 370 StructureType table<int,*main.deepMap9>
+      Pointee: 385 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 193 StructureType table<int,int>
     - __kind: PointerType
-      ID: 384
+      ID: 399
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 385 StructureType table<int,interface {}>
+      Pointee: 400 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '*table<int,uint8>'
@@ -6105,7 +6105,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 310
+      ID: 323
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474528
@@ -6113,21 +6113,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 311 PointerType **main.deepSlice3
+          Type: 324 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 314 GoSliceDataType []*main.deepSlice3.array
+      Data: 327 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 314
+      ID: 327
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 312 PointerType *main.deepSlice3
+      Element: 325 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 335
+      ID: 350
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474208
@@ -6135,21 +6135,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 336 PointerType **main.deepSlice8
+          Type: 351 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 339 GoSliceDataType []*main.deepSlice8.array
+      Data: 354 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 354
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 337 PointerType *main.deepSlice8
+      Element: 352 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 341
+      ID: 356
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474144
@@ -6157,19 +6157,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 342 PointerType **main.deepSlice9
+          Type: 357 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 345 GoSliceDataType []*main.deepSlice9.array
+      Data: 360 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 360
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 343 PointerType *main.deepSlice9
+      Element: 358 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6218,30 +6218,30 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 342
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 320 PointerType *table<int,*main.deepMap3>
-    - __kind: GoSliceDataType
-      ID: 363
-      Name: '[]*table<int,*main.deepMap8>.array'
-      ByteSize: 8192
-      Element: 354 PointerType *table<int,*main.deepMap8>
+      Element: 333 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 378
+      Name: '[]*table<int,*main.deepMap8>.array'
+      ByteSize: 8192
+      Element: 369 PointerType *table<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 393
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 369 PointerType *table<int,*main.deepMap9>
+      Element: 384 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 199
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 94 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 406
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 384 PointerType *table<int,interface {}>
+      Element: 399 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]*table<int,uint8>.array'
@@ -6321,7 +6321,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 347
+      ID: 362
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 483808
@@ -6336,9 +6336,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 348 GoSliceDataType []interface {}.array
+      Data: 363 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 348
+      ID: 363
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
@@ -6358,9 +6358,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 406 GoSliceDataType []main.structWithMap.array
+      Data: 344 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 344
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 89 StructureType main.structWithMap
@@ -6411,30 +6411,30 @@ Types:
       ByteSize: 2048
       Element: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 330
+      ID: 343
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 324 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: GoSliceDataType
-      ID: 364
-      Name: '[]noalg.map.group[int]*main.deepMap8.array'
-      ByteSize: 2048
-      Element: 358 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 379
+      Name: '[]noalg.map.group[int]*main.deepMap8.array'
+      ByteSize: 2048
+      Element: 373 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSliceDataType
+      ID: 394
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 373 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 196 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 392
+      ID: 407
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 388 StructureType noalg.map.group[int]interface {}
+      Element: 403 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]noalg.map.group[int]uint8.array'
@@ -6666,47 +6666,47 @@ Types:
       GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 322
+      ID: 335
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 323 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 336 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 356
+      ID: 371
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 357 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 372 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 358 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 364 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 386
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 387 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 394 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 194
       Name: groupReference<int,int>
@@ -6722,19 +6722,19 @@ Types:
       GroupType: 196 StructureType noalg.map.group[int]int
       GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 386
+      ID: 401
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 387 PointerType *noalg.map.group[int]interface {}
+          Type: 402 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 388 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 392 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 403 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 253
       Name: groupReference<int,uint8>
@@ -6877,7 +6877,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 395
+      ID: 312
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.466816e+06
@@ -6967,9 +6967,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 316 GoMapType map[int]*main.deepMap3
+          Type: 329 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 328
+      ID: 341
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -6981,9 +6981,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 350 GoMapType map[int]*main.deepMap8
+          Type: 365 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 362
+      ID: 377
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.180192e+06
@@ -6991,9 +6991,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 365 GoMapType map[int]*main.deepMap9
+          Type: 380 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 377
+      ID: 392
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.180064e+06
@@ -7001,7 +7001,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 380 GoMapType map[int]interface {}
+          Type: 395 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7035,9 +7035,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 331 PointerType *main.deepPtr8
+          Type: 346 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 332
+      ID: 347
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.181344e+06
@@ -7045,9 +7045,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 333 PointerType *main.deepPtr9
+          Type: 348 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 334
+      ID: 349
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.181216e+06
@@ -7075,9 +7075,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 310 GoSliceHeaderType []*main.deepSlice3
+          Type: 323 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 313
+      ID: 326
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7089,9 +7089,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 335 GoSliceHeaderType []*main.deepSlice8
+          Type: 350 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 338
+      ID: 353
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.182496e+06
@@ -7099,9 +7099,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 341 GoSliceHeaderType []*main.deepSlice9
+          Type: 356 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 344
+      ID: 359
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.182368e+06
@@ -7109,7 +7109,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 347 GoSliceHeaderType []interface {}
+          Type: 362 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 174
       Name: main.emptyStruct
@@ -7127,16 +7127,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 393 StructureType sync.Mutex
+          Type: 310 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 396 StructureType sync.Once
+          Type: 313 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 399 StructureType sync.WaitGroup
+          Type: 316 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 402 StructureType sync/atomic.Int32
+          Type: 319 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -7276,16 +7276,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 403 PointerType **main.t
+          Type: 320 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 404 GoSliceDataType main.t.array
+      Data: 321 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 404
+      ID: 321
       Name: main.t.array
       ByteSize: 2048
       Element: 157 PointerType *main.t
@@ -7470,7 +7470,7 @@ Types:
       TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 318
+      ID: 331
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7483,7 +7483,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 319 PointerType **table<int,*main.deepMap3>
+          Type: 332 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7499,10 +7499,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 342 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 352
+      ID: 367
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7515,7 +7515,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 353 PointerType **table<int,*main.deepMap8>
+          Type: 368 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7531,10 +7531,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 363 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 358 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 367
+      ID: 382
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7547,7 +7547,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 368 PointerType **table<int,*main.deepMap9>
+          Type: 383 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7563,8 +7563,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 393 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 92
       Name: map<int,int>
@@ -7598,7 +7598,7 @@ Types:
       TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
       GroupType: 196 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 382
+      ID: 397
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7611,7 +7611,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 383 PointerType **table<int,interface {}>
+          Type: 398 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7627,8 +7627,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 391 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 388 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 406 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 403 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 129
       Name: map<int,uint8>
@@ -7889,26 +7889,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 316
+      ID: 329
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.123744e+06
       GoKind: 21
-      HeaderType: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 350
+      ID: 365
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.123104e+06
       GoKind: 21
-      HeaderType: 352 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 365
+      ID: 380
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.122976e+06
       GoKind: 21
-      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 90
       Name: map[int]int
@@ -7917,12 +7917,12 @@ Types:
       GoKind: 21
       HeaderType: 92 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 380
+      ID: 395
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.122848e+06
       GoKind: 21
-      HeaderType: 382 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 397 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 127
       Name: map[int]uint8
@@ -8018,32 +8018,32 @@ Types:
       HasCount: true
       Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 325
+      ID: 338
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 677984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 339 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 359
+      ID: 374
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 677504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 360 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 374
+      ID: 389
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 390 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 197
       Name: noalg.[8]struct { key int; elem int }
@@ -8054,14 +8054,14 @@ Types:
       HasCount: true
       Element: 198 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 389
+      ID: 404
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 677312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 390 StructureType noalg.struct { key int; elem interface {} }
+      Element: 405 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 256
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -8191,7 +8191,7 @@ Types:
           Offset: 8
           Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 324
+      ID: 337
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.288928e+06
@@ -8202,9 +8202,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 338 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 358
+      ID: 373
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.287648e+06
@@ -8215,9 +8215,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 359 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 373
+      ID: 388
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.287392e+06
@@ -8228,7 +8228,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 389 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 196
       Name: noalg.map.group[int]int
@@ -8243,7 +8243,7 @@ Types:
           Offset: 8
           Type: 197 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 388
+      ID: 403
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.287136e+06
@@ -8254,7 +8254,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 389 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 404 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 255
       Name: noalg.map.group[int]uint8
@@ -8412,7 +8412,7 @@ Types:
           Offset: 8
           Type: 189 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 326
+      ID: 339
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.2888e+06
@@ -8423,9 +8423,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 327 PointerType *main.deepMap3
+          Type: 340 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 360
+      ID: 375
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.28752e+06
@@ -8436,9 +8436,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 361 PointerType *main.deepMap8
+          Type: 376 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 375
+      ID: 390
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.287264e+06
@@ -8449,7 +8449,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 376 PointerType *main.deepMap9
+          Type: 391 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 198
       Name: noalg.struct { key int; elem int }
@@ -8464,7 +8464,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 390
+      ID: 405
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.287008e+06
@@ -8586,7 +8586,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 393
+      ID: 310
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.457536e+06
@@ -8594,12 +8594,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 395 StructureType internal/sync.Mutex
+          Type: 312 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 396
+      ID: 313
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.606048e+06
@@ -8607,15 +8607,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 397 StructureType sync/atomic.Uint32
+          Type: 314 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 393 StructureType sync.Mutex
+          Type: 310 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 399
+      ID: 316
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.60624e+06
@@ -8623,21 +8623,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 400 StructureType sync/atomic.Uint64
+          Type: 317 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 394
+      ID: 311
       Name: sync.noCopy
       GoRuntimeType: 983008
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 402
+      ID: 319
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.458816e+06
@@ -8645,12 +8645,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 397
+      ID: 314
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.458976e+06
@@ -8658,12 +8658,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 400
+      ID: 317
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.606624e+06
@@ -8671,21 +8671,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 401 StructureType sync/atomic.align64
+          Type: 318 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 401
+      ID: 318
       Name: sync/atomic.align64
       GoRuntimeType: 983200
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 398
+      ID: 315
       Name: sync/atomic.noCopy
       GoRuntimeType: 983104
       GoKind: 25
@@ -8811,7 +8811,7 @@ Types:
           Offset: 16
           Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 321
+      ID: 334
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8833,9 +8833,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 335 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 355
+      ID: 370
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8857,9 +8857,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 356 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 370
+      ID: 385
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8881,7 +8881,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 386 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 193
       Name: table<int,int>
@@ -8907,7 +8907,7 @@ Types:
           Offset: 16
           Type: 194 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 385
+      ID: 400
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8929,7 +8929,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 386 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 401 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 252
       Name: table<int,uint8>

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 504 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84d8dc", Frameless: true}]
+        - ID: 98
+          Type: 506 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x84d92c", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 460 EventRootType Probe[main.testAny]
+          Type: 461 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b22c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 462 EventRootType Probe[main.testAnyPtr]
+          Type: 463 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b2ac", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 422 EventRootType Probe[main.testArrayOfArrays]
+          Type: 423 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 424 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 425 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -78,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 469 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x84b8b0", Frameless: true}]
+        - ID: 63
+          Type: 471 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x84b900", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 423 EventRootType Probe[main.testArrayOfStrings]
+          Type: 424 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 442 EventRootType Probe[main.testBigStruct]
+          Type: 443 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849fd0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 411 EventRootType Probe[main.testBoolArray]
+          Type: 412 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 408 EventRootType Probe[main.testByteArray]
+          Type: 409 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849970", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 485 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84cf00", Frameless: true}]
+        - ID: 79
+          Type: 487 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x84cf50", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -162,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 483 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x84cc80", Frameless: true}]
+        - ID: 77
+          Type: 485 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x84ccd0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -176,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 493 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84d1a0", Frameless: true}]
+        - ID: 87
+          Type: 495 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x84d1f0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 447 EventRootType Probe[main.testDeepMap1]
+          Type: 448 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3b0", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 448 EventRootType Probe[main.testDeepMap7]
+          Type: 449 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3c0", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 443 EventRootType Probe[main.testDeepPtr1]
+          Type: 444 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0a0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 444 EventRootType Probe[main.testDeepPtr7]
+          Type: 445 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0b0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 445 EventRootType Probe[main.testDeepSlice1]
+          Type: 446 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a250", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 446 EventRootType Probe[main.testDeepSlice7]
+          Type: 447 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a260", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -292,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 495 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84d580", Frameless: true}]
+        - ID: 89
+          Type: 497 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -306,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 498 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
+        - ID: 92
+          Type: 500 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84d600", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -320,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 512 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84d9c0", Frameless: true}]
+        - ID: 106
+          Type: 514 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x84da10", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 514 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84dcd0", Frameless: true}]
+        - ID: 108
+          Type: 516 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x84dd20", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 515 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x84dce0", Frameless: true}]
+        - ID: 109
+          Type: 517 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x84dd30", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 461 EventRootType Probe[main.testError]
+          Type: 462 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b290", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 452 EventRootType Probe[main.testEsotericHeap]
+          Type: 453 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84a84c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 451 EventRootType Probe[main.testEsotericStack]
+          Type: 452 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a77c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 457 EventRootType Probe[main.testFrameless]
+          Type: 458 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84af70", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 458 EventRootType Probe[main.testFramelessArray]
+          Type: 459 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84af80", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 453 EventRootType Probe[main.testInlinedBA]
+          Type: 454 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84ac8c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 454 EventRootType Probe[main.testInlinedBB]
+          Type: 455 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84ad1c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 455 EventRootType Probe[main.testInlinedBBA]
+          Type: 456 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84addc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 517 EventRootType Probe[main.testInlinedBBB]
+        - ID: 111
+          Type: 519 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84ad78", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 456 EventRootType Probe[main.testInlinedBC]
+          Type: 457 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84ae5c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 518 EventRootType Probe[main.testInlinedBCA]
+        - ID: 112
+          Type: 520 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84ae6c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 519 EventRootType Probe[main.testInlinedBCB]
+        - ID: 113
+          Type: 521 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84af20", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 516 EventRootType Probe[main.testInlinedPrint]
+        - ID: 110
+          Type: 518 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84aaec"
               Frameless: true
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 520 EventRootType Probe[main.testInlinedSq]
+        - ID: 114
+          Type: 522 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84af74", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 114
-          Type: 521 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 115
+          Type: 523 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84afa4"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 414 EventRootType Probe[main.testInt16Array]
+          Type: 415 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 415 EventRootType Probe[main.testInt32Array]
+          Type: 416 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 416 EventRootType Probe[main.testInt64Array]
+          Type: 417 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 413 EventRootType Probe[main.testInt8Array]
+          Type: 414 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 412 EventRootType Probe[main.testIntArray]
+          Type: 413 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 459 EventRootType Probe[main.testInterface]
+          Type: 460 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b210", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -671,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 487 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84d0b0", Frameless: true}]
+        - ID: 81
+          Type: 489 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x84d100", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -685,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 467 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x84b890", Frameless: true}]
+        - ID: 61
+          Type: 469 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x84b8e0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -699,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 473 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x84b8f0", Frameless: true}]
+        - ID: 67
+          Type: 475 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x84b940", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -713,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 471 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x84b8d0", Frameless: true}]
+        - ID: 65
+          Type: 473 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x84b920", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -727,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 482 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x84b980", Frameless: true}]
+        - ID: 76
+          Type: 484 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x84b9d0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -741,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 481 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x84b970", Frameless: true}]
+        - ID: 75
+          Type: 483 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x84b9c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -755,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 472 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84b8e0", Frameless: true}]
+        - ID: 66
+          Type: 474 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84b930", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -769,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 480 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x84b960", Frameless: true}]
+        - ID: 74
+          Type: 482 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x84b9b0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -783,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 479 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x84b950", Frameless: true}]
+        - ID: 73
+          Type: 481 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x84b9a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -797,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 465 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x84b870", Frameless: true}]
+        - ID: 59
+          Type: 467 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x84b8c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -811,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 466 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x84b880", Frameless: true}]
+        - ID: 60
+          Type: 468 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x84b8d0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -825,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 464 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x84b860", Frameless: true}]
+        - ID: 58
+          Type: 466 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x84b8b0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -839,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 474 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x84b900", Frameless: true}]
+        - ID: 68
+          Type: 476 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x84b950", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -853,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x84b930", Frameless: true}]
+        - ID: 71
+          Type: 479 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x84b980", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -867,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 478 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x84b940", Frameless: true}]
+        - ID: 72
+          Type: 480 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x84b990", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -881,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 475 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x84b910", Frameless: true}]
+        - ID: 69
+          Type: 477 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x84b960", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -895,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 476 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x84b920", Frameless: true}]
+        - ID: 70
+          Type: 478 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x84b970", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -909,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 510 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84d9a0", Frameless: true}]
+        - ID: 104
+          Type: 512 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84d9f0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -923,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 484 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x84cd60", Frameless: true}]
+        - ID: 78
+          Type: 486 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x84cdb0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -937,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 492 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84d180", Frameless: true}]
+        - ID: 86
+          Type: 494 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x84d1d0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -951,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 502 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
+        - ID: 96
+          Type: 504 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84d640", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -965,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 499 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
+        - ID: 93
+          Type: 501 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84d610", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -979,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 501 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
+        - ID: 95
+          Type: 503 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84d630", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -993,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 509 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84d990", Frameless: true}]
+        - ID: 103
+          Type: 511 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x84d9e0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1007,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 488 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84d0c0", Frameless: true}]
+        - ID: 82
+          Type: 490 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x84d110", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1021,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 470 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x84b8c0", Frameless: true}]
+        - ID: 64
+          Type: 472 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x84b910", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1035,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 486 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84d0a0", Frameless: true}]
+        - ID: 80
+          Type: 488 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x84d0f0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 409 EventRootType Probe[main.testRuneArray]
+          Type: 410 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 428 EventRootType Probe[main.testSingleBool]
+          Type: 429 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 426 EventRootType Probe[main.testSingleByte]
+          Type: 427 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849dd0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 439 EventRootType Probe[main.testSingleFloat32]
+          Type: 440 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 440 EventRootType Probe[main.testSingleFloat64]
+          Type: 441 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 429 EventRootType Probe[main.testSingleInt]
+          Type: 430 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 431 EventRootType Probe[main.testSingleInt16]
+          Type: 432 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 432 EventRootType Probe[main.testSingleInt32]
+          Type: 433 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 433 EventRootType Probe[main.testSingleInt64]
+          Type: 434 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 430 EventRootType Probe[main.testSingleInt8]
+          Type: 431 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 427 EventRootType Probe[main.testSingleRune]
+          Type: 428 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849de0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1203,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 505 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84d940", Frameless: true}]
+        - ID: 99
+          Type: 507 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x84d990", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 434 EventRootType Probe[main.testSingleUint]
+          Type: 435 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 436 EventRootType Probe[main.testSingleUint16]
+          Type: 437 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 437 EventRootType Probe[main.testSingleUint32]
+          Type: 438 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 438 EventRootType Probe[main.testSingleUint64]
+          Type: 439 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 435 EventRootType Probe[main.testSingleUint8]
+          Type: 436 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1287,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 496 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84d590", Frameless: true}]
+        - ID: 90
+          Type: 498 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1301,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 468 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x84b8a0", Frameless: true}]
+        - ID: 62
+          Type: 470 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x84b8f0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 410 EventRootType Probe[main.testStringArray]
+          Type: 411 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1329,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 491 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84d160", Frameless: true}]
+        - ID: 85
+          Type: 493 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x84d1b0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1343,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 500 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
+        - ID: 94
+          Type: 502 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84d620", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 449 EventRootType Probe[main.testStringType1]
+          Type: 450 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 450 EventRootType Probe[main.testStringType2]
+          Type: 451 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 513 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84dbd0", Frameless: true}]
+        - ID: 107
+          Type: 515 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x84dc20", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1405,11 +1405,28 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 497 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84d5a0", Frameless: true}]
+        - ID: 91
+          Type: 499 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
+          Condition: null
+    - id: testStructWithAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithAny}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 56}
+      events:
+        - ID: 56
+          Type: 464 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x84b310", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1419,11 +1436,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 463 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x84b850", Frameless: true}]
+        - ID: 57
+          Type: 465 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x84b8a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1433,11 +1450,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 506 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84d950", Frameless: true}]
+        - ID: 100
+          Type: 508 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x84d9a0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1447,11 +1464,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 507 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84d960", Frameless: true}]
+        - ID: 101
+          Type: 509 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84d9b0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1461,11 +1478,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 508 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84d980", Frameless: true}]
+        - ID: 102
+          Type: 510 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84d9d0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1478,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 441 EventRootType Probe[main.testTypeAlias]
+          Type: 442 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1492,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 419 EventRootType Probe[main.testUint16Array]
+          Type: 420 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1506,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 420 EventRootType Probe[main.testUint32Array]
+          Type: 421 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1520,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 421 EventRootType Probe[main.testUint64Array]
+          Type: 422 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1534,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 418 EventRootType Probe[main.testUint8Array]
+          Type: 419 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1548,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 417 EventRootType Probe[main.testUintArray]
+          Type: 418 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1559,11 +1576,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 490 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84d0f0", Frameless: true}]
+        - ID: 84
+          Type: 492 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x84d140", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1573,11 +1590,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 494 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84d570", Frameless: true}]
+        - ID: 88
+          Type: 496 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1587,11 +1604,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 511 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84d9b0", Frameless: true}]
+        - ID: 105
+          Type: 513 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x84da00", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1601,11 +1618,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 489 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84d0d0", Frameless: true}]
+        - ID: 83
+          Type: 491 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x84d120", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1618,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 425 EventRootType Probe[main.testVeryLargeArray]
+          Type: 426 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1629,11 +1646,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 503 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84d600", Frameless: true}]
+        - ID: 97
+          Type: 505 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84d650", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2442,308 +2459,324 @@ Subprograms:
           IsParameter: true
           IsReturn: true
     - ID: 56
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84b850..0x84b860]
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0x84b310..0x84b320]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 89 StructureType main.structWithMap
+          Type: 89 StructureType main.structWithAny
           Locations:
-            - Range: 0x84b850..0x84b860
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84b310..0x84b320
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84b860..0x84b870]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 95 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x84b860..0x84b870
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84b870..0x84b880]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0x84b870..0x84b880
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84b880..0x84b890]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 105 GoMapType map[string][]string
-          Locations:
-            - Range: 0x84b880..0x84b890
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84b890..0x84b8a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 110 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x84b890..0x84b8a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testSmallMap
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0x84b8a0..0x84b8b0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
+        - Name: s
+          Type: 90 StructureType main.structWithMap
           Locations:
             - Range: 0x84b8a0..0x84b8b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testArrayOfMaps
+    - ID: 58
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x84b8b0..0x84b8c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 115 ArrayType [2]map[string]int
+          Type: 96 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x84b8b0..0x84b8c0
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testPointerToMap
+    - ID: 59
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x84b8c0..0x84b8d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 116 PointerType *map[string]int
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0x84b8c0..0x84b8d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapIntToInt
+    - ID: 60
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x84b8d0..0x84b8e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 90 GoMapType map[int]int
+          Type: 106 GoMapType map[string][]string
           Locations:
             - Range: 0x84b8d0..0x84b8e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapMassive
+    - ID: 61
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x84b8e0..0x84b8f0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 117 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 111 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x84b8e0..0x84b8f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapEmbeddedMaps
+    - ID: 62
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0x84b8f0..0x84b900]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 117 GoMapType map[string][]main.structWithMap
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0x84b8f0..0x84b900
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithLinkedList
+    - ID: 63
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x84b900..0x84b910]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[bool]main.node
+          Type: 116 ArrayType [2]map[string]int
           Locations:
             - Range: 0x84b900..0x84b910
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValue
+    - ID: 64
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0x84b910..0x84b920]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[int]uint8
+          Type: 117 PointerType *map[string]int
           Locations:
             - Range: 0x84b910..0x84b920
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallValueMassive
+    - ID: 65
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x84b920..0x84b930]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 127 GoMapType map[int]uint8
+        - Name: m
+          Type: 91 GoMapType map[int]int
           Locations:
             - Range: 0x84b920..0x84b930
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 66
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x84b930..0x84b940]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84b930..0x84b940
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 67
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x84b940..0x84b950]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84b940..0x84b950
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeySmallValue
+    - ID: 68
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x84b950..0x84b960]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 123 GoMapType map[bool]main.node
           Locations:
             - Range: 0x84b950..0x84b960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 69
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x84b960..0x84b970]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 GoMapType map[uint8][4]int
+          Type: 128 GoMapType map[int]uint8
           Locations:
             - Range: 0x84b960..0x84b970
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeySmallValue
+    - ID: 70
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x84b970..0x84b980]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 142 GoMapType map[[4]int]uint8
+        - Name: redactMyEntries
+          Type: 128 GoMapType map[int]uint8
           Locations:
             - Range: 0x84b970..0x84b980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x84b980..0x84b990]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 147 GoMapType map[[4]int][4]int
+          Type: 133 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84b980..0x84b990
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 72
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x84b990..0x84b9a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84b990..0x84b9a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84b9a0..0x84b9b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84b9a0..0x84b9b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x84b9b0..0x84b9c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 138 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x84b9b0..0x84b9c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x84b9c0..0x84b9d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 143 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x84b9c0..0x84b9d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 76
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x84b9d0..0x84b9e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 148 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x84b9d0..0x84b9e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 77
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84cc80..0x84cc90]
+      OutOfLinePCRanges: [0x84ccd0..0x84cce0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84cc80..0x84cc90
+            - Range: 0x84ccd0..0x84cce0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84cc80..0x84cc90
+            - Range: 0x84ccd0..0x84cce0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84cc80..0x84cc90
+            - Range: 0x84ccd0..0x84cce0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84cd60..0x84cd70]
+      OutOfLinePCRanges: [0x84cdb0..0x84cdc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84cd60..0x84cd70
+            - Range: 0x84cdb0..0x84cdc0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84cd60..0x84cd70
+            - Range: 0x84cdb0..0x84cdc0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84cd60..0x84cd70
+            - Range: 0x84cdb0..0x84cdc0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84cd60..0x84cd70
+            - Range: 0x84cdb0..0x84cdc0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cd60..0x84cd70
+            - Range: 0x84cdb0..0x84cdc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2751,39 +2784,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84cf00..0x84cf10]
+      OutOfLinePCRanges: [0x84cf50..0x84cf60]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 152 GoChannelType chan bool
+          Type: 153 GoChannelType chan bool
           Locations:
-            - Range: 0x84cf00..0x84cf10
+            - Range: 0x84cf50..0x84cf60
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84d0a0..0x84d0b0]
+      OutOfLinePCRanges: [0x84d0f0..0x84d100]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 153 PointerType *main.structWithTwoValues
+          Type: 154 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84d0a0..0x84d0b0
+            - Range: 0x84d0f0..0x84d100
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84d0b0..0x84d0c0]
+      OutOfLinePCRanges: [0x84d100..0x84d110]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 StructureType main.node
+          Type: 156 StructureType main.node
           Locations:
-            - Range: 0x84d0b0..0x84d0c0
+            - Range: 0x84d100..0x84d110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2791,112 +2824,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84d0c0..0x84d0d0]
+      OutOfLinePCRanges: [0x84d110..0x84d120]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 156 PointerType *main.node
+          Type: 157 PointerType *main.node
           Locations:
-            - Range: 0x84d0c0..0x84d0d0
+            - Range: 0x84d110..0x84d120
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84d0d0..0x84d0e0]
+      OutOfLinePCRanges: [0x84d120..0x84d130]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84d0d0..0x84d0e0
+            - Range: 0x84d120..0x84d130
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84d0f0..0x84d100]
+      OutOfLinePCRanges: [0x84d140..0x84d150]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x84d0f0..0x84d100
+            - Range: 0x84d140..0x84d150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84d160..0x84d170]
+      OutOfLinePCRanges: [0x84d1b0..0x84d1c0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x84d160..0x84d170
+            - Range: 0x84d1b0..0x84d1c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84d180..0x84d190]
+      OutOfLinePCRanges: [0x84d1d0..0x84d1e0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x84d180..0x84d190
+            - Range: 0x84d1d0..0x84d1e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d180..0x84d190
+            - Range: 0x84d1d0..0x84d1e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84d1a0..0x84d1b0]
+      OutOfLinePCRanges: [0x84d1f0..0x84d200]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 157 PointerType *main.t
+          Type: 158 PointerType *main.t
           Locations:
-            - Range: 0x84d1a0..0x84d1b0
+            - Range: 0x84d1f0..0x84d200
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84d570..0x84d580]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 159 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84d570..0x84d580
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 88
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84d580..0x84d590]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84d5c0..0x84d5d0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType []uint
+          Type: 160 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84d580..0x84d590
+            - Range: 0x84d5c0..0x84d5d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2907,105 +2922,12 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84d590..0x84d5a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 160 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x84d590..0x84d5a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 90
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84d5a0..0x84d5b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84d5a0..0x84d5b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84d5a0..0x84d5b0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 91
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84d5b0..0x84d5c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84d5b0..0x84d5c0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84d5b0..0x84d5c0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84d5c0..0x84d5d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84d5c0..0x84d5d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84d5c0..0x84d5d0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 93
-      Name: main.testStringSlice
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 165 GoSliceHeaderType []string
+        - Name: u
+          Type: 160 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84d5d0..0x84d5e0
               Pieces:
@@ -3017,22 +2939,133 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSliceWithOtherParams
+    - ID: 90
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x84d5e0..0x84d5f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 161 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x84d5e0..0x84d5f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84d5f0..0x84d600]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84d5f0..0x84d600
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d5f0..0x84d600
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84d600..0x84d610]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84d600..0x84d610
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d600..0x84d610
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84d610..0x84d620]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84d610..0x84d620
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d610..0x84d620
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x84d620..0x84d630]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 166 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x84d620..0x84d630
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x84d630..0x84d640]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84d5e0..0x84d5f0
+            - Range: 0x84d630..0x84d640
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 166 GoSliceHeaderType []bool
+          Type: 167 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84d5e0..0x84d5f0
+            - Range: 0x84d630..0x84d640
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3045,37 +3078,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d5e0..0x84d5f0
+            - Range: 0x84d630..0x84d640
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 95
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84d5f0..0x84d600]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 167 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x84d5f0..0x84d600
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 96
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84d600..0x84d610]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x84d640..0x84d650]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 159 GoSliceHeaderType []uint
+          Type: 168 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84d600..0x84d610
+            - Range: 0x84d640..0x84d650
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3086,119 +3101,51 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 97
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x84d650..0x84d660]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 160 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x84d650..0x84d660
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0x84d8d0..0x84d940]
+      OutOfLinePCRanges: [0x84d920..0x84d990]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84d8d0..0x84d940, Pieces: []}]
+          Locations: [{Range: 0x84d920..0x84d990, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0x84d940..0x84d950]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84d940..0x84d950
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84d950..0x84d960]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84d950..0x84d960
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: y
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84d950..0x84d960
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: z
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84d950..0x84d960
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84d960..0x84d980]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0x84d960..0x84d980
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 101
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84d980..0x84d990]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 169 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x84d980..0x84d990
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 102
-      Name: main.testOneStringInStructPointer
+      Name: main.testSingleString
       OutOfLinePCRanges: [0x84d990..0x84d9a0]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 170 PointerType *main.oneStringStruct
+        - Name: x
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84d990..0x84d9a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
-      Name: main.testMassiveString
+    - ID: 100
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x84d9a0..0x84d9b0]
       InlinePCRanges: []
       Variables:
@@ -3213,15 +3160,85 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: y
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84d9a0..0x84d9b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84d9a0..0x84d9b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 101
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0x84d9b0..0x84d9d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 169 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0x84d9b0..0x84d9d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 102
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x84d9d0..0x84d9e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 170 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0x84d9d0..0x84d9e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x84d9e0..0x84d9f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 171 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0x84d9e0..0x84d9f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 104
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84d9b0..0x84d9c0]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x84d9f0..0x84da00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d9b0..0x84d9c0
+            - Range: 0x84d9f0..0x84da00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3230,14 +3247,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84d9c0..0x84d9d0]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x84da00..0x84da10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d9c0..0x84d9d0
+            - Range: 0x84da00..0x84da10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3246,14 +3263,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 106
-      Name: main.testStruct
-      OutOfLinePCRanges: [0x84dbd0..0x84dbf0]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x84da10..0x84da20]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 172 StructureType main.aStruct
+          Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84dbd0..0x84dbf0
+            - Range: 0x84da10..0x84da20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 107
+      Name: main.testStruct
+      OutOfLinePCRanges: [0x84dc20..0x84dc40]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 173 StructureType main.aStruct
+          Locations:
+            - Range: 0x84dc20..0x84dc40
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3271,29 +3304,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84dcd0..0x84dce0]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 174 StructureType main.emptyStruct
-          Locations: [{Range: 0x84dcd0..0x84dce0, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 108
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x84dce0..0x84dcf0]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0x84dd20..0x84dd30]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 175 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0x84dce0..0x84dcf0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 175 StructureType main.emptyStruct
+          Locations: [{Range: 0x84dd20..0x84dd30, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 109
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0x84dd30..0x84dd40]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 176 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0x84dd30..0x84dd40
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 110
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84aae0..0x84ab50]
       InlinePCRanges:
@@ -3323,28 +3356,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84ad78..0x84adb0]
           RootRanges: [0x84ad10..0x84add0]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84ae6c..0x84aeb0]
           RootRanges: [0x84ae50..0x84af70]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84af20..0x84af58]
           RootRanges: [0x84ae50..0x84af70]
       Variables: []
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3358,7 +3391,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 115
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3383,20 +3416,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 324
+      ID: 325
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 325 PointerType *main.deepSlice3
+      Pointee: 326 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 351
+      ID: 352
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 352 PointerType *main.deepSlice8
+      Pointee: 353 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 357
+      ID: 358
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 358 PointerType *main.deepSlice9
+      Pointee: 359 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3404,373 +3437,373 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 320
+      ID: 321
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 157 PointerType *main.t
+      Pointee: 158 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 526016
+      GoRuntimeType: 526112
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 151 PointerType *table<[4]int,[4]int>
+      Pointee: 152 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 146 PointerType *table<[4]int,uint8>
+      Pointee: 147 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 114 PointerType *table<[4]string,[2]int>
+      Pointee: 115 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<bool,main.node>
+      Pointee: 127 PointerType *table<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 332
+      ID: 333
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 333 PointerType *table<int,*main.deepMap3>
+      Pointee: 334 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 368
+      ID: 369
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 369 PointerType *table<int,*main.deepMap8>
+      Pointee: 370 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 383
+      ID: 384
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 384 PointerType *table<int,*main.deepMap9>
+      Pointee: 385 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 94 PointerType *table<int,int>
+      Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 399 PointerType *table<int,interface {}>
+      Pointee: 400 PointerType *table<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 131 PointerType *table<int,uint8>
+      Pointee: 132 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 121 PointerType *table<string,[]main.structWithMap>
+      Pointee: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 109 PointerType *table<string,[]string>
+      Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 104 PointerType *table<string,int>
+      Pointee: 105 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 99 PointerType *table<string,main.nestedStruct>
+      Pointee: 100 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 141 PointerType *table<uint8,[4]int>
+      Pointee: 142 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 136 PointerType *table<uint8,uint8>
+      Pointee: 137 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 182
+      ID: 183
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 328
+      ID: 329
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 327 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 328 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 355
+      ID: 356
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 354 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 355 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 361
+      ID: 362
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 360 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 361 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 179
+      ID: 180
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []*string.array
+      Pointee: 179 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 296
+      ID: 297
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 295 GoSliceDataType [][]uint.array
+      Pointee: 296 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 302
+      ID: 303
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 301 GoSliceDataType []bool.array
+      Pointee: 302 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 364
+      ID: 365
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 363 GoSliceDataType []interface {}.array
+      Pointee: 364 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 345
+      ID: 346
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 344 GoSliceDataType []main.structWithMap.array
+      Pointee: 345 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 298
+      ID: 299
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 297 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 298 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 300
+      ID: 301
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 299 GoSliceDataType []string.array
+      Pointee: 300 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 161
+      ID: 162
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 159 GoSliceHeaderType []uint
+      Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 294
+      ID: 295
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType []uint.array
+      Pointee: 294 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 303 GoSliceDataType []uint16.array
+      Pointee: 304 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 390176
+      GoRuntimeType: 390272
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 389088
+      GoRuntimeType: 389184
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 390048
+      GoRuntimeType: 390144
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 390112
+      GoRuntimeType: 390208
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 28
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 389728
+      GoRuntimeType: 389824
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 389344
+      GoRuntimeType: 389440
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 389472
+      GoRuntimeType: 389568
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 389600
+      GoRuntimeType: 389696
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 389216
+      GoRuntimeType: 389312
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
       ID: 88
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 390304
+      GoRuntimeType: 390400
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 189
+      ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 382880
+      GoRuntimeType: 382976
       GoKind: 22
-      Pointee: 190 StructureType main.deepMap2
+      Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 340
+      ID: 341
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 382816
+      GoRuntimeType: 382912
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType main.deepMap3
+      Pointee: 342 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 382560
+      GoRuntimeType: 382656
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 376
+      ID: 377
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 382496
+      GoRuntimeType: 382592
       GoKind: 22
-      Pointee: 377 StructureType main.deepMap8
+      Pointee: 378 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 391
+      ID: 392
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 382432
+      GoRuntimeType: 382528
       GoKind: 22
-      Pointee: 392 StructureType main.deepMap9
+      Pointee: 393 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 383456
+      GoRuntimeType: 383552
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 305
+      ID: 306
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 383392
+      GoRuntimeType: 383488
       GoKind: 22
-      Pointee: 306 UnresolvedPointeeType main.deepPtr3
+      Pointee: 307 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 383136
+      GoRuntimeType: 383232
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 346
+      ID: 347
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 383072
+      GoRuntimeType: 383168
       GoKind: 22
-      Pointee: 347 StructureType main.deepPtr8
+      Pointee: 348 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 348
+      ID: 349
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 383008
+      GoRuntimeType: 383104
       GoKind: 22
-      Pointee: 349 StructureType main.deepPtr9
+      Pointee: 350 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 384032
+      GoRuntimeType: 384128
       GoKind: 22
-      Pointee: 180 StructureType main.deepSlice2
+      Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 325
+      ID: 326
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 383968
+      GoRuntimeType: 384064
       GoKind: 22
-      Pointee: 326 UnresolvedPointeeType main.deepSlice3
+      Pointee: 327 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 383712
+      GoRuntimeType: 383808
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 352
+      ID: 353
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 383648
+      GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 353 StructureType main.deepSlice8
+      Pointee: 354 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 358
+      ID: 359
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 383584
+      GoRuntimeType: 383680
       GoKind: 22
-      Pointee: 359 StructureType main.deepSlice9
+      Pointee: 360 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 175
+      ID: 176
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 174 StructureType main.emptyStruct
+      Pointee: 175 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 384160
+      GoRuntimeType: 384256
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 156
+      ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 384224
+      GoRuntimeType: 384320
       GoKind: 22
-      Pointee: 155 StructureType main.node
+      Pointee: 156 StructureType main.node
     - __kind: PointerType
-      ID: 170
+      ID: 171
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 StructureType main.oneStringStruct
+      Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -3778,371 +3811,371 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 308
+      ID: 309
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType main.stringType1.str
+      Pointee: 308 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 309 UnresolvedPointeeType main.stringType2
+      Pointee: 310 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 241
+      ID: 242
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 382368
+      GoRuntimeType: 382464
       GoKind: 22
-      Pointee: 89 StructureType main.structWithMap
+      Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 163
+      ID: 164
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 164 StructureType main.structWithNoStrings
+      Pointee: 165 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 153
+      ID: 154
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 154 StructureType main.structWithTwoValues
+      Pointee: 155 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 157
+      ID: 158
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 158 GoSliceHeaderType main.t
+      Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 322
+      ID: 323
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 321 GoSliceDataType main.t.array
+      Pointee: 322 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 169
+      ID: 170
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 168 StructureType main.threeStringStruct
+      Pointee: 169 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 148
+      ID: 149
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 149 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 143
+      ID: 144
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 144 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 111
+      ID: 112
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 112 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 123
+      ID: 124
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 330
+      ID: 331
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 366
+      ID: 367
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 381
+      ID: 382
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 91
+      ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 92 GoSwissMapHeaderType map<int,int>
+      Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 396
+      ID: 397
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 397 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
-      ID: 128
+      ID: 129
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 129 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 106
+      ID: 107
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 107 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 101
+      ID: 102
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 102 GoSwissMapHeaderType map<string,int>
+      Pointee: 103 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 96
+      ID: 97
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 138
+      ID: 139
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 139 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 133
+      ID: 134
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 134 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 116
+      ID: 117
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 GoMapType map[string]int
+      Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 287
+      ID: 288
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 288 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 279
+      ID: 280
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 280 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 227
+      ID: 228
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 228 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 246
+      ID: 247
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 247 StructureType noalg.map.group[bool]main.node
+      Pointee: 248 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 185
+      ID: 186
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 336
+      ID: 337
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 337 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 372
+      ID: 373
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 387
+      ID: 388
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 388 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 195
+      ID: 196
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[int]int
+      Pointee: 197 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 402
+      ID: 403
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 403 StructureType noalg.map.group[int]interface {}
+      Pointee: 404 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 254
+      ID: 255
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 255 StructureType noalg.map.group[int]uint8
+      Pointee: 256 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 236
+      ID: 237
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 237 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 219
+      ID: 220
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 220 StructureType noalg.map.group[string][]string
+      Pointee: 221 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 211
+      ID: 212
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 212 StructureType noalg.map.group[string]int
+      Pointee: 213 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 203
+      ID: 204
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 270
+      ID: 271
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 271 StructureType noalg.map.group[uint8][4]int
+      Pointee: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 262
+      ID: 263
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 263 StructureType noalg.map.group[uint8]uint8
+      Pointee: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 389152
+      GoRuntimeType: 389248
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 177
+      ID: 178
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 176 GoStringDataType string.str
+      Pointee: 177 GoStringDataType string.str
     - __kind: PointerType
-      ID: 151
+      ID: 152
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 285 StructureType table<[4]int,[4]int>
+      Pointee: 286 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 146
+      ID: 147
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 277 StructureType table<[4]int,uint8>
+      Pointee: 278 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 114
+      ID: 115
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 225 StructureType table<[4]string,[2]int>
+      Pointee: 226 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 126
+      ID: 127
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 244 StructureType table<bool,main.node>
+      Pointee: 245 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 183 StructureType table<int,*main.deepMap2>
+      Pointee: 184 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 333
+      ID: 334
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 334 StructureType table<int,*main.deepMap3>
+      Pointee: 335 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 369
+      ID: 370
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 370 StructureType table<int,*main.deepMap8>
+      Pointee: 371 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 384
+      ID: 385
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 385 StructureType table<int,*main.deepMap9>
+      Pointee: 386 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 94
+      ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 193 StructureType table<int,int>
+      Pointee: 194 StructureType table<int,int>
     - __kind: PointerType
-      ID: 399
+      ID: 400
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 400 StructureType table<int,interface {}>
+      Pointee: 401 StructureType table<int,interface {}>
     - __kind: PointerType
-      ID: 131
+      ID: 132
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 252 StructureType table<int,uint8>
+      Pointee: 253 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 122
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 234 StructureType table<string,[]main.structWithMap>
+      Pointee: 235 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 109
+      ID: 110
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 217 StructureType table<string,[]string>
+      Pointee: 218 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 104
+      ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 209 StructureType table<string,int>
+      Pointee: 210 StructureType table<string,int>
     - __kind: PointerType
-      ID: 99
+      ID: 100
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 201 StructureType table<string,main.nestedStruct>
+      Pointee: 202 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 141
+      ID: 142
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 268 StructureType table<uint8,[4]int>
+      Pointee: 269 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 136
+      ID: 137
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 260 StructureType table<uint8,uint8>
+      Pointee: 261 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 389792
+      GoRuntimeType: 389888
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 389408
+      GoRuntimeType: 389504
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 389536
+      GoRuntimeType: 389632
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 29
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 389664
+      GoRuntimeType: 389760
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 389280
+      GoRuntimeType: 389376
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 389856
+      GoRuntimeType: 389952
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 504
+      ID: 506
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 462
+      ID: 463
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4157,7 +4190,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 460
+      ID: 461
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4172,7 +4205,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 424
+      ID: 425
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4187,7 +4220,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 422
+      ID: 423
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4202,7 +4235,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 469
+      ID: 471
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4210,14 +4243,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 ArrayType [2]map[string]int
+            Type: 116 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 423
+      ID: 424
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4232,7 +4265,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 442
+      ID: 443
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4247,7 +4280,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 411
+      ID: 412
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4262,7 +4295,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 408
+      ID: 409
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4277,7 +4310,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 485
+      ID: 487
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4285,14 +4318,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 152 GoChannelType chan bool
+            Type: 153 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: c}
+                  Variable: {subprogram: 79, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 483
+      ID: 485
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4303,7 +4336,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: w}
+                  Variable: {subprogram: 77, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4312,7 +4345,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: x}
+                  Variable: {subprogram: 77, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4321,11 +4354,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: y}
+                  Variable: {subprogram: 77, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 493
+      ID: 495
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4333,14 +4366,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 157 PointerType *main.t
+            Type: 158 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: t}
+                  Variable: {subprogram: 87, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 447
+      ID: 448
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4355,7 +4388,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 448
+      ID: 449
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4370,7 +4403,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 443
+      ID: 444
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4385,7 +4418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 444
+      ID: 445
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4400,7 +4433,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 445
+      ID: 446
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4415,7 +4448,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 446
+      ID: 447
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4430,7 +4463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4438,10 +4471,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4450,11 +4483,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 495
+      ID: 497
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4462,14 +4495,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 512
+      ID: 514
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4480,11 +4513,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 515
+      ID: 517
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4492,14 +4525,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 PointerType *main.emptyStruct
+            Type: 176 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 109, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 514
+      ID: 516
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4507,14 +4540,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 174 StructureType main.emptyStruct
+            Type: 175 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 461
+      ID: 462
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4529,7 +4562,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 452
+      ID: 453
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4544,7 +4577,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 451
+      ID: 452
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4559,7 +4592,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 458
+      ID: 459
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4574,7 +4607,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 457
+      ID: 458
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4589,7 +4622,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 453
+      ID: 454
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4604,7 +4637,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 455
+      ID: 456
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4619,10 +4652,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 517
+      ID: 519
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 454
+      ID: 455
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4646,16 +4679,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 518
+      ID: 520
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 519
+      ID: 521
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 456
+      ID: 457
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 516
+      ID: 518
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4666,11 +4699,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 522
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4681,11 +4714,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: x}
+                  Variable: {subprogram: 114, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 521
+      ID: 523
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4696,11 +4729,11 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: a}
+                  Variable: {subprogram: 115, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 414
+      ID: 415
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4715,7 +4748,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 415
+      ID: 416
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4730,7 +4763,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 416
+      ID: 417
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4745,7 +4778,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 413
+      ID: 414
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4760,7 +4793,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 412
+      ID: 413
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4775,7 +4808,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 459
+      ID: 460
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4790,7 +4823,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 487
+      ID: 489
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4798,14 +4831,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 StructureType main.node
+            Type: 156 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 467
+      ID: 469
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4813,14 +4846,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[[4]string][2]int
+            Type: 111 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 475
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4828,14 +4861,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 117 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 471
+      ID: 473
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4843,14 +4876,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 90 GoMapType map[int]int
+            Type: 91 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 482
+      ID: 484
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4858,14 +4891,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 147 GoMapType map[[4]int][4]int
+            Type: 148 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 483
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4873,14 +4906,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 142 GoMapType map[[4]int]uint8
+            Type: 143 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 474
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4888,14 +4921,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 117 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 482
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4903,14 +4936,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[uint8][4]int
+            Type: 138 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 481
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4918,14 +4951,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 465
+      ID: 467
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4933,14 +4966,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 466
+      ID: 468
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4948,14 +4981,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[string][]string
+            Type: 106 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 466
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4963,14 +4996,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 95 GoMapType map[string]main.nestedStruct
+            Type: 96 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 476
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4978,14 +5011,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[bool]main.node
+            Type: 123 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 480
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4993,14 +5026,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 479
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5008,14 +5041,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 478
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5023,14 +5056,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 477
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5038,14 +5071,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 510
+      ID: 512
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5056,11 +5089,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 484
+      ID: 486
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5071,7 +5104,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -5080,7 +5113,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: b}
+                  Variable: {subprogram: 78, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -5089,7 +5122,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: c}
+                  Variable: {subprogram: 78, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -5098,7 +5131,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 3, name: d}
+                  Variable: {subprogram: 78, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -5107,11 +5140,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 4, name: e}
+                  Variable: {subprogram: 78, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 492
+      ID: 494
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5122,7 +5155,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -5131,11 +5164,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: a}
+                  Variable: {subprogram: 86, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5143,10 +5176,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5155,11 +5188,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5170,16 +5203,16 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: a}
+                  Variable: {subprogram: 95, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 166 GoSliceHeaderType []bool
+            Type: 167 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: s}
+                  Variable: {subprogram: 95, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5188,11 +5221,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 2, name: x}
+                  Variable: {subprogram: 95, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 502
+      ID: 504
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5200,14 +5233,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 167 GoSliceHeaderType []uint16
+            Type: 168 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 509
+      ID: 511
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5215,14 +5248,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.oneStringStruct
+            Type: 171 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: a}
+                  Variable: {subprogram: 103, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 488
+      ID: 490
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5230,14 +5263,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.node
+            Type: 157 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 470
+      ID: 472
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5245,14 +5278,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 PointerType *map[string]int
+            Type: 117 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 486
+      ID: 488
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5260,14 +5293,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 153 PointerType *main.structWithTwoValues
+            Type: 154 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 409
+      ID: 410
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5282,7 +5315,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 428
+      ID: 429
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5297,7 +5330,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 426
+      ID: 427
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5312,7 +5345,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 439
+      ID: 440
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5327,7 +5360,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 440
+      ID: 441
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5342,7 +5375,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 431
+      ID: 432
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5357,7 +5390,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 432
+      ID: 433
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5372,7 +5405,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 433
+      ID: 434
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5387,7 +5420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 430
+      ID: 431
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5402,7 +5435,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 429
+      ID: 430
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5417,7 +5450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 427
+      ID: 428
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5432,7 +5465,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 505
+      ID: 507
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5443,11 +5476,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 436
+      ID: 437
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5462,7 +5495,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 437
+      ID: 438
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5477,7 +5510,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 438
+      ID: 439
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5492,7 +5525,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 435
+      ID: 436
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5507,7 +5540,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 434
+      ID: 435
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5522,7 +5555,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5530,14 +5563,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType [][]uint
+            Type: 161 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: u}
+                  Variable: {subprogram: 90, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 468
+      ID: 470
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5545,14 +5578,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 410
+      ID: 411
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5567,7 +5600,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 491
+      ID: 493
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5578,11 +5611,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 502
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5590,14 +5623,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 165 GoSliceHeaderType []string
+            Type: 166 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: s}
+                  Variable: {subprogram: 94, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 449
+      ID: 450
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5612,7 +5645,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 450
+      ID: 451
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5627,7 +5660,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 499
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5635,10 +5668,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5647,11 +5680,26 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 463
+      ID: 464
+      Name: Probe[main.testStructWithAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 89 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 465
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5659,14 +5707,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 89 StructureType main.structWithMap
+            Type: 90 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 513
+      ID: 515
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5674,14 +5722,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 172 StructureType main.aStruct
+            Type: 173 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 508
+      ID: 510
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5689,14 +5737,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.threeStringStruct
+            Type: 170 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 507
+      ID: 509
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5704,14 +5752,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 StructureType main.threeStringStruct
+            Type: 169 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 506
+      ID: 508
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5722,7 +5770,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5731,7 +5779,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: y}
+                  Variable: {subprogram: 100, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5740,11 +5788,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: z}
+                  Variable: {subprogram: 100, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 441
+      ID: 442
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5759,7 +5807,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 419
+      ID: 420
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5774,7 +5822,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 420
+      ID: 421
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5789,7 +5837,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 421
+      ID: 422
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5804,7 +5852,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 418
+      ID: 419
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5819,7 +5867,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 417
+      ID: 418
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5834,7 +5882,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 490
+      ID: 492
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5845,11 +5893,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 494
+      ID: 496
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5857,14 +5905,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 513
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5875,11 +5923,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 491
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5890,11 +5938,11 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 425
+      ID: 426
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5909,7 +5957,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 503
+      ID: 505
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5917,10 +5965,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: xs}
+                  Variable: {subprogram: 97, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5959,7 +6007,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 679040
+      GoRuntimeType: 679136
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5976,7 +6024,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 680384
+      GoRuntimeType: 680480
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5998,18 +6046,18 @@ Types:
       HasCount: true
       Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 115
+      ID: 116
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 100 GoMapType map[string]int
+      Element: 101 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 680480
+      GoRuntimeType: 680576
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6042,7 +6090,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 680576
+      GoRuntimeType: 680672
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6051,25 +6099,25 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 680288
+      GoRuntimeType: 680384
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 274
+      ID: 275
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 678656
+      GoRuntimeType: 678752
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 231
+      ID: 232
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 678944
+      GoRuntimeType: 679040
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6086,7 +6134,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 474592
+      GoRuntimeType: 474688
       GoKind: 23
       RawFields:
         - Name: array
@@ -6098,83 +6146,83 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 181 GoSliceDataType []*main.deepSlice2.array
+      Data: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 182
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 323
+      ID: 324
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 474528
+      GoRuntimeType: 474624
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 324 PointerType **main.deepSlice3
+          Type: 325 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 327 GoSliceDataType []*main.deepSlice3.array
+      Data: 328 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 327
+      ID: 328
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 325 PointerType *main.deepSlice3
+      Element: 326 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 350
+      ID: 351
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 474208
+      GoRuntimeType: 474304
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 351 PointerType **main.deepSlice8
+          Type: 352 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 354 GoSliceDataType []*main.deepSlice8.array
+      Data: 355 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 354
+      ID: 355
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 352 PointerType *main.deepSlice8
+      Element: 353 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 356
+      ID: 357
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 474144
+      GoRuntimeType: 474240
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 357 PointerType **main.deepSlice9
+          Type: 358 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 360 GoSliceDataType []*main.deepSlice9.array
+      Data: 361 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 360
+      ID: 361
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 358 PointerType *main.deepSlice9
+      Element: 359 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 475616
+      GoRuntimeType: 475712
       GoKind: 23
       RawFields:
         - Name: array
@@ -6186,123 +6234,123 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 178 GoSliceDataType []*string.array
+      Data: 179 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 179
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 292
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 151 PointerType *table<[4]int,[4]int>
+      Element: 152 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 146 PointerType *table<[4]int,uint8>
+      Element: 147 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 233
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 114 PointerType *table<[4]string,[2]int>
+      Element: 115 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<bool,main.node>
+      Element: 127 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 342
+      ID: 343
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 333 PointerType *table<int,*main.deepMap3>
+      Element: 334 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 378
+      ID: 379
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 369 PointerType *table<int,*main.deepMap8>
+      Element: 370 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 393
+      ID: 394
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 384 PointerType *table<int,*main.deepMap9>
+      Element: 385 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 94 PointerType *table<int,int>
+      Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 407
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 399 PointerType *table<int,interface {}>
+      Element: 400 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 259
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 131 PointerType *table<int,uint8>
+      Element: 132 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 243
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 121 PointerType *table<string,[]main.structWithMap>
+      Element: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 109 PointerType *table<string,[]string>
+      Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 104 PointerType *table<string,int>
+      Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 208
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 99 PointerType *table<string,main.nestedStruct>
+      Element: 100 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 276
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 141 PointerType *table<uint8,[4]int>
+      Element: 142 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 267
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 136 PointerType *table<uint8,uint8>
+      Element: 137 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 161
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType *[]uint
+          Type: 162 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 295 GoSliceDataType [][]uint.array
+      Data: 296 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 296
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 159 GoSliceHeaderType []uint
+      Element: 160 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 483488
+      GoRuntimeType: 483584
       GoKind: 23
       RawFields:
         - Name: array
@@ -6314,17 +6362,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 301 GoSliceDataType []bool.array
+      Data: 302 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 301
+      ID: 302
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 362
+      ID: 363
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 483808
+      GoRuntimeType: 483904
       GoKind: 23
       RawFields:
         - Name: array
@@ -6336,145 +6384,145 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 363 GoSliceDataType []interface {}.array
+      Data: 364 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 363
+      ID: 364
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 240
+      ID: 241
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 474848
+      GoRuntimeType: 474944
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 241 PointerType *main.structWithMap
+          Type: 242 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 344 GoSliceDataType []main.structWithMap.array
+      Data: 345 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 345
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 89 StructureType main.structWithMap
+      Element: 90 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 163
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *main.structWithNoStrings
+          Type: 164 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 297 GoSliceDataType []main.structWithNoStrings.array
+      Data: 298 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 297
+      ID: 298
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 164 StructureType main.structWithNoStrings
+      Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 293
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 288 StructureType noalg.map.group[[4]int][4]int
+      Element: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 285
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 280 StructureType noalg.map.group[[4]int]uint8
+      Element: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 234
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 228 StructureType noalg.map.group[[4]string][2]int
+      Element: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 252
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 247 StructureType noalg.map.group[bool]main.node
+      Element: 248 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 193
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 186 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 344
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 337 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 379
+      ID: 380
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 373 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 395
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 388 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 201
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 196 StructureType noalg.map.group[int]int
+      Element: 197 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 408
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 403 StructureType noalg.map.group[int]interface {}
+      Element: 404 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 260
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 255 StructureType noalg.map.group[int]uint8
+      Element: 256 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 244
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 237 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 225
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 220 StructureType noalg.map.group[string][]string
+      Element: 221 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 217
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 212 StructureType noalg.map.group[string]int
+      Element: 213 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 209
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 204 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 277
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 271 StructureType noalg.map.group[uint8][4]int
+      Element: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 268
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 263 StructureType noalg.map.group[uint8]uint8
+      Element: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 483616
+      GoRuntimeType: 483712
       GoKind: 23
       RawFields:
         - Name: array
@@ -6486,17 +6534,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 299 GoSliceDataType []string.array
+      Data: 300 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 299
+      ID: 300
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 483104
+      GoRuntimeType: 483200
       GoKind: 23
       RawFields:
         - Name: array
@@ -6508,17 +6556,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType []uint.array
+      Data: 294 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 294
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 482464
+      GoRuntimeType: 482560
       GoKind: 23
       RawFields:
         - Name: array
@@ -6530,9 +6578,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 303 GoSliceDataType []uint16.array
+      Data: 304 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 303
+      ID: 304
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -6540,35 +6588,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 580928
+      GoRuntimeType: 581024
       GoKind: 1
     - __kind: GoChannelType
-      ID: 152
+      ID: 153
       Name: chan bool
-      GoRuntimeType: 592256
+      GoRuntimeType: 592352
       GoKind: 18
     - __kind: GoChannelType
       ID: 80
       Name: chan struct {}
-      GoRuntimeType: 591168
+      GoRuntimeType: 591264
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 580736
+      GoRuntimeType: 580832
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 580672
+      GoRuntimeType: 580768
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.021696e+06
+      GoRuntimeType: 1.021792e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6581,293 +6629,293 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 580800
+      GoRuntimeType: 580896
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 580864
+      GoRuntimeType: 580960
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 472800
+      GoRuntimeType: 472896
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 286
+      ID: 287
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 287 PointerType *noalg.map.group[[4]int][4]int
+          Type: 288 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 292 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 293 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 278
+      ID: 279
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 279 PointerType *noalg.map.group[[4]int]uint8
+          Type: 280 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 284 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 285 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 226
+      ID: 227
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 227 PointerType *noalg.map.group[[4]string][2]int
+          Type: 228 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 233 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 245
+      ID: 246
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 246 PointerType *noalg.map.group[bool]main.node
+          Type: 247 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 247 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 248 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 252 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 184
+      ID: 185
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 185 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 186 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 335
+      ID: 336
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 336 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 337 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 344 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 372
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 373 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 380 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 386
+      ID: 387
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 387 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 388 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 394 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 395 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 195
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[int]int
+          Type: 196 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[int]int
-      GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 197 StructureType noalg.map.group[int]int
+      GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 401
+      ID: 402
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 402 PointerType *noalg.map.group[int]interface {}
+          Type: 403 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 403 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 404 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 408 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 253
+      ID: 254
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 254 PointerType *noalg.map.group[int]uint8
+          Type: 255 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 255 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 256 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 260 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 235
+      ID: 236
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 236 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 237 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 218
+      ID: 219
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 219 PointerType *noalg.map.group[string][]string
+          Type: 220 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 220 StructureType noalg.map.group[string][]string
-      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 221 StructureType noalg.map.group[string][]string
+      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 210
+      ID: 211
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 211 PointerType *noalg.map.group[string]int
+          Type: 212 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 212 StructureType noalg.map.group[string]int
-      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 213 StructureType noalg.map.group[string]int
+      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 203
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 204 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 269
+      ID: 270
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 270 PointerType *noalg.map.group[uint8][4]int
+          Type: 271 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 271 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 276 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 272 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 277 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 261
+      ID: 262
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 262 PointerType *noalg.map.group[uint8]uint8
+          Type: 263 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 263 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 264 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 580480
+      GoRuntimeType: 580576
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 580096
+      GoRuntimeType: 580192
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 580224
+      GoRuntimeType: 580320
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 580352
+      GoRuntimeType: 580448
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 579968
+      GoRuntimeType: 580064
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 843712
+      GoRuntimeType: 843808
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6877,10 +6925,10 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 312
+      ID: 313
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.466816e+06
+      GoRuntimeType: 1.46704e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6893,7 +6941,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.017728e+06
+      GoRuntimeType: 1.017824e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6903,7 +6951,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6919,12 +6967,12 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 173 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.017344e+06
+      GoRuntimeType: 1.01744e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6952,61 +7000,61 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.181088e+06
+      GoRuntimeType: 1.181312e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 190
+      ID: 191
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.18096e+06
+      GoRuntimeType: 1.181184e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 329 GoMapType map[int]*main.deepMap3
+          Type: 330 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 342
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
       ID: 74
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.18032e+06
+      GoRuntimeType: 1.180544e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 365 GoMapType map[int]*main.deepMap8
+          Type: 366 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 377
+      ID: 378
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.180192e+06
+      GoRuntimeType: 1.180416e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 380 GoMapType map[int]*main.deepMap9
+          Type: 381 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 392
+      ID: 393
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.180064e+06
+      GoRuntimeType: 1.180288e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 395 GoMapType map[int]interface {}
+          Type: 396 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.18224e+06
+      GoRuntimeType: 1.182464e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7016,41 +7064,41 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.182112e+06
+      GoRuntimeType: 1.182336e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 305 PointerType *main.deepPtr3
+          Type: 306 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 306
+      ID: 307
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.181472e+06
+      GoRuntimeType: 1.181696e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 346 PointerType *main.deepPtr8
+          Type: 347 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 347
+      ID: 348
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.181344e+06
+      GoRuntimeType: 1.181568e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 348 PointerType *main.deepPtr9
+          Type: 349 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 349
+      ID: 350
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.181216e+06
+      GoRuntimeType: 1.18144e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7060,58 +7108,58 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.183392e+06
+      GoRuntimeType: 1.183616e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 180
+      ID: 181
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.183264e+06
+      GoRuntimeType: 1.183488e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 323 GoSliceHeaderType []*main.deepSlice3
+          Type: 324 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 326
+      ID: 327
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.182624e+06
+      GoRuntimeType: 1.182848e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 350 GoSliceHeaderType []*main.deepSlice8
+          Type: 351 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 353
+      ID: 354
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.182496e+06
+      GoRuntimeType: 1.18272e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 356 GoSliceHeaderType []*main.deepSlice9
+          Type: 357 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 359
+      ID: 360
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.182368e+06
+      GoRuntimeType: 1.182592e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 362 GoSliceHeaderType []interface {}
+          Type: 363 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 174
+      ID: 175
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7119,7 +7167,7 @@ Types:
       ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.824032e+06
+      GoRuntimeType: 1.824256e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7127,21 +7175,21 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 310 StructureType sync.Mutex
+          Type: 311 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 313 StructureType sync.Once
+          Type: 314 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 316 StructureType sync.WaitGroup
+          Type: 317 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 319 StructureType sync/atomic.Int32
+          Type: 320 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.957632e+06
+      GoRuntimeType: 1.957856e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7166,10 +7214,10 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.456256e+06
+      GoRuntimeType: 1.45648e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7179,10 +7227,10 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 155
+      ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.456096e+06
+      GoRuntimeType: 1.45632e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7190,9 +7238,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 156 PointerType *main.node
+          Type: 157 PointerType *main.node
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7204,7 +7252,7 @@ Types:
       ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.017472e+06
+      GoRuntimeType: 1.017568e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7221,31 +7269,41 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *main.stringType1.str
+          Type: 309 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 307 GoStringDataType main.stringType1.str
+      Data: 308 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 308
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 309
+      ID: 310
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
       ID: 89
+      Name: main.structWithAny
+      ByteSize: 16
+      GoRuntimeType: 1.180032e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.179936e+06
+      GoRuntimeType: 1.18016e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 90 GoMapType map[int]int
+          Type: 91 GoMapType map[int]int
     - __kind: StructureType
-      ID: 164
+      ID: 165
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7257,7 +7315,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 154
+      ID: 155
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7269,28 +7327,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 159
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 320 PointerType **main.t
+          Type: 321 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 321 GoSliceDataType main.t.array
+      Data: 322 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 321
+      ID: 322
       Name: main.t.array
       ByteSize: 2048
-      Element: 157 PointerType *main.t
+      Element: 158 PointerType *main.t
     - __kind: StructureType
-      ID: 168
+      ID: 169
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7310,7 +7368,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 149
+      ID: 150
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7323,7 +7381,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 150 PointerType **table<[4]int,[4]int>
+          Type: 151 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7339,10 +7397,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 291 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 292 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 144
+      ID: 145
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7355,7 +7413,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 145 PointerType **table<[4]int,uint8>
+          Type: 146 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7371,10 +7429,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 283 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 284 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 112
+      ID: 113
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -7387,7 +7445,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 113 PointerType **table<[4]string,[2]int>
+          Type: 114 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7403,10 +7461,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 232 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 233 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 125
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -7419,7 +7477,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<bool,main.node>
+          Type: 126 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7435,8 +7493,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 247 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 251 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 248 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -7467,10 +7525,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 331
+      ID: 332
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7483,7 +7541,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 332 PointerType **table<int,*main.deepMap3>
+          Type: 333 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7499,10 +7557,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 342 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 343 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 367
+      ID: 368
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7515,7 +7573,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 368 PointerType **table<int,*main.deepMap8>
+          Type: 369 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7531,10 +7589,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 379 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 382
+      ID: 383
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7547,7 +7605,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 383 PointerType **table<int,*main.deepMap9>
+          Type: 384 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7563,10 +7621,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 393 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 394 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
-      ID: 92
+      ID: 93
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -7579,7 +7637,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 93 PointerType **table<int,int>
+          Type: 94 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7595,10 +7653,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
-      GroupType: 196 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
+      GroupType: 197 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 397
+      ID: 398
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7611,7 +7669,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 398 PointerType **table<int,interface {}>
+          Type: 399 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7627,10 +7685,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 406 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 403 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 407 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 404 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 129
+      ID: 130
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7643,7 +7701,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 130 PointerType **table<int,uint8>
+          Type: 131 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7659,10 +7717,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 255 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 259 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 256 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 119
+      ID: 120
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -7675,7 +7733,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 120 PointerType **table<string,[]main.structWithMap>
+          Type: 121 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7691,10 +7749,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 107
+      ID: 108
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -7707,7 +7765,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 108 PointerType **table<string,[]string>
+          Type: 109 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7723,10 +7781,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 223 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 220 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 221 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 102
+      ID: 103
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -7739,7 +7797,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 103 PointerType **table<string,int>
+          Type: 104 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7755,10 +7813,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 215 GoSliceDataType []*table<string,int>.array
-      GroupType: 212 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 216 GoSliceDataType []*table<string,int>.array
+      GroupType: 213 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 97
+      ID: 98
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -7771,7 +7829,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 98 PointerType **table<string,main.nestedStruct>
+          Type: 99 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7787,10 +7845,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 207 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 208 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 139
+      ID: 140
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7803,7 +7861,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 140 PointerType **table<uint8,[4]int>
+          Type: 141 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7819,10 +7877,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 275 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 271 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 276 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 134
+      ID: 135
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7835,7 +7893,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 135 PointerType **table<uint8,uint8>
+          Type: 136 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7851,285 +7909,285 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 263 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 267 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 147
+      ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.124e+06
+      GoRuntimeType: 1.124096e+06
       GoKind: 21
-      HeaderType: 149 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 142
+      ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.124128e+06
+      GoRuntimeType: 1.124224e+06
       GoKind: 21
-      HeaderType: 144 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 110
+      ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.124256e+06
+      GoRuntimeType: 1.124352e+06
       GoKind: 21
-      HeaderType: 112 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 122
+      ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.124384e+06
+      GoRuntimeType: 1.12448e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.123872e+06
+      GoRuntimeType: 1.123968e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 329
+      ID: 330
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.123744e+06
+      GoRuntimeType: 1.12384e+06
       GoKind: 21
-      HeaderType: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 365
+      ID: 366
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.123104e+06
+      GoRuntimeType: 1.1232e+06
       GoKind: 21
-      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 380
+      ID: 381
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.122976e+06
+      GoRuntimeType: 1.123072e+06
       GoKind: 21
-      HeaderType: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 90
+      ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.122464e+06
+      GoRuntimeType: 1.12256e+06
       GoKind: 21
-      HeaderType: 92 GoSwissMapHeaderType map<int,int>
+      HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 395
+      ID: 396
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.122848e+06
+      GoRuntimeType: 1.122944e+06
       GoKind: 21
-      HeaderType: 397 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
-      ID: 127
+      ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.124512e+06
+      GoRuntimeType: 1.124608e+06
       GoKind: 21
-      HeaderType: 129 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 117
+      ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.12464e+06
+      GoRuntimeType: 1.124736e+06
       GoKind: 21
-      HeaderType: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 105
+      ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.124768e+06
+      GoRuntimeType: 1.124864e+06
       GoKind: 21
-      HeaderType: 107 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 100
+      ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.124896e+06
+      GoRuntimeType: 1.124992e+06
       GoKind: 21
-      HeaderType: 102 GoSwissMapHeaderType map<string,int>
+      HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 95
+      ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.125024e+06
+      GoRuntimeType: 1.12512e+06
       GoKind: 21
-      HeaderType: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 137
+      ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.125152e+06
+      GoRuntimeType: 1.125248e+06
       GoKind: 21
-      HeaderType: 139 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 132
+      ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.12528e+06
+      GoRuntimeType: 1.125376e+06
       GoKind: 21
-      HeaderType: 134 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 289
+      ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 678752
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 290 StructureType noalg.struct { key [4]int; elem [4]int }
-    - __kind: ArrayType
-      ID: 281
-      Name: noalg.[8]struct { key [4]int; elem uint8 }
-      ByteSize: 320
       GoRuntimeType: 678848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 282 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 291 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 229
-      Name: noalg.[8]struct { key [4]string; elem [2]int }
-      ByteSize: 640
-      GoRuntimeType: 679136
+      ID: 282
+      Name: noalg.[8]struct { key [4]int; elem uint8 }
+      ByteSize: 320
+      GoRuntimeType: 678944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 230 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 283 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 248
-      Name: noalg.[8]struct { key bool; elem main.node }
-      ByteSize: 192
+      ID: 230
+      Name: noalg.[8]struct { key [4]string; elem [2]int }
+      ByteSize: 640
       GoRuntimeType: 679232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 249 StructureType noalg.struct { key bool; elem main.node }
+      Element: 231 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 187
+      ID: 249
+      Name: noalg.[8]struct { key bool; elem main.node }
+      ByteSize: 192
+      GoRuntimeType: 679328
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 250 StructureType noalg.struct { key bool; elem main.node }
+    - __kind: ArrayType
+      ID: 188
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
+      ByteSize: 128
+      GoRuntimeType: 678176
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
+    - __kind: ArrayType
+      ID: 339
+      Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 340 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 338
-      Name: noalg.[8]struct { key int; elem *main.deepMap3 }
+      ID: 375
+      Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 677984
+      GoRuntimeType: 677600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 339 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 376 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 374
-      Name: noalg.[8]struct { key int; elem *main.deepMap8 }
+      ID: 390
+      Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 391 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 389
-      Name: noalg.[8]struct { key int; elem *main.deepMap9 }
+      ID: 198
+      Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
+      GoRuntimeType: 676256
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 199 StructureType noalg.struct { key int; elem int }
+    - __kind: ArrayType
+      ID: 405
+      Name: noalg.[8]struct { key int; elem interface {} }
+      ByteSize: 192
       GoRuntimeType: 677408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 390 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 406 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 197
-      Name: noalg.[8]struct { key int; elem int }
-      ByteSize: 128
-      GoRuntimeType: 676160
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 198 StructureType noalg.struct { key int; elem int }
-    - __kind: ArrayType
-      ID: 404
-      Name: noalg.[8]struct { key int; elem interface {} }
-      ByteSize: 192
-      GoRuntimeType: 677312
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 405 StructureType noalg.struct { key int; elem interface {} }
-    - __kind: ArrayType
-      ID: 256
+      ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 679328
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 257 StructureType noalg.struct { key int; elem uint8 }
-    - __kind: ArrayType
-      ID: 238
-      Name: noalg.[8]struct { key string; elem []main.structWithMap }
-      ByteSize: 320
       GoRuntimeType: 679424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 239 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 258 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 221
-      Name: noalg.[8]struct { key string; elem []string }
+      ID: 239
+      Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 679520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem []string }
+      Element: 240 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 213
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
+      ID: 222
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
       GoRuntimeType: 679616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 214 StructureType noalg.struct { key string; elem int }
+      Element: 223 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 205
-      Name: noalg.[8]struct { key string; elem main.nestedStruct }
-      ByteSize: 320
+      ID: 214
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
       GoRuntimeType: 679712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 215 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 272
-      Name: noalg.[8]struct { key uint8; elem [4]int }
+      ID: 206
+      Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 679808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 273 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 207 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 264
-      Name: noalg.[8]struct { key uint8; elem uint8 }
-      ByteSize: 16
+      ID: 273
+      Name: noalg.[8]struct { key uint8; elem [4]int }
+      ByteSize: 320
       GoRuntimeType: 679904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 265 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 274 StructureType noalg.struct { key uint8; elem [4]int }
+    - __kind: ArrayType
+      ID: 265
+      Name: noalg.[8]struct { key uint8; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 680000
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 266 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 288
+      ID: 289
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.28944e+06
+      GoRuntimeType: 1.289664e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8137,12 +8195,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 289 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 290 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 280
+      ID: 281
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.289696e+06
+      GoRuntimeType: 1.28992e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8150,12 +8208,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 281 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 282 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 228
+      ID: 229
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.289952e+06
+      GoRuntimeType: 1.290176e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8163,12 +8221,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 229 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 230 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 247
+      ID: 248
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.290208e+06
+      GoRuntimeType: 1.290432e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8176,12 +8234,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 248 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 249 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 186
+      ID: 187
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.289184e+06
+      GoRuntimeType: 1.289408e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8189,12 +8247,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 337
+      ID: 338
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.288928e+06
+      GoRuntimeType: 1.289152e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8202,12 +8260,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 338 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 339 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 373
+      ID: 374
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.287648e+06
+      GoRuntimeType: 1.287872e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8215,12 +8273,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 375 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 388
+      ID: 389
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.287392e+06
+      GoRuntimeType: 1.287616e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8228,12 +8286,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 389 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 390 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 196
+      ID: 197
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.286368e+06
+      GoRuntimeType: 1.286592e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8241,12 +8299,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 198 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 403
+      ID: 404
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.287136e+06
+      GoRuntimeType: 1.28736e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8254,12 +8312,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 404 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 405 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 255
+      ID: 256
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.290464e+06
+      GoRuntimeType: 1.290688e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8267,12 +8325,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 256 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 257 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 237
+      ID: 238
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.29072e+06
+      GoRuntimeType: 1.290944e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8280,12 +8338,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 238 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 239 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 220
+      ID: 221
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.290976e+06
+      GoRuntimeType: 1.2912e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8293,12 +8351,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 212
+      ID: 213
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.291232e+06
+      GoRuntimeType: 1.291456e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8306,12 +8364,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 213 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 204
+      ID: 205
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.291488e+06
+      GoRuntimeType: 1.291712e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8319,12 +8377,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 206 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 271
+      ID: 272
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.291744e+06
+      GoRuntimeType: 1.291968e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8332,12 +8390,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 272 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 273 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 263
+      ID: 264
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.292e+06
+      GoRuntimeType: 1.292224e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8345,51 +8403,51 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 264 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 265 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 290
+      ID: 291
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.289312e+06
+      GoRuntimeType: 1.289536e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
     - __kind: StructureType
-      ID: 282
+      ID: 283
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.289568e+06
+      GoRuntimeType: 1.289792e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 230
+      ID: 231
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.289824e+06
+      GoRuntimeType: 1.290048e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 231 ArrayType [4]string
+          Type: 232 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 249
+      ID: 250
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.29008e+06
+      GoRuntimeType: 1.290304e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8397,12 +8455,12 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 155 StructureType main.node
+          Type: 156 StructureType main.node
     - __kind: StructureType
-      ID: 188
+      ID: 189
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.289056e+06
+      GoRuntimeType: 1.28928e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8410,12 +8468,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 189 PointerType *main.deepMap2
+          Type: 190 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 339
+      ID: 340
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.2888e+06
+      GoRuntimeType: 1.289024e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8423,12 +8481,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 340 PointerType *main.deepMap3
+          Type: 341 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 375
+      ID: 376
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.28752e+06
+      GoRuntimeType: 1.287744e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8436,12 +8494,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 376 PointerType *main.deepMap8
+          Type: 377 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 390
+      ID: 391
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.287264e+06
+      GoRuntimeType: 1.287488e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8449,12 +8507,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 391 PointerType *main.deepMap9
+          Type: 392 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 198
+      ID: 199
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.28624e+06
+      GoRuntimeType: 1.286464e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8464,10 +8522,10 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 405
+      ID: 406
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.287008e+06
+      GoRuntimeType: 1.287232e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8477,10 +8535,10 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 257
+      ID: 258
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.290336e+06
+      GoRuntimeType: 1.29056e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8490,10 +8548,10 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 239
+      ID: 240
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.290592e+06
+      GoRuntimeType: 1.290816e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8501,12 +8559,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 240 GoSliceHeaderType []main.structWithMap
+          Type: 241 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 222
+      ID: 223
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.290848e+06
+      GoRuntimeType: 1.291072e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8514,12 +8572,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 165 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 214
+      ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.291104e+06
+      GoRuntimeType: 1.291328e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8529,10 +8587,10 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 206
+      ID: 207
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.29136e+06
+      GoRuntimeType: 1.291584e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8540,12 +8598,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 173 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 273
+      ID: 274
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.291616e+06
+      GoRuntimeType: 1.29184e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8553,12 +8611,12 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
     - __kind: StructureType
-      ID: 265
+      ID: 266
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.291872e+06
+      GoRuntimeType: 1.292096e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8571,127 +8629,127 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 579904
+      GoRuntimeType: 580000
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 177 PointerType *string.str
+          Type: 178 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 176 GoStringDataType string.str
+      Data: 177 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 176
+      ID: 177
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 310
+      ID: 311
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.457536e+06
+      GoRuntimeType: 1.45776e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 312 StructureType internal/sync.Mutex
+          Type: 313 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 313
+      ID: 314
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.606048e+06
+      GoRuntimeType: 1.606272e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 314 StructureType sync/atomic.Uint32
+          Type: 315 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 310 StructureType sync.Mutex
+          Type: 311 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 316
+      ID: 317
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.60624e+06
+      GoRuntimeType: 1.606464e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 317 StructureType sync/atomic.Uint64
+          Type: 318 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 311
+      ID: 312
       Name: sync.noCopy
-      GoRuntimeType: 983008
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 319
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.458816e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 12 BaseType int32
-    - __kind: StructureType
-      ID: 314
-      Name: sync/atomic.Uint32
-      ByteSize: 4
-      GoRuntimeType: 1.458976e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 2 BaseType uint32
-    - __kind: StructureType
-      ID: 317
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.606624e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 318 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 8 BaseType uint64
-    - __kind: StructureType
-      ID: 318
-      Name: sync/atomic.align64
-      GoRuntimeType: 983200
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 315
-      Name: sync/atomic.noCopy
       GoRuntimeType: 983104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 285
+      ID: 320
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.45904e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 12 BaseType int32
+    - __kind: StructureType
+      ID: 315
+      Name: sync/atomic.Uint32
+      ByteSize: 4
+      GoRuntimeType: 1.4592e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 2 BaseType uint32
+    - __kind: StructureType
+      ID: 318
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.606848e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 319 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 8 BaseType uint64
+    - __kind: StructureType
+      ID: 319
+      Name: sync/atomic.align64
+      GoRuntimeType: 983296
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 316
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 983200
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 286
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -8713,9 +8771,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 286 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 287 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 277
+      ID: 278
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8737,9 +8795,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 278 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 279 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 225
+      ID: 226
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -8761,9 +8819,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 226 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 227 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 244
+      ID: 245
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -8785,9 +8843,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 245 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 246 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 183
+      ID: 184
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -8809,9 +8867,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 334
+      ID: 335
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8833,9 +8891,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 335 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 336 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 370
+      ID: 371
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8857,9 +8915,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 372 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 385
+      ID: 386
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8881,9 +8939,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 386 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 387 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 193
+      ID: 194
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -8905,9 +8963,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<int,int>
+          Type: 195 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 400
+      ID: 401
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8929,9 +8987,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 401 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 402 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 252
+      ID: 253
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8953,9 +9011,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 253 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 254 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 234
+      ID: 235
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -8977,9 +9035,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 235 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 236 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 217
+      ID: 218
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9001,9 +9059,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 218 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 209
+      ID: 210
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -9025,9 +9083,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 210 GoSwissMapGroupsType groupReference<string,int>
+          Type: 211 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 201
+      ID: 202
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -9049,9 +9107,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 203 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 268
+      ID: 269
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -9073,9 +9131,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 269 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 270 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 260
+      ID: 261
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9097,49 +9155,49 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 261 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 580544
+      GoRuntimeType: 580640
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 580160
+      GoRuntimeType: 580256
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 580288
+      GoRuntimeType: 580384
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 580416
+      GoRuntimeType: 580512
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 580032
+      GoRuntimeType: 580128
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 580608
+      GoRuntimeType: 580704
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 580992
+      GoRuntimeType: 581088
       GoKind: 26
-MaxTypeID: 521
+MaxTypeID: 523
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x131d360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 504 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x809f6c", Frameless: true}]
+        - ID: 98
+          Type: 506 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x809fac", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 460 EventRootType Probe[main.testAny]
+          Type: 461 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807a0c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 462 EventRootType Probe[main.testAnyPtr]
+          Type: 463 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807a7c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 422 EventRootType Probe[main.testArrayOfArrays]
+          Type: 423 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 424 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 425 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -78,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 469 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x808020", Frameless: true}]
+        - ID: 63
+          Type: 471 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x808060", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 423 EventRootType Probe[main.testArrayOfStrings]
+          Type: 424 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 442 EventRootType Probe[main.testBigStruct]
+          Type: 443 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 411 EventRootType Probe[main.testBoolArray]
+          Type: 412 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 408 EventRootType Probe[main.testByteArray]
+          Type: 409 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806280", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 485 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x809610", Frameless: true}]
+        - ID: 79
+          Type: 487 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x809650", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -162,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 483 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x809390", Frameless: true}]
+        - ID: 77
+          Type: 485 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x8093d0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -176,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 493 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x809890", Frameless: true}]
+        - ID: 87
+          Type: 495 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x8098d0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 447 EventRootType Probe[main.testDeepMap1]
+          Type: 448 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c70", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 448 EventRootType Probe[main.testDeepMap7]
+          Type: 449 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806c80", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 443 EventRootType Probe[main.testDeepPtr1]
+          Type: 444 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x806990", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 444 EventRootType Probe[main.testDeepPtr7]
+          Type: 445 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069a0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 445 EventRootType Probe[main.testDeepSlice1]
+          Type: 446 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b10", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 446 EventRootType Probe[main.testDeepSlice7]
+          Type: 447 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b20", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -292,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 495 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x809c40", Frameless: true}]
+        - ID: 89
+          Type: 497 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x809c80", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -306,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 498 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x809c70", Frameless: true}]
+        - ID: 92
+          Type: 500 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -320,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 512 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x80a030", Frameless: true}]
+        - ID: 106
+          Type: 514 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x80a070", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 514 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x80a2d0", Frameless: true}]
+        - ID: 108
+          Type: 516 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x80a310", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 515 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x80a2e0", Frameless: true}]
+        - ID: 109
+          Type: 517 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x80a320", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 461 EventRootType Probe[main.testError]
+          Type: 462 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807a60", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 452 EventRootType Probe[main.testEsotericHeap]
+          Type: 453 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8070ac", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 451 EventRootType Probe[main.testEsotericStack]
+          Type: 452 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x806fec", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 457 EventRootType Probe[main.testFrameless]
+          Type: 458 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807780", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 458 EventRootType Probe[main.testFramelessArray]
+          Type: 459 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x807790", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 453 EventRootType Probe[main.testInlinedBA]
+          Type: 454 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8074bc", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 454 EventRootType Probe[main.testInlinedBB]
+          Type: 455 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x80754c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 455 EventRootType Probe[main.testInlinedBBA]
+          Type: 456 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x80760c", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 517 EventRootType Probe[main.testInlinedBBB]
+        - ID: 111
+          Type: 519 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8075a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 456 EventRootType Probe[main.testInlinedBC]
+          Type: 457 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x80767c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 518 EventRootType Probe[main.testInlinedBCA]
+        - ID: 112
+          Type: 520 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80768c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 519 EventRootType Probe[main.testInlinedBCB]
+        - ID: 113
+          Type: 521 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807730", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 516 EventRootType Probe[main.testInlinedPrint]
+        - ID: 110
+          Type: 518 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x80732c"
               Frameless: true
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 520 EventRootType Probe[main.testInlinedSq]
+        - ID: 114
+          Type: 522 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807784", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 114
-          Type: 521 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 115
+          Type: 523 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8077b4"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 414 EventRootType Probe[main.testInt16Array]
+          Type: 415 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 415 EventRootType Probe[main.testInt32Array]
+          Type: 416 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 416 EventRootType Probe[main.testInt64Array]
+          Type: 417 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 413 EventRootType Probe[main.testInt8Array]
+          Type: 414 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 412 EventRootType Probe[main.testIntArray]
+          Type: 413 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 459 EventRootType Probe[main.testInterface]
+          Type: 460 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x8079f0", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -671,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 487 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x8097a0", Frameless: true}]
+        - ID: 81
+          Type: 489 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x8097e0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -685,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 467 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x808000", Frameless: true}]
+        - ID: 61
+          Type: 469 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x808040", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -699,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 473 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x808060", Frameless: true}]
+        - ID: 67
+          Type: 475 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x8080a0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -713,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 471 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x808040", Frameless: true}]
+        - ID: 65
+          Type: 473 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x808080", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -727,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 482 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x8080f0", Frameless: true}]
+        - ID: 76
+          Type: 484 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x808130", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -741,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 481 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x8080e0", Frameless: true}]
+        - ID: 75
+          Type: 483 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x808120", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -755,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 472 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x808050", Frameless: true}]
+        - ID: 66
+          Type: 474 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x808090", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -769,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 480 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x8080d0", Frameless: true}]
+        - ID: 74
+          Type: 482 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x808110", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -783,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 479 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x8080c0", Frameless: true}]
+        - ID: 73
+          Type: 481 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x808100", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -797,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 465 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x807fe0", Frameless: true}]
+        - ID: 59
+          Type: 467 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x808020", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -811,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 466 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x807ff0", Frameless: true}]
+        - ID: 60
+          Type: 468 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x808030", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -825,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 464 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x807fd0", Frameless: true}]
+        - ID: 58
+          Type: 466 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x808010", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -839,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 474 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x808070", Frameless: true}]
+        - ID: 68
+          Type: 476 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x8080b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -853,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x8080a0", Frameless: true}]
+        - ID: 71
+          Type: 479 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x8080e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -867,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 478 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x8080b0", Frameless: true}]
+        - ID: 72
+          Type: 480 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x8080f0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -881,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 475 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x808080", Frameless: true}]
+        - ID: 69
+          Type: 477 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x8080c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -895,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 476 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x808090", Frameless: true}]
+        - ID: 70
+          Type: 478 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x8080d0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -909,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 510 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80a010", Frameless: true}]
+        - ID: 104
+          Type: 512 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80a050", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -923,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 484 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x809470", Frameless: true}]
+        - ID: 78
+          Type: 486 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x8094b0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -937,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 492 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x809870", Frameless: true}]
+        - ID: 86
+          Type: 494 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x8098b0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -951,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 502 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
+        - ID: 96
+          Type: 504 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x809cf0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -965,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 499 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x809c80", Frameless: true}]
+        - ID: 93
+          Type: 501 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -979,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 501 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
+        - ID: 95
+          Type: 503 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x809ce0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -993,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 509 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x80a000", Frameless: true}]
+        - ID: 103
+          Type: 511 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x80a040", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1007,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 488 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x8097b0", Frameless: true}]
+        - ID: 82
+          Type: 490 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x8097f0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1021,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 470 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x808030", Frameless: true}]
+        - ID: 64
+          Type: 472 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x808070", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1035,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 486 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x809790", Frameless: true}]
+        - ID: 80
+          Type: 488 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x8097d0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 409 EventRootType Probe[main.testRuneArray]
+          Type: 410 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 428 EventRootType Probe[main.testSingleBool]
+          Type: 429 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 426 EventRootType Probe[main.testSingleByte]
+          Type: 427 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x8066e0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 439 EventRootType Probe[main.testSingleFloat32]
+          Type: 440 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 440 EventRootType Probe[main.testSingleFloat64]
+          Type: 441 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 429 EventRootType Probe[main.testSingleInt]
+          Type: 430 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 431 EventRootType Probe[main.testSingleInt16]
+          Type: 432 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 432 EventRootType Probe[main.testSingleInt32]
+          Type: 433 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 433 EventRootType Probe[main.testSingleInt64]
+          Type: 434 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 430 EventRootType Probe[main.testSingleInt8]
+          Type: 431 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 427 EventRootType Probe[main.testSingleRune]
+          Type: 428 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x8066f0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1203,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 505 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x809fc0", Frameless: true}]
+        - ID: 99
+          Type: 507 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x80a000", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 434 EventRootType Probe[main.testSingleUint]
+          Type: 435 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 436 EventRootType Probe[main.testSingleUint16]
+          Type: 437 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 437 EventRootType Probe[main.testSingleUint32]
+          Type: 438 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 438 EventRootType Probe[main.testSingleUint64]
+          Type: 439 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 435 EventRootType Probe[main.testSingleUint8]
+          Type: 436 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1287,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 496 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x809c50", Frameless: true}]
+        - ID: 90
+          Type: 498 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x809c90", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1301,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 468 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x808010", Frameless: true}]
+        - ID: 62
+          Type: 470 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x808050", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 410 EventRootType Probe[main.testStringArray]
+          Type: 411 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1329,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 491 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x809850", Frameless: true}]
+        - ID: 85
+          Type: 493 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x809890", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1343,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 500 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x809c90", Frameless: true}]
+        - ID: 94
+          Type: 502 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x809cd0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 449 EventRootType Probe[main.testStringType1]
+          Type: 450 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 450 EventRootType Probe[main.testStringType2]
+          Type: 451 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 513 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80a200", Frameless: true}]
+        - ID: 107
+          Type: 515 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80a240", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1405,11 +1405,28 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 497 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x809c60", Frameless: true}]
+        - ID: 91
+          Type: 499 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
+          Condition: null
+    - id: testStructWithAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithAny}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 56}
+      events:
+        - ID: 56
+          Type: 464 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x807ad0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1419,11 +1436,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 463 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x807fc0", Frameless: true}]
+        - ID: 57
+          Type: 465 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x808000", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1433,11 +1450,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 506 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x809fd0", Frameless: true}]
+        - ID: 100
+          Type: 508 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x80a010", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1447,11 +1464,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 507 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x809fe0", Frameless: true}]
+        - ID: 101
+          Type: 509 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x80a020", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1461,11 +1478,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 508 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x809ff0", Frameless: true}]
+        - ID: 102
+          Type: 510 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x80a030", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1478,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 441 EventRootType Probe[main.testTypeAlias]
+          Type: 442 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1492,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 419 EventRootType Probe[main.testUint16Array]
+          Type: 420 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1506,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 420 EventRootType Probe[main.testUint32Array]
+          Type: 421 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1520,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 421 EventRootType Probe[main.testUint64Array]
+          Type: 422 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1534,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 418 EventRootType Probe[main.testUint8Array]
+          Type: 419 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1548,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 417 EventRootType Probe[main.testUintArray]
+          Type: 418 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1559,11 +1576,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 490 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x8097e0", Frameless: true}]
+        - ID: 84
+          Type: 492 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x809820", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1573,11 +1590,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 494 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x809c30", Frameless: true}]
+        - ID: 88
+          Type: 496 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x809c70", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1587,11 +1604,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 511 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x80a020", Frameless: true}]
+        - ID: 105
+          Type: 513 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x80a060", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1601,11 +1618,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 489 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x8097c0", Frameless: true}]
+        - ID: 83
+          Type: 491 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x809800", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1618,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 425 EventRootType Probe[main.testVeryLargeArray]
+          Type: 426 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1629,11 +1646,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 503 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
+        - ID: 97
+          Type: 505 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x809d00", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2438,308 +2455,324 @@ Subprograms:
           IsParameter: true
           IsReturn: true
     - ID: 56
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x807fc0..0x807fd0]
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0x807ad0..0x807ae0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 89 StructureType main.structWithMap
+          Type: 89 StructureType main.structWithAny
           Locations:
-            - Range: 0x807fc0..0x807fd0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x807ad0..0x807ae0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x807fd0..0x807fe0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 95 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x807fd0..0x807fe0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x807fe0..0x807ff0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0x807fe0..0x807ff0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x807ff0..0x808000]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 105 GoMapType map[string][]string
-          Locations:
-            - Range: 0x807ff0..0x808000
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testMapArrayToArray
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0x808000..0x808010]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 110 GoMapType map[[4]string][2]int
+        - Name: s
+          Type: 90 StructureType main.structWithMap
           Locations:
             - Range: 0x808000..0x808010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
-      Name: main.testSmallMap
+    - ID: 58
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x808010..0x808020]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 100 GoMapType map[string]int
+          Type: 96 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x808010..0x808020
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testArrayOfMaps
+    - ID: 59
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x808020..0x808030]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 115 ArrayType [2]map[string]int
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0x808020..0x808030
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testPointerToMap
+    - ID: 60
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x808030..0x808040]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 116 PointerType *map[string]int
+          Type: 106 GoMapType map[string][]string
           Locations:
             - Range: 0x808030..0x808040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapIntToInt
+    - ID: 61
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x808040..0x808050]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 90 GoMapType map[int]int
+          Type: 111 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x808040..0x808050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapMassive
+    - ID: 62
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0x808050..0x808060]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 117 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0x808050..0x808060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapEmbeddedMaps
+    - ID: 63
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x808060..0x808070]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 117 GoMapType map[string][]main.structWithMap
+          Type: 116 ArrayType [2]map[string]int
           Locations:
             - Range: 0x808060..0x808070
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithLinkedList
+    - ID: 64
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0x808070..0x808080]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[bool]main.node
+          Type: 117 PointerType *map[string]int
           Locations:
             - Range: 0x808070..0x808080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapWithSmallValue
+    - ID: 65
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x808080..0x808090]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[int]uint8
+          Type: 91 GoMapType map[int]int
           Locations:
             - Range: 0x808080..0x808090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapWithSmallValueMassive
+    - ID: 66
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x808090..0x8080a0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 127 GoMapType map[int]uint8
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x808090..0x8080a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 67
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x8080a0..0x8080b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x8080a0..0x8080b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 68
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x8080b0..0x8080c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 123 GoMapType map[bool]main.node
           Locations:
             - Range: 0x8080b0..0x8080c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
-      Name: main.testMapSmallKeySmallValue
+    - ID: 69
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x8080c0..0x8080d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 132 GoMapType map[uint8]uint8
+          Type: 128 GoMapType map[int]uint8
           Locations:
             - Range: 0x8080c0..0x8080d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 70
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x8080d0..0x8080e0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 137 GoMapType map[uint8][4]int
+        - Name: redactMyEntries
+          Type: 128 GoMapType map[int]uint8
           Locations:
             - Range: 0x8080d0..0x8080e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
-      Name: main.testMapLargeKeySmallValue
+    - ID: 71
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x8080e0..0x8080f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 142 GoMapType map[[4]int]uint8
+          Type: 133 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x8080e0..0x8080f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 72
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x8080f0..0x808100]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 147 GoMapType map[[4]int][4]int
+          Type: 133 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x8080f0..0x808100
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 73
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x808100..0x808110]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x808100..0x808110
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x808110..0x808120]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 138 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x808110..0x808120
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x808120..0x808130]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 143 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x808120..0x808130
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 76
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x808130..0x808140]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 148 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x808130..0x808140
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 77
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x809390..0x8093a0]
+      OutOfLinePCRanges: [0x8093d0..0x8093e0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809390..0x8093a0
+            - Range: 0x8093d0..0x8093e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809390..0x8093a0
+            - Range: 0x8093d0..0x8093e0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x809390..0x8093a0
+            - Range: 0x8093d0..0x8093e0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x809470..0x809480]
+      OutOfLinePCRanges: [0x8094b0..0x8094c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x809470..0x809480
+            - Range: 0x8094b0..0x8094c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809470..0x809480
+            - Range: 0x8094b0..0x8094c0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x809470..0x809480
+            - Range: 0x8094b0..0x8094c0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809470..0x809480
+            - Range: 0x8094b0..0x8094c0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809470..0x809480
+            - Range: 0x8094b0..0x8094c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2747,39 +2780,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testChannel
-      OutOfLinePCRanges: [0x809610..0x809620]
+      OutOfLinePCRanges: [0x809650..0x809660]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 152 GoChannelType chan bool
+          Type: 153 GoChannelType chan bool
           Locations:
-            - Range: 0x809610..0x809620
+            - Range: 0x809650..0x809660
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x809790..0x8097a0]
+      OutOfLinePCRanges: [0x8097d0..0x8097e0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 153 PointerType *main.structWithTwoValues
+          Type: 154 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x809790..0x8097a0
+            - Range: 0x8097d0..0x8097e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x8097a0..0x8097b0]
+      OutOfLinePCRanges: [0x8097e0..0x8097f0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 StructureType main.node
+          Type: 156 StructureType main.node
           Locations:
-            - Range: 0x8097a0..0x8097b0
+            - Range: 0x8097e0..0x8097f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2787,112 +2820,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x8097b0..0x8097c0]
+      OutOfLinePCRanges: [0x8097f0..0x809800]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 156 PointerType *main.node
+          Type: 157 PointerType *main.node
           Locations:
-            - Range: 0x8097b0..0x8097c0
+            - Range: 0x8097f0..0x809800
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x8097c0..0x8097d0]
+      OutOfLinePCRanges: [0x809800..0x809810]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x8097c0..0x8097d0
+            - Range: 0x809800..0x809810
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x8097e0..0x8097f0]
+      OutOfLinePCRanges: [0x809820..0x809830]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x8097e0..0x8097f0
+            - Range: 0x809820..0x809830
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x809850..0x809860]
+      OutOfLinePCRanges: [0x809890..0x8098a0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x809850..0x809860
+            - Range: 0x809890..0x8098a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x809870..0x809880]
+      OutOfLinePCRanges: [0x8098b0..0x8098c0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x809870..0x809880
+            - Range: 0x8098b0..0x8098c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809870..0x809880
+            - Range: 0x8098b0..0x8098c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testCycle
-      OutOfLinePCRanges: [0x809890..0x8098a0]
+      OutOfLinePCRanges: [0x8098d0..0x8098e0]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 157 PointerType *main.t
+          Type: 158 PointerType *main.t
           Locations:
-            - Range: 0x809890..0x8098a0
+            - Range: 0x8098d0..0x8098e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x809c30..0x809c40]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 159 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x809c30..0x809c40
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 88
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x809c40..0x809c50]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x809c70..0x809c80]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType []uint
+          Type: 160 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x809c40..0x809c50
+            - Range: 0x809c70..0x809c80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2903,14 +2918,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x809c50..0x809c60]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x809c80..0x809c90]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 160 GoSliceHeaderType [][]uint
+          Type: 160 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x809c50..0x809c60
+            - Range: 0x809c80..0x809c90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2921,87 +2936,12 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 90
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x809c60..0x809c70]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x809c60..0x809c70
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x809c60..0x809c70
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 91
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x809c70..0x809c80]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x809c70..0x809c80
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x809c70..0x809c80
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x809c80..0x809c90]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x809c80..0x809c90
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x809c80..0x809c90
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 93
-      Name: main.testStringSlice
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x809c90..0x809ca0]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 165 GoSliceHeaderType []string
+        - Name: u
+          Type: 161 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x809c90..0x809ca0
               Pieces:
@@ -3013,22 +2953,115 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSliceWithOtherParams
+    - ID: 91
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x809ca0..0x809cb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x809ca0..0x809cb0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809ca0..0x809cb0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x809cb0..0x809cc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x809cb0..0x809cc0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809cb0..0x809cc0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x809cc0..0x809cd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x809cc0..0x809cd0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809cc0..0x809cd0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x809cd0..0x809ce0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 166 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x809cd0..0x809ce0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x809ce0..0x809cf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x809ca0..0x809cb0
+            - Range: 0x809ce0..0x809cf0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 166 GoSliceHeaderType []bool
+          Type: 167 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x809ca0..0x809cb0
+            - Range: 0x809ce0..0x809cf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3041,37 +3074,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809ca0..0x809cb0
+            - Range: 0x809ce0..0x809cf0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 95
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x809cb0..0x809cc0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 167 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x809cb0..0x809cc0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 96
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x809cc0..0x809cd0]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x809cf0..0x809d00]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 159 GoSliceHeaderType []uint
+          Type: 168 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x809cc0..0x809cd0
+            - Range: 0x809cf0..0x809d00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3082,119 +3097,51 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 97
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x809d00..0x809d10]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 160 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x809d00..0x809d10
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0x809f60..0x809fc0]
+      OutOfLinePCRanges: [0x809fa0..0x80a000]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x809f60..0x809fc0, Pieces: []}]
+          Locations: [{Range: 0x809fa0..0x80a000, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0x809fc0..0x809fd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x809fc0..0x809fd0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x809fd0..0x809fe0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x809fd0..0x809fe0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: y
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x809fd0..0x809fe0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: z
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x809fd0..0x809fe0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x809fe0..0x809ff0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0x809fe0..0x809ff0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 101
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x809ff0..0x80a000]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 169 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x809ff0..0x80a000
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 102
-      Name: main.testOneStringInStructPointer
+      Name: main.testSingleString
       OutOfLinePCRanges: [0x80a000..0x80a010]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 170 PointerType *main.oneStringStruct
+        - Name: x
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x80a000..0x80a010
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
-      Name: main.testMassiveString
+    - ID: 100
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x80a010..0x80a020]
       InlinePCRanges: []
       Variables:
@@ -3209,15 +3156,85 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
-      Name: main.testUnitializedString
+        - Name: y
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80a010..0x80a020
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80a010..0x80a020
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 101
+      Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x80a020..0x80a030]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 169 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0x80a020..0x80a030
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 102
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x80a030..0x80a040]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 170 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0x80a030..0x80a040
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x80a040..0x80a050]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 171 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0x80a040..0x80a050
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 104
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x80a050..0x80a060]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a020..0x80a030
+            - Range: 0x80a050..0x80a060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3226,14 +3243,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80a030..0x80a040]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x80a060..0x80a070]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a030..0x80a040
+            - Range: 0x80a060..0x80a070
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3242,14 +3259,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 106
-      Name: main.testStruct
-      OutOfLinePCRanges: [0x80a200..0x80a220]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x80a070..0x80a080]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 172 StructureType main.aStruct
+          Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a200..0x80a220
+            - Range: 0x80a070..0x80a080
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 107
+      Name: main.testStruct
+      OutOfLinePCRanges: [0x80a240..0x80a260]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 173 StructureType main.aStruct
+          Locations:
+            - Range: 0x80a240..0x80a260
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3267,29 +3300,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80a2d0..0x80a2e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 174 StructureType main.emptyStruct
-          Locations: [{Range: 0x80a2d0..0x80a2e0, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 108
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80a2e0..0x80a2f0]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0x80a310..0x80a320]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 175 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0x80a2e0..0x80a2f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 175 StructureType main.emptyStruct
+          Locations: [{Range: 0x80a310..0x80a320, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 109
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0x80a320..0x80a330]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 176 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0x80a320..0x80a330
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 110
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x807320..0x807390]
       InlinePCRanges:
@@ -3319,28 +3352,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x8075a4..0x8075d8]
           RootRanges: [0x807540..0x807600]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x80768c..0x8076c0, 0x8076c8..0x8076cc]
           RootRanges: [0x807670..0x807780]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x807730..0x807764]
           RootRanges: [0x807670..0x807780]
       Variables: []
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3354,7 +3387,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 115
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3379,20 +3412,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 324
+      ID: 325
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 325 PointerType *main.deepSlice3
+      Pointee: 326 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 351
+      ID: 352
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 352 PointerType *main.deepSlice8
+      Pointee: 353 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 357
+      ID: 358
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 358 PointerType *main.deepSlice9
+      Pointee: 359 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3400,373 +3433,373 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 320
+      ID: 321
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 157 PointerType *main.t
+      Pointee: 158 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 530400
+      GoRuntimeType: 530464
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 151 PointerType *table<[4]int,[4]int>
+      Pointee: 152 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 146 PointerType *table<[4]int,uint8>
+      Pointee: 147 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 114 PointerType *table<[4]string,[2]int>
+      Pointee: 115 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<bool,main.node>
+      Pointee: 127 PointerType *table<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 332
+      ID: 333
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 333 PointerType *table<int,*main.deepMap3>
+      Pointee: 334 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 368
+      ID: 369
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 369 PointerType *table<int,*main.deepMap8>
+      Pointee: 370 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 383
+      ID: 384
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 384 PointerType *table<int,*main.deepMap9>
+      Pointee: 385 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 94 PointerType *table<int,int>
+      Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 399 PointerType *table<int,interface {}>
+      Pointee: 400 PointerType *table<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 131 PointerType *table<int,uint8>
+      Pointee: 132 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 121 PointerType *table<string,[]main.structWithMap>
+      Pointee: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 109 PointerType *table<string,[]string>
+      Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 104 PointerType *table<string,int>
+      Pointee: 105 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 99 PointerType *table<string,main.nestedStruct>
+      Pointee: 100 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 141 PointerType *table<uint8,[4]int>
+      Pointee: 142 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 136 PointerType *table<uint8,uint8>
+      Pointee: 137 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 182
+      ID: 183
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 328
+      ID: 329
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 327 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 328 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 355
+      ID: 356
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 354 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 355 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 361
+      ID: 362
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 360 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 361 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 179
+      ID: 180
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []*string.array
+      Pointee: 179 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 296
+      ID: 297
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 295 GoSliceDataType [][]uint.array
+      Pointee: 296 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 302
+      ID: 303
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 301 GoSliceDataType []bool.array
+      Pointee: 302 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 364
+      ID: 365
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 363 GoSliceDataType []interface {}.array
+      Pointee: 364 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 345
+      ID: 346
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 344 GoSliceDataType []main.structWithMap.array
+      Pointee: 345 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 298
+      ID: 299
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 297 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 298 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 300
+      ID: 301
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 299 GoSliceDataType []string.array
+      Pointee: 300 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 161
+      ID: 162
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 159 GoSliceHeaderType []uint
+      Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 294
+      ID: 295
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType []uint.array
+      Pointee: 294 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 303 GoSliceDataType []uint16.array
+      Pointee: 304 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 392928
+      GoRuntimeType: 392992
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 391840
+      GoRuntimeType: 391904
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 392800
+      GoRuntimeType: 392864
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 392864
+      GoRuntimeType: 392928
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 392480
+      GoRuntimeType: 392544
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 392096
+      GoRuntimeType: 392160
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 392224
+      GoRuntimeType: 392288
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 29
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 392352
+      GoRuntimeType: 392416
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 391968
+      GoRuntimeType: 392032
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
       ID: 88
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 393056
+      GoRuntimeType: 393120
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 189
+      ID: 190
       Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 385760
+      GoKind: 22
+      Pointee: 191 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 341
+      Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385696
       GoKind: 22
-      Pointee: 190 StructureType main.deepMap2
-    - __kind: PointerType
-      ID: 340
-      Name: '*main.deepMap3'
-      ByteSize: 8
-      GoRuntimeType: 385632
-      GoKind: 22
-      Pointee: 341 UnresolvedPointeeType main.deepMap3
+      Pointee: 342 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 385376
+      GoRuntimeType: 385440
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 376
+      ID: 377
       Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 385376
+      GoKind: 22
+      Pointee: 378 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 392
+      Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385312
       GoKind: 22
-      Pointee: 377 StructureType main.deepMap8
-    - __kind: PointerType
-      ID: 391
-      Name: '*main.deepMap9'
-      ByteSize: 8
-      GoRuntimeType: 385248
-      GoKind: 22
-      Pointee: 392 StructureType main.deepMap9
+      Pointee: 393 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 386272
+      GoRuntimeType: 386336
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 305
+      ID: 306
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 386208
+      GoRuntimeType: 386272
       GoKind: 22
-      Pointee: 306 UnresolvedPointeeType main.deepPtr3
+      Pointee: 307 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 385952
+      GoRuntimeType: 386016
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 346
+      ID: 347
       Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 385952
+      GoKind: 22
+      Pointee: 348 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 349
+      Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 385888
       GoKind: 22
-      Pointee: 347 StructureType main.deepPtr8
-    - __kind: PointerType
-      ID: 348
-      Name: '*main.deepPtr9'
-      ByteSize: 8
-      GoRuntimeType: 385824
-      GoKind: 22
-      Pointee: 349 StructureType main.deepPtr9
+      Pointee: 350 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 386848
+      GoRuntimeType: 386912
       GoKind: 22
-      Pointee: 180 StructureType main.deepSlice2
+      Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 325
+      ID: 326
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 386784
+      GoRuntimeType: 386848
       GoKind: 22
-      Pointee: 326 UnresolvedPointeeType main.deepSlice3
+      Pointee: 327 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 386528
+      GoRuntimeType: 386592
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 352
+      ID: 353
       Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 386528
+      GoKind: 22
+      Pointee: 354 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 359
+      Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 353 StructureType main.deepSlice8
+      Pointee: 360 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 358
-      Name: '*main.deepSlice9'
-      ByteSize: 8
-      GoRuntimeType: 386400
-      GoKind: 22
-      Pointee: 359 StructureType main.deepSlice9
-    - __kind: PointerType
-      ID: 175
+      ID: 176
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 174 StructureType main.emptyStruct
+      Pointee: 175 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 386976
+      GoRuntimeType: 387040
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 156
+      ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 387040
+      GoRuntimeType: 387104
       GoKind: 22
-      Pointee: 155 StructureType main.node
+      Pointee: 156 StructureType main.node
     - __kind: PointerType
-      ID: 170
+      ID: 171
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 StructureType main.oneStringStruct
+      Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -3774,371 +3807,371 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 308
+      ID: 309
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType main.stringType1.str
+      Pointee: 308 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 309 UnresolvedPointeeType main.stringType2
+      Pointee: 310 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 241
+      ID: 242
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 385184
+      GoRuntimeType: 385248
       GoKind: 22
-      Pointee: 89 StructureType main.structWithMap
+      Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 163
+      ID: 164
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 164 StructureType main.structWithNoStrings
+      Pointee: 165 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 153
+      ID: 154
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 154 StructureType main.structWithTwoValues
+      Pointee: 155 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 157
+      ID: 158
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 158 GoSliceHeaderType main.t
+      Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 322
+      ID: 323
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 321 GoSliceDataType main.t.array
+      Pointee: 322 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 169
+      ID: 170
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 168 StructureType main.threeStringStruct
+      Pointee: 169 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 148
+      ID: 149
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 149 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 143
+      ID: 144
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 144 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 111
+      ID: 112
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 112 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 123
+      ID: 124
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 330
+      ID: 331
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 366
+      ID: 367
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 381
+      ID: 382
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 91
+      ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 92 GoSwissMapHeaderType map<int,int>
+      Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 396
+      ID: 397
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 397 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
-      ID: 128
+      ID: 129
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 129 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 106
+      ID: 107
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 107 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 101
+      ID: 102
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 102 GoSwissMapHeaderType map<string,int>
+      Pointee: 103 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 96
+      ID: 97
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 138
+      ID: 139
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 139 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 133
+      ID: 134
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 134 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 116
+      ID: 117
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 GoMapType map[string]int
+      Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 287
+      ID: 288
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 288 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 279
+      ID: 280
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 280 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 227
+      ID: 228
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 228 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 246
+      ID: 247
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 247 StructureType noalg.map.group[bool]main.node
+      Pointee: 248 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 185
+      ID: 186
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 336
+      ID: 337
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 337 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 372
+      ID: 373
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 387
+      ID: 388
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 388 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 195
+      ID: 196
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[int]int
+      Pointee: 197 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 402
+      ID: 403
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 403 StructureType noalg.map.group[int]interface {}
+      Pointee: 404 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 254
+      ID: 255
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 255 StructureType noalg.map.group[int]uint8
+      Pointee: 256 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 236
+      ID: 237
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 237 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 219
+      ID: 220
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 220 StructureType noalg.map.group[string][]string
+      Pointee: 221 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 211
+      ID: 212
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 212 StructureType noalg.map.group[string]int
+      Pointee: 213 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 203
+      ID: 204
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 270
+      ID: 271
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 271 StructureType noalg.map.group[uint8][4]int
+      Pointee: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 262
+      ID: 263
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 263 StructureType noalg.map.group[uint8]uint8
+      Pointee: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 391904
+      GoRuntimeType: 391968
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 177
+      ID: 178
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 176 GoStringDataType string.str
+      Pointee: 177 GoStringDataType string.str
     - __kind: PointerType
-      ID: 151
+      ID: 152
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 285 StructureType table<[4]int,[4]int>
+      Pointee: 286 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 146
+      ID: 147
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 277 StructureType table<[4]int,uint8>
+      Pointee: 278 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 114
+      ID: 115
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 225 StructureType table<[4]string,[2]int>
+      Pointee: 226 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 126
+      ID: 127
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 244 StructureType table<bool,main.node>
+      Pointee: 245 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 183 StructureType table<int,*main.deepMap2>
+      Pointee: 184 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 333
+      ID: 334
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 334 StructureType table<int,*main.deepMap3>
+      Pointee: 335 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 369
+      ID: 370
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 370 StructureType table<int,*main.deepMap8>
+      Pointee: 371 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 384
+      ID: 385
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 385 StructureType table<int,*main.deepMap9>
+      Pointee: 386 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 94
+      ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 193 StructureType table<int,int>
+      Pointee: 194 StructureType table<int,int>
     - __kind: PointerType
-      ID: 399
+      ID: 400
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 400 StructureType table<int,interface {}>
+      Pointee: 401 StructureType table<int,interface {}>
     - __kind: PointerType
-      ID: 131
+      ID: 132
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 252 StructureType table<int,uint8>
+      Pointee: 253 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 122
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 234 StructureType table<string,[]main.structWithMap>
+      Pointee: 235 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 109
+      ID: 110
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 217 StructureType table<string,[]string>
+      Pointee: 218 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 104
+      ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 209 StructureType table<string,int>
+      Pointee: 210 StructureType table<string,int>
     - __kind: PointerType
-      ID: 99
+      ID: 100
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 201 StructureType table<string,main.nestedStruct>
+      Pointee: 202 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 141
+      ID: 142
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 268 StructureType table<uint8,[4]int>
+      Pointee: 269 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 136
+      ID: 137
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 260 StructureType table<uint8,uint8>
+      Pointee: 261 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 392544
+      GoRuntimeType: 392608
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 392160
+      GoRuntimeType: 392224
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 392288
+      GoRuntimeType: 392352
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 392416
+      GoRuntimeType: 392480
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 392032
+      GoRuntimeType: 392096
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 392608
+      GoRuntimeType: 392672
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 504
+      ID: 506
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 462
+      ID: 463
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4153,7 +4186,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 460
+      ID: 461
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4168,7 +4201,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 424
+      ID: 425
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4183,7 +4216,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 422
+      ID: 423
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4198,7 +4231,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 469
+      ID: 471
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4206,14 +4239,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 ArrayType [2]map[string]int
+            Type: 116 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 423
+      ID: 424
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4228,7 +4261,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 442
+      ID: 443
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4243,7 +4276,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 411
+      ID: 412
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4258,7 +4291,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 408
+      ID: 409
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4273,7 +4306,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 485
+      ID: 487
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4281,14 +4314,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 152 GoChannelType chan bool
+            Type: 153 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: c}
+                  Variable: {subprogram: 79, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 483
+      ID: 485
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4299,7 +4332,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: w}
+                  Variable: {subprogram: 77, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4308,7 +4341,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: x}
+                  Variable: {subprogram: 77, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4317,11 +4350,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: y}
+                  Variable: {subprogram: 77, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 493
+      ID: 495
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4329,14 +4362,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 157 PointerType *main.t
+            Type: 158 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: t}
+                  Variable: {subprogram: 87, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 447
+      ID: 448
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4351,7 +4384,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 448
+      ID: 449
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4366,7 +4399,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 443
+      ID: 444
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4381,7 +4414,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 444
+      ID: 445
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4396,7 +4429,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 445
+      ID: 446
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4411,7 +4444,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 446
+      ID: 447
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4426,7 +4459,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4434,10 +4467,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4446,11 +4479,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 495
+      ID: 497
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4458,14 +4491,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 512
+      ID: 514
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4476,11 +4509,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 515
+      ID: 517
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4488,14 +4521,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 PointerType *main.emptyStruct
+            Type: 176 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 109, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 514
+      ID: 516
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4503,14 +4536,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 174 StructureType main.emptyStruct
+            Type: 175 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 461
+      ID: 462
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4525,7 +4558,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 452
+      ID: 453
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4540,7 +4573,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 451
+      ID: 452
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4555,7 +4588,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 458
+      ID: 459
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4570,7 +4603,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 457
+      ID: 458
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4585,7 +4618,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 453
+      ID: 454
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4600,7 +4633,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 455
+      ID: 456
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4615,10 +4648,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 517
+      ID: 519
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 454
+      ID: 455
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4642,16 +4675,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 518
+      ID: 520
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 519
+      ID: 521
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 456
+      ID: 457
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 516
+      ID: 518
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4662,11 +4695,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 522
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4677,11 +4710,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: x}
+                  Variable: {subprogram: 114, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 521
+      ID: 523
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4692,11 +4725,11 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: a}
+                  Variable: {subprogram: 115, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 414
+      ID: 415
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4711,7 +4744,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 415
+      ID: 416
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4726,7 +4759,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 416
+      ID: 417
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4741,7 +4774,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 413
+      ID: 414
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4756,7 +4789,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 412
+      ID: 413
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4771,7 +4804,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 459
+      ID: 460
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4786,7 +4819,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 487
+      ID: 489
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4794,14 +4827,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 StructureType main.node
+            Type: 156 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 467
+      ID: 469
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4809,14 +4842,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[[4]string][2]int
+            Type: 111 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 475
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4824,14 +4857,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 117 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 471
+      ID: 473
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4839,14 +4872,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 90 GoMapType map[int]int
+            Type: 91 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 482
+      ID: 484
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4854,14 +4887,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 147 GoMapType map[[4]int][4]int
+            Type: 148 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 483
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4869,14 +4902,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 142 GoMapType map[[4]int]uint8
+            Type: 143 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 474
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4884,14 +4917,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 117 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 482
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4899,14 +4932,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[uint8][4]int
+            Type: 138 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 481
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4914,14 +4947,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 465
+      ID: 467
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4929,14 +4962,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 466
+      ID: 468
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4944,14 +4977,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[string][]string
+            Type: 106 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 466
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4959,14 +4992,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 95 GoMapType map[string]main.nestedStruct
+            Type: 96 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 476
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4974,14 +5007,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[bool]main.node
+            Type: 123 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 480
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4989,14 +5022,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 479
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5004,14 +5037,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 132 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 478
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5019,14 +5052,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 477
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5034,14 +5067,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 510
+      ID: 512
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5052,11 +5085,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 484
+      ID: 486
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5067,7 +5100,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -5076,7 +5109,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: b}
+                  Variable: {subprogram: 78, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -5085,7 +5118,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: c}
+                  Variable: {subprogram: 78, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -5094,7 +5127,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 3, name: d}
+                  Variable: {subprogram: 78, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -5103,11 +5136,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 4, name: e}
+                  Variable: {subprogram: 78, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 492
+      ID: 494
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5118,7 +5151,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -5127,11 +5160,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: a}
+                  Variable: {subprogram: 86, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5139,10 +5172,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5151,11 +5184,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5166,16 +5199,16 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: a}
+                  Variable: {subprogram: 95, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 166 GoSliceHeaderType []bool
+            Type: 167 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: s}
+                  Variable: {subprogram: 95, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5184,11 +5217,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 2, name: x}
+                  Variable: {subprogram: 95, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 502
+      ID: 504
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5196,14 +5229,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 167 GoSliceHeaderType []uint16
+            Type: 168 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 509
+      ID: 511
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5211,14 +5244,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.oneStringStruct
+            Type: 171 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: a}
+                  Variable: {subprogram: 103, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 488
+      ID: 490
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5226,14 +5259,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.node
+            Type: 157 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 470
+      ID: 472
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5241,14 +5274,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 PointerType *map[string]int
+            Type: 117 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 486
+      ID: 488
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5256,14 +5289,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 153 PointerType *main.structWithTwoValues
+            Type: 154 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 409
+      ID: 410
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5278,7 +5311,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 428
+      ID: 429
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5293,7 +5326,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 426
+      ID: 427
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5308,7 +5341,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 439
+      ID: 440
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5323,7 +5356,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 440
+      ID: 441
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5338,7 +5371,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 431
+      ID: 432
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5353,7 +5386,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 432
+      ID: 433
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5368,7 +5401,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 433
+      ID: 434
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5383,7 +5416,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 430
+      ID: 431
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5398,7 +5431,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 429
+      ID: 430
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5413,7 +5446,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 427
+      ID: 428
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5428,7 +5461,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 505
+      ID: 507
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5439,11 +5472,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 436
+      ID: 437
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5458,7 +5491,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 437
+      ID: 438
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5473,7 +5506,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 438
+      ID: 439
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5488,7 +5521,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 435
+      ID: 436
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5503,7 +5536,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 434
+      ID: 435
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5518,7 +5551,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5526,14 +5559,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType [][]uint
+            Type: 161 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: u}
+                  Variable: {subprogram: 90, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 468
+      ID: 470
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5541,14 +5574,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 410
+      ID: 411
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5563,7 +5596,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 491
+      ID: 493
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5574,11 +5607,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 502
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5586,14 +5619,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 165 GoSliceHeaderType []string
+            Type: 166 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: s}
+                  Variable: {subprogram: 94, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 449
+      ID: 450
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5608,7 +5641,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 450
+      ID: 451
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5623,7 +5656,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 499
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5631,10 +5664,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5643,11 +5676,26 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 463
+      ID: 464
+      Name: Probe[main.testStructWithAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 89 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 465
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5655,14 +5703,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 89 StructureType main.structWithMap
+            Type: 90 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 513
+      ID: 515
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5670,14 +5718,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 172 StructureType main.aStruct
+            Type: 173 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 508
+      ID: 510
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5685,14 +5733,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.threeStringStruct
+            Type: 170 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 507
+      ID: 509
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5700,14 +5748,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 StructureType main.threeStringStruct
+            Type: 169 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 506
+      ID: 508
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5718,7 +5766,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5727,7 +5775,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: y}
+                  Variable: {subprogram: 100, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5736,11 +5784,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: z}
+                  Variable: {subprogram: 100, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 441
+      ID: 442
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5755,7 +5803,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 419
+      ID: 420
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5770,7 +5818,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 420
+      ID: 421
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5785,7 +5833,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 421
+      ID: 422
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5800,7 +5848,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 418
+      ID: 419
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5815,7 +5863,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 417
+      ID: 418
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5830,7 +5878,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 490
+      ID: 492
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5841,11 +5889,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 494
+      ID: 496
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5853,14 +5901,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 513
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5871,11 +5919,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 491
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5886,11 +5934,11 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 425
+      ID: 426
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5905,7 +5953,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 503
+      ID: 505
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5913,10 +5961,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: xs}
+                  Variable: {subprogram: 97, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5955,7 +6003,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 682784
+      GoRuntimeType: 682848
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5972,7 +6020,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 684128
+      GoRuntimeType: 684192
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5994,18 +6042,18 @@ Types:
       HasCount: true
       Element: 17 BaseType int8
     - __kind: ArrayType
-      ID: 115
+      ID: 116
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 100 GoMapType map[string]int
+      Element: 101 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 684224
+      GoRuntimeType: 684288
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6038,7 +6086,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 684320
+      GoRuntimeType: 684384
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6047,25 +6095,25 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 684032
+      GoRuntimeType: 684096
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 274
+      ID: 275
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 682400
+      GoRuntimeType: 682464
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 231
+      ID: 232
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 682688
+      GoRuntimeType: 682752
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6082,7 +6130,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 477472
+      GoRuntimeType: 477536
       GoKind: 23
       RawFields:
         - Name: array
@@ -6094,83 +6142,83 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 181 GoSliceDataType []*main.deepSlice2.array
+      Data: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 182
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 323
+      ID: 324
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 477408
+      GoRuntimeType: 477472
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 324 PointerType **main.deepSlice3
+          Type: 325 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 327 GoSliceDataType []*main.deepSlice3.array
+      Data: 328 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 327
+      ID: 328
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 325 PointerType *main.deepSlice3
+      Element: 326 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 350
+      ID: 351
       Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 477152
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 352 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 355 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 355
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 353 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 357
+      Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477088
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 351 PointerType **main.deepSlice8
+          Type: 358 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 354 GoSliceDataType []*main.deepSlice8.array
+      Data: 361 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 354
-      Name: '[]*main.deepSlice8.array'
-      ByteSize: 2048
-      Element: 352 PointerType *main.deepSlice8
-    - __kind: GoSliceHeaderType
-      ID: 356
-      Name: '[]*main.deepSlice9'
-      ByteSize: 24
-      GoRuntimeType: 477024
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 357 PointerType **main.deepSlice9
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 360 GoSliceDataType []*main.deepSlice9.array
-    - __kind: GoSliceDataType
-      ID: 360
+      ID: 361
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 358 PointerType *main.deepSlice9
+      Element: 359 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 478496
+      GoRuntimeType: 478560
       GoKind: 23
       RawFields:
         - Name: array
@@ -6182,123 +6230,123 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 178 GoSliceDataType []*string.array
+      Data: 179 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 179
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 292
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 151 PointerType *table<[4]int,[4]int>
+      Element: 152 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 146 PointerType *table<[4]int,uint8>
+      Element: 147 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 233
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 114 PointerType *table<[4]string,[2]int>
+      Element: 115 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<bool,main.node>
+      Element: 127 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 342
+      ID: 343
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 333 PointerType *table<int,*main.deepMap3>
+      Element: 334 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 378
+      ID: 379
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 369 PointerType *table<int,*main.deepMap8>
+      Element: 370 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 393
+      ID: 394
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 384 PointerType *table<int,*main.deepMap9>
+      Element: 385 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 94 PointerType *table<int,int>
+      Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 407
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 399 PointerType *table<int,interface {}>
+      Element: 400 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 259
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 131 PointerType *table<int,uint8>
+      Element: 132 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 243
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 121 PointerType *table<string,[]main.structWithMap>
+      Element: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 109 PointerType *table<string,[]string>
+      Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 104 PointerType *table<string,int>
+      Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 208
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 99 PointerType *table<string,main.nestedStruct>
+      Element: 100 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 276
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 141 PointerType *table<uint8,[4]int>
+      Element: 142 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 267
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 136 PointerType *table<uint8,uint8>
+      Element: 137 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 161
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType *[]uint
+          Type: 162 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 295 GoSliceDataType [][]uint.array
+      Data: 296 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 296
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 159 GoSliceHeaderType []uint
+      Element: 160 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 486816
+      GoRuntimeType: 486880
       GoKind: 23
       RawFields:
         - Name: array
@@ -6310,17 +6358,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 301 GoSliceDataType []bool.array
+      Data: 302 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 301
+      ID: 302
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 362
+      ID: 363
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 487136
+      GoRuntimeType: 487200
       GoKind: 23
       RawFields:
         - Name: array
@@ -6332,145 +6380,145 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 363 GoSliceDataType []interface {}.array
+      Data: 364 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 363
+      ID: 364
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 240
+      ID: 241
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 477728
+      GoRuntimeType: 477792
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 241 PointerType *main.structWithMap
+          Type: 242 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 344 GoSliceDataType []main.structWithMap.array
+      Data: 345 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 345
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 89 StructureType main.structWithMap
+      Element: 90 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 163
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *main.structWithNoStrings
+          Type: 164 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 297 GoSliceDataType []main.structWithNoStrings.array
+      Data: 298 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 297
+      ID: 298
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 164 StructureType main.structWithNoStrings
+      Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 293
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 288 StructureType noalg.map.group[[4]int][4]int
+      Element: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 285
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 280 StructureType noalg.map.group[[4]int]uint8
+      Element: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 234
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 228 StructureType noalg.map.group[[4]string][2]int
+      Element: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 252
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 247 StructureType noalg.map.group[bool]main.node
+      Element: 248 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 193
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 186 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 344
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 337 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 379
+      ID: 380
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 373 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 395
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 388 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 201
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 196 StructureType noalg.map.group[int]int
+      Element: 197 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 408
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 403 StructureType noalg.map.group[int]interface {}
+      Element: 404 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 260
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 255 StructureType noalg.map.group[int]uint8
+      Element: 256 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 244
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 237 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 225
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 220 StructureType noalg.map.group[string][]string
+      Element: 221 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 217
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 212 StructureType noalg.map.group[string]int
+      Element: 213 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 209
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 204 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 277
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 271 StructureType noalg.map.group[uint8][4]int
+      Element: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 268
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 263 StructureType noalg.map.group[uint8]uint8
+      Element: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 486944
+      GoRuntimeType: 487008
       GoKind: 23
       RawFields:
         - Name: array
@@ -6482,17 +6530,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 299 GoSliceDataType []string.array
+      Data: 300 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 299
+      ID: 300
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 486432
+      GoRuntimeType: 486496
       GoKind: 23
       RawFields:
         - Name: array
@@ -6504,17 +6552,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType []uint.array
+      Data: 294 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 294
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 485792
+      GoRuntimeType: 485856
       GoKind: 23
       RawFields:
         - Name: array
@@ -6526,9 +6574,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 303 GoSliceDataType []uint16.array
+      Data: 304 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 303
+      ID: 304
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -6536,35 +6584,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 584704
+      GoRuntimeType: 584768
       GoKind: 1
     - __kind: GoChannelType
-      ID: 152
+      ID: 153
       Name: chan bool
-      GoRuntimeType: 596032
+      GoRuntimeType: 596096
       GoKind: 18
     - __kind: GoChannelType
       ID: 80
       Name: chan struct {}
-      GoRuntimeType: 594944
+      GoRuntimeType: 595008
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 584512
+      GoRuntimeType: 584576
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 584448
+      GoRuntimeType: 584512
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.025984e+06
+      GoRuntimeType: 1.026048e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6577,293 +6625,293 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 584576
+      GoRuntimeType: 584640
       GoKind: 13
     - __kind: BaseType
       ID: 16
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 584640
+      GoRuntimeType: 584704
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 475616
+      GoRuntimeType: 475680
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 286
+      ID: 287
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 287 PointerType *noalg.map.group[[4]int][4]int
+          Type: 288 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 292 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 293 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 278
+      ID: 279
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 279 PointerType *noalg.map.group[[4]int]uint8
+          Type: 280 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 284 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 285 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 226
+      ID: 227
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 227 PointerType *noalg.map.group[[4]string][2]int
+          Type: 228 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 233 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 245
+      ID: 246
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 246 PointerType *noalg.map.group[bool]main.node
+          Type: 247 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 247 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 248 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 252 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 184
+      ID: 185
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 185 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 186 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 335
+      ID: 336
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 336 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 337 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 344 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 372
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 373 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 380 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 386
+      ID: 387
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 387 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 388 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 394 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 395 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 195
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[int]int
+          Type: 196 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[int]int
-      GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 197 StructureType noalg.map.group[int]int
+      GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 401
+      ID: 402
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 402 PointerType *noalg.map.group[int]interface {}
+          Type: 403 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 403 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 404 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 408 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 253
+      ID: 254
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 254 PointerType *noalg.map.group[int]uint8
+          Type: 255 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 255 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 256 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 260 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 235
+      ID: 236
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 236 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 237 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 218
+      ID: 219
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 219 PointerType *noalg.map.group[string][]string
+          Type: 220 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 220 StructureType noalg.map.group[string][]string
-      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 221 StructureType noalg.map.group[string][]string
+      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 210
+      ID: 211
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 211 PointerType *noalg.map.group[string]int
+          Type: 212 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 212 StructureType noalg.map.group[string]int
-      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 213 StructureType noalg.map.group[string]int
+      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 203
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 204 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 269
+      ID: 270
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 270 PointerType *noalg.map.group[uint8][4]int
+          Type: 271 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 271 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 276 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 272 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 277 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 261
+      ID: 262
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 262 PointerType *noalg.map.group[uint8]uint8
+          Type: 263 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 263 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 264 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 584256
+      GoRuntimeType: 584320
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 583872
+      GoRuntimeType: 583936
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 584000
+      GoRuntimeType: 584064
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 584128
+      GoRuntimeType: 584192
       GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 583744
+      GoRuntimeType: 583808
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 847232
+      GoRuntimeType: 847296
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6873,10 +6921,10 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 312
+      ID: 313
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.472192e+06
+      GoRuntimeType: 1.472384e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6889,7 +6937,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.022016e+06
+      GoRuntimeType: 1.02208e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6899,7 +6947,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6915,12 +6963,12 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 173 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.021632e+06
+      GoRuntimeType: 1.021696e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6948,61 +6996,61 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.185088e+06
+      GoRuntimeType: 1.18528e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 190
+      ID: 191
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.18496e+06
+      GoRuntimeType: 1.185152e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 329 GoMapType map[int]*main.deepMap3
+          Type: 330 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 342
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
       ID: 74
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.18432e+06
+      GoRuntimeType: 1.184512e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 365 GoMapType map[int]*main.deepMap8
+          Type: 366 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 377
+      ID: 378
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.184192e+06
+      GoRuntimeType: 1.184384e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 380 GoMapType map[int]*main.deepMap9
+          Type: 381 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 392
+      ID: 393
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.184064e+06
+      GoRuntimeType: 1.184256e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 395 GoMapType map[int]interface {}
+          Type: 396 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.18624e+06
+      GoRuntimeType: 1.186432e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7012,41 +7060,41 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.186112e+06
+      GoRuntimeType: 1.186304e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 305 PointerType *main.deepPtr3
+          Type: 306 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 306
+      ID: 307
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.185472e+06
+      GoRuntimeType: 1.185664e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 346 PointerType *main.deepPtr8
+          Type: 347 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 347
+      ID: 348
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.185344e+06
+      GoRuntimeType: 1.185536e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 348 PointerType *main.deepPtr9
+          Type: 349 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 349
+      ID: 350
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.185216e+06
+      GoRuntimeType: 1.185408e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7056,58 +7104,58 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.187392e+06
+      GoRuntimeType: 1.187584e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 180
+      ID: 181
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.187264e+06
+      GoRuntimeType: 1.187456e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 323 GoSliceHeaderType []*main.deepSlice3
+          Type: 324 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 326
+      ID: 327
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.186624e+06
+      GoRuntimeType: 1.186816e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 350 GoSliceHeaderType []*main.deepSlice8
+          Type: 351 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 353
+      ID: 354
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.186496e+06
+      GoRuntimeType: 1.186688e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 356 GoSliceHeaderType []*main.deepSlice9
+          Type: 357 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 359
+      ID: 360
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.186368e+06
+      GoRuntimeType: 1.18656e+06
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 362 GoSliceHeaderType []interface {}
+          Type: 363 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 174
+      ID: 175
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7115,7 +7163,7 @@ Types:
       ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.833312e+06
+      GoRuntimeType: 1.833504e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7123,21 +7171,21 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 310 StructureType sync.Mutex
+          Type: 311 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 313 StructureType sync.Once
+          Type: 314 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 316 StructureType sync.WaitGroup
+          Type: 317 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 319 StructureType sync/atomic.Int32
+          Type: 320 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.9664e+06
+      GoRuntimeType: 1.966592e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7162,10 +7210,10 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.460832e+06
+      GoRuntimeType: 1.461024e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7175,10 +7223,10 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 155
+      ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.460672e+06
+      GoRuntimeType: 1.460864e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7186,9 +7234,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 156 PointerType *main.node
+          Type: 157 PointerType *main.node
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7200,7 +7248,7 @@ Types:
       ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.02176e+06
+      GoRuntimeType: 1.021824e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7217,31 +7265,41 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *main.stringType1.str
+          Type: 309 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 307 GoStringDataType main.stringType1.str
+      Data: 308 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 308
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 309
+      ID: 310
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
       ID: 89
+      Name: main.structWithAny
+      ByteSize: 16
+      GoRuntimeType: 1.184e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.183936e+06
+      GoRuntimeType: 1.184128e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 90 GoMapType map[int]int
+          Type: 91 GoMapType map[int]int
     - __kind: StructureType
-      ID: 164
+      ID: 165
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7253,7 +7311,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 154
+      ID: 155
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7265,28 +7323,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 159
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 320 PointerType **main.t
+          Type: 321 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 321 GoSliceDataType main.t.array
+      Data: 322 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 321
+      ID: 322
       Name: main.t.array
       ByteSize: 2048
-      Element: 157 PointerType *main.t
+      Element: 158 PointerType *main.t
     - __kind: StructureType
-      ID: 168
+      ID: 169
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7306,7 +7364,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 149
+      ID: 150
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7319,7 +7377,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 150 PointerType **table<[4]int,[4]int>
+          Type: 151 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7338,10 +7396,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 291 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 292 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 144
+      ID: 145
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7354,7 +7412,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 145 PointerType **table<[4]int,uint8>
+          Type: 146 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7373,10 +7431,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 283 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 284 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 112
+      ID: 113
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -7389,7 +7447,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 113 PointerType **table<[4]string,[2]int>
+          Type: 114 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7408,10 +7466,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 232 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 233 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 125
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -7424,7 +7482,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<bool,main.node>
+          Type: 126 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7443,8 +7501,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 247 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 251 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 248 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -7478,10 +7536,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 331
+      ID: 332
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7494,7 +7552,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 332 PointerType **table<int,*main.deepMap3>
+          Type: 333 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7513,10 +7571,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 342 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 343 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 367
+      ID: 368
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7529,7 +7587,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 368 PointerType **table<int,*main.deepMap8>
+          Type: 369 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7548,10 +7606,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 379 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 382
+      ID: 383
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7564,7 +7622,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 383 PointerType **table<int,*main.deepMap9>
+          Type: 384 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7583,10 +7641,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 393 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 394 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
-      ID: 92
+      ID: 93
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -7599,7 +7657,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 93 PointerType **table<int,int>
+          Type: 94 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7618,10 +7676,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
-      GroupType: 196 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
+      GroupType: 197 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 397
+      ID: 398
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7634,7 +7692,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 398 PointerType **table<int,interface {}>
+          Type: 399 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7653,10 +7711,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 406 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 403 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 407 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 404 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 129
+      ID: 130
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7669,7 +7727,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 130 PointerType **table<int,uint8>
+          Type: 131 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7688,10 +7746,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 255 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 259 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 256 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 119
+      ID: 120
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -7704,7 +7762,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 120 PointerType **table<string,[]main.structWithMap>
+          Type: 121 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7723,10 +7781,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 107
+      ID: 108
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -7739,7 +7797,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 108 PointerType **table<string,[]string>
+          Type: 109 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7758,10 +7816,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 223 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 220 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 221 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 102
+      ID: 103
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -7774,7 +7832,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 103 PointerType **table<string,int>
+          Type: 104 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7793,10 +7851,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 215 GoSliceDataType []*table<string,int>.array
-      GroupType: 212 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 216 GoSliceDataType []*table<string,int>.array
+      GroupType: 213 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 97
+      ID: 98
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -7809,7 +7867,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 98 PointerType **table<string,main.nestedStruct>
+          Type: 99 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7828,10 +7886,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 207 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 208 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 139
+      ID: 140
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7844,7 +7902,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 140 PointerType **table<uint8,[4]int>
+          Type: 141 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7863,10 +7921,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 275 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 271 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 276 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 272 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 134
+      ID: 135
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7879,7 +7937,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 135 PointerType **table<uint8,uint8>
+          Type: 136 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7898,285 +7956,285 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 263 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 267 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 147
+      ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.128832e+06
+      GoRuntimeType: 1.128896e+06
       GoKind: 21
-      HeaderType: 149 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 142
+      ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.12896e+06
+      GoRuntimeType: 1.129024e+06
       GoKind: 21
-      HeaderType: 144 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 110
+      ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.129088e+06
+      GoRuntimeType: 1.129152e+06
       GoKind: 21
-      HeaderType: 112 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 122
+      ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.129216e+06
+      GoRuntimeType: 1.12928e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.128704e+06
+      GoRuntimeType: 1.128768e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 329
+      ID: 330
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.128576e+06
+      GoRuntimeType: 1.12864e+06
       GoKind: 21
-      HeaderType: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 365
+      ID: 366
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.127936e+06
+      GoRuntimeType: 1.128e+06
       GoKind: 21
-      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 380
+      ID: 381
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.127808e+06
+      GoRuntimeType: 1.127872e+06
       GoKind: 21
-      HeaderType: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 90
+      ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.127296e+06
+      GoRuntimeType: 1.12736e+06
       GoKind: 21
-      HeaderType: 92 GoSwissMapHeaderType map<int,int>
+      HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 395
+      ID: 396
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.12768e+06
+      GoRuntimeType: 1.127744e+06
       GoKind: 21
-      HeaderType: 397 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
-      ID: 127
+      ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.129344e+06
+      GoRuntimeType: 1.129408e+06
       GoKind: 21
-      HeaderType: 129 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 117
+      ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.129472e+06
+      GoRuntimeType: 1.129536e+06
       GoKind: 21
-      HeaderType: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 105
+      ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.1296e+06
+      GoRuntimeType: 1.129664e+06
       GoKind: 21
-      HeaderType: 107 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 100
+      ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.129728e+06
+      GoRuntimeType: 1.129792e+06
       GoKind: 21
-      HeaderType: 102 GoSwissMapHeaderType map<string,int>
+      HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 95
+      ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.129856e+06
+      GoRuntimeType: 1.12992e+06
       GoKind: 21
-      HeaderType: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 137
+      ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.129984e+06
+      GoRuntimeType: 1.130048e+06
       GoKind: 21
-      HeaderType: 139 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 132
+      ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.130112e+06
+      GoRuntimeType: 1.130176e+06
       GoKind: 21
-      HeaderType: 134 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 289
+      ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 682496
+      GoRuntimeType: 682560
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 290 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 291 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 281
+      ID: 282
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 682592
+      GoRuntimeType: 682656
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 282 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 283 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 229
+      ID: 230
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 682880
+      GoRuntimeType: 682944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 230 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 231 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 248
+      ID: 249
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 682976
+      GoRuntimeType: 683040
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 249 StructureType noalg.struct { key bool; elem main.node }
+      Element: 250 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 187
+      ID: 188
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 681824
+      GoRuntimeType: 681888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 338
+      ID: 339
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 681728
+      GoRuntimeType: 681792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 339 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 340 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 374
+      ID: 375
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 681248
+      GoRuntimeType: 681312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 376 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 389
+      ID: 390
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 681152
+      GoRuntimeType: 681216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 390 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 391 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 197
+      ID: 198
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 679904
+      GoRuntimeType: 679968
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key int; elem int }
+      Element: 199 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 404
+      ID: 405
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 681056
+      GoRuntimeType: 681120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 405 StructureType noalg.struct { key int; elem interface {} }
+      Element: 406 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 256
+      ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 683072
+      GoRuntimeType: 683136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 257 StructureType noalg.struct { key int; elem uint8 }
+      Element: 258 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 238
+      ID: 239
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 683168
+      GoRuntimeType: 683232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 239 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 240 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 221
+      ID: 222
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 683264
+      GoRuntimeType: 683328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem []string }
+      Element: 223 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 213
+      ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 683360
+      GoRuntimeType: 683424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 214 StructureType noalg.struct { key string; elem int }
+      Element: 215 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 205
+      ID: 206
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 683456
+      GoRuntimeType: 683520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 207 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 272
+      ID: 273
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 683552
+      GoRuntimeType: 683616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 273 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 274 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 264
+      ID: 265
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 683648
+      GoRuntimeType: 683712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 265 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 266 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 288
+      ID: 289
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.293952e+06
+      GoRuntimeType: 1.294144e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8184,12 +8242,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 289 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 290 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 280
+      ID: 281
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.294208e+06
+      GoRuntimeType: 1.2944e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8197,12 +8255,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 281 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 282 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 228
+      ID: 229
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.294464e+06
+      GoRuntimeType: 1.294656e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8210,12 +8268,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 229 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 230 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 247
+      ID: 248
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.29472e+06
+      GoRuntimeType: 1.294912e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8223,12 +8281,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 248 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 249 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 186
+      ID: 187
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.293696e+06
+      GoRuntimeType: 1.293888e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8236,12 +8294,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 337
+      ID: 338
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.29344e+06
+      GoRuntimeType: 1.293632e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8249,12 +8307,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 338 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 339 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 373
+      ID: 374
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.29216e+06
+      GoRuntimeType: 1.292352e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8262,12 +8320,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 375 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 388
+      ID: 389
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.291904e+06
+      GoRuntimeType: 1.292096e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8275,12 +8333,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 389 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 390 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 196
+      ID: 197
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.29088e+06
+      GoRuntimeType: 1.291072e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8288,12 +8346,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 198 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 403
+      ID: 404
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.291648e+06
+      GoRuntimeType: 1.29184e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8301,12 +8359,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 404 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 405 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 255
+      ID: 256
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.294976e+06
+      GoRuntimeType: 1.295168e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8314,12 +8372,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 256 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 257 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 237
+      ID: 238
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.295232e+06
+      GoRuntimeType: 1.295424e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8327,12 +8385,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 238 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 239 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 220
+      ID: 221
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.295488e+06
+      GoRuntimeType: 1.29568e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8340,12 +8398,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 212
+      ID: 213
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.295744e+06
+      GoRuntimeType: 1.295936e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8353,12 +8411,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 213 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 204
+      ID: 205
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.296e+06
+      GoRuntimeType: 1.296192e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8366,12 +8424,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 206 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 271
+      ID: 272
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.296256e+06
+      GoRuntimeType: 1.296448e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8379,12 +8437,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 272 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 273 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 263
+      ID: 264
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.296512e+06
+      GoRuntimeType: 1.296704e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8392,51 +8450,51 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 264 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 265 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 290
+      ID: 291
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.293824e+06
+      GoRuntimeType: 1.294016e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
     - __kind: StructureType
-      ID: 282
+      ID: 283
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.29408e+06
+      GoRuntimeType: 1.294272e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 230
+      ID: 231
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.294336e+06
+      GoRuntimeType: 1.294528e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 231 ArrayType [4]string
+          Type: 232 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 249
+      ID: 250
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.294592e+06
+      GoRuntimeType: 1.294784e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8444,12 +8502,12 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 155 StructureType main.node
+          Type: 156 StructureType main.node
     - __kind: StructureType
-      ID: 188
+      ID: 189
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.293568e+06
+      GoRuntimeType: 1.29376e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8457,12 +8515,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 189 PointerType *main.deepMap2
+          Type: 190 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 339
+      ID: 340
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.293312e+06
+      GoRuntimeType: 1.293504e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8470,12 +8528,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 340 PointerType *main.deepMap3
+          Type: 341 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 375
+      ID: 376
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.292032e+06
+      GoRuntimeType: 1.292224e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8483,12 +8541,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 376 PointerType *main.deepMap8
+          Type: 377 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 390
+      ID: 391
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.291776e+06
+      GoRuntimeType: 1.291968e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8496,12 +8554,12 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 391 PointerType *main.deepMap9
+          Type: 392 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 198
+      ID: 199
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.290752e+06
+      GoRuntimeType: 1.290944e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8511,10 +8569,10 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 405
+      ID: 406
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.29152e+06
+      GoRuntimeType: 1.291712e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8524,10 +8582,10 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 257
+      ID: 258
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.294848e+06
+      GoRuntimeType: 1.29504e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8537,10 +8595,10 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 239
+      ID: 240
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.295104e+06
+      GoRuntimeType: 1.295296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8548,12 +8606,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 240 GoSliceHeaderType []main.structWithMap
+          Type: 241 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 222
+      ID: 223
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.29536e+06
+      GoRuntimeType: 1.295552e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8561,12 +8619,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 165 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 214
+      ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.295616e+06
+      GoRuntimeType: 1.295808e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8576,10 +8634,10 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 206
+      ID: 207
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.295872e+06
+      GoRuntimeType: 1.296064e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8587,12 +8645,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 173 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 273
+      ID: 274
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.296128e+06
+      GoRuntimeType: 1.29632e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8600,12 +8658,12 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 274 ArrayType [4]int
+          Type: 275 ArrayType [4]int
     - __kind: StructureType
-      ID: 265
+      ID: 266
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.296384e+06
+      GoRuntimeType: 1.296576e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8618,127 +8676,127 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 583680
+      GoRuntimeType: 583744
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 177 PointerType *string.str
+          Type: 178 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 176 GoStringDataType string.str
+      Data: 177 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 176
+      ID: 177
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 310
+      ID: 311
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.462112e+06
+      GoRuntimeType: 1.462304e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 312 StructureType internal/sync.Mutex
+          Type: 313 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 313
+      ID: 314
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.611168e+06
+      GoRuntimeType: 1.61136e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 314 StructureType sync/atomic.Bool
+          Type: 315 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 310 StructureType sync.Mutex
+          Type: 311 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 316
+      ID: 317
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.610976e+06
+      GoRuntimeType: 1.611168e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 311 StructureType sync.noCopy
+          Type: 312 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 317 StructureType sync/atomic.Uint64
+          Type: 318 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 311
+      ID: 312
       Name: sync.noCopy
-      GoRuntimeType: 987424
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 314
-      Name: sync/atomic.Bool
-      ByteSize: 4
-      GoRuntimeType: 1.463232e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 2 BaseType uint32
-    - __kind: StructureType
-      ID: 319
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.463392e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 12 BaseType int32
-    - __kind: StructureType
-      ID: 317
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.611552e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 315 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 318 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 8 BaseType uint64
-    - __kind: StructureType
-      ID: 318
-      Name: sync/atomic.align64
-      GoRuntimeType: 987616
+      GoRuntimeType: 987488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 315
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 987520
+      Name: sync/atomic.Bool
+      ByteSize: 4
+      GoRuntimeType: 1.463424e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 2 BaseType uint32
+    - __kind: StructureType
+      ID: 320
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.463584e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 12 BaseType int32
+    - __kind: StructureType
+      ID: 318
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.611744e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 316 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 319 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 8 BaseType uint64
+    - __kind: StructureType
+      ID: 319
+      Name: sync/atomic.align64
+      GoRuntimeType: 987680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 285
+      ID: 316
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 987584
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 286
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -8760,9 +8818,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 286 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 287 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 277
+      ID: 278
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8784,9 +8842,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 278 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 279 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 225
+      ID: 226
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -8808,9 +8866,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 226 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 227 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 244
+      ID: 245
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -8832,9 +8890,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 245 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 246 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 183
+      ID: 184
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -8856,9 +8914,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 334
+      ID: 335
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8880,9 +8938,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 335 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 336 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 370
+      ID: 371
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8904,9 +8962,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 372 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 385
+      ID: 386
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8928,9 +8986,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 386 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 387 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 193
+      ID: 194
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -8952,9 +9010,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<int,int>
+          Type: 195 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 400
+      ID: 401
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8976,9 +9034,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 401 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 402 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 252
+      ID: 253
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9000,9 +9058,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 253 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 254 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 234
+      ID: 235
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -9024,9 +9082,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 235 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 236 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 217
+      ID: 218
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9048,9 +9106,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 218 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 209
+      ID: 210
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -9072,9 +9130,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 210 GoSwissMapGroupsType groupReference<string,int>
+          Type: 211 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 201
+      ID: 202
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -9096,9 +9154,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 203 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 268
+      ID: 269
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -9120,9 +9178,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 269 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 270 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 260
+      ID: 261
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9144,49 +9202,49 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 261 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 584320
+      GoRuntimeType: 584384
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 583936
+      GoRuntimeType: 584000
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 584064
+      GoRuntimeType: 584128
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 584192
+      GoRuntimeType: 584256
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 583808
+      GoRuntimeType: 583872
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 584384
+      GoRuntimeType: 584448
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 584768
+      GoRuntimeType: 584832
       GoKind: 26
-MaxTypeID: 521
+MaxTypeID: 523
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 506 EventRootType Probe[main.stackC]
+          Type: 1185 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x809fac", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 461 EventRootType Probe[main.testAny]
+          Type: 1140 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807a0c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 463 EventRootType Probe[main.testAnyPtr]
+          Type: 1142 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807a7c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 423 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1102 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 425 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1104 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 471 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1150 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x808060", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 424 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1103 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 443 EventRootType Probe[main.testBigStruct]
+          Type: 1122 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 412 EventRootType Probe[main.testBoolArray]
+          Type: 1091 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 409 EventRootType Probe[main.testByteArray]
+          Type: 1088 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806280", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 487 EventRootType Probe[main.testChannel]
+          Type: 1166 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x809650", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 485 EventRootType Probe[main.testCombinedByte]
+          Type: 1164 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x8093d0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 495 EventRootType Probe[main.testCycle]
+          Type: 1174 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x8098d0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 448 EventRootType Probe[main.testDeepMap1]
+          Type: 1127 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c70", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 449 EventRootType Probe[main.testDeepMap7]
+          Type: 1128 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806c80", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 444 EventRootType Probe[main.testDeepPtr1]
+          Type: 1123 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x806990", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 445 EventRootType Probe[main.testDeepPtr7]
+          Type: 1124 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069a0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 446 EventRootType Probe[main.testDeepSlice1]
+          Type: 1125 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b10", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 447 EventRootType Probe[main.testDeepSlice7]
+          Type: 1126 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b20", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 497 EventRootType Probe[main.testEmptySlice]
+          Type: 1176 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x809c80", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 500 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1179 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 514 EventRootType Probe[main.testEmptyString]
+          Type: 1193 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80a070", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -337,7 +337,7 @@ Probes:
       subprogram: {subprogram: 108}
       events:
         - ID: 108
-          Type: 516 EventRootType Probe[main.testEmptyStruct]
+          Type: 1195 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80a310", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -350,7 +350,7 @@ Probes:
       subprogram: {subprogram: 109}
       events:
         - ID: 109
-          Type: 517 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1196 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80a320", Frameless: true}]
           Condition: null
     - id: testError
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 462 EventRootType Probe[main.testError]
+          Type: 1141 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807a60", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 453 EventRootType Probe[main.testEsotericHeap]
+          Type: 1132 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8070ac", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 452 EventRootType Probe[main.testEsotericStack]
+          Type: 1131 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x806fec", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 458 EventRootType Probe[main.testFrameless]
+          Type: 1137 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807780", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 459 EventRootType Probe[main.testFramelessArray]
+          Type: 1138 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x807790", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 454 EventRootType Probe[main.testInlinedBA]
+          Type: 1133 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8074bc", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 455 EventRootType Probe[main.testInlinedBB]
+          Type: 1134 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x80754c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 456 EventRootType Probe[main.testInlinedBBA]
+          Type: 1135 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x80760c", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -476,7 +476,7 @@ Probes:
       subprogram: {subprogram: 111}
       events:
         - ID: 111
-          Type: 519 EventRootType Probe[main.testInlinedBBB]
+          Type: 1198 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8075a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 457 EventRootType Probe[main.testInlinedBC]
+          Type: 1136 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x80767c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -504,7 +504,7 @@ Probes:
       subprogram: {subprogram: 112}
       events:
         - ID: 112
-          Type: 520 EventRootType Probe[main.testInlinedBCA]
+          Type: 1199 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80768c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -518,7 +518,7 @@ Probes:
       subprogram: {subprogram: 113}
       events:
         - ID: 113
-          Type: 521 EventRootType Probe[main.testInlinedBCB]
+          Type: 1200 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807730", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 110}
       events:
         - ID: 110
-          Type: 518 EventRootType Probe[main.testInlinedPrint]
+          Type: 1197 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x80732c"
               Frameless: true
@@ -557,7 +557,7 @@ Probes:
       subprogram: {subprogram: 114}
       events:
         - ID: 114
-          Type: 522 EventRootType Probe[main.testInlinedSq]
+          Type: 1201 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807784", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -572,7 +572,7 @@ Probes:
       subprogram: {subprogram: 115}
       events:
         - ID: 115
-          Type: 523 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1202 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8077b4"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 415 EventRootType Probe[main.testInt16Array]
+          Type: 1094 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 416 EventRootType Probe[main.testInt32Array]
+          Type: 1095 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 417 EventRootType Probe[main.testInt64Array]
+          Type: 1096 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 414 EventRootType Probe[main.testInt8Array]
+          Type: 1093 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 413 EventRootType Probe[main.testIntArray]
+          Type: 1092 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 460 EventRootType Probe[main.testInterface]
+          Type: 1139 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x8079f0", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 489 EventRootType Probe[main.testLinkedList]
+          Type: 1168 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x8097e0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 469 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1148 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x808040", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 475 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1154 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x8080a0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 473 EventRootType Probe[main.testMapIntToInt]
+          Type: 1152 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x808080", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 484 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1163 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x808130", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 483 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1162 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x808120", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 474 EventRootType Probe[main.testMapMassive]
+          Type: 1153 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x808090", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 482 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1161 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x808110", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 481 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1160 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x808100", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 467 EventRootType Probe[main.testMapStringToInt]
+          Type: 1146 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x808020", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 468 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1147 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x808030", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 466 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1145 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x808010", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 476 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1155 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x8080b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 479 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1158 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x8080e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 480 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1159 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x8080f0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 477 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1156 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x8080c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 478 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1157 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x8080d0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 512 EventRootType Probe[main.testMassiveString]
+          Type: 1191 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80a050", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 486 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1165 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x8094b0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 494 EventRootType Probe[main.testNilPointer]
+          Type: 1173 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x8098b0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 504 EventRootType Probe[main.testNilSlice]
+          Type: 1183 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x809cf0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 501 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1180 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 503 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1182 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x809ce0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 511 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1190 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80a040", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 490 EventRootType Probe[main.testPointerLoop]
+          Type: 1169 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x8097f0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 472 EventRootType Probe[main.testPointerToMap]
+          Type: 1151 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x808070", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 488 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1167 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x8097d0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 410 EventRootType Probe[main.testRuneArray]
+          Type: 1089 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 429 EventRootType Probe[main.testSingleBool]
+          Type: 1108 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 427 EventRootType Probe[main.testSingleByte]
+          Type: 1106 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x8066e0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 440 EventRootType Probe[main.testSingleFloat32]
+          Type: 1119 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 441 EventRootType Probe[main.testSingleFloat64]
+          Type: 1120 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 430 EventRootType Probe[main.testSingleInt]
+          Type: 1109 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 432 EventRootType Probe[main.testSingleInt16]
+          Type: 1111 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 433 EventRootType Probe[main.testSingleInt32]
+          Type: 1112 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 434 EventRootType Probe[main.testSingleInt64]
+          Type: 1113 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 431 EventRootType Probe[main.testSingleInt8]
+          Type: 1110 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 428 EventRootType Probe[main.testSingleRune]
+          Type: 1107 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x8066f0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 507 EventRootType Probe[main.testSingleString]
+          Type: 1186 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80a000", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 435 EventRootType Probe[main.testSingleUint]
+          Type: 1114 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 437 EventRootType Probe[main.testSingleUint16]
+          Type: 1116 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 438 EventRootType Probe[main.testSingleUint32]
+          Type: 1117 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 439 EventRootType Probe[main.testSingleUint64]
+          Type: 1118 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 436 EventRootType Probe[main.testSingleUint8]
+          Type: 1115 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 498 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1177 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x809c90", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 470 EventRootType Probe[main.testSmallMap]
+          Type: 1149 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x808050", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 411 EventRootType Probe[main.testStringArray]
+          Type: 1090 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 493 EventRootType Probe[main.testStringPointer]
+          Type: 1172 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809890", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 502 EventRootType Probe[main.testStringSlice]
+          Type: 1181 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x809cd0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 450 EventRootType Probe[main.testStringType1]
+          Type: 1129 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 451 EventRootType Probe[main.testStringType2]
+          Type: 1130 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1394,7 +1394,7 @@ Probes:
       subprogram: {subprogram: 107}
       events:
         - ID: 107
-          Type: 515 EventRootType Probe[main.testStruct]
+          Type: 1194 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80a240", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 499 EventRootType Probe[main.testStructSlice]
+          Type: 1178 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,7 +1425,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 464 EventRootType Probe[main.testStructWithAny]
+          Type: 1143 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x807ad0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1439,7 +1439,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 465 EventRootType Probe[main.testStructWithMap]
+          Type: 1144 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808000", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1453,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 508 EventRootType Probe[main.testThreeStrings]
+          Type: 1187 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80a010", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1467,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 509 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1188 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80a020", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1481,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 510 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1189 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80a030", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1495,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 442 EventRootType Probe[main.testTypeAlias]
+          Type: 1121 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1509,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 420 EventRootType Probe[main.testUint16Array]
+          Type: 1099 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1523,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 421 EventRootType Probe[main.testUint32Array]
+          Type: 1100 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1537,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 422 EventRootType Probe[main.testUint64Array]
+          Type: 1101 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1551,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 419 EventRootType Probe[main.testUint8Array]
+          Type: 1098 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1565,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 418 EventRootType Probe[main.testUintArray]
+          Type: 1097 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1579,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 492 EventRootType Probe[main.testUintPointer]
+          Type: 1171 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809820", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1593,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 496 EventRootType Probe[main.testUintSlice]
+          Type: 1175 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x809c70", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1607,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 513 EventRootType Probe[main.testUnitializedString]
+          Type: 1192 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80a060", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1621,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 491 EventRootType Probe[main.testUnsafePointer]
+          Type: 1170 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809800", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1635,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 426 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1105 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1649,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 505 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1184 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x809d00", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3412,20 +3412,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 325
+      ID: 1004
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 326 PointerType *main.deepSlice3
+      Pointee: 1005 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 352
+      ID: 1031
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 353 PointerType *main.deepSlice8
+      Pointee: 1032 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 358
+      ID: 1037
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 359 PointerType *main.deepSlice9
+      Pointee: 1038 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3433,7 +3433,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 321
+      ID: 1000
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3470,30 +3470,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 333
+      ID: 1012
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 334 PointerType *table<int,*main.deepMap3>
+      Pointee: 1013 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 369
+      ID: 1048
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 370 PointerType *table<int,*main.deepMap8>
+      Pointee: 1049 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 384
+      ID: 1063
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 385 PointerType *table<int,*main.deepMap9>
+      Pointee: 1064 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 399
+      ID: 1078
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 400 PointerType *table<int,interface {}>
+      Pointee: 1079 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '**table<int,uint8>'
@@ -3509,6 +3509,11 @@ Types:
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
+    - __kind: PointerType
+      ID: 743
+      Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 744 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3535,20 +3540,20 @@ Types:
       ByteSize: 8
       Pointee: 182 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 329
+      ID: 1008
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 328 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1007 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 356
+      ID: 1035
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 355 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1034 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 362
+      ID: 1041
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 361 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1040 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 180
       Name: '*[]*string.array'
@@ -3565,15 +3570,20 @@ Types:
       ByteSize: 8
       Pointee: 302 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 365
+      ID: 783
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 782 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 1044
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 364 GoSliceDataType []interface {}.array
+      Pointee: 1043 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 346
+      ID: 1025
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 345 GoSliceDataType []main.structWithMap.array
+      Pointee: 1024 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 299
       Name: '*[]main.structWithNoStrings.array'
@@ -3600,6 +3610,72 @@ Types:
       ByteSize: 8
       Pointee: 304 GoSliceDataType []uint16.array
     - __kind: PointerType
+      ID: 781
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 780 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 913
+      Name: '*archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.985184e+06
+      GoKind: 22
+      Pointee: 914 UnresolvedPointeeType archive/tar.Writer
+    - __kind: PointerType
+      ID: 543
+      Name: '*archive/tar.headerError'
+      ByteSize: 8
+      GoRuntimeType: 930688
+      GoKind: 22
+      Pointee: 544 GoSliceHeaderType archive/tar.headerError
+    - __kind: PointerType
+      ID: 546
+      Name: '*archive/tar.headerError.array'
+      ByteSize: 8
+      Pointee: 545 GoSliceDataType archive/tar.headerError.array
+    - __kind: PointerType
+      ID: 848
+      Name: '*archive/tar.regFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.434368e+06
+      GoKind: 22
+      Pointee: 849 UnresolvedPointeeType archive/tar.regFileWriter
+    - __kind: PointerType
+      ID: 796
+      Name: '*archive/zip.countWriter'
+      ByteSize: 8
+      GoRuntimeType: 930880
+      GoKind: 22
+      Pointee: 797 UnresolvedPointeeType archive/zip.countWriter
+    - __kind: PointerType
+      ID: 798
+      Name: '*archive/zip.dirWriter'
+      ByteSize: 8
+      GoRuntimeType: 930976
+      GoKind: 22
+      Pointee: 799 StructureType archive/zip.dirWriter
+    - __kind: PointerType
+      ID: 892
+      Name: '*archive/zip.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.903328e+06
+      GoKind: 22
+      Pointee: 893 UnresolvedPointeeType archive/zip.fileWriter
+    - __kind: PointerType
+      ID: 824
+      Name: '*archive/zip.nopCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.057088e+06
+      GoKind: 22
+      Pointee: 825 StructureType archive/zip.nopCloser
+    - __kind: PointerType
+      ID: 826
+      Name: '*archive/zip.pooledFlateWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.057344e+06
+      GoKind: 22
+      Pointee: 827 UnresolvedPointeeType archive/zip.pooledFlateWriter
+    - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
@@ -3607,12 +3683,456 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
+      ID: 871
+      Name: '*bufio.Reader'
+      ByteSize: 8
+      GoRuntimeType: 2.17328e+06
+      GoKind: 22
+      Pointee: 872 UnresolvedPointeeType bufio.Reader
+    - __kind: PointerType
+      ID: 900
+      Name: '*bufio.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.948064e+06
+      GoKind: 22
+      Pointee: 901 UnresolvedPointeeType bufio.Writer
+    - __kind: PointerType
+      ID: 951
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.266144e+06
+      GoKind: 22
+      Pointee: 952 UnresolvedPointeeType bytes.Buffer
+    - __kind: PointerType
+      ID: 453
+      Name: '*compress/flate.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 913216
+      GoKind: 22
+      Pointee: 342 BaseType compress/flate.CorruptInputError
+    - __kind: PointerType
+      ID: 454
+      Name: '*compress/flate.InternalError'
+      ByteSize: 8
+      GoRuntimeType: 913312
+      GoKind: 22
+      Pointee: 343 GoStringHeaderType compress/flate.InternalError
+    - __kind: PointerType
+      ID: 345
+      Name: '*compress/flate.InternalError.str'
+      ByteSize: 8
+      Pointee: 344 GoStringDataType compress/flate.InternalError.str
+    - __kind: PointerType
+      ID: 846
+      Name: '*compress/flate.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.423968e+06
+      GoKind: 22
+      Pointee: 847 UnresolvedPointeeType compress/flate.Writer
+    - __kind: PointerType
+      ID: 792
+      Name: '*compress/flate.dictWriter'
+      ByteSize: 8
+      GoRuntimeType: 913408
+      GoKind: 22
+      Pointee: 793 UnresolvedPointeeType compress/flate.dictWriter
+    - __kind: PointerType
+      ID: 868
+      Name: '*compress/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.724832e+06
+      GoKind: 22
+      Pointee: 869 UnresolvedPointeeType compress/gzip.Writer
+    - __kind: PointerType
+      ID: 691
+      Name: '*context.deadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.202624e+06
+      GoKind: 22
+      Pointee: 692 StructureType context.deadlineExceededError
+    - __kind: PointerType
+      ID: 535
+      Name: '*crypto/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 925312
+      GoKind: 22
+      Pointee: 356 BaseType crypto/aes.KeySizeError
+    - __kind: PointerType
+      ID: 536
+      Name: '*crypto/des.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 925504
+      GoKind: 22
+      Pointee: 357 BaseType crypto/des.KeySizeError
+    - __kind: PointerType
+      ID: 537
+      Name: '*crypto/internal/fips140/aes.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 925792
+      GoKind: 22
+      Pointee: 358 BaseType crypto/internal/fips140/aes.KeySizeError
+    - __kind: PointerType
+      ID: 863
+      Name: '*crypto/internal/fips140/hmac.HMAC'
+      ByteSize: 8
+      GoRuntimeType: 1.665568e+06
+      GoKind: 22
+      Pointee: 864 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+    - __kind: PointerType
+      ID: 640
+      Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
+      ByteSize: 8
+      GoRuntimeType: 1.064896e+06
+      GoKind: 22
+      Pointee: 641 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+    - __kind: PointerType
+      ID: 894
+      Name: '*crypto/internal/fips140/sha256.Digest'
+      ByteSize: 8
+      GoRuntimeType: 1.90384e+06
+      GoKind: 22
+      Pointee: 895 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+    - __kind: PointerType
+      ID: 924
+      Name: '*crypto/internal/fips140/sha3.Digest'
+      ByteSize: 8
+      GoRuntimeType: 2.118432e+06
+      GoKind: 22
+      Pointee: 925 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+    - __kind: PointerType
+      ID: 898
+      Name: '*crypto/internal/fips140/sha3.SHAKE'
+      ByteSize: 8
+      GoRuntimeType: 1.904352e+06
+      GoKind: 22
+      Pointee: 899 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+    - __kind: PointerType
+      ID: 896
+      Name: '*crypto/internal/fips140/sha512.Digest'
+      ByteSize: 8
+      GoRuntimeType: 1.904096e+06
+      GoKind: 22
+      Pointee: 897 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+    - __kind: PointerType
+      ID: 890
+      Name: '*crypto/md5.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.901536e+06
+      GoKind: 22
+      Pointee: 891 UnresolvedPointeeType crypto/md5.digest
+    - __kind: PointerType
+      ID: 538
+      Name: '*crypto/rc4.KeySizeError'
+      ByteSize: 8
+      GoRuntimeType: 926080
+      GoKind: 22
+      Pointee: 359 BaseType crypto/rc4.KeySizeError
+    - __kind: PointerType
+      ID: 911
+      Name: '*crypto/sha1.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.982304e+06
+      GoKind: 22
+      Pointee: 912 UnresolvedPointeeType crypto/sha1.digest
+    - __kind: PointerType
+      ID: 886
+      Name: '*crypto/sha3.SHA3'
+      ByteSize: 8
+      GoRuntimeType: 1.870912e+06
+      GoKind: 22
+      Pointee: 887 UnresolvedPointeeType crypto/sha3.SHA3
+    - __kind: PointerType
+      ID: 461
+      Name: '*crypto/tls.AlertError'
+      ByteSize: 8
+      GoRuntimeType: 914944
+      GoKind: 22
+      Pointee: 346 BaseType crypto/tls.AlertError
+    - __kind: PointerType
+      ID: 629
+      Name: '*crypto/tls.CertificateVerificationError'
+      ByteSize: 8
+      GoRuntimeType: 1.045696e+06
+      GoKind: 22
+      Pointee: 630 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+    - __kind: PointerType
+      ID: 977
+      Name: '*crypto/tls.Conn'
+      ByteSize: 8
+      GoRuntimeType: 2.377664e+06
+      GoKind: 22
+      Pointee: 978 UnresolvedPointeeType crypto/tls.Conn
+    - __kind: PointerType
+      ID: 457
+      Name: '*crypto/tls.ECHRejectionError'
+      ByteSize: 8
+      GoRuntimeType: 914656
+      GoKind: 22
+      Pointee: 458 UnresolvedPointeeType crypto/tls.ECHRejectionError
+    - __kind: PointerType
+      ID: 455
+      Name: '*crypto/tls.RecordHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 914560
+      GoKind: 22
+      Pointee: 456 StructureType crypto/tls.RecordHeaderError
+    - __kind: PointerType
+      ID: 628
+      Name: '*crypto/tls.alert'
+      ByteSize: 8
+      GoRuntimeType: 1.044032e+06
+      GoKind: 22
+      Pointee: 583 BaseType crypto/tls.alert
+    - __kind: PointerType
+      ID: 856
+      Name: '*crypto/tls.cthWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.558432e+06
+      GoKind: 22
+      Pointee: 857 UnresolvedPointeeType crypto/tls.cthWrapper
+    - __kind: PointerType
+      ID: 459
+      Name: '*crypto/tls.echConfigErr'
+      ByteSize: 8
+      GoRuntimeType: 914752
+      GoKind: 22
+      Pointee: 460 UnresolvedPointeeType crypto/tls.echConfigErr
+    - __kind: PointerType
+      ID: 861
+      Name: '*crypto/tls.finishedHash'
+      ByteSize: 8
+      GoRuntimeType: 1.640608e+06
+      GoKind: 22
+      Pointee: 862 UnresolvedPointeeType crypto/tls.finishedHash
+    - __kind: PointerType
+      ID: 726
+      Name: '*crypto/tls.permanentError'
+      ByteSize: 8
+      GoRuntimeType: 1.424448e+06
+      GoKind: 22
+      Pointee: 727 UnresolvedPointeeType crypto/tls.permanentError
+    - __kind: PointerType
+      ID: 745
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.041472e+06
+      GoKind: 22
+      Pointee: 746 UnresolvedPointeeType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 531
+      Name: '*crypto/x509.CertificateInvalidError'
+      ByteSize: 8
+      GoRuntimeType: 924352
+      GoKind: 22
+      Pointee: 532 StructureType crypto/x509.CertificateInvalidError
+    - __kind: PointerType
+      ID: 525
+      Name: '*crypto/x509.ConstraintViolationError'
+      ByteSize: 8
+      GoRuntimeType: 923872
+      GoKind: 22
+      Pointee: 526 StructureType crypto/x509.ConstraintViolationError
+    - __kind: PointerType
+      ID: 527
+      Name: '*crypto/x509.HostnameError'
+      ByteSize: 8
+      GoRuntimeType: 923968
+      GoKind: 22
+      Pointee: 528 StructureType crypto/x509.HostnameError
+    - __kind: PointerType
+      ID: 524
+      Name: '*crypto/x509.InsecureAlgorithmError'
+      ByteSize: 8
+      GoRuntimeType: 923776
+      GoKind: 22
+      Pointee: 355 BaseType crypto/x509.InsecureAlgorithmError
+    - __kind: PointerType
+      ID: 634
+      Name: '*crypto/x509.SystemRootsError'
+      ByteSize: 8
+      GoRuntimeType: 1.051456e+06
+      GoKind: 22
+      Pointee: 635 StructureType crypto/x509.SystemRootsError
+    - __kind: PointerType
+      ID: 533
+      Name: '*crypto/x509.UnhandledCriticalExtension'
+      ByteSize: 8
+      GoRuntimeType: 924448
+      GoKind: 22
+      Pointee: 534 StructureType crypto/x509.UnhandledCriticalExtension
+    - __kind: PointerType
+      ID: 529
+      Name: '*crypto/x509.UnknownAuthorityError'
+      ByteSize: 8
+      GoRuntimeType: 924256
+      GoKind: 22
+      Pointee: 530 StructureType crypto/x509.UnknownAuthorityError
+    - __kind: PointerType
+      ID: 547
+      Name: '*encoding/asn1.StructuralError'
+      ByteSize: 8
+      GoRuntimeType: 931168
+      GoKind: 22
+      Pointee: 548 StructureType encoding/asn1.StructuralError
+    - __kind: PointerType
+      ID: 551
+      Name: '*encoding/asn1.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 931360
+      GoKind: 22
+      Pointee: 552 StructureType encoding/asn1.SyntaxError
+    - __kind: PointerType
+      ID: 549
+      Name: '*encoding/asn1.invalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 931264
+      GoKind: 22
+      Pointee: 550 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+    - __kind: PointerType
+      ID: 442
+      Name: '*encoding/base64.CorruptInputError'
+      ByteSize: 8
+      GoRuntimeType: 911200
+      GoKind: 22
+      Pointee: 337 BaseType encoding/base64.CorruptInputError
+    - __kind: PointerType
+      ID: 814
+      Name: '*encoding/base64.encoder'
+      ByteSize: 8
+      GoRuntimeType: 1.041088e+06
+      GoKind: 22
+      Pointee: 815 UnresolvedPointeeType encoding/base64.encoder
+    - __kind: PointerType
+      ID: 445
+      Name: '*encoding/hex.InvalidByteError'
+      ByteSize: 8
+      GoRuntimeType: 912064
+      GoKind: 22
+      Pointee: 338 BaseType encoding/hex.InvalidByteError
+    - __kind: PointerType
+      ID: 413
+      Name: '*encoding/json.InvalidUnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 906016
+      GoKind: 22
+      Pointee: 414 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+    - __kind: PointerType
+      ID: 618
+      Name: '*encoding/json.MarshalerError'
+      ByteSize: 8
+      GoRuntimeType: 1.037248e+06
+      GoKind: 22
+      Pointee: 619 UnresolvedPointeeType encoding/json.MarshalerError
+    - __kind: PointerType
+      ID: 405
+      Name: '*encoding/json.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 905632
+      GoKind: 22
+      Pointee: 406 UnresolvedPointeeType encoding/json.SyntaxError
+    - __kind: PointerType
+      ID: 411
+      Name: '*encoding/json.UnmarshalTypeError'
+      ByteSize: 8
+      GoRuntimeType: 905920
+      GoKind: 22
+      Pointee: 412 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+    - __kind: PointerType
+      ID: 409
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 905824
+      GoKind: 22
+      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 407
+      Name: '*encoding/json.UnsupportedValueError'
+      ByteSize: 8
+      GoRuntimeType: 905728
+      GoKind: 22
+      Pointee: 408 UnresolvedPointeeType encoding/json.UnsupportedValueError
+    - __kind: PointerType
+      ID: 957
+      Name: '*encoding/json.encodeState'
+      ByteSize: 8
+      GoRuntimeType: 2.29168e+06
+      GoKind: 22
+      Pointee: 958 UnresolvedPointeeType encoding/json.encodeState
+    - __kind: PointerType
+      ID: 415
+      Name: '*encoding/json.jsonError'
+      ByteSize: 8
+      GoRuntimeType: 906400
+      GoKind: 22
+      Pointee: 416 StructureType encoding/json.jsonError
+    - __kind: PointerType
+      ID: 822
+      Name: '*encoding/pem.lineBreaker'
+      ByteSize: 8
+      GoRuntimeType: 1.054016e+06
+      GoKind: 22
+      Pointee: 823 UnresolvedPointeeType encoding/pem.lineBreaker
+    - __kind: PointerType
+      ID: 519
+      Name: '*encoding/xml.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 922816
+      GoKind: 22
+      Pointee: 520 UnresolvedPointeeType encoding/xml.SyntaxError
+    - __kind: PointerType
+      ID: 517
+      Name: '*encoding/xml.TagPathError'
+      ByteSize: 8
+      GoRuntimeType: 922720
+      GoKind: 22
+      Pointee: 518 UnresolvedPointeeType encoding/xml.TagPathError
+    - __kind: PointerType
+      ID: 521
+      Name: '*encoding/xml.UnmarshalError'
+      ByteSize: 8
+      GoRuntimeType: 922912
+      GoKind: 22
+      Pointee: 352 GoStringHeaderType encoding/xml.UnmarshalError
+    - __kind: PointerType
+      ID: 354
+      Name: '*encoding/xml.UnmarshalError.str'
+      ByteSize: 8
+      Pointee: 353 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: PointerType
+      ID: 522
+      Name: '*encoding/xml.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 923008
+      GoKind: 22
+      Pointee: 523 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 935
+      Name: '*encoding/xml.printer'
+      ByteSize: 8
+      GoRuntimeType: 2.158272e+06
+      GoKind: 22
+      Pointee: 936 UnresolvedPointeeType encoding/xml.printer
+    - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 392096
       GoKind: 22
       Pointee: 14 GoInterfaceType error
+    - __kind: PointerType
+      ID: 381
+      Name: '*errors.errorString'
+      ByteSize: 8
+      GoRuntimeType: 896032
+      GoKind: 22
+      Pointee: 382 UnresolvedPointeeType errors.errorString
+    - __kind: PointerType
+      ID: 585
+      Name: '*errors.joinError'
+      ByteSize: 8
+      GoRuntimeType: 1.022144e+06
+      GoKind: 22
+      Pointee: 586 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -3627,6 +4147,814 @@ Types:
       GoRuntimeType: 393120
       GoKind: 22
       Pointee: 16 BaseType float64
+    - __kind: PointerType
+      ID: 945
+      Name: '*fmt.pp'
+      ByteSize: 8
+      GoRuntimeType: 2.258464e+06
+      GoKind: 22
+      Pointee: 946 UnresolvedPointeeType fmt.pp
+    - __kind: PointerType
+      ID: 587
+      Name: '*fmt.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.023936e+06
+      GoKind: 22
+      Pointee: 588 UnresolvedPointeeType fmt.wrapError
+    - __kind: PointerType
+      ID: 589
+      Name: '*fmt.wrapErrors'
+      ByteSize: 8
+      GoRuntimeType: 1.024064e+06
+      GoKind: 22
+      Pointee: 590 UnresolvedPointeeType fmt.wrapErrors
+    - __kind: PointerType
+      ID: 443
+      Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
+      ByteSize: 8
+      GoRuntimeType: 911584
+      GoKind: 22
+      Pointee: 444 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+    - __kind: PointerType
+      ID: 424
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 908800
+      GoKind: 22
+      Pointee: 425 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+    - __kind: PointerType
+      ID: 426
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
+      ByteSize: 8
+      GoRuntimeType: 908896
+      GoKind: 22
+      Pointee: 427 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+    - __kind: PointerType
+      ID: 758
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
+      ByteSize: 8
+      GoRuntimeType: 908608
+      GoKind: 22
+      Pointee: 759 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+    - __kind: PointerType
+      ID: 430
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
+      ByteSize: 8
+      GoRuntimeType: 909184
+      GoKind: 22
+      Pointee: 431 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+    - __kind: PointerType
+      ID: 760
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
+      ByteSize: 8
+      GoRuntimeType: 908704
+      GoKind: 22
+      Pointee: 761 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+    - __kind: PointerType
+      ID: 428
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
+      ByteSize: 8
+      GoRuntimeType: 908992
+      GoKind: 22
+      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+    - __kind: PointerType
+      ID: 333
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
+      ByteSize: 8
+      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: PointerType
+      ID: 423
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
+      ByteSize: 8
+      GoRuntimeType: 908512
+      GoKind: 22
+      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+    - __kind: PointerType
+      ID: 330
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
+      ByteSize: 8
+      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: PointerType
+      ID: 429
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
+      ByteSize: 8
+      GoRuntimeType: 909088
+      GoKind: 22
+      Pointee: 334 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+    - __kind: PointerType
+      ID: 336
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
+      ByteSize: 8
+      Pointee: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: PointerType
+      ID: 834
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.208128e+06
+      GoKind: 22
+      Pointee: 835 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+    - __kind: PointerType
+      ID: 921
+      Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
+      ByteSize: 8
+      GoRuntimeType: 2.05648e+06
+      GoKind: 22
+      Pointee: 922 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+    - __kind: PointerType
+      ID: 541
+      Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
+      ByteSize: 8
+      GoRuntimeType: 929632
+      GoKind: 22
+      Pointee: 542 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+    - __kind: PointerType
+      ID: 700
+      Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
+      ByteSize: 8
+      GoRuntimeType: 1.211712e+06
+      GoKind: 22
+      Pointee: 701 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+    - __kind: PointerType
+      ID: 953
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
+      ByteSize: 8
+      GoRuntimeType: 2.268192e+06
+      GoKind: 22
+      Pointee: 954 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+    - __kind: PointerType
+      ID: 468
+      Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
+      ByteSize: 8
+      GoRuntimeType: 918304
+      GoKind: 22
+      Pointee: 469 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+    - __kind: PointerType
+      ID: 475
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
+      ByteSize: 8
+      GoRuntimeType: 919360
+      GoKind: 22
+      Pointee: 476 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+    - __kind: PointerType
+      ID: 470
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
+      ByteSize: 8
+      GoRuntimeType: 919072
+      GoKind: 22
+      Pointee: 351 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+    - __kind: PointerType
+      ID: 473
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
+      ByteSize: 8
+      GoRuntimeType: 919264
+      GoKind: 22
+      Pointee: 474 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+    - __kind: PointerType
+      ID: 471
+      Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
+      ByteSize: 8
+      GoRuntimeType: 919168
+      GoKind: 22
+      Pointee: 472 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+    - __kind: PointerType
+      ID: 491
+      Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
+      ByteSize: 8
+      GoRuntimeType: 921280
+      GoKind: 22
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+    - __kind: PointerType
+      ID: 495
+      Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
+      ByteSize: 8
+      GoRuntimeType: 921472
+      GoKind: 22
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+    - __kind: PointerType
+      ID: 493
+      Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
+      ByteSize: 8
+      GoRuntimeType: 921376
+      GoKind: 22
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+    - __kind: PointerType
+      ID: 489
+      Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
+      ByteSize: 8
+      GoRuntimeType: 921184
+      GoKind: 22
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+    - __kind: PointerType
+      ID: 785
+      Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 8
+      Pointee: 784 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: PointerType
+      ID: 503
+      Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
+      ByteSize: 8
+      GoRuntimeType: 921856
+      GoKind: 22
+      Pointee: 504 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+    - __kind: PointerType
+      ID: 497
+      Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
+      ByteSize: 8
+      GoRuntimeType: 921568
+      GoKind: 22
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+    - __kind: PointerType
+      ID: 501
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
+      ByteSize: 8
+      GoRuntimeType: 921760
+      GoKind: 22
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+    - __kind: PointerType
+      ID: 499
+      Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
+      ByteSize: 8
+      GoRuntimeType: 921664
+      GoKind: 22
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+    - __kind: PointerType
+      ID: 505
+      Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
+      ByteSize: 8
+      GoRuntimeType: 921952
+      GoKind: 22
+      Pointee: 506 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+    - __kind: PointerType
+      ID: 511
+      Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
+      ByteSize: 8
+      GoRuntimeType: 922240
+      GoKind: 22
+      Pointee: 512 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+    - __kind: PointerType
+      ID: 513
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
+      ByteSize: 8
+      GoRuntimeType: 922336
+      GoKind: 22
+      Pointee: 514 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+    - __kind: PointerType
+      ID: 509
+      Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
+      ByteSize: 8
+      GoRuntimeType: 922144
+      GoKind: 22
+      Pointee: 510 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+    - __kind: PointerType
+      ID: 507
+      Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
+      ByteSize: 8
+      GoRuntimeType: 922048
+      GoKind: 22
+      Pointee: 508 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+    - __kind: PointerType
+      ID: 515
+      Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
+      ByteSize: 8
+      GoRuntimeType: 922528
+      GoKind: 22
+      Pointee: 516 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+    - __kind: PointerType
+      ID: 432
+      Name: '*github.com/cihub/seelog.baseError'
+      ByteSize: 8
+      GoRuntimeType: 910336
+      GoKind: 22
+      Pointee: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: PointerType
+      ID: 874
+      Name: '*github.com/cihub/seelog.bufferedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.801696e+06
+      GoKind: 22
+      Pointee: 875 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+    - __kind: PointerType
+      ID: 434
+      Name: '*github.com/cihub/seelog.cannotOpenFileError'
+      ByteSize: 8
+      GoRuntimeType: 910432
+      GoKind: 22
+      Pointee: 435 StructureType github.com/cihub/seelog.cannotOpenFileError
+    - __kind: PointerType
+      ID: 854
+      Name: '*github.com/cihub/seelog.connWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.557152e+06
+      GoKind: 22
+      Pointee: 855 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+    - __kind: PointerType
+      ID: 810
+      Name: '*github.com/cihub/seelog.consoleWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.039936e+06
+      GoKind: 22
+      Pointee: 811 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+    - __kind: PointerType
+      ID: 844
+      Name: '*github.com/cihub/seelog.fileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.422048e+06
+      GoKind: 22
+      Pointee: 845 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+    - __kind: PointerType
+      ID: 438
+      Name: '*github.com/cihub/seelog.missingArgumentError'
+      ByteSize: 8
+      GoRuntimeType: 910624
+      GoKind: 22
+      Pointee: 439 StructureType github.com/cihub/seelog.missingArgumentError
+    - __kind: PointerType
+      ID: 909
+      Name: '*github.com/cihub/seelog.rollingFileWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.974528e+06
+      GoKind: 22
+      Pointee: 910 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+    - __kind: PointerType
+      ID: 928
+      Name: '*github.com/cihub/seelog.rollingFileWriterSize'
+      ByteSize: 8
+      GoRuntimeType: 2.131072e+06
+      GoKind: 22
+      Pointee: 923 StructureType github.com/cihub/seelog.rollingFileWriterSize
+    - __kind: PointerType
+      ID: 927
+      Name: '*github.com/cihub/seelog.rollingFileWriterTime'
+      ByteSize: 8
+      GoRuntimeType: 2.130688e+06
+      GoKind: 22
+      Pointee: 926 StructureType github.com/cihub/seelog.rollingFileWriterTime
+    - __kind: PointerType
+      ID: 812
+      Name: '*github.com/cihub/seelog.smtpWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.040064e+06
+      GoKind: 22
+      Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+    - __kind: PointerType
+      ID: 436
+      Name: '*github.com/cihub/seelog.unexpectedAttributeError'
+      ByteSize: 8
+      GoRuntimeType: 910528
+      GoKind: 22
+      Pointee: 437 StructureType github.com/cihub/seelog.unexpectedAttributeError
+    - __kind: PointerType
+      ID: 440
+      Name: '*github.com/cihub/seelog.unexpectedChildElementError'
+      ByteSize: 8
+      GoRuntimeType: 910720
+      GoKind: 22
+      Pointee: 441 StructureType github.com/cihub/seelog.unexpectedChildElementError
+    - __kind: PointerType
+      ID: 876
+      Name: '*github.com/cihub/seelog/archive/gzip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 1.803488e+06
+      GoKind: 22
+      Pointee: 877 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+    - __kind: PointerType
+      ID: 917
+      Name: '*github.com/cihub/seelog/archive/tar.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.010656e+06
+      GoKind: 22
+      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+    - __kind: PointerType
+      ID: 919
+      Name: '*github.com/cihub/seelog/archive/zip.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.041152e+06
+      GoKind: 22
+      Pointee: 920 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+    - __kind: PointerType
+      ID: 731
+      Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
+      ByteSize: 8
+      GoRuntimeType: 1.436768e+06
+      GoKind: 22
+      Pointee: 732 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+    - __kind: PointerType
+      ID: 644
+      Name: '*github.com/go-viper/mapstructure/v2.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.065664e+06
+      GoKind: 22
+      Pointee: 645 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+    - __kind: PointerType
+      ID: 642
+      Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.065536e+06
+      GoKind: 22
+      Pointee: 643 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+    - __kind: PointerType
+      ID: 646
+      Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.069632e+06
+      GoKind: 22
+      Pointee: 647 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 648
+      Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
+      ByteSize: 8
+      GoRuntimeType: 1.06976e+06
+      GoKind: 22
+      Pointee: 649 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+    - __kind: PointerType
+      ID: 865
+      Name: '*github.com/gogo/protobuf/proto.textWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.667872e+06
+      GoKind: 22
+      Pointee: 866 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+    - __kind: PointerType
+      ID: 636
+      Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
+      ByteSize: 8
+      GoRuntimeType: 1.052096e+06
+      GoKind: 22
+      Pointee: 637 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+    - __kind: PointerType
+      ID: 446
+      Name: '*github.com/google/uuid.invalidLengthError'
+      ByteSize: 8
+      GoRuntimeType: 912256
+      GoKind: 22
+      Pointee: 447 StructureType github.com/google/uuid.invalidLengthError
+    - __kind: PointerType
+      ID: 969
+      Name: '*github.com/json-iterator/go.Stream'
+      ByteSize: 8
+      GoRuntimeType: 2.354112e+06
+      GoKind: 22
+      Pointee: 970 UnresolvedPointeeType github.com/json-iterator/go.Stream
+    - __kind: PointerType
+      ID: 702
+      Name: '*github.com/pkg/errors.fundamental'
+      ByteSize: 8
+      GoRuntimeType: 1.220288e+06
+      GoKind: 22
+      Pointee: 703 UnresolvedPointeeType github.com/pkg/errors.fundamental
+    - __kind: PointerType
+      ID: 675
+      Name: '*github.com/tinylib/msgp/msgp.ArrayError'
+      ByteSize: 8
+      GoRuntimeType: 1.199168e+06
+      GoKind: 22
+      Pointee: 676 StructureType github.com/tinylib/msgp/msgp.ArrayError
+    - __kind: PointerType
+      ID: 669
+      Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
+      ByteSize: 8
+      GoRuntimeType: 1.198784e+06
+      GoKind: 22
+      Pointee: 670 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+    - __kind: PointerType
+      ID: 604
+      Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.031232e+06
+      GoKind: 22
+      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+    - __kind: PointerType
+      ID: 681
+      Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.199552e+06
+      GoKind: 22
+      Pointee: 682 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+    - __kind: PointerType
+      ID: 603
+      Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.031104e+06
+      GoKind: 22
+      Pointee: 582 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+    - __kind: PointerType
+      ID: 673
+      Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
+      ByteSize: 8
+      GoRuntimeType: 1.19904e+06
+      GoKind: 22
+      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+    - __kind: PointerType
+      ID: 671
+      Name: '*github.com/tinylib/msgp/msgp.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.198912e+06
+      GoKind: 22
+      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.TypeError
+    - __kind: PointerType
+      ID: 679
+      Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
+      ByteSize: 8
+      GoRuntimeType: 1.199424e+06
+      GoKind: 22
+      Pointee: 680 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+    - __kind: PointerType
+      ID: 677
+      Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
+      ByteSize: 8
+      GoRuntimeType: 1.199296e+06
+      GoKind: 22
+      Pointee: 678 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+    - __kind: PointerType
+      ID: 973
+      Name: '*github.com/tinylib/msgp/msgp.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.36672e+06
+      GoKind: 22
+      Pointee: 974 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+    - __kind: PointerType
+      ID: 685
+      Name: '*github.com/tinylib/msgp/msgp.errFatal'
+      ByteSize: 8
+      GoRuntimeType: 1.199936e+06
+      GoKind: 22
+      Pointee: 686 StructureType github.com/tinylib/msgp/msgp.errFatal
+    - __kind: PointerType
+      ID: 608
+      Name: '*github.com/tinylib/msgp/msgp.errRecursion'
+      ByteSize: 8
+      GoRuntimeType: 1.031488e+06
+      GoKind: 22
+      Pointee: 609 StructureType github.com/tinylib/msgp/msgp.errRecursion
+    - __kind: PointerType
+      ID: 606
+      Name: '*github.com/tinylib/msgp/msgp.errShort'
+      ByteSize: 8
+      GoRuntimeType: 1.03136e+06
+      GoKind: 22
+      Pointee: 607 StructureType github.com/tinylib/msgp/msgp.errShort
+    - __kind: PointerType
+      ID: 683
+      Name: '*github.com/tinylib/msgp/msgp.errWrapped'
+      ByteSize: 8
+      GoRuntimeType: 1.199808e+06
+      GoKind: 22
+      Pointee: 684 StructureType github.com/tinylib/msgp/msgp.errWrapped
+    - __kind: PointerType
+      ID: 563
+      Name: '*go.opentelemetry.io/otel/trace.errorConst'
+      ByteSize: 8
+      GoRuntimeType: 944128
+      GoKind: 22
+      Pointee: 364 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+    - __kind: PointerType
+      ID: 366
+      Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
+      ByteSize: 8
+      Pointee: 365 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: PointerType
+      ID: 748
+      Name: '*go.uber.org/multierr.multiError'
+      ByteSize: 8
+      GoRuntimeType: 1.666336e+06
+      GoKind: 22
+      Pointee: 749 UnresolvedPointeeType go.uber.org/multierr.multiError
+    - __kind: PointerType
+      ID: 652
+      Name: '*go.uber.org/zap.errArrayElem'
+      ByteSize: 8
+      GoRuntimeType: 1.08448e+06
+      GoKind: 22
+      Pointee: 653 StructureType go.uber.org/zap.errArrayElem
+    - __kind: PointerType
+      ID: 840
+      Name: '*go.uber.org/zap.nopCloserSink'
+      ByteSize: 8
+      GoRuntimeType: 1.260096e+06
+      GoKind: 22
+      Pointee: 841 StructureType go.uber.org/zap.nopCloserSink
+    - __kind: PointerType
+      ID: 933
+      Name: '*go.uber.org/zap/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.146432e+06
+      GoKind: 22
+      Pointee: 934 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+    - __kind: PointerType
+      ID: 828
+      Name: '*go.uber.org/zap/zapcore.writerWrapper'
+      ByteSize: 8
+      GoRuntimeType: 1.086784e+06
+      GoKind: 22
+      Pointee: 829 StructureType go.uber.org/zap/zapcore.writerWrapper
+    - __kind: PointerType
+      ID: 564
+      Name: '*golang.org/x/net/http2.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 945376
+      GoKind: 22
+      Pointee: 367 BaseType golang.org/x/net/http2.ConnectionError
+    - __kind: PointerType
+      ID: 710
+      Name: '*golang.org/x/net/http2.StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.26176e+06
+      GoKind: 22
+      Pointee: 711 StructureType golang.org/x/net/http2.StreamError
+    - __kind: PointerType
+      ID: 567
+      Name: '*golang.org/x/net/http2.connError'
+      ByteSize: 8
+      GoRuntimeType: 945664
+      GoKind: 22
+      Pointee: 568 StructureType golang.org/x/net/http2.connError
+    - __kind: PointerType
+      ID: 566
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 945568
+      GoKind: 22
+      Pointee: 371 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 373
+      Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 372 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 570
+      Name: '*golang.org/x/net/http2.headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 945856
+      GoKind: 22
+      Pointee: 377 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+    - __kind: PointerType
+      ID: 379
+      Name: '*golang.org/x/net/http2.headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 378 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: PointerType
+      ID: 569
+      Name: '*golang.org/x/net/http2.headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 945760
+      GoKind: 22
+      Pointee: 374 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+    - __kind: PointerType
+      ID: 376
+      Name: '*golang.org/x/net/http2.headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 375 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: PointerType
+      ID: 565
+      Name: '*golang.org/x/net/http2.pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 945472
+      GoKind: 22
+      Pointee: 368 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+    - __kind: PointerType
+      ID: 370
+      Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 369 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 931
+      Name: '*golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.144512e+06
+      GoKind: 22
+      Pointee: 932 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 571
+      Name: '*golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 945952
+      GoKind: 22
+      Pointee: 572 StructureType golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 573
+      Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 946048
+      GoKind: 22
+      Pointee: 380 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 559
+      Name: '*google.golang.org/grpc.dropError'
+      ByteSize: 8
+      GoRuntimeType: 939328
+      GoKind: 22
+      Pointee: 560 StructureType google.golang.org/grpc.dropError
+    - __kind: PointerType
+      ID: 708
+      Name: '*google.golang.org/grpc/internal/status.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.258816e+06
+      GoKind: 22
+      Pointee: 709 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+    - __kind: PointerType
+      ID: 733
+      Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 1.444128e+06
+      GoKind: 22
+      Pointee: 734 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+    - __kind: PointerType
+      ID: 561
+      Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
+      ByteSize: 8
+      GoRuntimeType: 942400
+      GoKind: 22
+      Pointee: 562 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+    - __kind: PointerType
+      ID: 880
+      Name: '*google.golang.org/grpc/internal/transport.bufConn'
+      ByteSize: 8
+      GoRuntimeType: 1.809088e+06
+      GoKind: 22
+      Pointee: 881 StructureType google.golang.org/grpc/internal/transport.bufConn
+    - __kind: PointerType
+      ID: 838
+      Name: '*google.golang.org/grpc/internal/transport.bufWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.25536e+06
+      GoKind: 22
+      Pointee: 839 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+    - __kind: PointerType
+      ID: 650
+      Name: '*google.golang.org/grpc/internal/transport.ioError'
+      ByteSize: 8
+      GoRuntimeType: 1.07872e+06
+      GoKind: 22
+      Pointee: 651 StructureType google.golang.org/grpc/internal/transport.ioError
+    - __kind: PointerType
+      ID: 800
+      Name: '*google.golang.org/grpc/mem.writer'
+      ByteSize: 8
+      GoRuntimeType: 942496
+      GoKind: 22
+      Pointee: 801 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+    - __kind: PointerType
+      ID: 539
+      Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
+      ByteSize: 8
+      GoRuntimeType: 927520
+      GoKind: 22
+      Pointee: 540 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+    - __kind: PointerType
+      ID: 638
+      Name: '*google.golang.org/protobuf/internal/errors.prefixError'
+      ByteSize: 8
+      GoRuntimeType: 1.055424e+06
+      GoKind: 22
+      Pointee: 639 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+    - __kind: PointerType
+      ID: 706
+      Name: '*google.golang.org/protobuf/internal/errors.wrapError'
+      ByteSize: 8
+      GoRuntimeType: 1.226688e+06
+      GoKind: 22
+      Pointee: 707 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+    - __kind: PointerType
+      ID: 704
+      Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
+      ByteSize: 8
+      GoRuntimeType: 1.226432e+06
+      GoKind: 22
+      Pointee: 705 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+    - __kind: PointerType
+      ID: 553
+      Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
+      ByteSize: 8
+      GoRuntimeType: 932224
+      GoKind: 22
+      Pointee: 554 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+    - __kind: PointerType
+      ID: 555
+      Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
+      ByteSize: 8
+      GoRuntimeType: 932320
+      GoKind: 22
+      Pointee: 556 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+    - __kind: PointerType
+      ID: 483
+      Name: '*gopkg.in/yaml%2ev3.TypeError'
+      ByteSize: 8
+      GoRuntimeType: 919744
+      GoKind: 22
+      Pointee: 484 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+    - __kind: PointerType
+      ID: 888
+      Name: '*hash/crc32.digest'
+      ByteSize: 8
+      GoRuntimeType: 1.899488e+06
+      GoKind: 22
+      Pointee: 889 UnresolvedPointeeType hash/crc32.digest
+    - __kind: PointerType
+      ID: 574
+      Name: '*html/template.Error'
+      ByteSize: 8
+      GoRuntimeType: 946816
+      GoKind: 22
+      Pointee: 575 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -3670,6 +4998,116 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
+      ID: 735
+      Name: '*internal/abi.Type'
+      ByteSize: 8
+      GoRuntimeType: 2.210784e+06
+      GoKind: 22
+      Pointee: 736 UnresolvedPointeeType internal/abi.Type
+    - __kind: PointerType
+      ID: 451
+      Name: '*internal/bisect.parseError'
+      ByteSize: 8
+      GoRuntimeType: 912928
+      GoKind: 22
+      Pointee: 452 UnresolvedPointeeType internal/bisect.parseError
+    - __kind: PointerType
+      ID: 449
+      Name: '*internal/chacha8rand.errUnmarshalChaCha8'
+      ByteSize: 8
+      GoRuntimeType: 912832
+      GoKind: 22
+      Pointee: 450 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+    - __kind: PointerType
+      ID: 786
+      Name: '*internal/godebug.runtimeStderr'
+      ByteSize: 8
+      GoRuntimeType: 900832
+      GoKind: 22
+      Pointee: 787 UnresolvedPointeeType internal/godebug.runtimeStderr
+    - __kind: PointerType
+      ID: 667
+      Name: '*internal/poll.DeadlineExceededError'
+      ByteSize: 8
+      GoRuntimeType: 1.198016e+06
+      GoKind: 22
+      Pointee: 668 UnresolvedPointeeType internal/poll.DeadlineExceededError
+    - __kind: PointerType
+      ID: 975
+      Name: '*internal/poll.FD'
+      ByteSize: 8
+      GoRuntimeType: 2.372384e+06
+      GoKind: 22
+      Pointee: 976 UnresolvedPointeeType internal/poll.FD
+    - __kind: PointerType
+      ID: 665
+      Name: '*internal/poll.errNetClosing'
+      ByteSize: 8
+      GoRuntimeType: 1.197888e+06
+      GoKind: 22
+      Pointee: 666 StructureType internal/poll.errNetClosing
+    - __kind: PointerType
+      ID: 385
+      Name: '*internal/reflectlite.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 900064
+      GoKind: 22
+      Pointee: 386 UnresolvedPointeeType internal/reflectlite.ValueError
+    - __kind: PointerType
+      ID: 448
+      Name: '*internal/runtime/cgroup.stringError'
+      ByteSize: 8
+      GoRuntimeType: 912640
+      GoKind: 22
+      Pointee: 339 GoStringHeaderType internal/runtime/cgroup.stringError
+    - __kind: PointerType
+      ID: 341
+      Name: '*internal/runtime/cgroup.stringError.str'
+      ByteSize: 8
+      Pointee: 340 GoStringDataType internal/runtime/cgroup.stringError.str
+    - __kind: PointerType
+      ID: 622
+      Name: '*internal/runtime/maps.unhashableTypeError'
+      ByteSize: 8
+      GoRuntimeType: 1.042368e+06
+      GoKind: 22
+      Pointee: 623 StructureType internal/runtime/maps.unhashableTypeError
+    - __kind: PointerType
+      ID: 832
+      Name: '*io.PipeWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.189312e+06
+      GoKind: 22
+      Pointee: 833 UnresolvedPointeeType io.PipeWriter
+    - __kind: PointerType
+      ID: 830
+      Name: '*io.discard'
+      ByteSize: 8
+      GoRuntimeType: 1.188928e+06
+      GoKind: 22
+      Pointee: 831 StructureType io.discard
+    - __kind: PointerType
+      ID: 804
+      Name: '*io.multiWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.0224e+06
+      GoKind: 22
+      Pointee: 805 UnresolvedPointeeType io.multiWriter
+    - __kind: PointerType
+      ID: 663
+      Name: '*io/fs.PathError'
+      ByteSize: 8
+      GoRuntimeType: 1.197376e+06
+      GoKind: 22
+      Pointee: 664 UnresolvedPointeeType io/fs.PathError
+    - __kind: PointerType
+      ID: 878
+      Name: '*log/slog/internal/buffer.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 1.803712e+06
+      GoKind: 22
+      Pointee: 879 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+    - __kind: PointerType
       ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
@@ -3677,12 +5115,12 @@ Types:
       GoKind: 22
       Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 341
+      ID: 1020
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385888
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType main.deepMap3
+      Pointee: 1021 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3691,19 +5129,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 377
+      ID: 1056
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 385568
       GoKind: 22
-      Pointee: 378 StructureType main.deepMap8
+      Pointee: 1057 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 392
+      ID: 1071
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385504
       GoKind: 22
-      Pointee: 393 StructureType main.deepMap9
+      Pointee: 1072 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3712,12 +5150,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 306
+      ID: 979
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 307 UnresolvedPointeeType main.deepPtr3
+      Pointee: 980 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3726,19 +5164,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 347
+      ID: 1026
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386144
       GoKind: 22
-      Pointee: 348 StructureType main.deepPtr8
+      Pointee: 1027 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 349
+      ID: 1028
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386080
       GoKind: 22
-      Pointee: 350 StructureType main.deepPtr9
+      Pointee: 1029 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3747,12 +5185,12 @@ Types:
       GoKind: 22
       Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 326
+      ID: 1005
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387040
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1006 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3761,19 +5199,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 353
+      ID: 1032
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386720
       GoKind: 22
-      Pointee: 354 StructureType main.deepSlice8
+      Pointee: 1033 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 359
+      ID: 1038
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386656
       GoKind: 22
-      Pointee: 360 StructureType main.deepSlice9
+      Pointee: 1039 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 176
       Name: '*main.emptyStruct'
@@ -3788,6 +5226,13 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
+      ID: 996
+      Name: '*main.firstBehavior'
+      ByteSize: 8
+      GoRuntimeType: 895744
+      GoKind: 22
+      Pointee: 997 StructureType main.firstBehavior
+    - __kind: PointerType
       ID: 157
       Name: '*main.node'
       ByteSize: 8
@@ -3801,22 +5246,36 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
+      ID: 998
+      Name: '*main.secondBehavior'
+      ByteSize: 8
+      GoRuntimeType: 895840
+      GoKind: 22
+      Pointee: 999 StructureType main.secondBehavior
+    - __kind: PointerType
+      ID: 984
+      Name: '*main.somethingImpl'
+      ByteSize: 8
+      GoRuntimeType: 895936
+      GoKind: 22
+      Pointee: 985 UnresolvedPointeeType main.somethingImpl
+    - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
       ByteSize: 8
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 309
+      ID: 982
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType main.stringType1.str
+      Pointee: 981 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 310 UnresolvedPointeeType main.stringType2
+      Pointee: 983 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 242
       Name: '*main.structWithMap'
@@ -3842,10 +5301,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 323
+      ID: 1002
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 322 GoSliceDataType main.t.array
+      Pointee: 1001 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -3878,30 +5337,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 331
+      ID: 1010
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1011 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 367
+      ID: 1046
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1047 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 382
+      ID: 1061
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1062 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 397
+      ID: 1076
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 398 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1077 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 129
       Name: '*map<int,uint8>'
@@ -3917,6 +5376,11 @@ Types:
       Name: '*map<string,[]string>'
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 741
+      Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 742 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -3944,6 +5408,452 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
+      ID: 487
+      Name: '*math/big.ErrNaN'
+      ByteSize: 8
+      GoRuntimeType: 920608
+      GoKind: 22
+      Pointee: 488 StructureType math/big.ErrNaN
+    - __kind: PointerType
+      ID: 794
+      Name: '*mime/multipart.writerOnly·1'
+      ByteSize: 8
+      GoRuntimeType: 915424
+      GoKind: 22
+      Pointee: 795 StructureType mime/multipart.writerOnly·1
+    - __kind: PointerType
+      ID: 694
+      Name: '*net.AddrError'
+      ByteSize: 8
+      GoRuntimeType: 1.205952e+06
+      GoKind: 22
+      Pointee: 695 UnresolvedPointeeType net.AddrError
+    - __kind: PointerType
+      ID: 720
+      Name: '*net.DNSError'
+      ByteSize: 8
+      GoRuntimeType: 1.420288e+06
+      GoKind: 22
+      Pointee: 721 UnresolvedPointeeType net.DNSError
+    - __kind: PointerType
+      ID: 939
+      Name: '*net.IPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.230656e+06
+      GoKind: 22
+      Pointee: 940 UnresolvedPointeeType net.IPConn
+    - __kind: PointerType
+      ID: 718
+      Name: '*net.OpError'
+      ByteSize: 8
+      GoRuntimeType: 1.419968e+06
+      GoKind: 22
+      Pointee: 719 UnresolvedPointeeType net.OpError
+    - __kind: PointerType
+      ID: 696
+      Name: '*net.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 1.20608e+06
+      GoKind: 22
+      Pointee: 697 UnresolvedPointeeType net.ParseError
+    - __kind: PointerType
+      ID: 949
+      Name: '*net.TCPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.259488e+06
+      GoKind: 22
+      Pointee: 950 UnresolvedPointeeType net.TCPConn
+    - __kind: PointerType
+      ID: 959
+      Name: '*net.UDPConn'
+      ByteSize: 8
+      GoRuntimeType: 2.304992e+06
+      GoKind: 22
+      Pointee: 960 UnresolvedPointeeType net.UDPConn
+    - __kind: PointerType
+      ID: 947
+      Name: '*net.UnixConn'
+      ByteSize: 8
+      GoRuntimeType: 2.258976e+06
+      GoKind: 22
+      Pointee: 948 UnresolvedPointeeType net.UnixConn
+    - __kind: PointerType
+      ID: 693
+      Name: '*net.UnknownNetworkError'
+      ByteSize: 8
+      GoRuntimeType: 1.205184e+06
+      GoKind: 22
+      Pointee: 656 GoStringHeaderType net.UnknownNetworkError
+    - __kind: PointerType
+      ID: 658
+      Name: '*net.UnknownNetworkError.str'
+      ByteSize: 8
+      Pointee: 657 GoStringDataType net.UnknownNetworkError.str
+    - __kind: PointerType
+      ID: 620
+      Name: '*net.canceledError'
+      ByteSize: 8
+      GoRuntimeType: 1.038144e+06
+      GoKind: 22
+      Pointee: 621 StructureType net.canceledError
+    - __kind: PointerType
+      ID: 915
+      Name: '*net.conn'
+      ByteSize: 8
+      GoRuntimeType: 2.008064e+06
+      GoKind: 22
+      Pointee: 916 UnresolvedPointeeType net.conn
+    - __kind: PointerType
+      ID: 767
+      Name: '*net.dialResult·1'
+      ByteSize: 8
+      GoRuntimeType: 1.846496e+06
+      GoKind: 22
+      Pointee: 768 StructureType net.dialResult·1
+    - __kind: PointerType
+      ID: 961
+      Name: '*net.netFD'
+      ByteSize: 8
+      GoRuntimeType: 2.309248e+06
+      GoKind: 22
+      Pointee: 962 UnresolvedPointeeType net.netFD
+    - __kind: PointerType
+      ID: 417
+      Name: '*net.notFoundError'
+      ByteSize: 8
+      GoRuntimeType: 907360
+      GoKind: 22
+      Pointee: 418 UnresolvedPointeeType net.notFoundError
+    - __kind: PointerType
+      ID: 419
+      Name: '*net.result·2'
+      ByteSize: 8
+      GoRuntimeType: 908032
+      GoKind: 22
+      Pointee: 420 StructureType net.result·2
+    - __kind: PointerType
+      ID: 943
+      Name: '*net.tcpConnWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.245024e+06
+      GoKind: 22
+      Pointee: 944 StructureType net.tcpConnWithoutReadFrom
+    - __kind: PointerType
+      ID: 941
+      Name: '*net.tcpConnWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.244544e+06
+      GoKind: 22
+      Pointee: 942 StructureType net.tcpConnWithoutWriteTo
+    - __kind: PointerType
+      ID: 698
+      Name: '*net.temporaryError'
+      ByteSize: 8
+      GoRuntimeType: 1.20672e+06
+      GoKind: 22
+      Pointee: 699 UnresolvedPointeeType net.temporaryError
+    - __kind: PointerType
+      ID: 722
+      Name: '*net.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.420448e+06
+      GoKind: 22
+      Pointee: 723 UnresolvedPointeeType net.timeoutError
+    - __kind: PointerType
+      ID: 610
+      Name: '*net/http.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 1.03392e+06
+      GoKind: 22
+      Pointee: 611 UnresolvedPointeeType net/http.ProtocolError
+    - __kind: PointerType
+      ID: 788
+      Name: '*net/http.bufioFlushWriter'
+      ByteSize: 8
+      GoRuntimeType: 903136
+      GoKind: 22
+      Pointee: 789 StructureType net/http.bufioFlushWriter
+    - __kind: PointerType
+      ID: 394
+      Name: '*net/http.http2ConnectionError'
+      ByteSize: 8
+      GoRuntimeType: 903808
+      GoKind: 22
+      Pointee: 309 BaseType net/http.http2ConnectionError
+    - __kind: PointerType
+      ID: 395
+      Name: '*net/http.http2GoAwayError'
+      ByteSize: 8
+      GoRuntimeType: 903904
+      GoKind: 22
+      Pointee: 396 StructureType net/http.http2GoAwayError
+    - __kind: PointerType
+      ID: 714
+      Name: '*net/http.http2StreamError'
+      ByteSize: 8
+      GoRuntimeType: 1.415968e+06
+      GoKind: 22
+      Pointee: 715 StructureType net/http.http2StreamError
+    - __kind: PointerType
+      ID: 399
+      Name: '*net/http.http2connError'
+      ByteSize: 8
+      GoRuntimeType: 904480
+      GoKind: 22
+      Pointee: 400 StructureType net/http.http2connError
+    - __kind: PointerType
+      ID: 850
+      Name: '*net/http.http2dataBuffer'
+      ByteSize: 8
+      GoRuntimeType: 1.553632e+06
+      GoKind: 22
+      Pointee: 851 UnresolvedPointeeType net/http.http2dataBuffer
+    - __kind: PointerType
+      ID: 398
+      Name: '*net/http.http2duplicatePseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 904384
+      GoKind: 22
+      Pointee: 313 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+    - __kind: PointerType
+      ID: 315
+      Name: '*net/http.http2duplicatePseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: PointerType
+      ID: 402
+      Name: '*net/http.http2headerFieldNameError'
+      ByteSize: 8
+      GoRuntimeType: 904672
+      GoKind: 22
+      Pointee: 319 GoStringHeaderType net/http.http2headerFieldNameError
+    - __kind: PointerType
+      ID: 321
+      Name: '*net/http.http2headerFieldNameError.str'
+      ByteSize: 8
+      Pointee: 320 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: PointerType
+      ID: 401
+      Name: '*net/http.http2headerFieldValueError'
+      ByteSize: 8
+      GoRuntimeType: 904576
+      GoKind: 22
+      Pointee: 316 GoStringHeaderType net/http.http2headerFieldValueError
+    - __kind: PointerType
+      ID: 318
+      Name: '*net/http.http2headerFieldValueError.str'
+      ByteSize: 8
+      Pointee: 317 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: PointerType
+      ID: 689
+      Name: '*net/http.http2httpError'
+      ByteSize: 8
+      GoRuntimeType: 1.201856e+06
+      GoKind: 22
+      Pointee: 690 UnresolvedPointeeType net/http.http2httpError
+    - __kind: PointerType
+      ID: 616
+      Name: '*net/http.http2noCachedConnError'
+      ByteSize: 8
+      GoRuntimeType: 1.03456e+06
+      GoKind: 22
+      Pointee: 617 StructureType net/http.http2noCachedConnError
+    - __kind: PointerType
+      ID: 904
+      Name: '*net/http.http2pipe'
+      ByteSize: 8
+      GoRuntimeType: 1.950368e+06
+      GoKind: 22
+      Pointee: 905 UnresolvedPointeeType net/http.http2pipe
+    - __kind: PointerType
+      ID: 397
+      Name: '*net/http.http2pseudoHeaderError'
+      ByteSize: 8
+      GoRuntimeType: 904288
+      GoKind: 22
+      Pointee: 310 GoStringHeaderType net/http.http2pseudoHeaderError
+    - __kind: PointerType
+      ID: 312
+      Name: '*net/http.http2pseudoHeaderError.str'
+      ByteSize: 8
+      Pointee: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: PointerType
+      ID: 790
+      Name: '*net/http.http2stickyErrWriter'
+      ByteSize: 8
+      GoRuntimeType: 904768
+      GoKind: 22
+      Pointee: 791 StructureType net/http.http2stickyErrWriter
+    - __kind: PointerType
+      ID: 612
+      Name: '*net/http.nothingWrittenError'
+      ByteSize: 8
+      GoRuntimeType: 1.034176e+06
+      GoKind: 22
+      Pointee: 613 StructureType net/http.nothingWrittenError
+    - __kind: PointerType
+      ID: 852
+      Name: '*net/http.persistConn'
+      ByteSize: 8
+      GoRuntimeType: 2.174528e+06
+      GoKind: 22
+      Pointee: 853 UnresolvedPointeeType net/http.persistConn
+    - __kind: PointerType
+      ID: 808
+      Name: '*net/http.persistConnWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.034048e+06
+      GoKind: 22
+      Pointee: 809 StructureType net/http.persistConnWriter
+    - __kind: PointerType
+      ID: 842
+      Name: '*net/http.readWriteCloserBody'
+      ByteSize: 8
+      GoRuntimeType: 1.416128e+06
+      GoKind: 22
+      Pointee: 843 StructureType net/http.readWriteCloserBody
+    - __kind: PointerType
+      ID: 403
+      Name: '*net/http.requestBodyReadError'
+      ByteSize: 8
+      GoRuntimeType: 904864
+      GoKind: 22
+      Pointee: 404 StructureType net/http.requestBodyReadError
+    - __kind: PointerType
+      ID: 716
+      Name: '*net/http.timeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.417248e+06
+      GoKind: 22
+      Pointee: 717 UnresolvedPointeeType net/http.timeoutError
+    - __kind: PointerType
+      ID: 687
+      Name: '*net/http.tlsHandshakeTimeoutError'
+      ByteSize: 8
+      GoRuntimeType: 1.201728e+06
+      GoKind: 22
+      Pointee: 688 StructureType net/http.tlsHandshakeTimeoutError
+    - __kind: PointerType
+      ID: 614
+      Name: '*net/http.transportReadFromServerError'
+      ByteSize: 8
+      GoRuntimeType: 1.034304e+06
+      GoKind: 22
+      Pointee: 615 StructureType net/http.transportReadFromServerError
+    - __kind: PointerType
+      ID: 884
+      Name: '*net/http.unencryptedNetConnInTLSConn'
+      ByteSize: 8
+      GoRuntimeType: 1.843136e+06
+      GoKind: 22
+      Pointee: 885 StructureType net/http.unencryptedNetConnInTLSConn
+    - __kind: PointerType
+      ID: 392
+      Name: '*net/http.unsupportedTEError'
+      ByteSize: 8
+      GoRuntimeType: 903040
+      GoKind: 22
+      Pointee: 393 UnresolvedPointeeType net/http.unsupportedTEError
+    - __kind: PointerType
+      ID: 906
+      Name: '*net/http/internal.FlushAfterChunkWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.95216e+06
+      GoKind: 22
+      Pointee: 907 StructureType net/http/internal.FlushAfterChunkWriter
+    - __kind: PointerType
+      ID: 818
+      Name: '*net/http/internal.chunkedWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.046848e+06
+      GoKind: 22
+      Pointee: 819 UnresolvedPointeeType net/http/internal.chunkedWriter
+    - __kind: PointerType
+      ID: 479
+      Name: '*net/netip.parseAddrError'
+      ByteSize: 8
+      GoRuntimeType: 919552
+      GoKind: 22
+      Pointee: 480 StructureType net/netip.parseAddrError
+    - __kind: PointerType
+      ID: 477
+      Name: '*net/netip.parsePrefixError'
+      ByteSize: 8
+      GoRuntimeType: 919456
+      GoKind: 22
+      Pointee: 478 StructureType net/netip.parsePrefixError
+    - __kind: PointerType
+      ID: 858
+      Name: '*net/smtp.Client'
+      ByteSize: 8
+      GoRuntimeType: 2.117024e+06
+      GoKind: 22
+      Pointee: 859 UnresolvedPointeeType net/smtp.Client
+    - __kind: PointerType
+      ID: 820
+      Name: '*net/smtp.dataCloser'
+      ByteSize: 8
+      GoRuntimeType: 1.051712e+06
+      GoKind: 22
+      Pointee: 821 StructureType net/smtp.dataCloser
+    - __kind: PointerType
+      ID: 463
+      Name: '*net/textproto.Error'
+      ByteSize: 8
+      GoRuntimeType: 915616
+      GoKind: 22
+      Pointee: 464 UnresolvedPointeeType net/textproto.Error
+    - __kind: PointerType
+      ID: 462
+      Name: '*net/textproto.ProtocolError'
+      ByteSize: 8
+      GoRuntimeType: 915520
+      GoKind: 22
+      Pointee: 347 GoStringHeaderType net/textproto.ProtocolError
+    - __kind: PointerType
+      ID: 349
+      Name: '*net/textproto.ProtocolError.str'
+      ByteSize: 8
+      Pointee: 348 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: PointerType
+      ID: 816
+      Name: '*net/textproto.dotWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.04608e+06
+      GoKind: 22
+      Pointee: 817 UnresolvedPointeeType net/textproto.dotWriter
+    - __kind: PointerType
+      ID: 724
+      Name: '*net/url.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.420768e+06
+      GoKind: 22
+      Pointee: 725 UnresolvedPointeeType net/url.Error
+    - __kind: PointerType
+      ID: 421
+      Name: '*net/url.EscapeError'
+      ByteSize: 8
+      GoRuntimeType: 908128
+      GoKind: 22
+      Pointee: 322 GoStringHeaderType net/url.EscapeError
+    - __kind: PointerType
+      ID: 324
+      Name: '*net/url.EscapeError.str'
+      ByteSize: 8
+      Pointee: 323 GoStringDataType net/url.EscapeError.str
+    - __kind: PointerType
+      ID: 422
+      Name: '*net/url.InvalidHostError'
+      ByteSize: 8
+      GoRuntimeType: 908224
+      GoKind: 22
+      Pointee: 325 GoStringHeaderType net/url.InvalidHostError
+    - __kind: PointerType
+      ID: 327
+      Name: '*net/url.InvalidHostError.str'
+      ByteSize: 8
+      Pointee: 326 GoStringDataType net/url.InvalidHostError.str
+    - __kind: PointerType
       ID: 288
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
@@ -3969,30 +5879,30 @@ Types:
       ByteSize: 8
       Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 337
+      ID: 1016
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 338 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1017 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 373
+      ID: 1052
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 374 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1053 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 388
+      ID: 1067
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 389 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1068 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 196
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 197 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 403
+      ID: 1082
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 404 StructureType noalg.map.group[int]interface {}
+      Pointee: 1083 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 255
       Name: '*noalg.map.group[int]uint8'
@@ -4008,6 +5918,11 @@ Types:
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
       Pointee: 221 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 774
+      Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
+      ByteSize: 8
+      Pointee: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 212
       Name: '*noalg.map.group[string]int'
@@ -4029,6 +5944,175 @@ Types:
       ByteSize: 8
       Pointee: 264 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
+      ID: 967
+      Name: '*os.File'
+      ByteSize: 8
+      GoRuntimeType: 2.348736e+06
+      GoKind: 22
+      Pointee: 968 UnresolvedPointeeType os.File
+    - __kind: PointerType
+      ID: 591
+      Name: '*os.LinkError'
+      ByteSize: 8
+      GoRuntimeType: 1.025216e+06
+      GoKind: 22
+      Pointee: 592 UnresolvedPointeeType os.LinkError
+    - __kind: PointerType
+      ID: 659
+      Name: '*os.SyscallError'
+      ByteSize: 8
+      GoRuntimeType: 1.19072e+06
+      GoKind: 22
+      Pointee: 660 UnresolvedPointeeType os.SyscallError
+    - __kind: PointerType
+      ID: 965
+      Name: '*os.fileWithoutReadFrom'
+      ByteSize: 8
+      GoRuntimeType: 2.347264e+06
+      GoKind: 22
+      Pointee: 966 StructureType os.fileWithoutReadFrom
+    - __kind: PointerType
+      ID: 963
+      Name: '*os.fileWithoutWriteTo'
+      ByteSize: 8
+      GoRuntimeType: 2.346528e+06
+      GoKind: 22
+      Pointee: 964 StructureType os.fileWithoutWriteTo
+    - __kind: PointerType
+      ID: 624
+      Name: '*os/exec.Error'
+      ByteSize: 8
+      GoRuntimeType: 1.042752e+06
+      GoKind: 22
+      Pointee: 625 UnresolvedPointeeType os/exec.Error
+    - __kind: PointerType
+      ID: 770
+      Name: '*os/exec.ExitError'
+      ByteSize: 8
+      GoRuntimeType: 2.088288e+06
+      GoKind: 22
+      Pointee: 771 UnresolvedPointeeType os/exec.ExitError
+    - __kind: PointerType
+      ID: 836
+      Name: '*os/exec.prefixSuffixSaver'
+      ByteSize: 8
+      GoRuntimeType: 1.212992e+06
+      GoKind: 22
+      Pointee: 837 UnresolvedPointeeType os/exec.prefixSuffixSaver
+    - __kind: PointerType
+      ID: 626
+      Name: '*os/exec.wrappedError'
+      ByteSize: 8
+      GoRuntimeType: 1.04288e+06
+      GoKind: 22
+      Pointee: 627 StructureType os/exec.wrappedError
+    - __kind: PointerType
+      ID: 558
+      Name: '*os/user.UnknownGroupIdError'
+      ByteSize: 8
+      GoRuntimeType: 937408
+      GoKind: 22
+      Pointee: 361 GoStringHeaderType os/user.UnknownGroupIdError
+    - __kind: PointerType
+      ID: 363
+      Name: '*os/user.UnknownGroupIdError.str'
+      ByteSize: 8
+      Pointee: 362 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: PointerType
+      ID: 557
+      Name: '*os/user.UnknownUserIdError'
+      ByteSize: 8
+      GoRuntimeType: 937312
+      GoKind: 22
+      Pointee: 360 BaseType os/user.UnknownUserIdError
+    - __kind: PointerType
+      ID: 387
+      Name: '*reflect.ValueError'
+      ByteSize: 8
+      GoRuntimeType: 900736
+      GoKind: 22
+      Pointee: 388 UnresolvedPointeeType reflect.ValueError
+    - __kind: PointerType
+      ID: 485
+      Name: '*regexp/syntax.Error'
+      ByteSize: 8
+      GoRuntimeType: 920224
+      GoKind: 22
+      Pointee: 486 UnresolvedPointeeType regexp/syntax.Error
+    - __kind: PointerType
+      ID: 595
+      Name: '*runtime.PanicNilError'
+      ByteSize: 8
+      GoRuntimeType: 1.026752e+06
+      GoKind: 22
+      Pointee: 596 UnresolvedPointeeType runtime.PanicNilError
+    - __kind: PointerType
+      ID: 599
+      Name: '*runtime.TypeAssertionError'
+      ByteSize: 8
+      GoRuntimeType: 1.028544e+06
+      GoKind: 22
+      Pointee: 600 UnresolvedPointeeType runtime.TypeAssertionError
+    - __kind: PointerType
+      ID: 597
+      Name: '*runtime.boundsError'
+      ByteSize: 8
+      GoRuntimeType: 1.02688e+06
+      GoKind: 22
+      Pointee: 598 StructureType runtime.boundsError
+    - __kind: PointerType
+      ID: 661
+      Name: '*runtime.errorAddressString'
+      ByteSize: 8
+      GoRuntimeType: 1.196224e+06
+      GoKind: 22
+      Pointee: 662 StructureType runtime.errorAddressString
+    - __kind: PointerType
+      ID: 593
+      Name: '*runtime.errorString'
+      ByteSize: 8
+      GoRuntimeType: 1.026368e+06
+      GoKind: 22
+      Pointee: 576 GoStringHeaderType runtime.errorString
+    - __kind: PointerType
+      ID: 578
+      Name: '*runtime.errorString.str'
+      ByteSize: 8
+      Pointee: 577 GoStringDataType runtime.errorString.str
+    - __kind: PointerType
+      ID: 594
+      Name: '*runtime.plainError'
+      ByteSize: 8
+      GoRuntimeType: 1.026496e+06
+      GoKind: 22
+      Pointee: 579 GoStringHeaderType runtime.plainError
+    - __kind: PointerType
+      ID: 581
+      Name: '*runtime.plainError.str'
+      ByteSize: 8
+      Pointee: 580 GoStringDataType runtime.plainError.str
+    - __kind: PointerType
+      ID: 737
+      Name: '*runtime.synctestBubble'
+      ByteSize: 8
+      GoRuntimeType: 1.551392e+06
+      GoKind: 22
+      Pointee: 738 UnresolvedPointeeType runtime.synctestBubble
+    - __kind: PointerType
+      ID: 383
+      Name: '*runtime.synctestDeadlockError'
+      ByteSize: 8
+      GoRuntimeType: 899392
+      GoKind: 22
+      Pointee: 384 StructureType runtime.synctestDeadlockError
+    - __kind: PointerType
+      ID: 601
+      Name: '*strconv.NumError'
+      ByteSize: 8
+      GoRuntimeType: 1.0288e+06
+      GoKind: 22
+      Pointee: 602 UnresolvedPointeeType strconv.NumError
+    - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
@@ -4040,6 +6124,34 @@ Types:
       Name: '*string.str'
       ByteSize: 8
       Pointee: 177 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 902
+      Name: '*strings.Builder'
+      ByteSize: 8
+      GoRuntimeType: 1.949088e+06
+      GoKind: 22
+      Pointee: 903 UnresolvedPointeeType strings.Builder
+    - __kind: PointerType
+      ID: 806
+      Name: '*strings.appendSliceWriter'
+      ByteSize: 8
+      GoRuntimeType: 1.028928e+06
+      GoKind: 22
+      Pointee: 807 UnresolvedPointeeType strings.appendSliceWriter
+    - __kind: PointerType
+      ID: 802
+      Name: '*struct { io.Writer }'
+      ByteSize: 8
+      GoRuntimeType: 970400
+      GoKind: 22
+      Pointee: 803 StructureType struct { io.Writer }
+    - __kind: PointerType
+      ID: 713
+      Name: '*syscall.Errno'
+      ByteSize: 8
+      GoRuntimeType: 1.415328e+06
+      GoKind: 22
+      Pointee: 712 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
@@ -4066,30 +6178,30 @@ Types:
       ByteSize: 8
       Pointee: 184 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 334
+      ID: 1013
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 335 StructureType table<int,*main.deepMap3>
+      Pointee: 1014 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 370
+      ID: 1049
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 371 StructureType table<int,*main.deepMap8>
+      Pointee: 1050 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 385
+      ID: 1064
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 386 StructureType table<int,*main.deepMap9>
+      Pointee: 1065 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 194 StructureType table<int,int>
     - __kind: PointerType
-      ID: 400
+      ID: 1079
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 401 StructureType table<int,interface {}>
+      Pointee: 1080 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*table<int,uint8>'
@@ -4105,6 +6217,11 @@ Types:
       Name: '*table<string,[]string>'
       ByteSize: 8
       Pointee: 218 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 744
+      Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
+      ByteSize: 8
+      Pointee: 772 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
@@ -4125,6 +6242,46 @@ Types:
       Name: '*table<uint8,uint8>'
       ByteSize: 8
       Pointee: 261 StructureType table<uint8,uint8>
+    - __kind: PointerType
+      ID: 937
+      Name: '*text/tabwriter.Writer'
+      ByteSize: 8
+      GoRuntimeType: 2.158656e+06
+      GoKind: 22
+      Pointee: 938 UnresolvedPointeeType text/tabwriter.Writer
+    - __kind: PointerType
+      ID: 654
+      Name: '*text/template.ExecError'
+      ByteSize: 8
+      GoRuntimeType: 1.08832e+06
+      GoKind: 22
+      Pointee: 655 StructureType text/template.ExecError
+    - __kind: PointerType
+      ID: 729
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.6216e+06
+      GoKind: 22
+      Pointee: 730 UnresolvedPointeeType time.Location
+    - __kind: PointerType
+      ID: 390
+      Name: '*time.ParseError'
+      ByteSize: 8
+      GoRuntimeType: 901600
+      GoKind: 22
+      Pointee: 391 UnresolvedPointeeType time.ParseError
+    - __kind: PointerType
+      ID: 389
+      Name: '*time.fileSizeError'
+      ByteSize: 8
+      GoRuntimeType: 901504
+      GoKind: 22
+      Pointee: 306 GoStringHeaderType time.fileSizeError
+    - __kind: PointerType
+      ID: 308
+      Name: '*time.fileSizeError.str'
+      ByteSize: 8
+      Pointee: 307 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4167,11 +6324,53 @@ Types:
       GoRuntimeType: 392864
       GoKind: 22
       Pointee: 1 BaseType uintptr
+    - __kind: PointerType
+      ID: 481
+      Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
+      ByteSize: 8
+      GoRuntimeType: 919648
+      GoKind: 22
+      Pointee: 482 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+    - __kind: PointerType
+      ID: 929
+      Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
+      ByteSize: 8
+      GoRuntimeType: 2.134144e+06
+      GoKind: 22
+      Pointee: 930 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+    - __kind: PointerType
+      ID: 465
+      Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
+      ByteSize: 8
+      GoRuntimeType: 915808
+      GoKind: 22
+      Pointee: 466 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+    - __kind: PointerType
+      ID: 467
+      Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
+      ByteSize: 8
+      GoRuntimeType: 915904
+      GoKind: 22
+      Pointee: 350 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+    - __kind: PointerType
+      ID: 631
+      Name: '*vendor/golang.org/x/net/idna.labelError'
+      ByteSize: 8
+      GoRuntimeType: 1.046592e+06
+      GoKind: 22
+      Pointee: 632 StructureType vendor/golang.org/x/net/idna.labelError
+    - __kind: PointerType
+      ID: 633
+      Name: '*vendor/golang.org/x/net/idna.runeError'
+      ByteSize: 8
+      GoRuntimeType: 1.04672e+06
+      GoKind: 22
+      Pointee: 584 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 506
+      ID: 1185
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 463
+      ID: 1142
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4186,7 +6385,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 461
+      ID: 1140
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4201,7 +6400,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 425
+      ID: 1104
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4216,7 +6415,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 423
+      ID: 1102
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4231,7 +6430,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 471
+      ID: 1150
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4246,7 +6445,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 424
+      ID: 1103
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4261,7 +6460,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 443
+      ID: 1122
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4276,7 +6475,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 412
+      ID: 1091
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4291,7 +6490,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 409
+      ID: 1088
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4306,7 +6505,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 487
+      ID: 1166
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4321,7 +6520,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 485
+      ID: 1164
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4354,7 +6553,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 495
+      ID: 1174
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4369,7 +6568,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 448
+      ID: 1127
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4384,7 +6583,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 449
+      ID: 1128
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4399,7 +6598,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 444
+      ID: 1123
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4414,7 +6613,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 445
+      ID: 1124
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4429,7 +6628,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 446
+      ID: 1125
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4444,7 +6643,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 447
+      ID: 1126
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4459,7 +6658,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 1179
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4483,7 +6682,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 1176
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4498,7 +6697,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 514
+      ID: 1193
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4513,7 +6712,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 517
+      ID: 1196
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4528,7 +6727,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 516
+      ID: 1195
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4543,7 +6742,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 462
+      ID: 1141
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4558,7 +6757,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 453
+      ID: 1132
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4573,7 +6772,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 452
+      ID: 1131
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -4588,7 +6787,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 459
+      ID: 1138
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4603,7 +6802,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 458
+      ID: 1137
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4618,7 +6817,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 454
+      ID: 1133
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4633,7 +6832,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 456
+      ID: 1135
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4648,10 +6847,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 519
+      ID: 1198
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 455
+      ID: 1134
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4675,16 +6874,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 1199
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 521
+      ID: 1200
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 457
+      ID: 1136
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 518
+      ID: 1197
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4699,7 +6898,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 522
+      ID: 1201
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4714,7 +6913,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 523
+      ID: 1202
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4729,7 +6928,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 415
+      ID: 1094
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4744,7 +6943,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 416
+      ID: 1095
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4759,7 +6958,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 417
+      ID: 1096
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4774,7 +6973,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 414
+      ID: 1093
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4789,7 +6988,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 413
+      ID: 1092
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4804,7 +7003,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 460
+      ID: 1139
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4819,7 +7018,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 1168
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4834,7 +7033,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 469
+      ID: 1148
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4849,7 +7048,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 1154
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4864,7 +7063,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 1152
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4879,7 +7078,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 484
+      ID: 1163
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4894,7 +7093,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 483
+      ID: 1162
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4909,7 +7108,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 1153
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4924,7 +7123,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 482
+      ID: 1161
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4939,7 +7138,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 1160
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4954,7 +7153,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 467
+      ID: 1146
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4969,7 +7168,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 468
+      ID: 1147
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4984,7 +7183,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 466
+      ID: 1145
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4999,7 +7198,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 1155
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5014,7 +7213,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 1159
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5029,7 +7228,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 1158
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5044,7 +7243,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 1157
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5059,7 +7258,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 1156
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5074,7 +7273,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 512
+      ID: 1191
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5089,7 +7288,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 486
+      ID: 1165
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5140,7 +7339,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 494
+      ID: 1173
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5164,7 +7363,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 1180
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5188,7 +7387,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 503
+      ID: 1182
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5221,7 +7420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 504
+      ID: 1183
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5236,7 +7435,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 1190
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5251,7 +7450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 490
+      ID: 1169
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5266,7 +7465,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 1151
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5281,7 +7480,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 488
+      ID: 1167
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5296,7 +7495,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 410
+      ID: 1089
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5311,7 +7510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 429
+      ID: 1108
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5326,7 +7525,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 427
+      ID: 1106
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5341,7 +7540,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 440
+      ID: 1119
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5356,7 +7555,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 441
+      ID: 1120
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5371,7 +7570,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 432
+      ID: 1111
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5386,7 +7585,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 433
+      ID: 1112
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5401,7 +7600,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 434
+      ID: 1113
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5416,7 +7615,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 431
+      ID: 1110
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5431,7 +7630,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 430
+      ID: 1109
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5446,7 +7645,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 428
+      ID: 1107
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5461,7 +7660,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 507
+      ID: 1186
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5476,7 +7675,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 437
+      ID: 1116
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5491,7 +7690,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 438
+      ID: 1117
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5506,7 +7705,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 439
+      ID: 1118
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5521,7 +7720,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 436
+      ID: 1115
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5536,7 +7735,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 435
+      ID: 1114
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5551,7 +7750,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 1177
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5566,7 +7765,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 470
+      ID: 1149
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5581,7 +7780,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 411
+      ID: 1090
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5596,7 +7795,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 493
+      ID: 1172
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5611,7 +7810,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 502
+      ID: 1181
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5626,7 +7825,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 450
+      ID: 1129
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5641,7 +7840,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 451
+      ID: 1130
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5656,7 +7855,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 1178
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5680,7 +7879,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 1143
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5695,7 +7894,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 465
+      ID: 1144
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5710,7 +7909,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 515
+      ID: 1194
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5725,7 +7924,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 510
+      ID: 1189
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5740,7 +7939,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 509
+      ID: 1188
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5755,7 +7954,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 508
+      ID: 1187
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5788,7 +7987,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 442
+      ID: 1121
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5803,7 +8002,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 420
+      ID: 1099
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5818,7 +8017,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 421
+      ID: 1100
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5833,7 +8032,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 422
+      ID: 1101
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5848,7 +8047,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 419
+      ID: 1098
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5863,7 +8062,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 418
+      ID: 1097
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5878,7 +8077,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 492
+      ID: 1171
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5893,7 +8092,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 1175
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5908,7 +8107,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 513
+      ID: 1192
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5923,7 +8122,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 491
+      ID: 1170
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5938,7 +8137,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 426
+      ID: 1105
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5953,7 +8152,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 505
+      ID: 1184
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6126,6 +8325,15 @@ Types:
       Count: 5
       HasCount: true
       Element: 7 BaseType int
+    - __kind: ArrayType
+      ID: 762
+      Name: '[5]uint8'
+      ByteSize: 5
+      GoRuntimeType: 684192
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*main.deepSlice2'
@@ -6149,7 +8357,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 324
+      ID: 1003
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477664
@@ -6157,21 +8365,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 325 PointerType **main.deepSlice3
+          Type: 1004 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 328 GoSliceDataType []*main.deepSlice3.array
+      Data: 1007 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 1007
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 326 PointerType *main.deepSlice3
+      Element: 1005 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 351
+      ID: 1030
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477344
@@ -6179,21 +8387,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 352 PointerType **main.deepSlice8
+          Type: 1031 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 355 GoSliceDataType []*main.deepSlice8.array
+      Data: 1034 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 355
+      ID: 1034
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 353 PointerType *main.deepSlice8
+      Element: 1032 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 357
+      ID: 1036
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477280
@@ -6201,19 +8409,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 358 PointerType **main.deepSlice9
+          Type: 1037 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 361 GoSliceDataType []*main.deepSlice9.array
+      Data: 1040 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 1040
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 359 PointerType *main.deepSlice9
+      Element: 1038 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6262,30 +8470,30 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 1022
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 334 PointerType *table<int,*main.deepMap3>
+      Element: 1013 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 379
+      ID: 1058
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 370 PointerType *table<int,*main.deepMap8>
+      Element: 1049 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 1073
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 385 PointerType *table<int,*main.deepMap9>
+      Element: 1064 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 407
+      ID: 1086
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 400 PointerType *table<int,interface {}>
+      Element: 1079 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]*table<int,uint8>.array'
@@ -6301,6 +8509,11 @@ Types:
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 778
+      Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
+      ByteSize: 8192
+      Element: 744 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 216
       Name: '[]*table<string,int>.array'
@@ -6365,7 +8578,29 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 363
+      ID: 757
+      Name: '[]float64'
+      ByteSize: 24
+      GoRuntimeType: 486944
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 26 PointerType *float64
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 782 GoSliceDataType []float64.array
+    - __kind: GoSliceDataType
+      ID: 782
+      Name: '[]float64.array'
+      ByteSize: 2048
+      Element: 16 BaseType float64
+    - __kind: GoSliceHeaderType
+      ID: 1042
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487392
@@ -6380,9 +8615,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 364 GoSliceDataType []interface {}.array
+      Data: 1043 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 1043
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
@@ -6402,9 +8637,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 345 GoSliceDataType []main.structWithMap.array
+      Data: 1024 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 1024
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -6455,30 +8690,30 @@ Types:
       ByteSize: 2048
       Element: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 1023
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 338 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1017 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 1059
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 374 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1053 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 1074
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 389 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1068 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 201
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 197 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 408
+      ID: 1087
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 404 StructureType noalg.map.group[int]interface {}
+      Element: 1083 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]noalg.map.group[int]uint8.array'
@@ -6494,6 +8729,11 @@ Types:
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 221 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 779
+      Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
+      ByteSize: 2048
+      Element: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 217
       Name: '[]noalg.map.group[string]int.array'
@@ -6580,12 +8820,104 @@ Types:
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
+    - __kind: GoSliceHeaderType
+      ID: 751
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 485920
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 5 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 780 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 780
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 914
+      Name: archive/tar.Writer
+      ByteSize: 8
+    - __kind: GoSliceHeaderType
+      ID: 544
+      Name: archive/tar.headerError
+      ByteSize: 24
+      GoRuntimeType: 930784
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 22 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 545 GoSliceDataType archive/tar.headerError.array
+    - __kind: GoSliceDataType
+      ID: 545
+      Name: archive/tar.headerError.array
+      ByteSize: 2048
+      Element: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 849
+      Name: archive/tar.regFileWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 797
+      Name: archive/zip.countWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 799
+      Name: archive/zip.dirWriter
+      GoRuntimeType: 1.119616e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 893
+      Name: archive/zip.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 825
+      Name: archive/zip.nopCloser
+      ByteSize: 16
+      GoRuntimeType: 1.564352e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 827
+      Name: archive/zip.pooledFlateWriter
+      ByteSize: 8
     - __kind: BaseType
       ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 584960
       GoKind: 1
+    - __kind: UnresolvedPointeeType
+      ID: 872
+      Name: bufio.Reader
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 901
+      Name: bufio.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 952
+      Name: bytes.Buffer
+      ByteSize: 8
     - __kind: GoChannelType
       ID: 153
       Name: chan bool
@@ -6608,6 +8940,365 @@ Types:
       ByteSize: 8
       GoRuntimeType: 584704
       GoKind: 15
+    - __kind: BaseType
+      ID: 342
+      Name: compress/flate.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 834048
+      GoKind: 6
+    - __kind: GoStringHeaderType
+      ID: 343
+      Name: compress/flate.InternalError
+      ByteSize: 16
+      GoRuntimeType: 834144
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 345 PointerType *compress/flate.InternalError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 344 GoStringDataType compress/flate.InternalError.str
+    - __kind: GoStringDataType
+      ID: 344
+      Name: compress/flate.InternalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 847
+      Name: compress/flate.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 793
+      Name: compress/flate.dictWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 869
+      Name: compress/gzip.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 692
+      Name: context.deadlineExceededError
+      GoRuntimeType: 1.478592e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 356
+      Name: crypto/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 836640
+      GoKind: 2
+    - __kind: BaseType
+      ID: 357
+      Name: crypto/des.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 836736
+      GoKind: 2
+    - __kind: BaseType
+      ID: 358
+      Name: crypto/internal/fips140/aes.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 836832
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 864
+      Name: crypto/internal/fips140/hmac.HMAC
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 641
+      Name: crypto/internal/fips140/hmac.errCloneUnsupported
+      GoRuntimeType: 1.288576e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 895
+      Name: crypto/internal/fips140/sha256.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 925
+      Name: crypto/internal/fips140/sha3.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 899
+      Name: crypto/internal/fips140/sha3.SHAKE
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 897
+      Name: crypto/internal/fips140/sha512.Digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 891
+      Name: crypto/md5.digest
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 359
+      Name: crypto/rc4.KeySizeError
+      ByteSize: 8
+      GoRuntimeType: 836928
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 912
+      Name: crypto/sha1.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 887
+      Name: crypto/sha3.SHA3
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 346
+      Name: crypto/tls.AlertError
+      ByteSize: 1
+      GoRuntimeType: 834624
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 630
+      Name: crypto/tls.CertificateVerificationError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 978
+      Name: crypto/tls.Conn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 458
+      Name: crypto/tls.ECHRejectionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 456
+      Name: crypto/tls.RecordHeaderError
+      ByteSize: 40
+      GoRuntimeType: 1.72944e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: RecordHeader
+          Offset: 16
+          Type: 762 ArrayType [5]uint8
+        - Name: Conn
+          Offset: 24
+          Type: 763 GoInterfaceType net.Conn
+    - __kind: BaseType
+      ID: 583
+      Name: crypto/tls.alert
+      ByteSize: 1
+      GoRuntimeType: 992768
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 857
+      Name: crypto/tls.cthWrapper
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 460
+      Name: crypto/tls.echConfigErr
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 862
+      Name: crypto/tls.finishedHash
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 727
+      Name: crypto/tls.permanentError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 746
+      Name: crypto/x509.Certificate
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 532
+      Name: crypto/x509.CertificateInvalidError
+      ByteSize: 32
+      GoRuntimeType: 1.73232e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 745 PointerType *crypto/x509.Certificate
+        - Name: Reason
+          Offset: 8
+          Type: 765 BaseType crypto/x509.InvalidReason
+        - Name: Detail
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 526
+      Name: crypto/x509.ConstraintViolationError
+      GoRuntimeType: 1.117184e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 528
+      Name: crypto/x509.HostnameError
+      ByteSize: 24
+      GoRuntimeType: 1.598464e+06
+      GoKind: 25
+      RawFields:
+        - Name: Certificate
+          Offset: 0
+          Type: 745 PointerType *crypto/x509.Certificate
+        - Name: Host
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 355
+      Name: crypto/x509.InsecureAlgorithmError
+      ByteSize: 8
+      GoRuntimeType: 836256
+      GoKind: 2
+    - __kind: BaseType
+      ID: 765
+      Name: crypto/x509.InvalidReason
+      ByteSize: 8
+      GoRuntimeType: 590144
+      GoKind: 2
+    - __kind: StructureType
+      ID: 635
+      Name: crypto/x509.SystemRootsError
+      ByteSize: 16
+      GoRuntimeType: 1.560352e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 534
+      Name: crypto/x509.UnhandledCriticalExtension
+      GoRuntimeType: 1.11744e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 530
+      Name: crypto/x509.UnknownAuthorityError
+      ByteSize: 32
+      GoRuntimeType: 1.732128e+06
+      GoKind: 25
+      RawFields:
+        - Name: Cert
+          Offset: 0
+          Type: 745 PointerType *crypto/x509.Certificate
+        - Name: hintErr
+          Offset: 8
+          Type: 14 GoInterfaceType error
+        - Name: hintCert
+          Offset: 24
+          Type: 745 PointerType *crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 548
+      Name: encoding/asn1.StructuralError
+      ByteSize: 16
+      GoRuntimeType: 1.435008e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 552
+      Name: encoding/asn1.SyntaxError
+      ByteSize: 16
+      GoRuntimeType: 1.435168e+06
+      GoKind: 25
+      RawFields:
+        - Name: Msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 550
+      Name: encoding/asn1.invalidUnmarshalError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 337
+      Name: encoding/base64.CorruptInputError
+      ByteSize: 8
+      GoRuntimeType: 833568
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 815
+      Name: encoding/base64.encoder
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 338
+      Name: encoding/hex.InvalidByteError
+      ByteSize: 1
+      GoRuntimeType: 833760
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 414
+      Name: encoding/json.InvalidUnmarshalError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 619
+      Name: encoding/json.MarshalerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 406
+      Name: encoding/json.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 412
+      Name: encoding/json.UnmarshalTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 410
+      Name: encoding/json.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 408
+      Name: encoding/json.UnsupportedValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 958
+      Name: encoding/json.encodeState
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 416
+      Name: encoding/json.jsonError
+      ByteSize: 16
+      GoRuntimeType: 1.419008e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 823
+      Name: encoding/pem.lineBreaker
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 520
+      Name: encoding/xml.SyntaxError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 518
+      Name: encoding/xml.TagPathError
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 352
+      Name: encoding/xml.UnmarshalError
+      ByteSize: 16
+      GoRuntimeType: 836160
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 354 PointerType *encoding/xml.UnmarshalError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 353 GoStringDataType encoding/xml.UnmarshalError.str
+    - __kind: GoStringDataType
+      ID: 353
+      Name: encoding/xml.UnmarshalError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 523
+      Name: encoding/xml.UnsupportedTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 936
+      Name: encoding/xml.printer
+      ByteSize: 8
     - __kind: GoInterfaceType
       ID: 14
       Name: error
@@ -6621,6 +9312,14 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 382
+      Name: errors.errorString
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 586
+      Name: errors.joinError
+      ByteSize: 8
     - __kind: BaseType
       ID: 18
       Name: float32
@@ -6633,12 +9332,1062 @@ Types:
       ByteSize: 8
       GoRuntimeType: 584896
       GoKind: 14
+    - __kind: UnresolvedPointeeType
+      ID: 946
+      Name: fmt.pp
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 588
+      Name: fmt.wrapError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 590
+      Name: fmt.wrapErrors
+      ByteSize: 8
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
       GoRuntimeType: 475872
       GoKind: 19
+    - __kind: UnresolvedPointeeType
+      ID: 444
+      Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 425
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      ByteSize: 216
+      GoRuntimeType: 1.728288e+06
+      GoKind: 25
+      RawFields:
+        - Name: Metric
+          Offset: 0
+          Type: 755 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+        - Name: ChannelSize
+          Offset: 192
+          Type: 7 BaseType int
+        - Name: Msg
+          Offset: 200
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 427
+      Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 759
+      Name: github.com/DataDog/datadog-go/v5/statsd.Event
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 431
+      Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      GoRuntimeType: 1.113472e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 761
+      Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 331
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      ByteSize: 16
+      GoRuntimeType: 832992
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+    - __kind: GoStringDataType
+      ID: 332
+      Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 755
+      Name: github.com/DataDog/datadog-go/v5/statsd.metric
+      ByteSize: 192
+      GoRuntimeType: 2.217952e+06
+      GoKind: 25
+      RawFields:
+        - Name: metricType
+          Offset: 0
+          Type: 756 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+        - Name: namespace
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+        - Name: globalTags
+          Offset: 24
+          Type: 166 GoSliceHeaderType []string
+        - Name: name
+          Offset: 48
+          Type: 9 GoStringHeaderType string
+        - Name: fvalue
+          Offset: 64
+          Type: 16 BaseType float64
+        - Name: fvalues
+          Offset: 72
+          Type: 757 GoSliceHeaderType []float64
+        - Name: ivalue
+          Offset: 96
+          Type: 13 BaseType int64
+        - Name: svalue
+          Offset: 104
+          Type: 9 GoStringHeaderType string
+        - Name: evalue
+          Offset: 120
+          Type: 758 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+        - Name: scvalue
+          Offset: 128
+          Type: 760 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+        - Name: tags
+          Offset: 136
+          Type: 166 GoSliceHeaderType []string
+        - Name: stags
+          Offset: 160
+          Type: 9 GoStringHeaderType string
+        - Name: rate
+          Offset: 176
+          Type: 16 BaseType float64
+        - Name: timestamp
+          Offset: 184
+          Type: 13 BaseType int64
+    - __kind: BaseType
+      ID: 756
+      Name: github.com/DataDog/datadog-go/v5/statsd.metricType
+      ByteSize: 8
+      GoRuntimeType: 586752
+      GoKind: 2
+    - __kind: GoStringHeaderType
+      ID: 328
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      ByteSize: 16
+      GoRuntimeType: 832896
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+    - __kind: GoStringDataType
+      ID: 329
+      Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 334
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      ByteSize: 16
+      GoRuntimeType: 833088
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 336 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+    - __kind: GoStringDataType
+      ID: 335
+      Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 835
+      Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 922
+      Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 542
+      Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 701
+      Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 954
+      Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 469
+      Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 476
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      GoRuntimeType: 1.116416e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 351
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      ByteSize: 8
+      GoRuntimeType: 835296
+      GoKind: 2
+    - __kind: StructureType
+      ID: 474
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      GoRuntimeType: 1.116288e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 472
+      Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      ByteSize: 32
+      GoRuntimeType: 1.596544e+06
+      GoKind: 25
+      RawFields:
+        - Name: OS
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Arch
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 492
+      Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      ByteSize: 32
+      GoRuntimeType: 1.597344e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 496
+      Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      ByteSize: 32
+      GoRuntimeType: 1.731552e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Size
+          Offset: 16
+          Type: 13 BaseType int64
+        - Name: MaxSize
+          Offset: 24
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 494
+      Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      ByteSize: 16
+      GoRuntimeType: 1.428928e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 490
+      Name: github.com/DataDog/go-tuf/client.ErrNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.428608e+06
+      GoKind: 25
+      RawFields:
+        - Name: File
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 740
+      Name: github.com/DataDog/go-tuf/data.Hashes
+      ByteSize: 8
+      GoRuntimeType: 1.499552e+06
+      GoKind: 21
+      HeaderType: 742 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+    - __kind: GoSliceHeaderType
+      ID: 764
+      Name: github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 24
+      GoRuntimeType: 1.050176e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 5 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 784 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+    - __kind: GoSliceDataType
+      ID: 784
+      Name: github.com/DataDog/go-tuf/data.HexBytes.array
+      ByteSize: 2048
+      Element: 3 BaseType uint8
+    - __kind: StructureType
+      ID: 504
+      Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      ByteSize: 16
+      GoRuntimeType: 1.597664e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 740 GoMapType github.com/DataDog/go-tuf/data.Hashes
+        - Name: Actual
+          Offset: 8
+          Type: 740 GoMapType github.com/DataDog/go-tuf/data.Hashes
+    - __kind: StructureType
+      ID: 498
+      Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      ByteSize: 16
+      GoRuntimeType: 1.429088e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 502
+      Name: github.com/DataDog/go-tuf/util.ErrWrongHash
+      ByteSize: 64
+      GoRuntimeType: 1.731744e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Expected
+          Offset: 16
+          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+        - Name: Actual
+          Offset: 40
+          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+    - __kind: StructureType
+      ID: 500
+      Name: github.com/DataDog/go-tuf/util.ErrWrongLength
+      ByteSize: 16
+      GoRuntimeType: 1.597504e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Actual
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 506
+      Name: github.com/DataDog/go-tuf/verify.ErrExpired
+      ByteSize: 24
+      GoRuntimeType: 1.429248e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expired
+          Offset: 0
+          Type: 728 StructureType time.Time
+    - __kind: StructureType
+      ID: 512
+      Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
+      ByteSize: 16
+      GoRuntimeType: 1.597984e+06
+      GoKind: 25
+      RawFields:
+        - Name: Actual
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Current
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 514
+      Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
+      ByteSize: 16
+      GoRuntimeType: 1.429568e+06
+      GoKind: 25
+      RawFields:
+        - Name: KeyID
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 510
+      Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      ByteSize: 16
+      GoRuntimeType: 1.597824e+06
+      GoKind: 25
+      RawFields:
+        - Name: Expected
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: Actual
+          Offset: 8
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 508
+      Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      ByteSize: 16
+      GoRuntimeType: 1.429408e+06
+      GoKind: 25
+      RawFields:
+        - Name: Role
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 516
+      Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      ByteSize: 16
+      GoRuntimeType: 1.598144e+06
+      GoKind: 25
+      RawFields:
+        - Name: Given
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: Expected
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 433
+      Name: github.com/cihub/seelog.baseError
+      ByteSize: 16
+      GoRuntimeType: 1.421248e+06
+      GoKind: 25
+      RawFields:
+        - Name: message
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 875
+      Name: github.com/cihub/seelog.bufferedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 435
+      Name: github.com/cihub/seelog.cannotOpenFileError
+      ByteSize: 16
+      GoRuntimeType: 1.421408e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 855
+      Name: github.com/cihub/seelog.connWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 811
+      Name: github.com/cihub/seelog.consoleWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 845
+      Name: github.com/cihub/seelog.fileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 439
+      Name: github.com/cihub/seelog.missingArgumentError
+      ByteSize: 16
+      GoRuntimeType: 1.421728e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 910
+      Name: github.com/cihub/seelog.rollingFileWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 923
+      Name: github.com/cihub/seelog.rollingFileWriterSize
+      ByteSize: 16
+      GoRuntimeType: 2.10544e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 909 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: maxFileSize
+          Offset: 8
+          Type: 13 BaseType int64
+    - __kind: StructureType
+      ID: 926
+      Name: github.com/cihub/seelog.rollingFileWriterTime
+      ByteSize: 40
+      GoRuntimeType: 2.130304e+06
+      GoKind: 25
+      RawFields:
+        - Name: rollingFileWriter
+          Offset: 0
+          Type: 909 PointerType *github.com/cihub/seelog.rollingFileWriter
+        - Name: timePattern
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+        - Name: currentTimeFileName
+          Offset: 24
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 813
+      Name: github.com/cihub/seelog.smtpWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 437
+      Name: github.com/cihub/seelog.unexpectedAttributeError
+      ByteSize: 16
+      GoRuntimeType: 1.421568e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: StructureType
+      ID: 441
+      Name: github.com/cihub/seelog.unexpectedChildElementError
+      ByteSize: 16
+      GoRuntimeType: 1.421888e+06
+      GoKind: 25
+      RawFields:
+        - Name: baseError
+          Offset: 0
+          Type: 433 StructureType github.com/cihub/seelog.baseError
+    - __kind: UnresolvedPointeeType
+      ID: 877
+      Name: github.com/cihub/seelog/archive/gzip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 918
+      Name: github.com/cihub/seelog/archive/tar.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 920
+      Name: github.com/cihub/seelog/archive/zip.Writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 732
+      Name: github.com/go-viper/mapstructure/v2.DecodeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 645
+      Name: github.com/go-viper/mapstructure/v2.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 643
+      Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 647
+      Name: github.com/gogo/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 649
+      Name: github.com/gogo/protobuf/proto.invalidUTF8Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 866
+      Name: github.com/gogo/protobuf/proto.textWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 637
+      Name: github.com/golang/protobuf/proto.RequiredNotSetError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 447
+      Name: github.com/google/uuid.invalidLengthError
+      ByteSize: 8
+      GoRuntimeType: 1.422848e+06
+      GoKind: 25
+      RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
+    - __kind: UnresolvedPointeeType
+      ID: 970
+      Name: github.com/json-iterator/go.Stream
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 703
+      Name: github.com/pkg/errors.fundamental
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 676
+      Name: github.com/tinylib/msgp/msgp.ArrayError
+      ByteSize: 24
+      GoRuntimeType: 1.841344e+06
+      GoKind: 25
+      RawFields:
+        - Name: Wanted
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Got
+          Offset: 4
+          Type: 2 BaseType uint32
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 670
+      Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 605
+      Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
+      ByteSize: 2
+      GoRuntimeType: 1.700992e+06
+      GoKind: 25
+      RawFields:
+        - Name: Got
+          Offset: 0
+          Type: 17 BaseType int8
+        - Name: Want
+          Offset: 1
+          Type: 17 BaseType int8
+    - __kind: StructureType
+      ID: 682
+      Name: github.com/tinylib/msgp/msgp.IntOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.841792e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 582
+      Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
+      ByteSize: 1
+      GoRuntimeType: 990080
+      GoKind: 8
+    - __kind: StructureType
+      ID: 674
+      Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
+      ByteSize: 32
+      GoRuntimeType: 1.84112e+06
+      GoKind: 25
+      RawFields:
+        - Name: Nanos
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: FieldLength
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 766
+      Name: github.com/tinylib/msgp/msgp.Type
+      ByteSize: 1
+      GoRuntimeType: 831168
+      GoKind: 8
+    - __kind: StructureType
+      ID: 672
+      Name: github.com/tinylib/msgp/msgp.TypeError
+      ByteSize: 24
+      GoRuntimeType: 1.840896e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 766 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: Encoded
+          Offset: 1
+          Type: 766 BaseType github.com/tinylib/msgp/msgp.Type
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 680
+      Name: github.com/tinylib/msgp/msgp.UintBelowZero
+      ByteSize: 24
+      GoRuntimeType: 1.754944e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: ctx
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 678
+      Name: github.com/tinylib/msgp/msgp.UintOverflow
+      ByteSize: 32
+      GoRuntimeType: 1.841568e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: FailedBitsize
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 974
+      Name: github.com/tinylib/msgp/msgp.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 686
+      Name: github.com/tinylib/msgp/msgp.errFatal
+      ByteSize: 16
+      GoRuntimeType: 1.62256e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctx
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 609
+      Name: github.com/tinylib/msgp/msgp.errRecursion
+      GoRuntimeType: 1.28256e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 607
+      Name: github.com/tinylib/msgp/msgp.errShort
+      GoRuntimeType: 1.282432e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 684
+      Name: github.com/tinylib/msgp/msgp.errWrapped
+      ByteSize: 32
+      GoRuntimeType: 1.755136e+06
+      GoKind: 25
+      RawFields:
+        - Name: cause
+          Offset: 0
+          Type: 14 GoInterfaceType error
+        - Name: ctx
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 364
+      Name: go.opentelemetry.io/otel/trace.errorConst
+      ByteSize: 16
+      GoRuntimeType: 838752
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 366 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 365 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+    - __kind: GoStringDataType
+      ID: 365
+      Name: go.opentelemetry.io/otel/trace.errorConst.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 749
+      Name: go.uber.org/multierr.multiError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 653
+      Name: go.uber.org/zap.errArrayElem
+      ByteSize: 16
+      GoRuntimeType: 1.446848e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 841
+      Name: go.uber.org/zap.nopCloserSink
+      ByteSize: 16
+      GoRuntimeType: 1.676704e+06
+      GoKind: 25
+      RawFields:
+        - Name: WriteSyncer
+          Offset: 0
+          Type: 867 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+    - __kind: UnresolvedPointeeType
+      ID: 934
+      Name: go.uber.org/zap/buffer.Buffer
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 867
+      Name: go.uber.org/zap/zapcore.WriteSyncer
+      ByteSize: 16
+      GoRuntimeType: 1.127168e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 829
+      Name: go.uber.org/zap/zapcore.writerWrapper
+      ByteSize: 16
+      GoRuntimeType: 1.569152e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 367
+      Name: golang.org/x/net/http2.ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 839328
+      GoKind: 10
+    - __kind: BaseType
+      ID: 747
+      Name: golang.org/x/net/http2.ErrCode
+      ByteSize: 4
+      GoRuntimeType: 1.003232e+06
+      GoKind: 10
+    - __kind: StructureType
+      ID: 711
+      Name: golang.org/x/net/http2.StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.879648e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 747 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 568
+      Name: golang.org/x/net/http2.connError
+      ByteSize: 24
+      GoRuntimeType: 1.605184e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 747 BaseType golang.org/x/net/http2.ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 371
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 839520
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 373 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 372 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 372
+      Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 377
+      Name: golang.org/x/net/http2.headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 839712
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 379 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 378 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 378
+      Name: golang.org/x/net/http2.headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 374
+      Name: golang.org/x/net/http2.headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 839616
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 376 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 375 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 375
+      Name: golang.org/x/net/http2.headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 368
+      Name: golang.org/x/net/http2.pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 839424
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 370 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 369 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 369
+      Name: golang.org/x/net/http2.pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 932
+      Name: golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 572
+      Name: golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.447488e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: BaseType
+      ID: 380
+      Name: golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 839808
+      GoKind: 2
+    - __kind: StructureType
+      ID: 560
+      Name: google.golang.org/grpc.dropError
+      ByteSize: 16
+      GoRuntimeType: 1.442528e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 709
+      Name: google.golang.org/grpc/internal/status.Error
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 734
+      Name: google.golang.org/grpc/internal/transport.ConnectionError
+      ByteSize: 40
+      GoRuntimeType: 1.907424e+06
+      GoKind: 25
+      RawFields:
+        - Name: Desc
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: temp
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: err
+          Offset: 24
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 562
+      Name: google.golang.org/grpc/internal/transport.NewStreamError
+      ByteSize: 24
+      GoRuntimeType: 1.604704e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+        - Name: AllowTransparentRetry
+          Offset: 16
+          Type: 4 BaseType bool
+    - __kind: StructureType
+      ID: 881
+      Name: google.golang.org/grpc/internal/transport.bufConn
+      ByteSize: 32
+      GoRuntimeType: 1.965472e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 763 GoInterfaceType net.Conn
+        - Name: r
+          Offset: 16
+          Type: 908 GoInterfaceType io.Reader
+    - __kind: UnresolvedPointeeType
+      ID: 839
+      Name: google.golang.org/grpc/internal/transport.bufWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 651
+      Name: google.golang.org/grpc/internal/transport.ioError
+      ByteSize: 16
+      GoRuntimeType: 1.566752e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 801
+      Name: google.golang.org/grpc/mem.writer
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 540
+      Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 639
+      Name: google.golang.org/protobuf/internal/errors.prefixError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 707
+      Name: google.golang.org/protobuf/internal/errors.wrapError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 705
+      Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      GoRuntimeType: 1.510272e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 554
+      Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      ByteSize: 16
+      GoRuntimeType: 1.435808e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 556
+      Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
+      ByteSize: 16
+      GoRuntimeType: 1.435968e+06
+      GoKind: 25
+      RawFields:
+        - Name: Line
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 484
+      Name: gopkg.in/yaml%2ev3.TypeError
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
       ID: 287
       Name: groupReference<[4]int,[4]int>
@@ -6710,47 +10459,47 @@ Types:
       GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 336
+      ID: 1015
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 337 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1016 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 344 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1017 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1023 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 372
+      ID: 1051
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 373 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1052 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 380 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1053 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1059 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 387
+      ID: 1066
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 388 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1067 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 395 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1068 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1074 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 195
       Name: groupReference<int,int>
@@ -6766,19 +10515,19 @@ Types:
       GroupType: 197 StructureType noalg.map.group[int]int
       GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 402
+      ID: 1081
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 403 PointerType *noalg.map.group[int]interface {}
+          Type: 1082 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 404 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 408 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1083 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1087 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 254
       Name: groupReference<int,uint8>
@@ -6821,6 +10570,20 @@ Types:
           Type: 8 BaseType uint64
       GroupType: 221 StructureType noalg.map.group[string][]string
       GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 773
+      Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 774 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 779 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 211
       Name: groupReference<string,int>
@@ -6877,6 +10640,14 @@ Types:
           Type: 8 BaseType uint64
       GroupType: 264 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
+    - __kind: UnresolvedPointeeType
+      ID: 889
+      Name: hash/crc32.digest
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 575
+      Name: html/template.Error
+      ByteSize: 8
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6920,8 +10691,70 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 736
+      Name: internal/abi.Type
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 452
+      Name: internal/bisect.parseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 450
+      Name: internal/chacha8rand.errUnmarshalChaCha8
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 787
+      Name: internal/godebug.runtimeStderr
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 668
+      Name: internal/poll.DeadlineExceededError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 976
+      Name: internal/poll.FD
+      ByteSize: 8
     - __kind: StructureType
-      ID: 313
+      ID: 666
+      Name: internal/poll.errNetClosing
+      GoRuntimeType: 1.475392e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 386
+      Name: internal/reflectlite.ValueError
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 339
+      Name: internal/runtime/cgroup.stringError
+      ByteSize: 16
+      GoRuntimeType: 833952
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 341 PointerType *internal/runtime/cgroup.stringError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 340 GoStringDataType internal/runtime/cgroup.stringError.str
+    - __kind: GoStringDataType
+      ID: 340
+      Name: internal/runtime/cgroup.stringError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 623
+      Name: internal/runtime/maps.unhashableTypeError
+      ByteSize: 8
+      GoRuntimeType: 1.558112e+06
+      GoKind: 25
+      RawFields:
+        - Name: typ
+          Offset: 0
+          Type: 735 PointerType *internal/abi.Type
+    - __kind: StructureType
+      ID: 988
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.472832e+06
@@ -6933,6 +10766,49 @@ Types:
         - Name: sema
           Offset: 4
           Type: 2 BaseType uint32
+    - __kind: UnresolvedPointeeType
+      ID: 833
+      Name: io.PipeWriter
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 873
+      Name: io.ReadWriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.189056e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 908
+      Name: io.Reader
+      ByteSize: 16
+      GoRuntimeType: 1.022528e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 860
+      Name: io.WriteCloser
+      ByteSize: 16
+      GoRuntimeType: 1.10976e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
       ID: 55
       Name: io.Writer
@@ -6946,6 +10822,24 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 831
+      Name: io.discard
+      GoRuntimeType: 1.461952e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 805
+      Name: io.multiWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 664
+      Name: io/fs.PathError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 879
+      Name: log/slog/internal/buffer.Buffer
+      ByteSize: 8
     - __kind: StructureType
       ID: 173
       Name: main.aStruct
@@ -7011,9 +10905,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 330 GoMapType map[int]*main.deepMap3
+          Type: 1009 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 1021
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -7025,9 +10919,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 366 GoMapType map[int]*main.deepMap8
+          Type: 1045 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 378
+      ID: 1057
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.184832e+06
@@ -7035,9 +10929,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 381 GoMapType map[int]*main.deepMap9
+          Type: 1060 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 393
+      ID: 1072
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.184704e+06
@@ -7045,7 +10939,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 396 GoMapType map[int]interface {}
+          Type: 1075 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7065,9 +10959,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 306 PointerType *main.deepPtr3
+          Type: 979 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 307
+      ID: 980
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -7079,9 +10973,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 347 PointerType *main.deepPtr8
+          Type: 1026 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 348
+      ID: 1027
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.185984e+06
@@ -7089,9 +10983,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 349 PointerType *main.deepPtr9
+          Type: 1028 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 350
+      ID: 1029
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.185856e+06
@@ -7119,9 +11013,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 324 GoSliceHeaderType []*main.deepSlice3
+          Type: 1003 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 1006
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7133,9 +11027,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 351 GoSliceHeaderType []*main.deepSlice8
+          Type: 1030 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 354
+      ID: 1033
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.187136e+06
@@ -7143,9 +11037,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 357 GoSliceHeaderType []*main.deepSlice9
+          Type: 1036 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 360
+      ID: 1039
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.187008e+06
@@ -7153,7 +11047,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 363 GoSliceHeaderType []interface {}
+          Type: 1042 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 175
       Name: main.emptyStruct
@@ -7171,16 +11065,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 311 StructureType sync.Mutex
+          Type: 986 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 314 StructureType sync.Once
+          Type: 989 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 317 StructureType sync.WaitGroup
+          Type: 992 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 320 StructureType sync/atomic.Int32
+          Type: 995 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -7209,6 +11103,16 @@ Types:
         - Name: foo
           Offset: 56
           Type: 83 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 997
+      Name: main.firstBehavior
+      ByteSize: 16
+      GoRuntimeType: 1.411488e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
       ID: 174
       Name: main.nestedStruct
@@ -7244,6 +11148,13 @@ Types:
         - Name: a
           Offset: 0
           Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 999
+      Name: main.secondBehavior
+      ByteSize: 8
+      GoRuntimeType: 1.411648e+06
+      GoKind: 25
+      RawFields: [{Name: i, Offset: 0, Type: 7 BaseType int}]
     - __kind: GoInterfaceType
       ID: 82
       Name: main.something
@@ -7257,6 +11168,10 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 985
+      Name: main.somethingImpl
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 76
       Name: main.stringType1
@@ -7265,17 +11180,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *main.stringType1.str
+          Type: 982 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 308 GoStringDataType main.stringType1.str
+      Data: 981 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 981
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 310
+      ID: 983
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -7330,16 +11245,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 321 PointerType **main.t
+          Type: 1000 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 322 GoSliceDataType main.t.array
+      Data: 1001 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 322
+      ID: 1001
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -7539,7 +11454,7 @@ Types:
       TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 332
+      ID: 1011
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7552,7 +11467,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 333 PointerType **table<int,*main.deepMap3>
+          Type: 1012 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7571,10 +11486,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 343 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 338 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1022 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1017 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 368
+      ID: 1047
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7587,7 +11502,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 369 PointerType **table<int,*main.deepMap8>
+          Type: 1048 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7606,10 +11521,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 379 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 374 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1058 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1053 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 383
+      ID: 1062
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7622,7 +11537,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 384 PointerType **table<int,*main.deepMap9>
+          Type: 1063 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7641,8 +11556,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 394 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 389 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1073 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1068 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 93
       Name: map<int,int>
@@ -7679,7 +11594,7 @@ Types:
       TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
       GroupType: 197 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 398
+      ID: 1077
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7692,7 +11607,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 399 PointerType **table<int,interface {}>
+          Type: 1078 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7711,8 +11626,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 407 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 404 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1086 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1083 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 130
       Name: map<int,uint8>
@@ -7818,6 +11733,41 @@ Types:
           Type: 8 BaseType uint64
       TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
       GroupType: 221 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 742
+      Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 743 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 778 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -7994,26 +11944,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 330
+      ID: 1009
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.128832e+06
       GoKind: 21
-      HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1011 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 366
+      ID: 1045
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.128192e+06
       GoKind: 21
-      HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1047 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 381
+      ID: 1060
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.128064e+06
       GoKind: 21
-      HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1062 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
@@ -8022,12 +11972,12 @@ Types:
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 396
+      ID: 1075
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.127936e+06
       GoKind: 21
-      HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1077 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
@@ -8077,6 +12027,601 @@ Types:
       GoRuntimeType: 1.130368e+06
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: StructureType
+      ID: 488
+      Name: math/big.ErrNaN
+      ByteSize: 16
+      GoRuntimeType: 1.428128e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 795
+      Name: mime/multipart.writerOnly·1
+      ByteSize: 16
+      GoRuntimeType: 1.424928e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 695
+      Name: net.AddrError
+      ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 763
+      Name: net.Conn
+      ByteSize: 16
+      GoRuntimeType: 1.595264e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: UnresolvedPointeeType
+      ID: 721
+      Name: net.DNSError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 940
+      Name: net.IPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 719
+      Name: net.OpError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 697
+      Name: net.ParseError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 950
+      Name: net.TCPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 960
+      Name: net.UDPConn
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 948
+      Name: net.UnixConn
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 656
+      Name: net.UnknownNetworkError
+      ByteSize: 16
+      GoRuntimeType: 1.113088e+06
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 658 PointerType *net.UnknownNetworkError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 657 GoStringDataType net.UnknownNetworkError.str
+    - __kind: GoStringDataType
+      ID: 657
+      Name: net.UnknownNetworkError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 621
+      Name: net.canceledError
+      GoRuntimeType: 1.283584e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 916
+      Name: net.conn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 768
+      Name: net.dialResult·1
+      ByteSize: 40
+      GoRuntimeType: 2.104736e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 763 GoInterfaceType net.Conn
+        - Name: error
+          Offset: 16
+          Type: 14 GoInterfaceType error
+        - Name: primary
+          Offset: 32
+          Type: 4 BaseType bool
+        - Name: done
+          Offset: 33
+          Type: 4 BaseType bool
+    - __kind: UnresolvedPointeeType
+      ID: 962
+      Name: net.netFD
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 956
+      Name: net.noReadFrom
+      GoRuntimeType: 1.113344e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 955
+      Name: net.noWriteTo
+      GoRuntimeType: 1.113216e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 418
+      Name: net.notFoundError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 420
+      Name: net.result·2
+      ByteSize: 112
+      GoRuntimeType: 1.728096e+06
+      GoKind: 25
+      RawFields:
+        - Name: p
+          Offset: 0
+          Type: 750 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+        - Name: server
+          Offset: 80
+          Type: 9 GoStringHeaderType string
+        - Name: error
+          Offset: 96
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 944
+      Name: net.tcpConnWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.287744e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 956 StructureType net.noReadFrom
+        - Name: TCPConn
+          Offset: 0
+          Type: 949 PointerType *net.TCPConn
+    - __kind: StructureType
+      ID: 942
+      Name: net.tcpConnWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.2872e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 955 StructureType net.noWriteTo
+        - Name: TCPConn
+          Offset: 0
+          Type: 949 PointerType *net.TCPConn
+    - __kind: UnresolvedPointeeType
+      ID: 699
+      Name: net.temporaryError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 723
+      Name: net.timeoutError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 611
+      Name: net/http.ProtocolError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 789
+      Name: net/http.bufioFlushWriter
+      ByteSize: 16
+      GoRuntimeType: 1.416448e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: BaseType
+      ID: 309
+      Name: net/http.http2ConnectionError
+      ByteSize: 4
+      GoRuntimeType: 831648
+      GoKind: 10
+    - __kind: BaseType
+      ID: 739
+      Name: net/http.http2ErrCode
+      ByteSize: 4
+      GoRuntimeType: 990176
+      GoKind: 10
+    - __kind: StructureType
+      ID: 396
+      Name: net/http.http2GoAwayError
+      ByteSize: 24
+      GoRuntimeType: 1.726368e+06
+      GoKind: 25
+      RawFields:
+        - Name: LastStreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: ErrCode
+          Offset: 4
+          Type: 739 BaseType net/http.http2ErrCode
+        - Name: DebugData
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 715
+      Name: net/http.http2StreamError
+      ByteSize: 24
+      GoRuntimeType: 1.897952e+06
+      GoKind: 25
+      RawFields:
+        - Name: StreamID
+          Offset: 0
+          Type: 2 BaseType uint32
+        - Name: Code
+          Offset: 4
+          Type: 739 BaseType net/http.http2ErrCode
+        - Name: Cause
+          Offset: 8
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 400
+      Name: net/http.http2connError
+      ByteSize: 24
+      GoRuntimeType: 1.594784e+06
+      GoKind: 25
+      RawFields:
+        - Name: Code
+          Offset: 0
+          Type: 739 BaseType net/http.http2ErrCode
+        - Name: Reason
+          Offset: 8
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 851
+      Name: net/http.http2dataBuffer
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 313
+      Name: net/http.http2duplicatePseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 831840
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 315 PointerType *net/http.http2duplicatePseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 314
+      Name: net/http.http2duplicatePseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 319
+      Name: net/http.http2headerFieldNameError
+      ByteSize: 16
+      GoRuntimeType: 832032
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 321 PointerType *net/http.http2headerFieldNameError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 320 GoStringDataType net/http.http2headerFieldNameError.str
+    - __kind: GoStringDataType
+      ID: 320
+      Name: net/http.http2headerFieldNameError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 316
+      Name: net/http.http2headerFieldValueError
+      ByteSize: 16
+      GoRuntimeType: 831936
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 318 PointerType *net/http.http2headerFieldValueError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 317 GoStringDataType net/http.http2headerFieldValueError.str
+    - __kind: GoStringDataType
+      ID: 317
+      Name: net/http.http2headerFieldValueError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 690
+      Name: net/http.http2httpError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 617
+      Name: net/http.http2noCachedConnError
+      GoRuntimeType: 1.282816e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 905
+      Name: net/http.http2pipe
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 310
+      Name: net/http.http2pseudoHeaderError
+      ByteSize: 16
+      GoRuntimeType: 831744
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 312 PointerType *net/http.http2pseudoHeaderError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+    - __kind: GoStringDataType
+      ID: 311
+      Name: net/http.http2pseudoHeaderError.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 791
+      Name: net/http.http2stickyErrWriter
+      ByteSize: 48
+      GoRuntimeType: 1.824032e+06
+      GoKind: 25
+      RawFields:
+        - Name: group
+          Offset: 0
+          Type: 882 GoInterfaceType net/http.http2synctestGroupInterface
+        - Name: conn
+          Offset: 16
+          Type: 763 GoInterfaceType net.Conn
+        - Name: timeout
+          Offset: 32
+          Type: 883 BaseType time.Duration
+        - Name: err
+          Offset: 40
+          Type: 33 PointerType *error
+    - __kind: GoInterfaceType
+      ID: 882
+      Name: net/http.http2synctestGroupInterface
+      ByteSize: 16
+      GoRuntimeType: 1.415648e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: ArrayType
+      ID: 870
+      Name: net/http.incomparable
+      GoRuntimeType: 902848
+      GoKind: 17
+      HasCount: true
+      Element: 83 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 613
+      Name: net/http.nothingWrittenError
+      ByteSize: 16
+      GoRuntimeType: 1.554272e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 853
+      Name: net/http.persistConn
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 809
+      Name: net/http.persistConnWriter
+      ByteSize: 8
+      GoRuntimeType: 1.554112e+06
+      GoKind: 25
+      RawFields:
+        - Name: pc
+          Offset: 0
+          Type: 852 PointerType *net/http.persistConn
+    - __kind: StructureType
+      ID: 843
+      Name: net/http.readWriteCloserBody
+      ByteSize: 24
+      GoRuntimeType: 1.799008e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 870 ArrayType net/http.incomparable
+        - Name: br
+          Offset: 0
+          Type: 871 PointerType *bufio.Reader
+        - Name: ReadWriteCloser
+          Offset: 8
+          Type: 873 GoInterfaceType io.ReadWriteCloser
+    - __kind: StructureType
+      ID: 404
+      Name: net/http.requestBodyReadError
+      ByteSize: 16
+      GoRuntimeType: 1.417408e+06
+      GoKind: 25
+      RawFields:
+        - Name: error
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: UnresolvedPointeeType
+      ID: 717
+      Name: net/http.timeoutError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 688
+      Name: net/http.tlsHandshakeTimeoutError
+      GoRuntimeType: 1.478272e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 615
+      Name: net/http.transportReadFromServerError
+      ByteSize: 16
+      GoRuntimeType: 1.554432e+06
+      GoKind: 25
+      RawFields:
+        - Name: err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: StructureType
+      ID: 885
+      Name: net/http.unencryptedNetConnInTLSConn
+      ByteSize: 32
+      GoRuntimeType: 2.024448e+06
+      GoKind: 25
+      RawFields:
+        - Name: Conn
+          Offset: 0
+          Type: 763 GoInterfaceType net.Conn
+        - Name: conn
+          Offset: 16
+          Type: 763 GoInterfaceType net.Conn
+    - __kind: UnresolvedPointeeType
+      ID: 393
+      Name: net/http.unsupportedTEError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 907
+      Name: net/http/internal.FlushAfterChunkWriter
+      ByteSize: 8
+      GoRuntimeType: 2.040192e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 900 PointerType *bufio.Writer
+    - __kind: UnresolvedPointeeType
+      ID: 819
+      Name: net/http/internal.chunkedWriter
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 480
+      Name: net/netip.parseAddrError
+      ByteSize: 48
+      GoRuntimeType: 1.731168e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+        - Name: at
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 478
+      Name: net/netip.parsePrefixError
+      ByteSize: 32
+      GoRuntimeType: 1.596704e+06
+      GoKind: 25
+      RawFields:
+        - Name: in
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: msg
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: UnresolvedPointeeType
+      ID: 859
+      Name: net/smtp.Client
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 821
+      Name: net/smtp.dataCloser
+      ByteSize: 24
+      GoRuntimeType: 1.598624e+06
+      GoKind: 25
+      RawFields:
+        - Name: c
+          Offset: 0
+          Type: 858 PointerType *net/smtp.Client
+        - Name: WriteCloser
+          Offset: 8
+          Type: 860 GoInterfaceType io.WriteCloser
+    - __kind: UnresolvedPointeeType
+      ID: 464
+      Name: net/textproto.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 347
+      Name: net/textproto.ProtocolError
+      ByteSize: 16
+      GoRuntimeType: 834720
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 349 PointerType *net/textproto.ProtocolError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 348 GoStringDataType net/textproto.ProtocolError.str
+    - __kind: GoStringDataType
+      ID: 348
+      Name: net/textproto.ProtocolError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 817
+      Name: net/textproto.dotWriter
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 725
+      Name: net/url.Error
+      ByteSize: 8
+    - __kind: GoStringHeaderType
+      ID: 322
+      Name: net/url.EscapeError
+      ByteSize: 16
+      GoRuntimeType: 832608
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 324 PointerType *net/url.EscapeError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 323 GoStringDataType net/url.EscapeError.str
+    - __kind: GoStringDataType
+      ID: 323
+      Name: net/url.EscapeError.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 325
+      Name: net/url.InvalidHostError
+      ByteSize: 16
+      GoRuntimeType: 832704
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 327 PointerType *net/url.InvalidHostError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 326 GoStringDataType net/url.InvalidHostError.str
+    - __kind: GoStringDataType
+      ID: 326
+      Name: net/url.InvalidHostError.str
+      ByteSize: 2048
     - __kind: ArrayType
       ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
@@ -8123,32 +12668,32 @@ Types:
       HasCount: true
       Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 339
+      ID: 1018
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 681984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 340 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1019 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 375
+      ID: 1054
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 376 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1055 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 390
+      ID: 1069
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 391 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1070 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 198
       Name: noalg.[8]struct { key int; elem int }
@@ -8159,14 +12704,14 @@ Types:
       HasCount: true
       Element: 199 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 405
+      ID: 1084
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 406 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1085 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -8194,6 +12739,15 @@ Types:
       Count: 8
       HasCount: true
       Element: 223 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 776
+      Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      ByteSize: 320
+      GoRuntimeType: 758976
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 777 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 214
       Name: noalg.[8]struct { key string; elem int }
@@ -8296,7 +12850,7 @@ Types:
           Offset: 8
           Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 338
+      ID: 1017
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.29408e+06
@@ -8307,9 +12861,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 339 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1018 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 374
+      ID: 1053
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.2928e+06
@@ -8320,9 +12874,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 375 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1054 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 389
+      ID: 1068
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.292544e+06
@@ -8333,7 +12887,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 390 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1069 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 197
       Name: noalg.map.group[int]int
@@ -8348,7 +12902,7 @@ Types:
           Offset: 8
           Type: 198 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 404
+      ID: 1083
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.292288e+06
@@ -8359,7 +12913,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 405 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1084 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 256
       Name: noalg.map.group[int]uint8
@@ -8399,6 +12953,19 @@ Types:
         - Name: slots
           Offset: 8
           Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 775
+      Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      ByteSize: 328
+      GoRuntimeType: 1.357056e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 776 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 213
       Name: noalg.map.group[string]int
@@ -8517,7 +13084,7 @@ Types:
           Offset: 8
           Type: 190 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 340
+      ID: 1019
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.293952e+06
@@ -8528,9 +13095,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 341 PointerType *main.deepMap3
+          Type: 1020 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 376
+      ID: 1055
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.292672e+06
@@ -8541,9 +13108,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 377 PointerType *main.deepMap8
+          Type: 1056 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 391
+      ID: 1070
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.292416e+06
@@ -8554,7 +13121,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 392 PointerType *main.deepMap9
+          Type: 1071 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 199
       Name: noalg.struct { key int; elem int }
@@ -8569,7 +13136,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 406
+      ID: 1085
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.29216e+06
@@ -8620,6 +13187,19 @@ Types:
         - Name: elem
           Offset: 16
           Type: 166 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 777
+      Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      ByteSize: 40
+      GoRuntimeType: 1.356928e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 215
       Name: noalg.struct { key string; elem int }
@@ -8672,6 +13252,216 @@ Types:
         - Name: elem
           Offset: 1
           Type: 3 BaseType uint8
+    - __kind: UnresolvedPointeeType
+      ID: 968
+      Name: os.File
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 592
+      Name: os.LinkError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 660
+      Name: os.SyscallError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 966
+      Name: os.fileWithoutReadFrom
+      ByteSize: 8
+      GoRuntimeType: 2.358112e+06
+      GoKind: 25
+      RawFields:
+        - Name: noReadFrom
+          Offset: 0
+          Type: 972 StructureType os.noReadFrom
+        - Name: File
+          Offset: 0
+          Type: 967 PointerType *os.File
+    - __kind: StructureType
+      ID: 964
+      Name: os.fileWithoutWriteTo
+      ByteSize: 8
+      GoRuntimeType: 2.357312e+06
+      GoKind: 25
+      RawFields:
+        - Name: noWriteTo
+          Offset: 0
+          Type: 971 StructureType os.noWriteTo
+        - Name: File
+          Offset: 0
+          Type: 967 PointerType *os.File
+    - __kind: StructureType
+      ID: 972
+      Name: os.noReadFrom
+      GoRuntimeType: 1.110656e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 971
+      Name: os.noWriteTo
+      GoRuntimeType: 1.110528e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 625
+      Name: os/exec.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 771
+      Name: os/exec.ExitError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 837
+      Name: os/exec.prefixSuffixSaver
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 627
+      Name: os/exec.wrappedError
+      ByteSize: 32
+      GoRuntimeType: 1.701568e+06
+      GoKind: 25
+      RawFields:
+        - Name: prefix
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: err
+          Offset: 16
+          Type: 14 GoInterfaceType error
+    - __kind: GoStringHeaderType
+      ID: 361
+      Name: os/user.UnknownGroupIdError
+      ByteSize: 16
+      GoRuntimeType: 837984
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 363 PointerType *os/user.UnknownGroupIdError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 362 GoStringDataType os/user.UnknownGroupIdError.str
+    - __kind: GoStringDataType
+      ID: 362
+      Name: os/user.UnknownGroupIdError.str
+      ByteSize: 2048
+    - __kind: BaseType
+      ID: 360
+      Name: os/user.UnknownUserIdError
+      ByteSize: 8
+      GoRuntimeType: 837888
+      GoKind: 2
+    - __kind: UnresolvedPointeeType
+      ID: 388
+      Name: reflect.ValueError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 486
+      Name: regexp/syntax.Error
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 596
+      Name: runtime.PanicNilError
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 600
+      Name: runtime.TypeAssertionError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 598
+      Name: runtime.boundsError
+      ByteSize: 24
+      GoRuntimeType: 1.886816e+06
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 13 BaseType int64
+        - Name: y
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: signed
+          Offset: 16
+          Type: 4 BaseType bool
+        - Name: code
+          Offset: 17
+          Type: 769 BaseType runtime.boundsErrorCode
+    - __kind: BaseType
+      ID: 769
+      Name: runtime.boundsErrorCode
+      ByteSize: 1
+      GoRuntimeType: 585088
+      GoKind: 8
+    - __kind: StructureType
+      ID: 662
+      Name: runtime.errorAddressString
+      ByteSize: 24
+      GoRuntimeType: 1.751872e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: addr
+          Offset: 16
+          Type: 1 BaseType uintptr
+    - __kind: GoStringHeaderType
+      ID: 576
+      Name: runtime.errorString
+      ByteSize: 16
+      GoRuntimeType: 988736
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 578 PointerType *runtime.errorString.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 577 GoStringDataType runtime.errorString.str
+    - __kind: GoStringDataType
+      ID: 577
+      Name: runtime.errorString.str
+      ByteSize: 2048
+    - __kind: GoStringHeaderType
+      ID: 579
+      Name: runtime.plainError
+      ByteSize: 16
+      GoRuntimeType: 988832
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 581 PointerType *runtime.plainError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 580 GoStringDataType runtime.plainError.str
+    - __kind: GoStringDataType
+      ID: 580
+      Name: runtime.plainError.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 738
+      Name: runtime.synctestBubble
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 384
+      Name: runtime.synctestDeadlockError
+      ByteSize: 24
+      GoRuntimeType: 1.594464e+06
+      GoKind: 25
+      RawFields:
+        - Name: reason
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: bubble
+          Offset: 16
+          Type: 737 PointerType *runtime.synctestBubble
+    - __kind: UnresolvedPointeeType
+      ID: 602
+      Name: strconv.NumError
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
@@ -8690,8 +13480,26 @@ Types:
       ID: 177
       Name: string.str
       ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 903
+      Name: strings.Builder
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 807
+      Name: strings.appendSliceWriter
+      ByteSize: 8
     - __kind: StructureType
-      ID: 311
+      ID: 803
+      Name: struct { io.Writer }
+      ByteSize: 16
+      GoRuntimeType: 1.454208e+06
+      GoKind: 25
+      RawFields:
+        - Name: Writer
+          Offset: 0
+          Type: 55 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 986
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.462752e+06
@@ -8699,12 +13507,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 987 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 313 StructureType internal/sync.Mutex
+          Type: 988 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 314
+      ID: 989
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.611808e+06
@@ -8712,15 +13520,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 987 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 315 StructureType sync/atomic.Bool
+          Type: 990 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 311 StructureType sync.Mutex
+          Type: 986 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 317
+      ID: 992
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.611616e+06
@@ -8728,21 +13536,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 312 StructureType sync.noCopy
+          Type: 987 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 318 StructureType sync/atomic.Uint64
+          Type: 993 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 312
+      ID: 987
       Name: sync.noCopy
       GoRuntimeType: 987680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 315
+      ID: 990
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.463872e+06
@@ -8750,12 +13558,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 991 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 320
+      ID: 995
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464032e+06
@@ -8763,12 +13571,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 991 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 318
+      ID: 993
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612192e+06
@@ -8776,25 +13584,31 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 316 StructureType sync/atomic.noCopy
+          Type: 991 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 319 StructureType sync/atomic.align64
+          Type: 994 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 319
+      ID: 994
       Name: sync/atomic.align64
       GoRuntimeType: 987872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 316
+      ID: 991
       Name: sync/atomic.noCopy
       GoRuntimeType: 987776
       GoKind: 25
       RawFields: []
+    - __kind: BaseType
+      ID: 712
+      Name: syscall.Errno
+      ByteSize: 8
+      GoRuntimeType: 1.282176e+06
+      GoKind: 12
     - __kind: StructureType
       ID: 286
       Name: table<[4]int,[4]int>
@@ -8916,7 +13730,7 @@ Types:
           Offset: 16
           Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 335
+      ID: 1014
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8938,9 +13752,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 336 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1015 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 371
+      ID: 1050
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8962,9 +13776,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 372 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1051 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 386
+      ID: 1065
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8986,7 +13800,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 387 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1066 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 194
       Name: table<int,int>
@@ -9012,7 +13826,7 @@ Types:
           Offset: 16
           Type: 195 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 401
+      ID: 1080
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9034,7 +13848,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 402 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1081 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 253
       Name: table<int,uint8>
@@ -9107,6 +13921,30 @@ Types:
         - Name: groups
           Offset: 16
           Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 772
+      Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 773 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 210
       Name: table<string,int>
@@ -9203,6 +14041,71 @@ Types:
         - Name: groups
           Offset: 16
           Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
+    - __kind: UnresolvedPointeeType
+      ID: 938
+      Name: text/tabwriter.Writer
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 655
+      Name: text/template.ExecError
+      ByteSize: 32
+      GoRuntimeType: 1.705984e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Err
+          Offset: 16
+          Type: 14 GoInterfaceType error
+    - __kind: BaseType
+      ID: 883
+      Name: time.Duration
+      ByteSize: 8
+      GoRuntimeType: 1.914272e+06
+      GoKind: 6
+    - __kind: UnresolvedPointeeType
+      ID: 730
+      Name: time.Location
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 391
+      Name: time.ParseError
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 728
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.371424e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 13 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 729 PointerType *time.Location
+    - __kind: GoStringHeaderType
+      ID: 306
+      Name: time.fileSizeError
+      ByteSize: 16
+      GoRuntimeType: 830784
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 308 PointerType *time.fileSizeError.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 307 GoStringDataType time.fileSizeError.str
+    - __kind: GoStringDataType
+      ID: 307
+      Name: time.fileSizeError.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -9245,6 +14148,120 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585024
       GoKind: 26
-MaxTypeID: 523
+    - __kind: StructureType
+      ID: 750
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
+      ByteSize: 80
+      GoRuntimeType: 2.06192e+06
+      GoKind: 25
+      RawFields:
+        - Name: msg
+          Offset: 0
+          Type: 751 GoSliceHeaderType []uint8
+        - Name: header
+          Offset: 24
+          Type: 752 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+        - Name: section
+          Offset: 36
+          Type: 753 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+        - Name: off
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: index
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: resHeaderValid
+          Offset: 56
+          Type: 4 BaseType bool
+        - Name: resHeaderOffset
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: resHeaderType
+          Offset: 72
+          Type: 754 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+        - Name: resHeaderLength
+          Offset: 74
+          Type: 6 BaseType uint16
+    - __kind: BaseType
+      ID: 754
+      Name: vendor/golang.org/x/net/dns/dnsmessage.Type
+      ByteSize: 2
+      GoRuntimeType: 994400
+      GoKind: 9
+    - __kind: StructureType
+      ID: 752
+      Name: vendor/golang.org/x/net/dns/dnsmessage.header
+      ByteSize: 12
+      GoRuntimeType: 1.92528e+06
+      GoKind: 25
+      RawFields:
+        - Name: id
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: bits
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: questions
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: answers
+          Offset: 6
+          Type: 6 BaseType uint16
+        - Name: authorities
+          Offset: 8
+          Type: 6 BaseType uint16
+        - Name: additionals
+          Offset: 10
+          Type: 6 BaseType uint16
+    - __kind: UnresolvedPointeeType
+      ID: 482
+      Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      ByteSize: 8
+    - __kind: BaseType
+      ID: 753
+      Name: vendor/golang.org/x/net/dns/dnsmessage.section
+      ByteSize: 1
+      GoRuntimeType: 588672
+      GoKind: 8
+    - __kind: UnresolvedPointeeType
+      ID: 930
+      Name: vendor/golang.org/x/net/http2/hpack.Decoder
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 466
+      Name: vendor/golang.org/x/net/http2/hpack.DecodingError
+      ByteSize: 16
+      GoRuntimeType: 1.425248e+06
+      GoKind: 25
+      RawFields:
+        - Name: Err
+          Offset: 0
+          Type: 14 GoInterfaceType error
+    - __kind: BaseType
+      ID: 350
+      Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      ByteSize: 8
+      GoRuntimeType: 834816
+      GoKind: 2
+    - __kind: StructureType
+      ID: 632
+      Name: vendor/golang.org/x/net/idna.labelError
+      ByteSize: 32
+      GoRuntimeType: 1.70176e+06
+      GoKind: 25
+      RawFields:
+        - Name: label
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: code_
+          Offset: 16
+          Type: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 584
+      Name: vendor/golang.org/x/net/idna.runeError
+      ByteSize: 4
+      GoRuntimeType: 993248
+      GoKind: 5
+MaxTypeID: 1202
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 96
-          Type: 503 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x809e0c", Frameless: true}]
+        - ID: 97
+          Type: 504 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x809f6c", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -26,7 +26,21 @@ Probes:
       events:
         - ID: 53
           Type: 460 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x807a4c", Frameless: true}]
+          InjectionPoints: [{PC: "0x807a0c", Frameless: true}]
+          Condition: null
+    - id: testAnyPtr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAnyPtr}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 55}
+      events:
+        - ID: 55
+          Type: 462 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x807a7c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -64,11 +78,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 61
-          Type: 468 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x807ec0", Frameless: true}]
+        - ID: 62
+          Type: 469 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x808020", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 77
-          Type: 484 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x8094b0", Frameless: true}]
+        - ID: 78
+          Type: 485 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x809610", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 75
-          Type: 482 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x809230", Frameless: true}]
+        - ID: 76
+          Type: 483 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x809390", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 85
-          Type: 492 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x809730", Frameless: true}]
+        - ID: 86
+          Type: 493 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x809890", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -278,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 87
-          Type: 494 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x809ae0", Frameless: true}]
+        - ID: 88
+          Type: 495 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x809c40", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 90
-          Type: 497 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x809b10", Frameless: true}]
+        - ID: 91
+          Type: 498 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x809c70", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -306,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 104
-          Type: 511 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x809ed0", Frameless: true}]
+        - ID: 105
+          Type: 512 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x80a030", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -320,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 106
-          Type: 513 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x80a170", Frameless: true}]
+        - ID: 107
+          Type: 514 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x80a2d0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -333,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 107
-          Type: 514 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x80a180", Frameless: true}]
+        - ID: 108
+          Type: 515 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x80a2e0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -351,7 +365,7 @@ Probes:
       events:
         - ID: 54
           Type: 461 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x807aa0", Frameless: true}]
+          InjectionPoints: [{PC: "0x807a60", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -459,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 109
-          Type: 516 EventRootType Probe[main.testInlinedBBB]
+        - ID: 110
+          Type: 517 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8075a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -487,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 110
-          Type: 517 EventRootType Probe[main.testInlinedBCA]
+        - ID: 111
+          Type: 518 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80768c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -501,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 111
-          Type: 518 EventRootType Probe[main.testInlinedBCB]
+        - ID: 112
+          Type: 519 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807730", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -516,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 108
-          Type: 515 EventRootType Probe[main.testInlinedPrint]
+        - ID: 109
+          Type: 516 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x80732c"
               Frameless: true
@@ -540,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 112
-          Type: 519 EventRootType Probe[main.testInlinedSq]
+        - ID: 113
+          Type: 520 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807784", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -555,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 113
-          Type: 520 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 114
+          Type: 521 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8077b4"
               Frameless: false
@@ -647,7 +661,7 @@ Probes:
       events:
         - ID: 52
           Type: 459 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x8079fc", Frameless: true}]
+          InjectionPoints: [{PC: "0x8079f0", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -657,11 +671,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 79
-          Type: 486 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x809640", Frameless: true}]
+        - ID: 80
+          Type: 487 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x8097a0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -671,11 +685,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 59
-          Type: 466 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x807ea0", Frameless: true}]
+        - ID: 60
+          Type: 467 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x808000", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -685,11 +699,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 65
-          Type: 472 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x807f00", Frameless: true}]
+        - ID: 66
+          Type: 473 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x808060", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -699,11 +713,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 63
-          Type: 470 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x807ee0", Frameless: true}]
+        - ID: 64
+          Type: 471 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x808040", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -713,11 +727,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 74
-          Type: 481 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x807f90", Frameless: true}]
+        - ID: 75
+          Type: 482 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x8080f0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -727,11 +741,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 73
-          Type: 480 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x807f80", Frameless: true}]
+        - ID: 74
+          Type: 481 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x8080e0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -741,11 +755,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 64
-          Type: 471 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x807ef0", Frameless: true}]
+        - ID: 65
+          Type: 472 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x808050", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -755,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 72
-          Type: 479 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x807f70", Frameless: true}]
+        - ID: 73
+          Type: 480 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x8080d0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -769,11 +783,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 71
-          Type: 478 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x807f60", Frameless: true}]
+        - ID: 72
+          Type: 479 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x8080c0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -783,11 +797,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 57
-          Type: 464 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x807e80", Frameless: true}]
+        - ID: 58
+          Type: 465 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x807fe0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -797,11 +811,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 58
-          Type: 465 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x807e90", Frameless: true}]
+        - ID: 59
+          Type: 466 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x807ff0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -811,11 +825,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 56
-          Type: 463 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x807e70", Frameless: true}]
+        - ID: 57
+          Type: 464 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x807fd0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -825,11 +839,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 66
-          Type: 473 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x807f10", Frameless: true}]
+        - ID: 67
+          Type: 474 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x808070", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -839,11 +853,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 69
-          Type: 476 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x807f40", Frameless: true}]
+        - ID: 70
+          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x8080a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -853,11 +867,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 70
-          Type: 477 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x807f50", Frameless: true}]
+        - ID: 71
+          Type: 478 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x8080b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -867,11 +881,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 67
-          Type: 474 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x807f20", Frameless: true}]
+        - ID: 68
+          Type: 475 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x808080", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -881,11 +895,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 68
-          Type: 475 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x807f30", Frameless: true}]
+        - ID: 69
+          Type: 476 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x808090", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -895,11 +909,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 102
-          Type: 509 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x809eb0", Frameless: true}]
+        - ID: 103
+          Type: 510 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80a010", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -909,11 +923,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 76
-          Type: 483 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x809310", Frameless: true}]
+        - ID: 77
+          Type: 484 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x809470", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -923,11 +937,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 84
-          Type: 491 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x809710", Frameless: true}]
+        - ID: 85
+          Type: 492 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x809870", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -937,11 +951,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 94
-          Type: 501 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x809b50", Frameless: true}]
+        - ID: 95
+          Type: 502 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -951,11 +965,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 91
-          Type: 498 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x809b20", Frameless: true}]
+        - ID: 92
+          Type: 499 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x809c80", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -965,11 +979,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 93
-          Type: 500 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x809b40", Frameless: true}]
+        - ID: 94
+          Type: 501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -979,11 +993,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 101
-          Type: 508 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x809ea0", Frameless: true}]
+        - ID: 102
+          Type: 509 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x80a000", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -993,11 +1007,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 80
-          Type: 487 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x809650", Frameless: true}]
+        - ID: 81
+          Type: 488 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x8097b0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1007,11 +1021,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 62
-          Type: 469 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x807ed0", Frameless: true}]
+        - ID: 63
+          Type: 470 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x808030", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1021,11 +1035,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 78
-          Type: 485 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x809630", Frameless: true}]
+        - ID: 79
+          Type: 486 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x809790", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1189,11 +1203,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 97
-          Type: 504 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x809e60", Frameless: true}]
+        - ID: 98
+          Type: 505 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x809fc0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1273,11 +1287,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 88
-          Type: 495 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x809af0", Frameless: true}]
+        - ID: 89
+          Type: 496 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x809c50", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1287,11 +1301,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 60
-          Type: 467 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x807eb0", Frameless: true}]
+        - ID: 61
+          Type: 468 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x808010", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1315,11 +1329,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 83
-          Type: 490 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x8096f0", Frameless: true}]
+        - ID: 84
+          Type: 491 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x809850", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1329,11 +1343,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 92
-          Type: 499 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x809b30", Frameless: true}]
+        - ID: 93
+          Type: 500 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x809c90", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1377,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 105
-          Type: 512 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80a0a0", Frameless: true}]
+        - ID: 106
+          Type: 513 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80a200", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1391,11 +1405,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 89
-          Type: 496 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x809b00", Frameless: true}]
+        - ID: 90
+          Type: 497 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x809c60", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1405,11 +1419,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 55
-          Type: 462 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x807e60", Frameless: true}]
+        - ID: 56
+          Type: 463 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x807fc0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1419,11 +1433,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 98
-          Type: 505 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x809e70", Frameless: true}]
+        - ID: 99
+          Type: 506 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x809fd0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1433,11 +1447,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 99
-          Type: 506 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x809e80", Frameless: true}]
+        - ID: 100
+          Type: 507 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x809fe0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1447,11 +1461,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 100
-          Type: 507 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x809e90", Frameless: true}]
+        - ID: 101
+          Type: 508 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x809ff0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1545,11 +1559,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 82
-          Type: 489 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x809680", Frameless: true}]
+        - ID: 83
+          Type: 490 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x8097e0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1559,11 +1573,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 86
-          Type: 493 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x809ad0", Frameless: true}]
+        - ID: 87
+          Type: 494 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x809c30", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1573,11 +1587,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 103
-          Type: 510 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x809ec0", Frameless: true}]
+        - ID: 104
+          Type: 511 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x80a020", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1587,11 +1601,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 81
-          Type: 488 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x809660", Frameless: true}]
+        - ID: 82
+          Type: 489 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x8097c0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1615,11 +1629,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 95
-          Type: 502 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x809b60", Frameless: true}]
+        - ID: 96
+          Type: 503 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2349,46 +2363,35 @@ Subprograms:
           IsReturn: true
     - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0x8079f0..0x807a40]
+      OutOfLinePCRanges: [0x8079f0..0x807a00]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 87 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8079f0..0x807a18
+            - Range: 0x8079f0..0x807a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807a18..0x807a1c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-        - Name: ~r0
-          Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x8079f0..0x807a40, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
     - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0x807a40..0x807aa0]
+      OutOfLinePCRanges: [0x807a00..0x807a60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 81 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x807a40..0x807a6c
+            - Range: 0x807a00..0x807a2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807a6c..0x807a70
+            - Range: 0x807a2c..0x807a30
               Pieces:
                 - Size: 8
                   Op: null
@@ -2398,18 +2401,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x807a40..0x807aa0, Pieces: []}]
+          Locations: [{Range: 0x807a00..0x807a60, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0x807aa0..0x807ab0]
+      OutOfLinePCRanges: [0x807a60..0x807a70]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x807aa0..0x807ab0
+            - Range: 0x807a60..0x807a70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2418,308 +2421,325 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 55
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x807e60..0x807e70]
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0x807a70..0x807ad0]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 88 StructureType main.structWithMap
+        - Name: a
+          Type: 88 PointerType *interface {}
           Locations:
-            - Range: 0x807e60..0x807e70
+            - Range: 0x807a70..0x807a9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: ~r0
+          Type: 9 GoStringHeaderType string
+          Locations: [{Range: 0x807a70..0x807ad0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 56
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x807e70..0x807e80]
+      Name: main.testStructWithMap
+      OutOfLinePCRanges: [0x807fc0..0x807fd0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 94 GoMapType map[string]main.nestedStruct
+        - Name: s
+          Type: 89 StructureType main.structWithMap
           Locations:
-            - Range: 0x807e70..0x807e80
+            - Range: 0x807fc0..0x807fd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x807e80..0x807e90]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0x807fd0..0x807fe0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 95 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x807e80..0x807e90
+            - Range: 0x807fd0..0x807fe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x807e90..0x807ea0]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x807fe0..0x807ff0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 104 GoMapType map[string][]string
+          Type: 100 GoMapType map[string]int
           Locations:
-            - Range: 0x807e90..0x807ea0
+            - Range: 0x807fe0..0x807ff0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x807ea0..0x807eb0]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x807ff0..0x808000]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 109 GoMapType map[[4]string][2]int
+          Type: 105 GoMapType map[string][]string
           Locations:
-            - Range: 0x807ea0..0x807eb0
+            - Range: 0x807ff0..0x808000
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x807eb0..0x807ec0]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x808000..0x808010]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 110 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x807eb0..0x807ec0
+            - Range: 0x808000..0x808010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x807ec0..0x807ed0]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x808010..0x808020]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 114 ArrayType [2]map[string]int
+          Type: 100 GoMapType map[string]int
           Locations:
-            - Range: 0x807ec0..0x807ed0
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x807ed0..0x807ee0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 115 PointerType *map[string]int
-          Locations:
-            - Range: 0x807ed0..0x807ee0
+            - Range: 0x808010..0x808020
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x807ee0..0x807ef0]
+    - ID: 62
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x808020..0x808030]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 89 GoMapType map[int]int
+          Type: 115 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x807ee0..0x807ef0
+            - Range: 0x808020..0x808030
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 63
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x808030..0x808040]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 PointerType *map[string]int
+          Locations:
+            - Range: 0x808030..0x808040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x807ef0..0x807f00]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x808040..0x808050]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 116 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 90 GoMapType map[int]int
           Locations:
-            - Range: 0x807ef0..0x807f00
+            - Range: 0x808040..0x808050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x807f00..0x807f10]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x808050..0x808060]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 116 GoMapType map[string][]main.structWithMap
+        - Name: redactMyEntries
+          Type: 117 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x807f00..0x807f10
+            - Range: 0x808050..0x808060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x807f10..0x807f20]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x808060..0x808070]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 121 GoMapType map[bool]main.node
+          Type: 117 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x807f10..0x807f20
+            - Range: 0x808060..0x808070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x807f20..0x807f30]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x808070..0x808080]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 126 GoMapType map[int]uint8
+          Type: 122 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x807f20..0x807f30
+            - Range: 0x808070..0x808080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 68
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x807f30..0x807f40]
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x808080..0x808090]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 126 GoMapType map[int]uint8
+        - Name: m
+          Type: 127 GoMapType map[int]uint8
           Locations:
-            - Range: 0x807f30..0x807f40
+            - Range: 0x808080..0x808090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 69
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x807f40..0x807f50]
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x808090..0x8080a0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 127 GoMapType map[int]uint8
           Locations:
-            - Range: 0x807f40..0x807f50
+            - Range: 0x808090..0x8080a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 70
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x807f50..0x807f60]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x8080a0..0x8080b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 132 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x807f50..0x807f60
+            - Range: 0x8080a0..0x8080b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 71
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x807f60..0x807f70]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x8080b0..0x8080c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 131 GoMapType map[uint8]uint8
+          Type: 132 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x807f60..0x807f70
+            - Range: 0x8080b0..0x8080c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x807f70..0x807f80]
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x8080c0..0x8080d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 GoMapType map[uint8][4]int
+          Type: 132 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x807f70..0x807f80
+            - Range: 0x8080c0..0x8080d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x807f80..0x807f90]
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x8080d0..0x8080e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 141 GoMapType map[[4]int]uint8
+          Type: 137 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x807f80..0x807f90
+            - Range: 0x8080d0..0x8080e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x807f90..0x807fa0]
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x8080e0..0x8080f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[[4]int][4]int
+          Type: 142 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x807f90..0x807fa0
+            - Range: 0x8080e0..0x8080f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 75
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x8080f0..0x808100]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 147 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x8080f0..0x808100
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 76
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x809230..0x809240]
+      OutOfLinePCRanges: [0x809390..0x8093a0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809230..0x809240
+            - Range: 0x809390..0x8093a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809230..0x809240
+            - Range: 0x809390..0x8093a0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x809230..0x809240
+            - Range: 0x809390..0x8093a0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x809310..0x809320]
+      OutOfLinePCRanges: [0x809470..0x809480]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x809310..0x809320
+            - Range: 0x809470..0x809480
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x809310..0x809320
+            - Range: 0x809470..0x809480
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x809310..0x809320
+            - Range: 0x809470..0x809480
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809310..0x809320
+            - Range: 0x809470..0x809480
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809310..0x809320
+            - Range: 0x809470..0x809480
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2727,39 +2747,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testChannel
-      OutOfLinePCRanges: [0x8094b0..0x8094c0]
+      OutOfLinePCRanges: [0x809610..0x809620]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 151 GoChannelType chan bool
+          Type: 152 GoChannelType chan bool
           Locations:
-            - Range: 0x8094b0..0x8094c0
+            - Range: 0x809610..0x809620
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x809630..0x809640]
+      OutOfLinePCRanges: [0x809790..0x8097a0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 152 PointerType *main.structWithTwoValues
+          Type: 153 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x809630..0x809640
+            - Range: 0x809790..0x8097a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x809640..0x809650]
+      OutOfLinePCRanges: [0x8097a0..0x8097b0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 154 StructureType main.node
+          Type: 155 StructureType main.node
           Locations:
-            - Range: 0x809640..0x809650
+            - Range: 0x8097a0..0x8097b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2767,112 +2787,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x809650..0x809660]
+      OutOfLinePCRanges: [0x8097b0..0x8097c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 155 PointerType *main.node
+          Type: 156 PointerType *main.node
           Locations:
-            - Range: 0x809650..0x809660
+            - Range: 0x8097b0..0x8097c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x809660..0x809670]
+      OutOfLinePCRanges: [0x8097c0..0x8097d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x809660..0x809670
+            - Range: 0x8097c0..0x8097d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x809680..0x809690]
+      OutOfLinePCRanges: [0x8097e0..0x8097f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x809680..0x809690
+            - Range: 0x8097e0..0x8097f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x8096f0..0x809700]
+      OutOfLinePCRanges: [0x809850..0x809860]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x8096f0..0x809700
+            - Range: 0x809850..0x809860
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x809710..0x809720]
+      OutOfLinePCRanges: [0x809870..0x809880]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x809710..0x809720
+            - Range: 0x809870..0x809880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809710..0x809720
+            - Range: 0x809870..0x809880
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testCycle
-      OutOfLinePCRanges: [0x809730..0x809740]
+      OutOfLinePCRanges: [0x809890..0x8098a0]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 156 PointerType *main.t
+          Type: 157 PointerType *main.t
           Locations:
-            - Range: 0x809730..0x809740
+            - Range: 0x809890..0x8098a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x809ad0..0x809ae0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 158 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x809ad0..0x809ae0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 87
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x809ae0..0x809af0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x809c30..0x809c40]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 158 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x809ae0..0x809af0
+            - Range: 0x809c30..0x809c40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2883,14 +2885,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x809af0..0x809b00]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x809c40..0x809c50]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType [][]uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x809af0..0x809b00
+            - Range: 0x809c40..0x809c50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2901,14 +2903,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 89
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x809b00..0x809b10]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x809c50..0x809c60]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 160 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x809b00..0x809b10
+            - Range: 0x809c50..0x809c60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2916,24 +2918,17 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x809b00..0x809b10
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 90
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x809b10..0x809b20]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x809c60..0x809c70]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x809b10..0x809b20
+            - Range: 0x809c60..0x809c70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2946,19 +2941,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809b10..0x809b20
+            - Range: 0x809c60..0x809c70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 91
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x809b20..0x809b30]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x809c70..0x809c80]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x809b20..0x809b30
+            - Range: 0x809c70..0x809c80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2971,19 +2966,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809b20..0x809b30
+            - Range: 0x809c70..0x809c80
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0x809b30..0x809b40]
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x809c80..0x809c90]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 164 GoSliceHeaderType []string
+        - Name: xs
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x809b30..0x809b40
+            - Range: 0x809c80..0x809c90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2993,22 +2988,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809c80..0x809c90
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 93
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x809c90..0x809ca0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 165 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x809c90..0x809ca0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x809b40..0x809b50]
+      OutOfLinePCRanges: [0x809ca0..0x809cb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x809b40..0x809b50
+            - Range: 0x809ca0..0x809cb0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 165 GoSliceHeaderType []bool
+          Type: 166 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x809b40..0x809b50
+            - Range: 0x809ca0..0x809cb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3021,37 +3041,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809b40..0x809b50
+            - Range: 0x809ca0..0x809cb0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x809b50..0x809b60]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 166 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x809b50..0x809b60
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 95
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x809b60..0x809b70]
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x809cb0..0x809cc0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 158 GoSliceHeaderType []uint
+          Type: 167 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x809b60..0x809b70
+            - Range: 0x809cb0..0x809cc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3062,24 +3064,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 96
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x809cc0..0x809cd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 159 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x809cc0..0x809cd0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 97
       Name: main.stackC
-      OutOfLinePCRanges: [0x809e00..0x809e60]
+      OutOfLinePCRanges: [0x809f60..0x809fc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x809e00..0x809e60, Pieces: []}]
+          Locations: [{Range: 0x809f60..0x809fc0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x809e60..0x809e70]
+      OutOfLinePCRanges: [0x809fc0..0x809fd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809e60..0x809e70
+            - Range: 0x809fc0..0x809fd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3087,15 +3107,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x809e70..0x809e80]
+      OutOfLinePCRanges: [0x809fd0..0x809fe0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809e70..0x809e80
+            - Range: 0x809fd0..0x809fe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3106,7 +3126,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809e70..0x809e80
+            - Range: 0x809fd0..0x809fe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3117,7 +3137,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809e70..0x809e80
+            - Range: 0x809fd0..0x809fe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3125,15 +3145,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 100
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x809e80..0x809e90]
+      OutOfLinePCRanges: [0x809fe0..0x809ff0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 167 StructureType main.threeStringStruct
+          Type: 168 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x809e80..0x809e90
+            - Range: 0x809fe0..0x809ff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3149,55 +3169,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 100
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x809e90..0x809ea0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x809e90..0x809ea0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 101
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x809ea0..0x809eb0]
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x809ff0..0x80a000]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 169 PointerType *main.oneStringStruct
+          Type: 169 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x809ea0..0x809eb0
+            - Range: 0x809ff0..0x80a000
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x809eb0..0x809ec0]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x80a000..0x80a010]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 170 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x809eb0..0x809ec0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a000..0x80a010
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x809ec0..0x809ed0]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x80a010..0x80a020]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809ec0..0x809ed0
+            - Range: 0x80a010..0x80a020
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3206,14 +3210,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 104
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x809ed0..0x809ee0]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x80a020..0x80a030]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809ed0..0x809ee0
+            - Range: 0x80a020..0x80a030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3222,14 +3226,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 105
-      Name: main.testStruct
-      OutOfLinePCRanges: [0x80a0a0..0x80a0c0]
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x80a030..0x80a040]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 171 StructureType main.aStruct
+          Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a0a0..0x80a0c0
+            - Range: 0x80a030..0x80a040
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 106
+      Name: main.testStruct
+      OutOfLinePCRanges: [0x80a200..0x80a220]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 172 StructureType main.aStruct
+          Locations:
+            - Range: 0x80a200..0x80a220
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3247,29 +3267,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 106
-      Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80a170..0x80a180]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 173 StructureType main.emptyStruct
-          Locations: [{Range: 0x80a170..0x80a180, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
     - ID: 107
-      Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80a180..0x80a190]
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0x80a2d0..0x80a2e0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 174 PointerType *main.emptyStruct
-          Locations:
-            - Range: 0x80a180..0x80a190
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Type: 174 StructureType main.emptyStruct
+          Locations: [{Range: 0x80a2d0..0x80a2e0, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testEmptyStructPointer
+      OutOfLinePCRanges: [0x80a2e0..0x80a2f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 175 PointerType *main.emptyStruct
+          Locations:
+            - Range: 0x80a2e0..0x80a2f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x807320..0x807390]
       InlinePCRanges:
@@ -3299,28 +3319,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 110
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x8075a4..0x8075d8]
           RootRanges: [0x807540..0x807600]
       Variables: []
-    - ID: 110
+    - ID: 111
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x80768c..0x8076c0, 0x8076c8..0x8076cc]
           RootRanges: [0x807670..0x807780]
       Variables: []
-    - ID: 111
+    - ID: 112
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x807730..0x807764]
           RootRanges: [0x807670..0x807780]
       Variables: []
-    - ID: 112
+    - ID: 113
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3334,7 +3354,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3359,20 +3379,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 310
+      ID: 311
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 311 PointerType *main.deepSlice3
+      Pointee: 312 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 335
+      ID: 336
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 336 PointerType *main.deepSlice8
+      Pointee: 337 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 341
+      ID: 342
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 342 PointerType *main.deepSlice9
+      Pointee: 343 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3383,7 +3403,7 @@ Types:
       ID: 403
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 156 PointerType *main.t
+      Pointee: 157 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3392,35 +3412,35 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 149
+      ID: 150
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<[4]int,[4]int>
+      Pointee: 151 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 144
+      ID: 145
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 145 PointerType *table<[4]int,uint8>
+      Pointee: 146 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 112
+      ID: 113
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 113 PointerType *table<[4]string,[2]int>
+      Pointee: 114 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 124
+      ID: 125
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 125 PointerType *table<bool,main.node>
+      Pointee: 126 PointerType *table<bool,main.node>
     - __kind: PointerType
       ID: 71
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 318
+      ID: 319
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 319 PointerType *table<int,*main.deepMap3>
+      Pointee: 320 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 353
       Name: '**table<int,*main.deepMap8>'
@@ -3432,85 +3452,85 @@ Types:
       ByteSize: 8
       Pointee: 369 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 92
+      ID: 93
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 93 PointerType *table<int,int>
+      Pointee: 94 PointerType *table<int,int>
     - __kind: PointerType
       ID: 383
       Name: '**table<int,interface {}>'
       ByteSize: 8
       Pointee: 384 PointerType *table<int,interface {}>
     - __kind: PointerType
-      ID: 129
+      ID: 130
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 130 PointerType *table<int,uint8>
+      Pointee: 131 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 120
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 120 PointerType *table<string,[]main.structWithMap>
+      Pointee: 121 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 107
+      ID: 108
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 108 PointerType *table<string,[]string>
+      Pointee: 109 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 103
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 103 PointerType *table<string,int>
+      Pointee: 104 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 97
+      ID: 98
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 98 PointerType *table<string,main.nestedStruct>
+      Pointee: 99 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 139
+      ID: 140
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<uint8,[4]int>
+      Pointee: 141 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 134
+      ID: 135
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 135 PointerType *table<uint8,uint8>
+      Pointee: 136 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 314
+      ID: 315
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 313 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 314 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 339
+      ID: 340
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 338 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 339 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 345
+      ID: 346
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 344 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 345 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 178
+      ID: 179
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []*string.array
+      Pointee: 178 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 295
+      ID: 296
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType [][]uint.array
+      Pointee: 295 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 301
+      ID: 302
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []bool.array
+      Pointee: 301 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 349
       Name: '*[]interface {}.array'
@@ -3522,30 +3542,30 @@ Types:
       ByteSize: 8
       Pointee: 406 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 297
+      ID: 298
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 297 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 299
+      ID: 300
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []string.array
+      Pointee: 299 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 160
+      ID: 161
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 158 GoSliceHeaderType []uint
+      Pointee: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 293
+      ID: 294
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []uint.array
+      Pointee: 293 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 303
+      ID: 304
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []uint16.array
+      Pointee: 303 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3610,26 +3630,26 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 347
+      ID: 88
       Name: '*interface {}'
       ByteSize: 8
       GoRuntimeType: 393056
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 188
+      ID: 189
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 385696
       GoKind: 22
-      Pointee: 189 StructureType main.deepMap2
+      Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 326
+      ID: 327
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385632
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType main.deepMap3
+      Pointee: 328 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3659,12 +3679,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 304
+      ID: 305
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386208
       GoKind: 22
-      Pointee: 305 UnresolvedPointeeType main.deepPtr3
+      Pointee: 306 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -3673,33 +3693,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 330
+      ID: 331
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 385888
       GoKind: 22
-      Pointee: 331 StructureType main.deepPtr8
+      Pointee: 332 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 332
+      ID: 333
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 385824
       GoKind: 22
-      Pointee: 333 StructureType main.deepPtr9
+      Pointee: 334 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 386848
       GoKind: 22
-      Pointee: 179 StructureType main.deepSlice2
+      Pointee: 180 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 311
+      ID: 312
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 386784
       GoKind: 22
-      Pointee: 312 UnresolvedPointeeType main.deepSlice3
+      Pointee: 313 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3708,25 +3728,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 336
+      ID: 337
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 337 StructureType main.deepSlice8
+      Pointee: 338 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 342
+      ID: 343
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386400
       GoKind: 22
-      Pointee: 343 StructureType main.deepSlice9
+      Pointee: 344 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 174
+      ID: 175
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 173 StructureType main.emptyStruct
+      Pointee: 174 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
@@ -3735,18 +3755,18 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 155
+      ID: 156
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 387040
       GoKind: 22
-      Pointee: 154 StructureType main.node
+      Pointee: 155 StructureType main.node
     - __kind: PointerType
-      ID: 169
+      ID: 170
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 170 StructureType main.oneStringStruct
+      Pointee: 171 StructureType main.oneStringStruct
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -3754,81 +3774,81 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 307
+      ID: 308
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType main.stringType1.str
+      Pointee: 307 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 308 UnresolvedPointeeType main.stringType2
+      Pointee: 309 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 240
+      ID: 241
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 385184
       GoKind: 22
-      Pointee: 88 StructureType main.structWithMap
+      Pointee: 89 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 162
+      ID: 163
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 163 StructureType main.structWithNoStrings
+      Pointee: 164 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 152
+      ID: 153
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 153 StructureType main.structWithTwoValues
+      Pointee: 154 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 156
+      ID: 157
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 GoSliceHeaderType main.t
+      Pointee: 158 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 405
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 404 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 168
+      ID: 169
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 167 StructureType main.threeStringStruct
+      Pointee: 168 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 147
+      ID: 148
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 149 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 142
+      ID: 143
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 143 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 144 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 110
+      ID: 111
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 111 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 112 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 122
+      ID: 123
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 123 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 124 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
       ID: 69
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 316
+      ID: 317
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 317 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 351
       Name: '*map<int,*main.deepMap8>'
@@ -3840,86 +3860,86 @@ Types:
       ByteSize: 8
       Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 90
+      ID: 91
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 91 GoSwissMapHeaderType map<int,int>
+      Pointee: 92 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
       ID: 381
       Name: '*map<int,interface {}>'
       ByteSize: 8
       Pointee: 382 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
-      ID: 127
+      ID: 128
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 128 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 129 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 117
+      ID: 118
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 105
+      ID: 106
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 106 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 107 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 100
+      ID: 101
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 101 GoSwissMapHeaderType map<string,int>
+      Pointee: 102 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 95
+      ID: 96
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 137
+      ID: 138
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 139 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 132
+      ID: 133
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 133 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 134 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 115
+      ID: 116
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 GoMapType map[string]int
+      Pointee: 100 GoMapType map[string]int
     - __kind: PointerType
-      ID: 286
+      ID: 287
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 287 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 278
+      ID: 279
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 279 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 226
+      ID: 227
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 227 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 245
+      ID: 246
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 246 StructureType noalg.map.group[bool]main.node
+      Pointee: 247 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 184
+      ID: 185
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 322
+      ID: 323
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 323 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 357
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -3931,50 +3951,50 @@ Types:
       ByteSize: 8
       Pointee: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 194
+      ID: 195
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 195 StructureType noalg.map.group[int]int
+      Pointee: 196 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 387
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 388 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 253
+      ID: 254
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 254 StructureType noalg.map.group[int]uint8
+      Pointee: 255 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 235
+      ID: 236
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 236 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 218
+      ID: 219
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 219 StructureType noalg.map.group[string][]string
+      Pointee: 220 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 210
+      ID: 211
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 211 StructureType noalg.map.group[string]int
+      Pointee: 212 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 202
+      ID: 203
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 269
+      ID: 270
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 270 StructureType noalg.map.group[uint8][4]int
+      Pointee: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 261
+      ID: 262
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 262 StructureType noalg.map.group[uint8]uint8
+      Pointee: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3983,40 +4003,40 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 176
+      ID: 177
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 175 GoStringDataType string.str
+      Pointee: 176 GoStringDataType string.str
     - __kind: PointerType
-      ID: 150
+      ID: 151
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 284 StructureType table<[4]int,[4]int>
+      Pointee: 285 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 145
+      ID: 146
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 276 StructureType table<[4]int,uint8>
+      Pointee: 277 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 224 StructureType table<[4]string,[2]int>
+      Pointee: 225 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 126
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 243 StructureType table<bool,main.node>
+      Pointee: 244 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 182 StructureType table<int,*main.deepMap2>
+      Pointee: 183 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 319
+      ID: 320
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 320 StructureType table<int,*main.deepMap3>
+      Pointee: 321 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 354
       Name: '*table<int,*main.deepMap8>'
@@ -4028,50 +4048,50 @@ Types:
       ByteSize: 8
       Pointee: 370 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
-      ID: 93
+      ID: 94
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 192 StructureType table<int,int>
+      Pointee: 193 StructureType table<int,int>
     - __kind: PointerType
       ID: 384
       Name: '*table<int,interface {}>'
       ByteSize: 8
       Pointee: 385 StructureType table<int,interface {}>
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 251 StructureType table<int,uint8>
+      Pointee: 252 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 233 StructureType table<string,[]main.structWithMap>
+      Pointee: 234 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 108
+      ID: 109
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 216 StructureType table<string,[]string>
+      Pointee: 217 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 104
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 208 StructureType table<string,int>
+      Pointee: 209 StructureType table<string,int>
     - __kind: PointerType
-      ID: 98
+      ID: 99
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 200 StructureType table<string,main.nestedStruct>
+      Pointee: 201 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 140
+      ID: 141
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 267 StructureType table<uint8,[4]int>
+      Pointee: 268 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 135
+      ID: 136
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 259 StructureType table<uint8,uint8>
+      Pointee: 260 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -4115,8 +4135,23 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 503
+      ID: 504
       Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 462
+      Name: Probe[main.testAnyPtr]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 88 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 460
       Name: Probe[main.testAny]
@@ -4163,7 +4198,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 468
+      ID: 469
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4171,10 +4206,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 114 ArrayType [2]map[string]int
+            Type: 115 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4238,7 +4273,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 484
+      ID: 485
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4246,14 +4281,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 151 GoChannelType chan bool
+            Type: 152 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: c}
+                  Variable: {subprogram: 78, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 482
+      ID: 483
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -4264,7 +4299,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: w}
+                  Variable: {subprogram: 76, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -4273,7 +4308,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 1, name: x}
+                  Variable: {subprogram: 76, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -4282,11 +4317,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 2, name: y}
+                  Variable: {subprogram: 76, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 492
+      ID: 493
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4294,10 +4329,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.t
+            Type: 157 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: t}
+                  Variable: {subprogram: 86, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4391,7 +4426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 497
+      ID: 498
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4399,10 +4434,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4411,11 +4446,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 494
+      ID: 495
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4423,14 +4458,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 511
+      ID: 512
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4441,11 +4476,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 514
+      ID: 515
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4453,14 +4488,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 174 PointerType *main.emptyStruct
+            Type: 175 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: e}
+                  Variable: {subprogram: 108, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 513
+      ID: 514
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -4468,10 +4503,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 173 StructureType main.emptyStruct
+            Type: 174 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: e}
+                  Variable: {subprogram: 107, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -4580,7 +4615,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 516
+      ID: 517
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 454
@@ -4607,16 +4642,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 517
+      ID: 518
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 518
+      ID: 519
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 456
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 515
+      ID: 516
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4627,11 +4662,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 519
+      ID: 520
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4642,11 +4677,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: x}
+                  Variable: {subprogram: 113, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 520
+      ID: 521
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4657,7 +4692,7 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4751,7 +4786,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 486
+      ID: 487
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4759,14 +4794,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 154 StructureType main.node
+            Type: 155 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 466
+      ID: 467
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4774,14 +4809,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 109 GoMapType map[[4]string][2]int
+            Type: 110 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 472
+      ID: 473
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4789,14 +4824,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 116 GoMapType map[string][]main.structWithMap
+            Type: 117 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 470
+      ID: 471
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4804,14 +4839,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 89 GoMapType map[int]int
+            Type: 90 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 481
+      ID: 482
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4819,14 +4854,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[[4]int][4]int
+            Type: 147 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: m}
+                  Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 480
+      ID: 481
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4834,14 +4869,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 141 GoMapType map[[4]int]uint8
+            Type: 142 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 471
+      ID: 472
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4849,14 +4884,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 116 GoMapType map[string][]main.structWithMap
+            Type: 117 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 479
+      ID: 480
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4864,14 +4899,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[uint8][4]int
+            Type: 137 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 478
+      ID: 479
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4879,14 +4914,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 464
+      ID: 465
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4894,14 +4929,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 465
+      ID: 466
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4909,14 +4944,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 104 GoMapType map[string][]string
+            Type: 105 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 463
+      ID: 464
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4924,14 +4959,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[string]main.nestedStruct
+            Type: 95 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 473
+      ID: 474
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4939,14 +4974,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[bool]main.node
+            Type: 122 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 477
+      ID: 478
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4954,14 +4989,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 476
+      ID: 477
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4969,14 +5004,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 131 GoMapType map[uint8]uint8
+            Type: 132 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 475
+      ID: 476
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4984,14 +5019,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 126 GoMapType map[int]uint8
+            Type: 127 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 474
+      ID: 475
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4999,14 +5034,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 126 GoMapType map[int]uint8
+            Type: 127 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 509
+      ID: 510
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5017,11 +5052,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 483
+      ID: 484
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -5032,7 +5067,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -5041,7 +5076,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: b}
+                  Variable: {subprogram: 77, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -5050,7 +5085,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 2, name: c}
+                  Variable: {subprogram: 77, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -5059,7 +5094,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 3, name: d}
+                  Variable: {subprogram: 77, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -5068,11 +5103,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 4, name: e}
+                  Variable: {subprogram: 77, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 491
+      ID: 492
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5083,7 +5118,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: z}
+                  Variable: {subprogram: 85, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -5092,11 +5127,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: a}
+                  Variable: {subprogram: 85, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 498
+      ID: 499
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5104,10 +5139,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5116,11 +5151,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: a}
+                  Variable: {subprogram: 92, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 500
+      ID: 501
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -5131,16 +5166,16 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 94, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 165 GoSliceHeaderType []bool
+            Type: 166 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: s}
+                  Variable: {subprogram: 94, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -5149,11 +5184,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 2, name: x}
+                  Variable: {subprogram: 94, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 501
+      ID: 502
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5161,14 +5196,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 166 GoSliceHeaderType []uint16
+            Type: 167 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 508
+      ID: 509
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5176,14 +5211,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.oneStringStruct
+            Type: 170 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: a}
+                  Variable: {subprogram: 102, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 487
+      ID: 488
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5191,14 +5226,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 155 PointerType *main.node
+            Type: 156 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 469
+      ID: 470
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5206,14 +5241,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 PointerType *map[string]int
+            Type: 116 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 485
+      ID: 486
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5221,10 +5256,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 152 PointerType *main.structWithTwoValues
+            Type: 153 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5393,7 +5428,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 504
+      ID: 505
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5404,7 +5439,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5483,7 +5518,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 495
+      ID: 496
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5491,14 +5526,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType [][]uint
+            Type: 160 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: u}
+                  Variable: {subprogram: 89, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 467
+      ID: 468
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5506,10 +5541,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5528,7 +5563,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 490
+      ID: 491
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5539,11 +5574,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 499
+      ID: 500
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5551,10 +5586,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 164 GoSliceHeaderType []string
+            Type: 165 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: s}
+                  Variable: {subprogram: 93, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5588,7 +5623,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 496
+      ID: 497
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5596,10 +5631,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 161 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -5608,11 +5643,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 462
+      ID: 463
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5620,14 +5655,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 88 StructureType main.structWithMap
+            Type: 89 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: s}
+                  Variable: {subprogram: 56, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 512
+      ID: 513
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -5635,14 +5670,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 171 StructureType main.aStruct
+            Type: 172 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: x}
+                  Variable: {subprogram: 106, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 507
+      ID: 508
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5650,14 +5685,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 PointerType *main.threeStringStruct
+            Type: 169 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 506
+      ID: 507
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5665,14 +5700,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 167 StructureType main.threeStringStruct
+            Type: 168 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 505
+      ID: 506
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5683,7 +5718,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5692,7 +5727,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: y}
+                  Variable: {subprogram: 99, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5701,7 +5736,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: z}
+                  Variable: {subprogram: 99, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5795,7 +5830,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 489
+      ID: 490
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5806,11 +5841,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: x}
+                  Variable: {subprogram: 83, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 493
+      ID: 494
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5818,14 +5853,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 510
+      ID: 511
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5836,11 +5871,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 488
+      ID: 489
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5851,7 +5886,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5870,7 +5905,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 502
+      ID: 503
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5878,10 +5913,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 158 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: xs}
+                  Variable: {subprogram: 96, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5959,13 +5994,13 @@ Types:
       HasCount: true
       Element: 17 BaseType int8
     - __kind: ArrayType
-      ID: 114
+      ID: 115
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 99 GoMapType map[string]int
+      Element: 100 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -6018,7 +6053,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 273
+      ID: 274
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 682400
@@ -6027,7 +6062,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 230
+      ID: 231
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 682688
@@ -6059,14 +6094,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 180 GoSliceDataType []*main.deepSlice2.array
+      Data: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 181
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 309
+      ID: 310
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477408
@@ -6074,21 +6109,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 310 PointerType **main.deepSlice3
+          Type: 311 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 313 GoSliceDataType []*main.deepSlice3.array
+      Data: 314 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 313
+      ID: 314
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 311 PointerType *main.deepSlice3
+      Element: 312 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 334
+      ID: 335
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477088
@@ -6096,21 +6131,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 335 PointerType **main.deepSlice8
+          Type: 336 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 338 GoSliceDataType []*main.deepSlice8.array
+      Data: 339 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 338
+      ID: 339
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 336 PointerType *main.deepSlice8
+      Element: 337 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 340
+      ID: 341
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477024
@@ -6118,19 +6153,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 341 PointerType **main.deepSlice9
+          Type: 342 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 344 GoSliceDataType []*main.deepSlice9.array
+      Data: 345 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 345
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 342 PointerType *main.deepSlice9
+      Element: 343 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6147,42 +6182,42 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 177 GoSliceDataType []*string.array
+      Data: 178 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 178
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 291
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<[4]int,[4]int>
+      Element: 151 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 283
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 145 PointerType *table<[4]int,uint8>
+      Element: 146 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 232
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 113 PointerType *table<[4]string,[2]int>
+      Element: 114 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 250
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 125 PointerType *table<bool,main.node>
+      Element: 126 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 329
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 319 PointerType *table<int,*main.deepMap3>
+      Element: 320 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 363
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -6194,73 +6229,73 @@ Types:
       ByteSize: 8192
       Element: 369 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 199
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 93 PointerType *table<int,int>
+      Element: 94 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 391
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
       Element: 384 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 258
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 130 PointerType *table<int,uint8>
+      Element: 131 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 242
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 120 PointerType *table<string,[]main.structWithMap>
+      Element: 121 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 223
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 108 PointerType *table<string,[]string>
+      Element: 109 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 215
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 103 PointerType *table<string,int>
+      Element: 104 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 207
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 98 PointerType *table<string,main.nestedStruct>
+      Element: 99 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 275
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 140 PointerType *table<uint8,[4]int>
+      Element: 141 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 266
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 135 PointerType *table<uint8,uint8>
+      Element: 136 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 160
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 160 PointerType *[]uint
+          Type: 161 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 294 GoSliceDataType [][]uint.array
+      Data: 295 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 295
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 158 GoSliceHeaderType []uint
+      Element: 159 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 166
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 486816
@@ -6275,14 +6310,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 300 GoSliceDataType []bool.array
+      Data: 301 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 301
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 346
+      ID: 347
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487136
@@ -6290,7 +6325,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 347 PointerType *interface {}
+          Type: 88 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -6304,7 +6339,7 @@ Types:
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 239
+      ID: 240
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 477728
@@ -6312,7 +6347,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 240 PointerType *main.structWithMap
+          Type: 241 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -6324,58 +6359,58 @@ Types:
       ID: 406
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 88 StructureType main.structWithMap
+      Element: 89 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 162
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *main.structWithNoStrings
+          Type: 163 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 296 GoSliceDataType []main.structWithNoStrings.array
+      Data: 297 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 297
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 163 StructureType main.structWithNoStrings
+      Element: 164 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 292
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 287 StructureType noalg.map.group[[4]int][4]int
+      Element: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 284
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 279 StructureType noalg.map.group[[4]int]uint8
+      Element: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 233
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 227 StructureType noalg.map.group[[4]string][2]int
+      Element: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 251
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 246 StructureType noalg.map.group[bool]main.node
+      Element: 247 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 330
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 323 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 364
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -6387,52 +6422,52 @@ Types:
       ByteSize: 2048
       Element: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 195 StructureType noalg.map.group[int]int
+      Element: 196 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 392
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
       Element: 388 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 259
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 254 StructureType noalg.map.group[int]uint8
+      Element: 255 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 243
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 236 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 224
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 219 StructureType noalg.map.group[string][]string
+      Element: 220 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 216
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 211 StructureType noalg.map.group[string]int
+      Element: 212 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 208
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 203 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 276
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 270 StructureType noalg.map.group[uint8][4]int
+      Element: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 267
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 262 StructureType noalg.map.group[uint8]uint8
+      Element: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 165
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 486944
@@ -6447,14 +6482,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 298 GoSliceDataType []string.array
+      Data: 299 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 299
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 159
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 486432
@@ -6469,14 +6504,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType []uint.array
+      Data: 293 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 293
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 167
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -6491,9 +6526,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 302 GoSliceDataType []uint16.array
+      Data: 303 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 303
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -6504,7 +6539,7 @@ Types:
       GoRuntimeType: 584704
       GoKind: 1
     - __kind: GoChannelType
-      ID: 151
+      ID: 152
       Name: chan bool
       GoRuntimeType: 596032
       GoKind: 18
@@ -6557,89 +6592,89 @@ Types:
       GoRuntimeType: 475616
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 285
+      ID: 286
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 286 PointerType *noalg.map.group[[4]int][4]int
+          Type: 287 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 287 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 291 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 292 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 277
+      ID: 278
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 278 PointerType *noalg.map.group[[4]int]uint8
+          Type: 279 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 279 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 283 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 284 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 225
+      ID: 226
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 226 PointerType *noalg.map.group[[4]string][2]int
+          Type: 227 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 227 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 233 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 244
+      ID: 245
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 245 PointerType *noalg.map.group[bool]main.node
+          Type: 246 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 246 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 250 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 247 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 184
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 185 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 191 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 321
+      ID: 322
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 322 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 323 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 323 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 329 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 356
       Name: groupReference<int,*main.deepMap8>
@@ -6669,19 +6704,19 @@ Types:
       GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 193
+      ID: 194
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 194 PointerType *noalg.map.group[int]int
+          Type: 195 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 195 StructureType noalg.map.group[int]int
-      GroupSliceType: 199 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 196 StructureType noalg.map.group[int]int
+      GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 386
       Name: groupReference<int,interface {}>
@@ -6697,103 +6732,103 @@ Types:
       GroupType: 388 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 392 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 252
+      ID: 253
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 253 PointerType *noalg.map.group[int]uint8
+          Type: 254 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 254 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 255 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 234
+      ID: 235
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 235 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 236 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 236 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 217
+      ID: 218
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 218 PointerType *noalg.map.group[string][]string
+          Type: 219 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 219 StructureType noalg.map.group[string][]string
-      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 220 StructureType noalg.map.group[string][]string
+      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 209
+      ID: 210
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 210 PointerType *noalg.map.group[string]int
+          Type: 211 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 211 StructureType noalg.map.group[string]int
-      GroupSliceType: 215 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 212 StructureType noalg.map.group[string]int
+      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 202
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 203 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 207 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 268
+      ID: 269
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 269 PointerType *noalg.map.group[uint8][4]int
+          Type: 270 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 270 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 275 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 271 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 276 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 260
+      ID: 261
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 261 PointerType *noalg.map.group[uint8]uint8
+          Type: 262 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 262 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 266 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 263 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6864,7 +6899,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6880,7 +6915,7 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 172 StructureType main.nestedStruct
+          Type: 173 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
@@ -6920,7 +6955,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 189
+      ID: 190
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.18496e+06
@@ -6928,9 +6963,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 315 GoMapType map[int]*main.deepMap3
+          Type: 316 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 328
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -6982,9 +7017,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 304 PointerType *main.deepPtr3
+          Type: 305 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 305
+      ID: 306
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -6996,9 +7031,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 330 PointerType *main.deepPtr8
+          Type: 331 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 331
+      ID: 332
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.185344e+06
@@ -7006,9 +7041,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 332 PointerType *main.deepPtr9
+          Type: 333 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 333
+      ID: 334
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.185216e+06
@@ -7028,7 +7063,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 179
+      ID: 180
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.187264e+06
@@ -7036,9 +7071,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 309 GoSliceHeaderType []*main.deepSlice3
+          Type: 310 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 312
+      ID: 313
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7050,9 +7085,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 334 GoSliceHeaderType []*main.deepSlice8
+          Type: 335 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 337
+      ID: 338
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.186496e+06
@@ -7060,9 +7095,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 340 GoSliceHeaderType []*main.deepSlice9
+          Type: 341 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 343
+      ID: 344
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.186368e+06
@@ -7070,9 +7105,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 346 GoSliceHeaderType []interface {}
+          Type: 347 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -7127,7 +7162,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 172
+      ID: 173
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.460832e+06
@@ -7140,7 +7175,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 154
+      ID: 155
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.460672e+06
@@ -7151,9 +7186,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 155 PointerType *main.node
+          Type: 156 PointerType *main.node
     - __kind: StructureType
-      ID: 170
+      ID: 171
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -7182,21 +7217,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *main.stringType1.str
+          Type: 308 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 306 GoStringDataType main.stringType1.str
+      Data: 307 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 307
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 308
+      ID: 309
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
-      ID: 88
+      ID: 89
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.183936e+06
@@ -7204,9 +7239,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 89 GoMapType map[int]int
+          Type: 90 GoMapType map[int]int
     - __kind: StructureType
-      ID: 163
+      ID: 164
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -7218,7 +7253,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 153
+      ID: 154
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -7230,7 +7265,7 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 157
+      ID: 158
       Name: main.t
       ByteSize: 24
       GoKind: 23
@@ -7249,9 +7284,9 @@ Types:
       ID: 404
       Name: main.t.array
       ByteSize: 2048
-      Element: 156 PointerType *main.t
+      Element: 157 PointerType *main.t
     - __kind: StructureType
-      ID: 167
+      ID: 168
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -7271,7 +7306,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 149
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7284,7 +7319,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<[4]int,[4]int>
+          Type: 150 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7303,10 +7338,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 290 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 287 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 291 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 288 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 143
+      ID: 144
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7319,7 +7354,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 144 PointerType **table<[4]int,uint8>
+          Type: 145 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7338,10 +7373,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 282 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 279 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 283 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 280 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 111
+      ID: 112
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -7354,7 +7389,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 112 PointerType **table<[4]string,[2]int>
+          Type: 113 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7373,10 +7408,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 227 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 232 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 228 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 123
+      ID: 124
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -7389,7 +7424,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 124 PointerType **table<bool,main.node>
+          Type: 125 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7408,8 +7443,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 249 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 246 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 250 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 247 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -7443,10 +7478,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 190 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 185 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 317
+      ID: 318
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7459,7 +7494,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 318 PointerType **table<int,*main.deepMap3>
+          Type: 319 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7478,8 +7513,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 328 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 323 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 352
       Name: map<int,*main.deepMap8>
@@ -7551,7 +7586,7 @@ Types:
       TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap9>.array
       GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
-      ID: 91
+      ID: 92
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -7564,7 +7599,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 92 PointerType **table<int,int>
+          Type: 93 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7583,8 +7618,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 198 GoSliceDataType []*table<int,int>.array
-      GroupType: 195 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
+      GroupType: 196 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 382
       Name: map<int,interface {}>
@@ -7621,7 +7656,7 @@ Types:
       TablePtrSliceType: 391 GoSliceDataType []*table<int,interface {}>.array
       GroupType: 388 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 128
+      ID: 129
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7634,7 +7669,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 129 PointerType **table<int,uint8>
+          Type: 130 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7653,10 +7688,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 254 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 258 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 255 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 118
+      ID: 119
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -7669,7 +7704,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 119 PointerType **table<string,[]main.structWithMap>
+          Type: 120 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7688,10 +7723,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 241 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 236 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 237 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 106
+      ID: 107
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -7704,7 +7739,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 107 PointerType **table<string,[]string>
+          Type: 108 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7723,10 +7758,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 222 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 219 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 223 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 220 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 101
+      ID: 102
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -7739,7 +7774,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 102 PointerType **table<string,int>
+          Type: 103 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7758,10 +7793,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 214 GoSliceDataType []*table<string,int>.array
-      GroupType: 211 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 215 GoSliceDataType []*table<string,int>.array
+      GroupType: 212 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 96
+      ID: 97
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -7774,7 +7809,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 97 PointerType **table<string,main.nestedStruct>
+          Type: 98 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7793,10 +7828,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 206 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 203 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 207 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 204 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 139
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -7809,7 +7844,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<uint8,[4]int>
+          Type: 140 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7828,10 +7863,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 274 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 270 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 275 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 271 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 133
+      ID: 134
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -7844,7 +7879,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 134 PointerType **table<uint8,uint8>
+          Type: 135 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7863,36 +7898,36 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 265 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 262 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 266 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 263 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 146
+      ID: 147
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.128832e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 149 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 141
+      ID: 142
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.12896e+06
       GoKind: 21
-      HeaderType: 143 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 144 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 109
+      ID: 110
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.129088e+06
       GoKind: 21
-      HeaderType: 111 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 112 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 121
+      ID: 122
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.129216e+06
       GoKind: 21
-      HeaderType: 123 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 124 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
@@ -7901,12 +7936,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 315
+      ID: 316
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.128576e+06
       GoKind: 21
-      HeaderType: 317 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 350
       Name: map[int]*main.deepMap8
@@ -7922,12 +7957,12 @@ Types:
       GoKind: 21
       HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
-      ID: 89
+      ID: 90
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.127296e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<int,int>
+      HeaderType: 92 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 380
       Name: map[int]interface {}
@@ -7936,108 +7971,108 @@ Types:
       GoKind: 21
       HeaderType: 382 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
-      ID: 126
+      ID: 127
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.129344e+06
       GoKind: 21
-      HeaderType: 128 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 129 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 116
+      ID: 117
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.129472e+06
       GoKind: 21
-      HeaderType: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 119 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 104
+      ID: 105
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.1296e+06
       GoKind: 21
-      HeaderType: 106 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 107 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 99
+      ID: 100
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.129728e+06
       GoKind: 21
-      HeaderType: 101 GoSwissMapHeaderType map<string,int>
+      HeaderType: 102 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 94
+      ID: 95
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.129856e+06
       GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 97 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 136
+      ID: 137
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.129984e+06
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 139 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 131
+      ID: 132
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.130112e+06
       GoKind: 21
-      HeaderType: 133 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 134 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 288
+      ID: 289
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 682496
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 289 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 290 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 280
+      ID: 281
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 682592
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 281 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 282 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 228
+      ID: 229
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 682880
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 229 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 230 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 247
+      ID: 248
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 682976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 248 StructureType noalg.struct { key bool; elem main.node }
+      Element: 249 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 186
+      ID: 187
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 681824
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 187 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 324
+      ID: 325
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 681728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 325 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 359
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -8057,14 +8092,14 @@ Types:
       HasCount: true
       Element: 375 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 196
+      ID: 197
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 679904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 197 StructureType noalg.struct { key int; elem int }
+      Element: 198 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 389
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -8075,70 +8110,70 @@ Types:
       HasCount: true
       Element: 390 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 255
+      ID: 256
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 683072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 256 StructureType noalg.struct { key int; elem uint8 }
+      Element: 257 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 237
+      ID: 238
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 683168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 238 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 239 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 220
+      ID: 221
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 221 StructureType noalg.struct { key string; elem []string }
+      Element: 222 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 212
+      ID: 213
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 683360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem int }
+      Element: 214 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 204
+      ID: 205
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 205 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 206 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 271
+      ID: 272
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 272 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 273 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 263
+      ID: 264
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 264 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 265 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 287
+      ID: 288
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.293952e+06
@@ -8149,9 +8184,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 288 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 289 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 279
+      ID: 280
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.294208e+06
@@ -8162,9 +8197,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 280 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 281 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 227
+      ID: 228
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.294464e+06
@@ -8175,9 +8210,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 228 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 229 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 246
+      ID: 247
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.29472e+06
@@ -8188,9 +8223,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 247 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 248 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 185
+      ID: 186
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.293696e+06
@@ -8201,9 +8236,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 186 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 323
+      ID: 324
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.29344e+06
@@ -8214,7 +8249,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 324 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 358
       Name: noalg.map.group[int]*main.deepMap8
@@ -8242,7 +8277,7 @@ Types:
           Offset: 8
           Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 195
+      ID: 196
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.29088e+06
@@ -8253,7 +8288,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 196 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 197 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 388
       Name: noalg.map.group[int]interface {}
@@ -8268,7 +8303,7 @@ Types:
           Offset: 8
           Type: 389 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 254
+      ID: 255
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.294976e+06
@@ -8279,9 +8314,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 255 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 256 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 236
+      ID: 237
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.295232e+06
@@ -8292,9 +8327,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 237 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 238 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 219
+      ID: 220
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.295488e+06
@@ -8305,9 +8340,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 220 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 211
+      ID: 212
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.295744e+06
@@ -8318,9 +8353,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 213 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 203
+      ID: 204
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.296e+06
@@ -8331,9 +8366,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 204 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 205 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 270
+      ID: 271
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.296256e+06
@@ -8344,9 +8379,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 271 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 272 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 262
+      ID: 263
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.296512e+06
@@ -8357,9 +8392,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 263 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 264 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 289
+      ID: 290
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.293824e+06
@@ -8367,12 +8402,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
     - __kind: StructureType
-      ID: 281
+      ID: 282
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.29408e+06
@@ -8380,12 +8415,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 229
+      ID: 230
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.294336e+06
@@ -8393,12 +8428,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 230 ArrayType [4]string
+          Type: 231 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 248
+      ID: 249
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.294592e+06
@@ -8409,9 +8444,9 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 154 StructureType main.node
+          Type: 155 StructureType main.node
     - __kind: StructureType
-      ID: 187
+      ID: 188
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.293568e+06
@@ -8422,9 +8457,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 188 PointerType *main.deepMap2
+          Type: 189 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 325
+      ID: 326
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.293312e+06
@@ -8435,7 +8470,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 326 PointerType *main.deepMap3
+          Type: 327 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 360
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -8463,7 +8498,7 @@ Types:
           Offset: 8
           Type: 376 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 197
+      ID: 198
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.290752e+06
@@ -8489,7 +8524,7 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 256
+      ID: 257
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.294848e+06
@@ -8502,7 +8537,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 238
+      ID: 239
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.295104e+06
@@ -8513,9 +8548,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 239 GoSliceHeaderType []main.structWithMap
+          Type: 240 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 221
+      ID: 222
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.29536e+06
@@ -8526,9 +8561,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 164 GoSliceHeaderType []string
+          Type: 165 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 213
+      ID: 214
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.295616e+06
@@ -8541,7 +8576,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 205
+      ID: 206
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.295872e+06
@@ -8552,9 +8587,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 172 StructureType main.nestedStruct
+          Type: 173 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 272
+      ID: 273
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.296128e+06
@@ -8565,9 +8600,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 273 ArrayType [4]int
+          Type: 274 ArrayType [4]int
     - __kind: StructureType
-      ID: 264
+      ID: 265
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.296384e+06
@@ -8588,13 +8623,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 176 PointerType *string.str
+          Type: 177 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 175 GoStringDataType string.str
+      Data: 176 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 175
+      ID: 176
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -8703,7 +8738,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 284
+      ID: 285
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -8725,9 +8760,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 285 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 286 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 276
+      ID: 277
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8749,9 +8784,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 277 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 278 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 224
+      ID: 225
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -8773,9 +8808,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 225 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 226 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 243
+      ID: 244
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -8797,9 +8832,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 244 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 245 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 182
+      ID: 183
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -8821,9 +8856,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 320
+      ID: 321
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8845,7 +8880,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 321 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 355
       Name: table<int,*main.deepMap8>
@@ -8895,7 +8930,7 @@ Types:
           Offset: 16
           Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 192
+      ID: 193
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -8917,7 +8952,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 193 GoSwissMapGroupsType groupReference<int,int>
+          Type: 194 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 385
       Name: table<int,interface {}>
@@ -8943,7 +8978,7 @@ Types:
           Offset: 16
           Type: 386 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 251
+      ID: 252
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -8965,9 +9000,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 252 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 253 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 233
+      ID: 234
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -8989,9 +9024,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 234 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 235 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 216
+      ID: 217
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9013,9 +9048,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 217 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 218 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 208
+      ID: 209
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -9037,9 +9072,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 209 GoSwissMapGroupsType groupReference<string,int>
+          Type: 210 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 200
+      ID: 201
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -9061,9 +9096,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 202 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 267
+      ID: 268
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -9085,9 +9120,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 268 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 269 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 259
+      ID: 260
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -9109,7 +9144,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 260 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 261 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -9152,6 +9187,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 584768
       GoKind: 26
-MaxTypeID: 520
+MaxTypeID: 521
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -3379,20 +3379,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 311
+      ID: 324
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 312 PointerType *main.deepSlice3
+      Pointee: 325 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 336
+      ID: 351
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 337 PointerType *main.deepSlice8
+      Pointee: 352 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 342
+      ID: 357
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 343 PointerType *main.deepSlice9
+      Pointee: 358 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3400,7 +3400,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 403
+      ID: 320
       Name: '**main.t'
       ByteSize: 8
       Pointee: 157 PointerType *main.t
@@ -3437,30 +3437,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 319
+      ID: 332
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 320 PointerType *table<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 353
-      Name: '**table<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 354 PointerType *table<int,*main.deepMap8>
+      Pointee: 333 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 368
+      Name: '**table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 369 PointerType *table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 383
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 369 PointerType *table<int,*main.deepMap9>
+      Pointee: 384 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 93
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 94 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 383
+      ID: 398
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 384 PointerType *table<int,interface {}>
+      Pointee: 399 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 130
       Name: '**table<int,uint8>'
@@ -3502,20 +3502,20 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 315
+      ID: 328
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 314 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 327 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 340
+      ID: 355
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 339 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 354 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 346
+      ID: 361
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 345 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 360 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 179
       Name: '*[]*string.array'
@@ -3532,15 +3532,15 @@ Types:
       ByteSize: 8
       Pointee: 301 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 349
+      ID: 364
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 348 GoSliceDataType []interface {}.array
+      Pointee: 363 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 407
+      ID: 345
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 406 GoSliceDataType []main.structWithMap.array
+      Pointee: 344 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 298
       Name: '*[]main.structWithNoStrings.array'
@@ -3644,12 +3644,12 @@ Types:
       GoKind: 22
       Pointee: 190 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 327
+      ID: 340
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385632
       GoKind: 22
-      Pointee: 328 UnresolvedPointeeType main.deepMap3
+      Pointee: 341 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -3658,19 +3658,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 361
+      ID: 376
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 385312
       GoKind: 22
-      Pointee: 362 StructureType main.deepMap8
+      Pointee: 377 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 376
+      ID: 391
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385248
       GoKind: 22
-      Pointee: 377 StructureType main.deepMap9
+      Pointee: 392 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -3693,19 +3693,19 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 331
+      ID: 346
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 385888
       GoKind: 22
-      Pointee: 332 StructureType main.deepPtr8
+      Pointee: 347 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 333
+      ID: 348
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 385824
       GoKind: 22
-      Pointee: 334 StructureType main.deepPtr9
+      Pointee: 349 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
@@ -3714,12 +3714,12 @@ Types:
       GoKind: 22
       Pointee: 180 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 312
+      ID: 325
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 386784
       GoKind: 22
-      Pointee: 313 UnresolvedPointeeType main.deepSlice3
+      Pointee: 326 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -3728,19 +3728,19 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 337
+      ID: 352
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 338 StructureType main.deepSlice8
+      Pointee: 353 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 343
+      ID: 358
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386400
       GoKind: 22
-      Pointee: 344 StructureType main.deepSlice9
+      Pointee: 359 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 175
       Name: '*main.emptyStruct'
@@ -3809,10 +3809,10 @@ Types:
       GoKind: 22
       Pointee: 158 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 405
+      ID: 322
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 404 GoSliceDataType main.t.array
+      Pointee: 321 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 169
       Name: '*main.threeStringStruct'
@@ -3845,30 +3845,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 317
+      ID: 330
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 351
-      Name: '*map<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 352 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 366
+      Name: '*map<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 381
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 91
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 92 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 381
+      ID: 396
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 382 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 397 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 128
       Name: '*map<int,uint8>'
@@ -3936,30 +3936,30 @@ Types:
       ByteSize: 8
       Pointee: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 323
+      ID: 336
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: PointerType
-      ID: 357
-      Name: '*noalg.map.group[int]*main.deepMap8'
-      ByteSize: 8
-      Pointee: 358 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 372
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 387
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 373 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 195
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 196 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 387
+      ID: 402
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 388 StructureType noalg.map.group[int]interface {}
+      Pointee: 403 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 254
       Name: '*noalg.map.group[int]uint8'
@@ -4033,30 +4033,30 @@ Types:
       ByteSize: 8
       Pointee: 183 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 320
+      ID: 333
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 321 StructureType table<int,*main.deepMap3>
-    - __kind: PointerType
-      ID: 354
-      Name: '*table<int,*main.deepMap8>'
-      ByteSize: 8
-      Pointee: 355 StructureType table<int,*main.deepMap8>
+      Pointee: 334 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 369
+      Name: '*table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 370 StructureType table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 384
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 370 StructureType table<int,*main.deepMap9>
+      Pointee: 385 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 193 StructureType table<int,int>
     - __kind: PointerType
-      ID: 384
+      ID: 399
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 385 StructureType table<int,interface {}>
+      Pointee: 400 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '*table<int,uint8>'
@@ -6101,7 +6101,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 310
+      ID: 323
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477408
@@ -6109,21 +6109,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 311 PointerType **main.deepSlice3
+          Type: 324 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 314 GoSliceDataType []*main.deepSlice3.array
+      Data: 327 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 314
+      ID: 327
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 312 PointerType *main.deepSlice3
+      Element: 325 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 335
+      ID: 350
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477088
@@ -6131,21 +6131,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 336 PointerType **main.deepSlice8
+          Type: 351 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 339 GoSliceDataType []*main.deepSlice8.array
+      Data: 354 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 354
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 337 PointerType *main.deepSlice8
+      Element: 352 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 341
+      ID: 356
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477024
@@ -6153,19 +6153,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 342 PointerType **main.deepSlice9
+          Type: 357 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 345 GoSliceDataType []*main.deepSlice9.array
+      Data: 360 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 360
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 343 PointerType *main.deepSlice9
+      Element: 358 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -6214,30 +6214,30 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 342
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 320 PointerType *table<int,*main.deepMap3>
-    - __kind: GoSliceDataType
-      ID: 363
-      Name: '[]*table<int,*main.deepMap8>.array'
-      ByteSize: 8192
-      Element: 354 PointerType *table<int,*main.deepMap8>
+      Element: 333 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 378
+      Name: '[]*table<int,*main.deepMap8>.array'
+      ByteSize: 8192
+      Element: 369 PointerType *table<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 393
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 369 PointerType *table<int,*main.deepMap9>
+      Element: 384 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 199
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 94 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 406
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 384 PointerType *table<int,interface {}>
+      Element: 399 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]*table<int,uint8>.array'
@@ -6317,7 +6317,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 347
+      ID: 362
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487136
@@ -6332,9 +6332,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 348 GoSliceDataType []interface {}.array
+      Data: 363 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 348
+      ID: 363
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
@@ -6354,9 +6354,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 406 GoSliceDataType []main.structWithMap.array
+      Data: 344 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 406
+      ID: 344
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 89 StructureType main.structWithMap
@@ -6407,30 +6407,30 @@ Types:
       ByteSize: 2048
       Element: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 330
+      ID: 343
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 324 StructureType noalg.map.group[int]*main.deepMap3
-    - __kind: GoSliceDataType
-      ID: 364
-      Name: '[]noalg.map.group[int]*main.deepMap8.array'
-      ByteSize: 2048
-      Element: 358 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 379
+      Name: '[]noalg.map.group[int]*main.deepMap8.array'
+      ByteSize: 2048
+      Element: 373 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSliceDataType
+      ID: 394
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 373 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 196 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 392
+      ID: 407
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 388 StructureType noalg.map.group[int]interface {}
+      Element: 403 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]noalg.map.group[int]uint8.array'
@@ -6662,47 +6662,47 @@ Types:
       GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 322
+      ID: 335
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 323 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 336 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 356
+      ID: 371
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 357 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 372 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 358 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 364 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 371
+      ID: 386
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 372 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 387 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 379 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 394 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 194
       Name: groupReference<int,int>
@@ -6718,19 +6718,19 @@ Types:
       GroupType: 196 StructureType noalg.map.group[int]int
       GroupSliceType: 200 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 386
+      ID: 401
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 387 PointerType *noalg.map.group[int]interface {}
+          Type: 402 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 388 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 392 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 403 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 407 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 253
       Name: groupReference<int,uint8>
@@ -6873,7 +6873,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 395
+      ID: 312
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.472192e+06
@@ -6963,9 +6963,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 316 GoMapType map[int]*main.deepMap3
+          Type: 329 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 328
+      ID: 341
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -6977,9 +6977,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 350 GoMapType map[int]*main.deepMap8
+          Type: 365 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 362
+      ID: 377
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.184192e+06
@@ -6987,9 +6987,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 365 GoMapType map[int]*main.deepMap9
+          Type: 380 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 377
+      ID: 392
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.184064e+06
@@ -6997,7 +6997,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 380 GoMapType map[int]interface {}
+          Type: 395 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -7031,9 +7031,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 331 PointerType *main.deepPtr8
+          Type: 346 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 332
+      ID: 347
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.185344e+06
@@ -7041,9 +7041,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 333 PointerType *main.deepPtr9
+          Type: 348 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 334
+      ID: 349
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.185216e+06
@@ -7071,9 +7071,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 310 GoSliceHeaderType []*main.deepSlice3
+          Type: 323 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 313
+      ID: 326
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -7085,9 +7085,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 335 GoSliceHeaderType []*main.deepSlice8
+          Type: 350 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 338
+      ID: 353
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.186496e+06
@@ -7095,9 +7095,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 341 GoSliceHeaderType []*main.deepSlice9
+          Type: 356 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 344
+      ID: 359
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.186368e+06
@@ -7105,7 +7105,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 347 GoSliceHeaderType []interface {}
+          Type: 362 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 174
       Name: main.emptyStruct
@@ -7123,16 +7123,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 393 StructureType sync.Mutex
+          Type: 310 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 396 StructureType sync.Once
+          Type: 313 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 399 StructureType sync.WaitGroup
+          Type: 316 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 402 StructureType sync/atomic.Int32
+          Type: 319 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -7272,16 +7272,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 403 PointerType **main.t
+          Type: 320 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 404 GoSliceDataType main.t.array
+      Data: 321 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 404
+      ID: 321
       Name: main.t.array
       ByteSize: 2048
       Element: 157 PointerType *main.t
@@ -7481,7 +7481,7 @@ Types:
       TablePtrSliceType: 191 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 186 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 318
+      ID: 331
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -7494,7 +7494,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 319 PointerType **table<int,*main.deepMap3>
+          Type: 332 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7513,10 +7513,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 342 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 337 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 352
+      ID: 367
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -7529,7 +7529,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 353 PointerType **table<int,*main.deepMap8>
+          Type: 368 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7548,10 +7548,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 363 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 358 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 367
+      ID: 382
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -7564,7 +7564,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 368 PointerType **table<int,*main.deepMap9>
+          Type: 383 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7583,8 +7583,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 378 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 373 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 393 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 388 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 92
       Name: map<int,int>
@@ -7621,7 +7621,7 @@ Types:
       TablePtrSliceType: 199 GoSliceDataType []*table<int,int>.array
       GroupType: 196 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 382
+      ID: 397
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -7634,7 +7634,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 383 PointerType **table<int,interface {}>
+          Type: 398 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -7653,8 +7653,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 391 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 388 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 406 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 403 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 129
       Name: map<int,uint8>
@@ -7936,26 +7936,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 316
+      ID: 329
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.128576e+06
       GoKind: 21
-      HeaderType: 318 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 331 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 350
+      ID: 365
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.127936e+06
       GoKind: 21
-      HeaderType: 352 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 365
+      ID: 380
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.127808e+06
       GoKind: 21
-      HeaderType: 367 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 382 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 90
       Name: map[int]int
@@ -7964,12 +7964,12 @@ Types:
       GoKind: 21
       HeaderType: 92 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 380
+      ID: 395
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.12768e+06
       GoKind: 21
-      HeaderType: 382 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 397 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 127
       Name: map[int]uint8
@@ -8065,32 +8065,32 @@ Types:
       HasCount: true
       Element: 188 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 325
+      ID: 338
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 681728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 339 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 359
+      ID: 374
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 360 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 374
+      ID: 389
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681152
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 375 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 390 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 197
       Name: noalg.[8]struct { key int; elem int }
@@ -8101,14 +8101,14 @@ Types:
       HasCount: true
       Element: 198 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 389
+      ID: 404
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 390 StructureType noalg.struct { key int; elem interface {} }
+      Element: 405 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 256
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -8238,7 +8238,7 @@ Types:
           Offset: 8
           Type: 187 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 324
+      ID: 337
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.29344e+06
@@ -8249,9 +8249,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 338 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 358
+      ID: 373
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.29216e+06
@@ -8262,9 +8262,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 359 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 373
+      ID: 388
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.291904e+06
@@ -8275,7 +8275,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 374 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 389 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 196
       Name: noalg.map.group[int]int
@@ -8290,7 +8290,7 @@ Types:
           Offset: 8
           Type: 197 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 388
+      ID: 403
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.291648e+06
@@ -8301,7 +8301,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 389 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 404 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 255
       Name: noalg.map.group[int]uint8
@@ -8459,7 +8459,7 @@ Types:
           Offset: 8
           Type: 189 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 326
+      ID: 339
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.293312e+06
@@ -8470,9 +8470,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 327 PointerType *main.deepMap3
+          Type: 340 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 360
+      ID: 375
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.292032e+06
@@ -8483,9 +8483,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 361 PointerType *main.deepMap8
+          Type: 376 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 375
+      ID: 390
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.291776e+06
@@ -8496,7 +8496,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 376 PointerType *main.deepMap9
+          Type: 391 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 198
       Name: noalg.struct { key int; elem int }
@@ -8511,7 +8511,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 390
+      ID: 405
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.29152e+06
@@ -8633,7 +8633,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 393
+      ID: 310
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.462112e+06
@@ -8641,12 +8641,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 395 StructureType internal/sync.Mutex
+          Type: 312 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 396
+      ID: 313
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.611168e+06
@@ -8654,15 +8654,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 397 StructureType sync/atomic.Bool
+          Type: 314 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 393 StructureType sync.Mutex
+          Type: 310 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 399
+      ID: 316
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.610976e+06
@@ -8670,21 +8670,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 394 StructureType sync.noCopy
+          Type: 311 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 400 StructureType sync/atomic.Uint64
+          Type: 317 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 394
+      ID: 311
       Name: sync.noCopy
       GoRuntimeType: 987424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 397
+      ID: 314
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.463232e+06
@@ -8692,12 +8692,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 402
+      ID: 319
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.463392e+06
@@ -8705,12 +8705,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 400
+      ID: 317
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.611552e+06
@@ -8718,21 +8718,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 398 StructureType sync/atomic.noCopy
+          Type: 315 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 401 StructureType sync/atomic.align64
+          Type: 318 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 401
+      ID: 318
       Name: sync/atomic.align64
       GoRuntimeType: 987616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 398
+      ID: 315
       Name: sync/atomic.noCopy
       GoRuntimeType: 987520
       GoKind: 25
@@ -8858,7 +8858,7 @@ Types:
           Offset: 16
           Type: 184 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 321
+      ID: 334
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -8880,9 +8880,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 335 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 355
+      ID: 370
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -8904,9 +8904,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 356 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 370
+      ID: 385
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -8928,7 +8928,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 371 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 386 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 193
       Name: table<int,int>
@@ -8954,7 +8954,7 @@ Types:
           Offset: 16
           Type: 194 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 385
+      ID: 400
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -8976,7 +8976,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 386 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 401 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 252
       Name: table<int,uint8>

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -3441,7 +3441,7 @@ Types:
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 530464
+      GoRuntimeType: 530656
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
@@ -3603,175 +3603,175 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 392992
+      GoRuntimeType: 393184
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 391904
+      GoRuntimeType: 392096
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 392864
+      GoRuntimeType: 393056
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 392928
+      GoRuntimeType: 393120
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 392544
+      GoRuntimeType: 392736
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 392160
+      GoRuntimeType: 392352
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 392288
+      GoRuntimeType: 392480
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 29
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 392416
+      GoRuntimeType: 392608
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 392032
+      GoRuntimeType: 392224
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
       ID: 88
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 393120
+      GoRuntimeType: 393312
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
       ID: 190
       Name: '*main.deepMap2'
       ByteSize: 8
-      GoRuntimeType: 385760
+      GoRuntimeType: 385952
       GoKind: 22
       Pointee: 191 StructureType main.deepMap2
     - __kind: PointerType
       ID: 341
       Name: '*main.deepMap3'
       ByteSize: 8
-      GoRuntimeType: 385696
+      GoRuntimeType: 385888
       GoKind: 22
       Pointee: 342 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
       ByteSize: 8
-      GoRuntimeType: 385440
+      GoRuntimeType: 385632
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
       ID: 377
       Name: '*main.deepMap8'
       ByteSize: 8
-      GoRuntimeType: 385376
+      GoRuntimeType: 385568
       GoKind: 22
       Pointee: 378 StructureType main.deepMap8
     - __kind: PointerType
       ID: 392
       Name: '*main.deepMap9'
       ByteSize: 8
-      GoRuntimeType: 385312
+      GoRuntimeType: 385504
       GoKind: 22
       Pointee: 393 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
       ByteSize: 8
-      GoRuntimeType: 386336
+      GoRuntimeType: 386528
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
       ID: 306
       Name: '*main.deepPtr3'
       ByteSize: 8
-      GoRuntimeType: 386272
+      GoRuntimeType: 386464
       GoKind: 22
       Pointee: 307 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
       ByteSize: 8
-      GoRuntimeType: 386016
+      GoRuntimeType: 386208
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
       ID: 347
       Name: '*main.deepPtr8'
       ByteSize: 8
-      GoRuntimeType: 385952
+      GoRuntimeType: 386144
       GoKind: 22
       Pointee: 348 StructureType main.deepPtr8
     - __kind: PointerType
       ID: 349
       Name: '*main.deepPtr9'
       ByteSize: 8
-      GoRuntimeType: 385888
+      GoRuntimeType: 386080
       GoKind: 22
       Pointee: 350 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
-      GoRuntimeType: 386912
+      GoRuntimeType: 387104
       GoKind: 22
       Pointee: 181 StructureType main.deepSlice2
     - __kind: PointerType
       ID: 326
       Name: '*main.deepSlice3'
       ByteSize: 8
-      GoRuntimeType: 386848
+      GoRuntimeType: 387040
       GoKind: 22
       Pointee: 327 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
       ByteSize: 8
-      GoRuntimeType: 386592
+      GoRuntimeType: 386784
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
       ID: 353
       Name: '*main.deepSlice8'
       ByteSize: 8
-      GoRuntimeType: 386528
+      GoRuntimeType: 386720
       GoKind: 22
       Pointee: 354 StructureType main.deepSlice8
     - __kind: PointerType
       ID: 359
       Name: '*main.deepSlice9'
       ByteSize: 8
-      GoRuntimeType: 386464
+      GoRuntimeType: 386656
       GoKind: 22
       Pointee: 360 StructureType main.deepSlice9
     - __kind: PointerType
@@ -3784,14 +3784,14 @@ Types:
       ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 387040
+      GoRuntimeType: 387232
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 387104
+      GoRuntimeType: 387296
       GoKind: 22
       Pointee: 156 StructureType main.node
     - __kind: PointerType
@@ -3821,7 +3821,7 @@ Types:
       ID: 242
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 385248
+      GoRuntimeType: 385440
       GoKind: 22
       Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
@@ -4032,7 +4032,7 @@ Types:
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 391968
+      GoRuntimeType: 392160
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -4129,42 +4129,42 @@ Types:
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 392608
+      GoRuntimeType: 392800
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 392224
+      GoRuntimeType: 392416
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 392352
+      GoRuntimeType: 392544
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 392480
+      GoRuntimeType: 392672
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 392096
+      GoRuntimeType: 392288
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 392672
+      GoRuntimeType: 392864
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -6003,7 +6003,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 682848
+      GoRuntimeType: 683040
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6020,7 +6020,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 684192
+      GoRuntimeType: 684384
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6053,7 +6053,7 @@ Types:
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 684288
+      GoRuntimeType: 684480
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6086,7 +6086,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 684384
+      GoRuntimeType: 684576
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6095,7 +6095,7 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 684096
+      GoRuntimeType: 684288
       GoKind: 17
       Count: 2
       HasCount: true
@@ -6104,7 +6104,7 @@ Types:
       ID: 275
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 682464
+      GoRuntimeType: 682656
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6113,7 +6113,7 @@ Types:
       ID: 232
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 682752
+      GoRuntimeType: 682944
       GoKind: 17
       Count: 4
       HasCount: true
@@ -6130,7 +6130,7 @@ Types:
       ID: 62
       Name: '[]*main.deepSlice2'
       ByteSize: 24
-      GoRuntimeType: 477536
+      GoRuntimeType: 477728
       GoKind: 23
       RawFields:
         - Name: array
@@ -6152,7 +6152,7 @@ Types:
       ID: 324
       Name: '[]*main.deepSlice3'
       ByteSize: 24
-      GoRuntimeType: 477472
+      GoRuntimeType: 477664
       GoKind: 23
       RawFields:
         - Name: array
@@ -6174,7 +6174,7 @@ Types:
       ID: 351
       Name: '[]*main.deepSlice8'
       ByteSize: 24
-      GoRuntimeType: 477152
+      GoRuntimeType: 477344
       GoKind: 23
       RawFields:
         - Name: array
@@ -6196,7 +6196,7 @@ Types:
       ID: 357
       Name: '[]*main.deepSlice9'
       ByteSize: 24
-      GoRuntimeType: 477088
+      GoRuntimeType: 477280
       GoKind: 23
       RawFields:
         - Name: array
@@ -6218,7 +6218,7 @@ Types:
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 478560
+      GoRuntimeType: 478752
       GoKind: 23
       RawFields:
         - Name: array
@@ -6346,7 +6346,7 @@ Types:
       ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 486880
+      GoRuntimeType: 487072
       GoKind: 23
       RawFields:
         - Name: array
@@ -6368,7 +6368,7 @@ Types:
       ID: 363
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 487200
+      GoRuntimeType: 487392
       GoKind: 23
       RawFields:
         - Name: array
@@ -6390,7 +6390,7 @@ Types:
       ID: 241
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 477792
+      GoRuntimeType: 477984
       GoKind: 23
       RawFields:
         - Name: array
@@ -6518,7 +6518,7 @@ Types:
       ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 487008
+      GoRuntimeType: 487200
       GoKind: 23
       RawFields:
         - Name: array
@@ -6540,7 +6540,7 @@ Types:
       ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 486496
+      GoRuntimeType: 486688
       GoKind: 23
       RawFields:
         - Name: array
@@ -6562,7 +6562,7 @@ Types:
       ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 485856
+      GoRuntimeType: 486048
       GoKind: 23
       RawFields:
         - Name: array
@@ -6584,35 +6584,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 584768
+      GoRuntimeType: 584960
       GoKind: 1
     - __kind: GoChannelType
       ID: 153
       Name: chan bool
-      GoRuntimeType: 596096
+      GoRuntimeType: 596288
       GoKind: 18
     - __kind: GoChannelType
       ID: 80
       Name: chan struct {}
-      GoRuntimeType: 595008
+      GoRuntimeType: 595200
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 584576
+      GoRuntimeType: 584768
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 584512
+      GoRuntimeType: 584704
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.026048e+06
+      GoRuntimeType: 1.02624e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6625,19 +6625,19 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 584640
+      GoRuntimeType: 584832
       GoKind: 13
     - __kind: BaseType
       ID: 16
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 584704
+      GoRuntimeType: 584896
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 475680
+      GoRuntimeType: 475872
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 287
@@ -6881,37 +6881,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 584320
+      GoRuntimeType: 584512
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 583936
+      GoRuntimeType: 584128
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 584064
+      GoRuntimeType: 584256
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 584192
+      GoRuntimeType: 584384
       GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 583808
+      GoRuntimeType: 584000
       GoKind: 3
     - __kind: GoEmptyInterfaceType
       ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 847296
+      GoRuntimeType: 847488
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6924,7 +6924,7 @@ Types:
       ID: 313
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.472384e+06
+      GoRuntimeType: 1.472832e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6937,7 +6937,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.02208e+06
+      GoRuntimeType: 1.022272e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6968,7 +6968,7 @@ Types:
       ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.021696e+06
+      GoRuntimeType: 1.021888e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6996,7 +6996,7 @@ Types:
       ID: 67
       Name: main.deepMap1
       ByteSize: 8
-      GoRuntimeType: 1.18528e+06
+      GoRuntimeType: 1.185728e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7006,7 +7006,7 @@ Types:
       ID: 191
       Name: main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.185152e+06
+      GoRuntimeType: 1.1856e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7020,7 +7020,7 @@ Types:
       ID: 74
       Name: main.deepMap7
       ByteSize: 8
-      GoRuntimeType: 1.184512e+06
+      GoRuntimeType: 1.18496e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7030,7 +7030,7 @@ Types:
       ID: 378
       Name: main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.184384e+06
+      GoRuntimeType: 1.184832e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7040,7 +7040,7 @@ Types:
       ID: 393
       Name: main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.184256e+06
+      GoRuntimeType: 1.184704e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7050,7 +7050,7 @@ Types:
       ID: 56
       Name: main.deepPtr1
       ByteSize: 8
-      GoRuntimeType: 1.186432e+06
+      GoRuntimeType: 1.18688e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7060,7 +7060,7 @@ Types:
       ID: 58
       Name: main.deepPtr2
       ByteSize: 8
-      GoRuntimeType: 1.186304e+06
+      GoRuntimeType: 1.186752e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7074,7 +7074,7 @@ Types:
       ID: 60
       Name: main.deepPtr7
       ByteSize: 8
-      GoRuntimeType: 1.185664e+06
+      GoRuntimeType: 1.186112e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7084,7 +7084,7 @@ Types:
       ID: 348
       Name: main.deepPtr8
       ByteSize: 8
-      GoRuntimeType: 1.185536e+06
+      GoRuntimeType: 1.185984e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7094,7 +7094,7 @@ Types:
       ID: 350
       Name: main.deepPtr9
       ByteSize: 16
-      GoRuntimeType: 1.185408e+06
+      GoRuntimeType: 1.185856e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7104,7 +7104,7 @@ Types:
       ID: 61
       Name: main.deepSlice1
       ByteSize: 24
-      GoRuntimeType: 1.187584e+06
+      GoRuntimeType: 1.188032e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7114,7 +7114,7 @@ Types:
       ID: 181
       Name: main.deepSlice2
       ByteSize: 24
-      GoRuntimeType: 1.187456e+06
+      GoRuntimeType: 1.187904e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7128,7 +7128,7 @@ Types:
       ID: 66
       Name: main.deepSlice7
       ByteSize: 24
-      GoRuntimeType: 1.186816e+06
+      GoRuntimeType: 1.187264e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7138,7 +7138,7 @@ Types:
       ID: 354
       Name: main.deepSlice8
       ByteSize: 24
-      GoRuntimeType: 1.186688e+06
+      GoRuntimeType: 1.187136e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7148,7 +7148,7 @@ Types:
       ID: 360
       Name: main.deepSlice9
       ByteSize: 24
-      GoRuntimeType: 1.18656e+06
+      GoRuntimeType: 1.187008e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7163,7 +7163,7 @@ Types:
       ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.833504e+06
+      GoRuntimeType: 1.833952e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -7185,7 +7185,7 @@ Types:
       ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.966592e+06
+      GoRuntimeType: 1.96704e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -7213,7 +7213,7 @@ Types:
       ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.461024e+06
+      GoRuntimeType: 1.461472e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -7226,7 +7226,7 @@ Types:
       ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.460864e+06
+      GoRuntimeType: 1.461312e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -7248,7 +7248,7 @@ Types:
       ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.021824e+06
+      GoRuntimeType: 1.022016e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -7282,7 +7282,7 @@ Types:
       ID: 89
       Name: main.structWithAny
       ByteSize: 16
-      GoRuntimeType: 1.184e+06
+      GoRuntimeType: 1.184448e+06
       GoKind: 25
       RawFields:
         - Name: a
@@ -7292,7 +7292,7 @@ Types:
       ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.184128e+06
+      GoRuntimeType: 1.184576e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -7962,126 +7962,126 @@ Types:
       ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.128896e+06
+      GoRuntimeType: 1.129088e+06
       GoKind: 21
       HeaderType: 150 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
       ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.129024e+06
+      GoRuntimeType: 1.129216e+06
       GoKind: 21
       HeaderType: 145 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
       ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.129152e+06
+      GoRuntimeType: 1.129344e+06
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
       ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.12928e+06
+      GoRuntimeType: 1.129472e+06
       GoKind: 21
       HeaderType: 125 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
       ID: 68
       Name: map[int]*main.deepMap2
       ByteSize: 8
-      GoRuntimeType: 1.128768e+06
+      GoRuntimeType: 1.12896e+06
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
       ID: 330
       Name: map[int]*main.deepMap3
       ByteSize: 8
-      GoRuntimeType: 1.12864e+06
+      GoRuntimeType: 1.128832e+06
       GoKind: 21
       HeaderType: 332 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 366
       Name: map[int]*main.deepMap8
       ByteSize: 8
-      GoRuntimeType: 1.128e+06
+      GoRuntimeType: 1.128192e+06
       GoKind: 21
       HeaderType: 368 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
       ID: 381
       Name: map[int]*main.deepMap9
       ByteSize: 8
-      GoRuntimeType: 1.127872e+06
+      GoRuntimeType: 1.128064e+06
       GoKind: 21
       HeaderType: 383 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.12736e+06
+      GoRuntimeType: 1.127552e+06
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
       ID: 396
       Name: map[int]interface {}
       ByteSize: 8
-      GoRuntimeType: 1.127744e+06
+      GoRuntimeType: 1.127936e+06
       GoKind: 21
       HeaderType: 398 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.129408e+06
+      GoRuntimeType: 1.1296e+06
       GoKind: 21
       HeaderType: 130 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
       ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.129536e+06
+      GoRuntimeType: 1.129728e+06
       GoKind: 21
       HeaderType: 120 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
       ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.129664e+06
+      GoRuntimeType: 1.129856e+06
       GoKind: 21
       HeaderType: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
       ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.129792e+06
+      GoRuntimeType: 1.129984e+06
       GoKind: 21
       HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.12992e+06
+      GoRuntimeType: 1.130112e+06
       GoKind: 21
       HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
       ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.130048e+06
+      GoRuntimeType: 1.13024e+06
       GoKind: 21
       HeaderType: 140 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
       ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.130176e+06
+      GoRuntimeType: 1.130368e+06
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
       ID: 290
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 682560
+      GoRuntimeType: 682752
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8090,7 +8090,7 @@ Types:
       ID: 282
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 682656
+      GoRuntimeType: 682848
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8099,7 +8099,7 @@ Types:
       ID: 230
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 682944
+      GoRuntimeType: 683136
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8108,7 +8108,7 @@ Types:
       ID: 249
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 683040
+      GoRuntimeType: 683232
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8117,7 +8117,7 @@ Types:
       ID: 188
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
-      GoRuntimeType: 681888
+      GoRuntimeType: 682080
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8126,7 +8126,7 @@ Types:
       ID: 339
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
-      GoRuntimeType: 681792
+      GoRuntimeType: 681984
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8135,7 +8135,7 @@ Types:
       ID: 375
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
-      GoRuntimeType: 681312
+      GoRuntimeType: 681504
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8144,7 +8144,7 @@ Types:
       ID: 390
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
-      GoRuntimeType: 681216
+      GoRuntimeType: 681408
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8153,7 +8153,7 @@ Types:
       ID: 198
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 679968
+      GoRuntimeType: 680160
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8162,7 +8162,7 @@ Types:
       ID: 405
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
-      GoRuntimeType: 681120
+      GoRuntimeType: 681312
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8171,7 +8171,7 @@ Types:
       ID: 257
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 683136
+      GoRuntimeType: 683328
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8180,7 +8180,7 @@ Types:
       ID: 239
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 683232
+      GoRuntimeType: 683424
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8189,7 +8189,7 @@ Types:
       ID: 222
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 683328
+      GoRuntimeType: 683520
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8198,7 +8198,7 @@ Types:
       ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 683424
+      GoRuntimeType: 683616
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8207,7 +8207,7 @@ Types:
       ID: 206
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 683520
+      GoRuntimeType: 683712
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8216,7 +8216,7 @@ Types:
       ID: 273
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 683616
+      GoRuntimeType: 683808
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8225,7 +8225,7 @@ Types:
       ID: 265
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 683712
+      GoRuntimeType: 683904
       GoKind: 17
       Count: 8
       HasCount: true
@@ -8234,7 +8234,7 @@ Types:
       ID: 289
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.294144e+06
+      GoRuntimeType: 1.294592e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8247,7 +8247,7 @@ Types:
       ID: 281
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.2944e+06
+      GoRuntimeType: 1.294848e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8260,7 +8260,7 @@ Types:
       ID: 229
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.294656e+06
+      GoRuntimeType: 1.295104e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8273,7 +8273,7 @@ Types:
       ID: 248
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.294912e+06
+      GoRuntimeType: 1.29536e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8286,7 +8286,7 @@ Types:
       ID: 187
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
-      GoRuntimeType: 1.293888e+06
+      GoRuntimeType: 1.294336e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8299,7 +8299,7 @@ Types:
       ID: 338
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
-      GoRuntimeType: 1.293632e+06
+      GoRuntimeType: 1.29408e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8312,7 +8312,7 @@ Types:
       ID: 374
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
-      GoRuntimeType: 1.292352e+06
+      GoRuntimeType: 1.2928e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8325,7 +8325,7 @@ Types:
       ID: 389
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
-      GoRuntimeType: 1.292096e+06
+      GoRuntimeType: 1.292544e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8338,7 +8338,7 @@ Types:
       ID: 197
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.291072e+06
+      GoRuntimeType: 1.29152e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8351,7 +8351,7 @@ Types:
       ID: 404
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
-      GoRuntimeType: 1.29184e+06
+      GoRuntimeType: 1.292288e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8364,7 +8364,7 @@ Types:
       ID: 256
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.295168e+06
+      GoRuntimeType: 1.295616e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8377,7 +8377,7 @@ Types:
       ID: 238
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.295424e+06
+      GoRuntimeType: 1.295872e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8390,7 +8390,7 @@ Types:
       ID: 221
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.29568e+06
+      GoRuntimeType: 1.296128e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8403,7 +8403,7 @@ Types:
       ID: 213
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.295936e+06
+      GoRuntimeType: 1.296384e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8416,7 +8416,7 @@ Types:
       ID: 205
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.296192e+06
+      GoRuntimeType: 1.29664e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8429,7 +8429,7 @@ Types:
       ID: 272
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.296448e+06
+      GoRuntimeType: 1.296896e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8442,7 +8442,7 @@ Types:
       ID: 264
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.296704e+06
+      GoRuntimeType: 1.297152e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -8455,7 +8455,7 @@ Types:
       ID: 291
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.294016e+06
+      GoRuntimeType: 1.294464e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8468,7 +8468,7 @@ Types:
       ID: 283
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.294272e+06
+      GoRuntimeType: 1.29472e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8481,7 +8481,7 @@ Types:
       ID: 231
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.294528e+06
+      GoRuntimeType: 1.294976e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8494,7 +8494,7 @@ Types:
       ID: 250
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.294784e+06
+      GoRuntimeType: 1.295232e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8507,7 +8507,7 @@ Types:
       ID: 189
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
-      GoRuntimeType: 1.29376e+06
+      GoRuntimeType: 1.294208e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8520,7 +8520,7 @@ Types:
       ID: 340
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
-      GoRuntimeType: 1.293504e+06
+      GoRuntimeType: 1.293952e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8533,7 +8533,7 @@ Types:
       ID: 376
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
-      GoRuntimeType: 1.292224e+06
+      GoRuntimeType: 1.292672e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8546,7 +8546,7 @@ Types:
       ID: 391
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
-      GoRuntimeType: 1.291968e+06
+      GoRuntimeType: 1.292416e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8559,7 +8559,7 @@ Types:
       ID: 199
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.290944e+06
+      GoRuntimeType: 1.291392e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8572,7 +8572,7 @@ Types:
       ID: 406
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
-      GoRuntimeType: 1.291712e+06
+      GoRuntimeType: 1.29216e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8585,7 +8585,7 @@ Types:
       ID: 258
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.29504e+06
+      GoRuntimeType: 1.295488e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8598,7 +8598,7 @@ Types:
       ID: 240
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.295296e+06
+      GoRuntimeType: 1.295744e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8611,7 +8611,7 @@ Types:
       ID: 223
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.295552e+06
+      GoRuntimeType: 1.296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8624,7 +8624,7 @@ Types:
       ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.295808e+06
+      GoRuntimeType: 1.296256e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8637,7 +8637,7 @@ Types:
       ID: 207
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.296064e+06
+      GoRuntimeType: 1.296512e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8650,7 +8650,7 @@ Types:
       ID: 274
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.29632e+06
+      GoRuntimeType: 1.296768e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8663,7 +8663,7 @@ Types:
       ID: 266
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.296576e+06
+      GoRuntimeType: 1.297024e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -8676,7 +8676,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 583744
+      GoRuntimeType: 583936
       GoKind: 24
       RawFields:
         - Name: str
@@ -8694,7 +8694,7 @@ Types:
       ID: 311
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.462304e+06
+      GoRuntimeType: 1.462752e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8707,7 +8707,7 @@ Types:
       ID: 314
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.61136e+06
+      GoRuntimeType: 1.611808e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8723,7 +8723,7 @@ Types:
       ID: 317
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.611168e+06
+      GoRuntimeType: 1.611616e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -8738,14 +8738,14 @@ Types:
     - __kind: StructureType
       ID: 312
       Name: sync.noCopy
-      GoRuntimeType: 987488
+      GoRuntimeType: 987680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 315
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.463424e+06
+      GoRuntimeType: 1.463872e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8758,7 +8758,7 @@ Types:
       ID: 320
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.463584e+06
+      GoRuntimeType: 1.464032e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8771,7 +8771,7 @@ Types:
       ID: 318
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.611744e+06
+      GoRuntimeType: 1.612192e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -8786,13 +8786,13 @@ Types:
     - __kind: StructureType
       ID: 319
       Name: sync/atomic.align64
-      GoRuntimeType: 987680
+      GoRuntimeType: 987872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 316
       Name: sync/atomic.noCopy
-      GoRuntimeType: 987584
+      GoRuntimeType: 987776
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -9207,43 +9207,43 @@ Types:
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 584384
+      GoRuntimeType: 584576
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 584000
+      GoRuntimeType: 584192
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 584128
+      GoRuntimeType: 584320
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 584256
+      GoRuntimeType: 584448
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 583872
+      GoRuntimeType: 584064
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 584448
+      GoRuntimeType: 584640
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 584832
+      GoRuntimeType: 585024
       GoKind: 26
 MaxTypeID: 523
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 32448
       GoKind: 22
-      Pointee: 66 PointerType ***int
+      Pointee: 67 PointerType ***int
     - __kind: PointerType
-      ID: 66
+      ID: 67
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32384
@@ -697,7 +697,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 67
+      ID: 66
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41888
@@ -1010,7 +1010,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 67 ArrayType [128]uint8
+          Type: 66 ArrayType [128]uint8
     - __kind: GoMapType
       ID: 37
       Name: map[string]int

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 35200
       GoKind: 22
-      Pointee: 74 PointerType ***int
+      Pointee: 75 PointerType ***int
     - __kind: PointerType
-      ID: 74
+      ID: 75
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35136
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 75
+      ID: 74
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 46240
@@ -925,7 +925,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 75 ArrayType [128]uint8
+          Type: 74 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 39
       Name: map<string,int>

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 36256
       GoKind: 22
-      Pointee: 74 PointerType ***int
+      Pointee: 75 PointerType ***int
     - __kind: PointerType
-      ID: 74
+      ID: 75
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36192
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 75
+      ID: 74
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47680
@@ -925,7 +925,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 75 ArrayType [128]uint8
+          Type: 74 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 39
       Name: map<string,int>

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 32416
       GoKind: 22
-      Pointee: 67 PointerType ***int
+      Pointee: 68 PointerType ***int
     - __kind: PointerType
-      ID: 67
+      ID: 68
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32352
@@ -697,7 +697,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 68
+      ID: 67
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41856
@@ -1016,7 +1016,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 68 ArrayType [128]uint8
+          Type: 67 ArrayType [128]uint8
     - __kind: GoMapType
       ID: 38
       Name: map[string]int

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 35168
       GoKind: 22
-      Pointee: 75 PointerType ***int
+      Pointee: 76 PointerType ***int
     - __kind: PointerType
-      ID: 75
+      ID: 76
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35104
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 76
+      ID: 75
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 46208
@@ -931,7 +931,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 76 ArrayType [128]uint8
+          Type: 75 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 40
       Name: map<string,int>

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 36224
       GoKind: 22
-      Pointee: 75 PointerType ***int
+      Pointee: 76 PointerType ***int
     - __kind: PointerType
-      ID: 75
+      ID: 76
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36160
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 76
+      ID: 75
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47648
@@ -931,7 +931,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 76 ArrayType [128]uint8
+          Type: 75 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 40
       Name: map<string,int>

--- a/pkg/dyninst/irgen/type_index.go
+++ b/pkg/dyninst/irgen/type_index.go
@@ -13,12 +13,20 @@ import (
 	"iter"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 )
 
 // goTypeIndexFactory is a factory for type index builders.
 type goTypeIndexFactory interface {
-	newGoTypeToOffsetIndexBuilder() (goTypeToOffsetIndexBuilder, error)
-	newMethodToGoTypeIndexBuilder() (methodToGoTypeIndexBuilder, error)
+	newGoTypeToOffsetIndexBuilder(
+		programID ir.ProgramID,
+		goTypeDataSize uint64,
+	) (goTypeToOffsetIndexBuilder, error)
+
+	newMethodToGoTypeIndexBuilder(
+		programID ir.ProgramID,
+		goTypeDataSize uint64,
+	) (methodToGoTypeIndexBuilder, error)
 }
 
 // goTypeToOffsetIndexBuilder is a builder for goTypeToOffsetIndex.

--- a/pkg/dyninst/irgen/type_index.go
+++ b/pkg/dyninst/irgen/type_index.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package irgen
+
+import (
+	"debug/dwarf"
+	"io"
+	"iter"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
+)
+
+// goTypeIndexFactory is a factory for type index builders.
+type goTypeIndexFactory interface {
+	newGoTypeToOffsetIndexBuilder() (goTypeToOffsetIndexBuilder, error)
+	newMethodToGoTypeIndexBuilder() (methodToGoTypeIndexBuilder, error)
+}
+
+// goTypeToOffsetIndexBuilder is a builder for goTypeToOffsetIndex.
+type goTypeToOffsetIndexBuilder interface {
+	addType(tid gotype.TypeID, dwarfOffset dwarf.Offset) error
+	build() (goTypeToOffsetIndex, error)
+	io.Closer
+}
+
+// goTypeToOffsetIndex is an index of the go types to their dwarf offsets.
+type goTypeToOffsetIndex interface {
+	allGoTypes() iter.Seq[gotype.TypeID]
+	resolveDwarfOffset(tid gotype.TypeID) (dwarf.Offset, bool)
+	io.Closer
+}
+
+// methodToGoTypeIndexBuilder is a builder for methodToGoTypeIndex.
+type methodToGoTypeIndexBuilder interface {
+	addMethod(method gotype.Method, receiver gotype.TypeID) error
+	build() (methodToGoTypeIndex, error)
+	io.Closer
+}
+
+// methodToGoTypeIndex is an index of the methods to the types that implement them.
+type methodToGoTypeIndex interface {
+	Iterator() methodToGoTypeIterator
+	io.Closer
+}
+
+// methodToGoTypeIterator is an iterator over the methods to the types that
+// implement them.
+type methodToGoTypeIterator = iterator[gotype.Method, gotype.TypeID]
+
+type iterator[Key any, Item any] interface {
+	seek(key Key)
+	valid() bool
+	cur() Item
+	next()
+}

--- a/pkg/dyninst/irgen/type_index_in_mem.go
+++ b/pkg/dyninst/irgen/type_index_in_mem.go
@@ -1,0 +1,173 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package irgen
+
+import (
+	"cmp"
+	"debug/dwarf"
+	"iter"
+	"slices"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
+)
+
+type inMemoryTypeIndexFactory struct{}
+
+var _ goTypeIndexFactory = (*inMemoryTypeIndexFactory)(nil)
+
+func (i *inMemoryTypeIndexFactory) newGoTypeToOffsetIndexBuilder() (
+	goTypeToOffsetIndexBuilder, error,
+) {
+	return &inMemoryGoTypeToOffsetIndexBuilder{}, nil
+}
+func (i inMemoryTypeIndexFactory) newMethodToGoTypeIndexBuilder() (
+	methodToGoTypeIndexBuilder, error,
+) {
+	return &inMemoryMethodToGoTypeIndexBuilder{}, nil
+}
+
+type inMemoryGoTypeToOffsetIndex []goTypeOffsetEntry
+
+var _ goTypeToOffsetIndex = (*inMemoryGoTypeToOffsetIndex)(nil)
+
+func (index inMemoryGoTypeToOffsetIndex) resolveDwarfOffset(typeID gotype.TypeID) (dwarf.Offset, bool) {
+	if idx := slices.IndexFunc(index, func(entry goTypeOffsetEntry) bool {
+		return entry.typeID == typeID
+	}); idx != -1 {
+		return index[idx].dwarfOffset, true
+	}
+	return 0, false
+}
+func (index inMemoryGoTypeToOffsetIndex) allGoTypes() iter.Seq[gotype.TypeID] {
+	return func(yield func(gotype.TypeID) bool) {
+		for _, entry := range index {
+			if !yield(entry.typeID) {
+				return
+			}
+		}
+	}
+}
+func (index *inMemoryGoTypeToOffsetIndex) Close() error { return nil }
+
+type inMemoryGoTypeToOffsetIndexBuilder inMemoryGoTypeToOffsetIndex
+
+var _ goTypeToOffsetIndexBuilder = (*inMemoryGoTypeToOffsetIndexBuilder)(nil)
+
+func (b *inMemoryGoTypeToOffsetIndexBuilder) addType(
+	typeID gotype.TypeID, dwarfOffset dwarf.Offset,
+) error {
+	*b = append(*b, goTypeOffsetEntry{typeID: typeID, dwarfOffset: dwarfOffset})
+	return nil
+}
+func (b *inMemoryGoTypeToOffsetIndexBuilder) build() (goTypeToOffsetIndex, error) {
+	slices.SortFunc(*b, func(a, b goTypeOffsetEntry) int {
+		return cmp.Compare(a.typeID, b.typeID)
+	})
+	return (*inMemoryGoTypeToOffsetIndex)(b), nil
+}
+func (b *inMemoryGoTypeToOffsetIndexBuilder) Close() error { return nil }
+
+type goTypeOffsetEntry struct {
+	typeID      gotype.TypeID
+	dwarfOffset dwarf.Offset
+}
+
+type methodEntry struct {
+	method   gotype.Method
+	receiver gotype.TypeID
+}
+
+func cmpMethod(a, b gotype.Method) int {
+	return cmp.Or(
+		cmp.Compare(a.Name, b.Name),
+		cmp.Compare(a.Mtyp, b.Mtyp),
+	)
+}
+
+func cmpMethodEntry(a, b methodEntry) int {
+	return cmp.Or(
+		cmpMethod(a.method, b.method),
+		cmp.Compare(a.receiver, b.receiver),
+	)
+}
+
+type inMemoryMethodToGoTypeIndexBuilder []methodEntry
+
+var _ methodToGoTypeIndexBuilder = (*inMemoryMethodToGoTypeIndexBuilder)(nil)
+
+func (b *inMemoryMethodToGoTypeIndexBuilder) addMethod(
+	method gotype.Method, receiver gotype.TypeID,
+) error {
+	*b = append(*b, methodEntry{method: method, receiver: receiver})
+	return nil
+}
+func (b inMemoryMethodToGoTypeIndexBuilder) build() (methodToGoTypeIndex, error) {
+	slices.SortFunc(b, cmpMethodEntry)
+	tids := make([]gotype.TypeID, 0, len(b))
+	m := make(map[gotype.Method][2]uint32)
+	if len(b) == 0 {
+		return &inMemoryMethodToGoTypeIndex{m: m, tids: tids}, nil
+	}
+
+	var prevIdx uint32
+	var curKey gotype.Method
+	for _, entry := range b {
+		if curKey != entry.method {
+			m[curKey] = [2]uint32{prevIdx, uint32(len(tids))}
+			prevIdx = uint32(len(tids))
+			curKey = entry.method
+		}
+		tids = append(tids, entry.receiver)
+	}
+	m[curKey] = [2]uint32{prevIdx, uint32(len(tids))}
+	return &inMemoryMethodToGoTypeIndex{m: m, tids: tids}, nil
+}
+func (b *inMemoryMethodToGoTypeIndexBuilder) Close() error {
+	return nil
+}
+
+type inMemoryMethodToGoTypeIndex struct {
+	m    map[gotype.Method][2]uint32
+	tids []gotype.TypeID
+}
+
+var _ methodToGoTypeIndex = (*inMemoryMethodToGoTypeIndex)(nil)
+
+func (b *inMemoryMethodToGoTypeIndex) Close() error {
+	return nil
+}
+func (b *inMemoryMethodToGoTypeIndex) Iterator() methodToGoTypeIterator {
+	return &inMemoryMethodToGoTypeIterator{index: b}
+}
+
+type inMemoryMethodToGoTypeIterator struct {
+	index *inMemoryMethodToGoTypeIndex
+	types []gotype.TypeID
+}
+
+var _ methodToGoTypeIterator = (*inMemoryMethodToGoTypeIterator)(nil)
+
+func (ii *inMemoryMethodToGoTypeIterator) seek(method gotype.Method) {
+	r, ok := ii.index.m[method]
+	if !ok {
+		ii.types = nil
+		return
+	}
+	ii.types = ii.index.tids[r[0]:r[1]]
+}
+func (ii *inMemoryMethodToGoTypeIterator) valid() bool {
+	return len(ii.types) > 0
+}
+func (ii *inMemoryMethodToGoTypeIterator) cur() gotype.TypeID {
+	return ii.types[0]
+}
+func (ii *inMemoryMethodToGoTypeIterator) next() {
+	if len(ii.types) > 0 {
+		ii.types = ii.types[1:]
+	}
+}

--- a/pkg/dyninst/irgen/type_index_on_disk.go
+++ b/pkg/dyninst/irgen/type_index_on_disk.go
@@ -1,0 +1,339 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package irgen
+
+import (
+	"bufio"
+	"cmp"
+	"debug/dwarf"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"iter"
+	"slices"
+	"syscall"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+)
+
+type onDiskGoTypeIndexFactory struct {
+	diskCache *object.DiskCache
+}
+
+var _ goTypeIndexFactory = (*onDiskGoTypeIndexFactory)(nil)
+
+func (i *onDiskGoTypeIndexFactory) newGoTypeToOffsetIndexBuilder(
+	programID ir.ProgramID, goTypeDataSize uint64,
+) (goTypeToOffsetIndexBuilder, error) {
+	f, err := openDiskFile(
+		i.diskCache, "goTypeToOffsetIndex", programID, goTypeDataSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &onDiskGoTypeToOffsetIndexBuilder{
+		f: f,
+		w: bufio.NewWriter(f),
+	}, nil
+}
+
+func (i *onDiskGoTypeIndexFactory) newMethodToGoTypeIndexBuilder(
+	programID ir.ProgramID, goTypeDataSize uint64,
+) (methodToGoTypeIndexBuilder, error) {
+	f, err := openDiskFile(
+		i.diskCache, "methodToGoTypeIndex", programID, goTypeDataSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &onDiskMethodToGoTypeIndexBuilder{
+		diskCache:      i.diskCache,
+		f:              f,
+		w:              bufio.NewWriter(f),
+		programID:      programID,
+		goTypeDataSize: goTypeDataSize,
+	}, nil
+}
+
+type onDiskGoTypeToOffsetIndexBuilder struct {
+	f        *object.DiskFile
+	w        *bufio.Writer
+	entryBuf goTypeOffsetEntry
+}
+
+// AddType implements typeIndexBuilder.
+func (o *onDiskGoTypeToOffsetIndexBuilder) addType(typeID gotype.TypeID, dwarfOffset dwarf.Offset) error {
+	if o.w == nil {
+		return fmt.Errorf("builder is closed")
+	}
+	o.entryBuf = goTypeOffsetEntry{typeID: typeID, dwarfOffset: dwarfOffset}
+	buf := unsafe.Slice((*uint8)(unsafe.Pointer(&o.entryBuf)), unsafe.Sizeof(o.entryBuf))
+	if _, err := o.w.Write(buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Build implements typeIndexBuilder.
+func (o *onDiskGoTypeToOffsetIndexBuilder) build() (_ goTypeToOffsetIndex, retErr error) {
+	if o.w == nil {
+		return nil, fmt.Errorf("builder is closed")
+	}
+	defer func() {
+		if retErr != nil {
+			_ = o.f.Close()
+		}
+	}()
+	if err := o.w.Flush(); err != nil {
+		return nil, err
+	}
+	o.w = nil
+	defer func() { o.f = nil }()
+	mm, err := o.f.IntoMMap(syscall.PROT_READ | syscall.PROT_WRITE)
+	if err != nil {
+		return nil, err
+	}
+	bytes := mm.Data()
+	entries := unsafe.Slice(
+		(*goTypeOffsetEntry)(unsafe.Pointer(unsafe.SliceData(bytes))),
+		uintptr(len(bytes))/unsafe.Sizeof(goTypeOffsetEntry{}),
+	)
+	slices.SortFunc(entries, func(a, b goTypeOffsetEntry) int {
+		return cmp.Compare(a.typeID, b.typeID)
+	})
+	return &onDiskGoTypeToOffsetIndex{mm: mm, entries: inMemoryGoTypeToOffsetIndex(entries)}, nil
+}
+
+func (o *onDiskGoTypeToOffsetIndexBuilder) Close() error {
+	if o.w == nil {
+		return nil
+	}
+	defer func() { *o = onDiskGoTypeToOffsetIndexBuilder{} }()
+	return o.f.Close()
+}
+
+type onDiskGoTypeToOffsetIndex struct {
+	mm      object.SectionData
+	entries inMemoryGoTypeToOffsetIndex
+}
+
+func (o *onDiskGoTypeToOffsetIndex) resolveDwarfOffset(typeID gotype.TypeID) (dwarf.Offset, bool) {
+	return o.entries.resolveDwarfOffset(gotype.TypeID(typeID))
+}
+func (o *onDiskGoTypeToOffsetIndex) allGoTypes() iter.Seq[gotype.TypeID] {
+	return o.entries.allGoTypes()
+}
+func (o *onDiskGoTypeToOffsetIndex) Close() error {
+	if o.mm == nil {
+		return nil
+	}
+	defer func() { *o = onDiskGoTypeToOffsetIndex{} }()
+	return o.mm.Close()
+}
+
+type onDiskMethodToGoTypeIndexBuilder struct {
+	diskCache      *object.DiskCache
+	f              *object.DiskFile
+	w              *bufio.Writer
+	programID      ir.ProgramID
+	goTypeDataSize uint64
+	entryBuf       [3]uint32
+}
+
+var _ methodToGoTypeIndexBuilder = (*onDiskMethodToGoTypeIndexBuilder)(nil)
+
+func (o *onDiskMethodToGoTypeIndexBuilder) addMethod(method gotype.Method, receiver gotype.TypeID) error {
+	if o.w == nil {
+		return fmt.Errorf("builder is closed")
+	}
+	o.entryBuf = [3]uint32{uint32(method.Name), uint32(method.Mtyp), uint32(receiver)}
+	buf := unsafe.Slice((*uint8)(unsafe.Pointer(&o.entryBuf)), unsafe.Sizeof(o.entryBuf))
+	if _, err := o.w.Write(buf); err != nil {
+		return err
+	}
+	return nil
+}
+func (o *onDiskMethodToGoTypeIndexBuilder) build() (_ methodToGoTypeIndex, retErr error) {
+	if o.w == nil {
+		return nil, fmt.Errorf("builder is closed")
+	}
+	defer func() { o.w = nil }()
+	if err := o.w.Flush(); err != nil {
+		return nil, err
+	}
+	o.w = nil
+	defer func() { o.f = nil }()
+	mm, err := o.f.IntoMMap(syscall.PROT_READ | syscall.PROT_WRITE)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = mm.Close() }()
+	entries := unsafe.Slice(
+		(*[3]uint32)(unsafe.Pointer(unsafe.SliceData(mm.Data()))),
+		uintptr(len(mm.Data()))/unsafe.Sizeof([3]uint32{}),
+	)
+	slices.SortFunc(entries, func(a, b [3]uint32) int {
+		return cmp.Or(
+			cmp.Compare(a[0], b[0]),
+			cmp.Compare(a[1], b[1]),
+			cmp.Compare(a[2], b[2]),
+		)
+	})
+
+	methodToOffsetFile, err := openDiskFile(
+		o.diskCache, "methodToOffsets", o.programID, o.goTypeDataSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = methodToOffsetFile.Close() }()
+	methodToOffsetWriter := bufio.NewWriter(methodToOffsetFile)
+
+	typeIDsFile, err := openDiskFile(
+		o.diskCache, "implementorsTypeIDs", o.programID, o.goTypeDataSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = typeIDsFile.Close() }()
+	typeIDsWriter := bufio.NewWriter(typeIDsFile)
+
+	var prevIdx uint32
+	entry := func(i uint32) (gotype.Method, gotype.TypeID) {
+		return gotype.Method{
+			Name: gotype.NameOff(entries[i][0]),
+			Mtyp: gotype.TypeID(entries[i][1]),
+		}, gotype.TypeID(entries[i][2])
+	}
+	var methodEntryBuf methodIndexEntry
+	curMethod, _ := entry(0)
+	var b [4]byte
+	for i := range uint32(len(entries)) {
+		method, tid := entry(i)
+		if curMethod != method {
+			methodEntryBuf.method = curMethod
+			methodEntryBuf.offsets = [2]uint32{prevIdx, i}
+			buf := unsafe.Slice(
+				(*uint8)(unsafe.Pointer(&methodEntryBuf)),
+				unsafe.Sizeof(methodEntryBuf),
+			)
+			if _, err := methodToOffsetWriter.Write(buf); err != nil {
+				return nil, err
+			}
+			prevIdx = i
+			curMethod = method
+		}
+		binary.NativeEndian.PutUint32(b[:], tid)
+		if _, err := typeIDsWriter.Write(b[:]); err != nil {
+			return nil, err
+		}
+	}
+
+	methodEntryBuf.method = curMethod
+	methodEntryBuf.offsets = [2]uint32{prevIdx, uint32(len(entries))}
+	buf := unsafe.Slice(
+		(*uint8)(unsafe.Pointer(&methodEntryBuf)),
+		unsafe.Sizeof(methodEntryBuf),
+	)
+	if _, err := methodToOffsetWriter.Write(buf); err != nil {
+		return nil, err
+	}
+	if err := methodToOffsetWriter.Flush(); err != nil {
+		return nil, err
+	}
+	if err := typeIDsWriter.Flush(); err != nil {
+		return nil, err
+	}
+	typeIDsData, err := typeIDsFile.IntoMMap(syscall.PROT_READ)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil {
+			_ = typeIDsData.Close()
+		}
+	}()
+	methodsData, err := methodToOffsetFile.IntoMMap(syscall.PROT_READ)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil {
+			_ = methodsData.Close()
+		}
+	}()
+	methodsDataBytes := methodsData.Data()
+	typeIDsDataBytes := typeIDsData.Data()
+	methodEntries := unsafe.Slice(
+		(*methodIndexEntry)(unsafe.Pointer(unsafe.SliceData(methodsDataBytes))),
+		uintptr(len(methodsDataBytes))/unsafe.Sizeof(methodIndexEntry{}),
+	)
+	typeIDsEntries := unsafe.Slice(
+		(*gotype.TypeID)(unsafe.Pointer(unsafe.SliceData(typeIDsDataBytes))),
+		uintptr(len(typeIDsDataBytes))/unsafe.Sizeof(gotype.TypeID(0)),
+	)
+
+	return &onDiskMethodToGoTypeIndex{
+		typeIDsData: typeIDsData,
+		methodsData: methodsData,
+		inMem: inMemoryMethodToGoTypeIndex{
+			methods: methodEntries,
+			tids:    typeIDsEntries,
+		},
+	}, nil
+}
+
+func (o *onDiskMethodToGoTypeIndexBuilder) Close() error {
+	if o.w == nil {
+		return nil
+	}
+	defer func() { o.w = nil }()
+	return o.f.Close()
+}
+
+type methodIndexEntry struct {
+	method  gotype.Method
+	offsets [2]uint32
+}
+
+type onDiskMethodToGoTypeIndex struct {
+	typeIDsData object.SectionData
+	methodsData object.SectionData
+	inMem       inMemoryMethodToGoTypeIndex
+}
+
+func (o *onDiskMethodToGoTypeIndex) Close() error {
+	if o.typeIDsData == nil {
+		return nil
+	}
+	defer func() { *o = onDiskMethodToGoTypeIndex{} }()
+	return errors.Join(
+		o.typeIDsData.Close(),
+		o.methodsData.Close(),
+	)
+}
+
+var _ methodToGoTypeIndex = (*onDiskMethodToGoTypeIndex)(nil)
+
+func (o *onDiskMethodToGoTypeIndex) Iterator() methodToGoTypeIterator {
+	return o.inMem.Iterator()
+}
+
+func openDiskFile(
+	d *object.DiskCache, name string, programID ir.ProgramID, goTypeDataSize uint64,
+) (*object.DiskFile, error) {
+	const initialSize = 1 << 20
+	return d.NewFile(
+		fmt.Sprintf("%s.%d", name, programID),
+		goTypeDataSize,
+		min(initialSize, goTypeDataSize),
+	)
+}

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -81,18 +81,26 @@ func NewModule(
 		return nil, fmt.Errorf("error creating loader: %w", err)
 	}
 	var objectLoader object.Loader
+	var irgenOptions []irgen.Option
 	if config.DiskCacheEnabled {
-		objectLoader, err = object.NewDiskCache(config.DiskCacheConfig)
+		diskCache, err := object.NewDiskCache(config.DiskCacheConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error creating disk cache: %w", err)
 		}
+		objectLoader = diskCache
+		irgenOptions = append(irgenOptions,
+			irgen.WithOnDiskGoTypeIndexFactory(diskCache),
+			irgen.WithObjectLoader(diskCache),
+		)
+
 	} else {
 		objectLoader = object.NewInMemoryLoader()
+		irgenOptions = append(irgenOptions, irgen.WithObjectLoader(objectLoader))
 	}
 
 	actuator := config.actuatorConstructor(loader)
 	rcScraper := rcscrape.NewScraper(actuator)
-	irGenerator := irgen.NewGenerator(irgen.WithObjectLoader(objectLoader))
+	irGenerator := irgen.NewGenerator(irgenOptions...)
 	controller := NewController(
 		actuator, logUploader, diagsUploader, symdbUploaderURL, objectLoader, rcScraper, DefaultDecoderFactory{}, irGenerator,
 	)

--- a/pkg/dyninst/object/disk_cache.go
+++ b/pkg/dyninst/object/disk_cache.go
@@ -8,13 +8,16 @@
 package object
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"syscall"
@@ -149,6 +152,55 @@ func (c *DiskCache) SpaceInUse() uint64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.mu.totalBytes
+}
+
+// reserveSpace attempts to reserve the given number of bytes from the cache's
+// capacity. The reservation counts against the cache size limit immediately.
+//
+// The method also enforces the disk space policy via spaceChecker.
+func (c *DiskCache) reserveSpace(toAdd uint64) error {
+	if toAdd == 0 {
+		return nil
+	}
+	// Avoid holding the mutex across IO operations.
+	if err := c.checker.check(toAdd); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	newTotal := c.mu.totalBytes + toAdd
+	if newTotal > c.maxTotalBytes {
+		return fmt.Errorf(
+			"adding %s would exceed cache size limit of %s by %s",
+			humanize.IBytes(toAdd),
+			humanize.IBytes(c.maxTotalBytes),
+			humanize.IBytes(newTotal-c.maxTotalBytes),
+		)
+	}
+	c.mu.totalBytes = newTotal
+	return nil
+}
+
+// releaseSpace releases a previously reserved number of bytes from the cache's
+// capacity accounting. It is safe to call with zero.
+func (c *DiskCache) releaseSpace(toRelease uint64) {
+	if toRelease == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	log.Infof("releaseSpace: releasing %s, total bytes: %s: %s", humanize.IBytes(toRelease), humanize.IBytes(c.mu.totalBytes), debug.Stack())
+	if toRelease > c.mu.totalBytes {
+		log.Errorf(
+			"releaseSpace: invariant violation: total size underflow: %s > %s (delta: %s)",
+			humanize.IBytes(toRelease),
+			humanize.IBytes(c.mu.totalBytes),
+			humanize.IBytes(toRelease-c.mu.totalBytes),
+		)
+		c.mu.totalBytes = 0
+		return
+	}
+	c.mu.totalBytes -= toRelease
 }
 
 // htlHashLoader is a sectionDataLoader that loads sections based on the executable's
@@ -339,6 +391,239 @@ func (c *cachedSectionData) Close() error {
 	err := c.entry.release()
 	c.entry = nil
 	return err
+}
+
+// DiskFile is a writable file that reserves space from the DiskCache. It
+// enforces a maximum size and can be converted to a memory map.
+type DiskFile struct {
+	c             *DiskCache
+	f             *os.File
+	name          string
+	reservedSpace uint64
+	maxSpace      uint64
+	used          uint64
+	cleanup       runtime.Cleanup
+	closed        bool
+}
+
+// NewFile creates a new writable file within the cache. The file starts with
+// an initial reservation against the cache's capacity. The file is unlinked
+// immediately, so it will be removed from the filesystem even if the process
+// crashes; it remains accessible via its file descriptor until closed.
+func (c *DiskCache) NewFile(name string, maxSize, initialSize uint64) (_ *DiskFile, retErr error) {
+	if name == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if initialSize > maxSize {
+		return nil, fmt.Errorf("initialSize must be <= maxSize")
+	}
+	// If the disk doesn't have enough space, we can't create the file.
+	if err := c.checker.check(maxSize); err != nil {
+		return nil, err
+	}
+	if base := path.Base(name); base != name {
+		return nil, fmt.Errorf("name must not contain path separators")
+	}
+	f, err := os.CreateTemp(c.dirPath, fmt.Sprintf("%s.%d", name, os.Getpid()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = f.Close()
+		}
+	}()
+
+	// Unlink immediately to avoid leaking the file.
+	if err := os.Remove(f.Name()); err != nil {
+		return nil, fmt.Errorf("failed to remove temp file: %w", err)
+	}
+	if err := c.reserveSpace(uint64(initialSize)); err != nil {
+		return nil, err
+	}
+	type spaceAndFile struct {
+		space uint64
+		file  *os.File
+	}
+	df := &DiskFile{
+		c:             c,
+		f:             f,
+		name:          name,
+		reservedSpace: initialSize,
+		maxSpace:      maxSize,
+	}
+	df.cleanup = runtime.AddCleanup(df, func(s spaceAndFile) {
+		_ = s.file.Close()
+		c.releaseSpace(s.space)
+	}, spaceAndFile{space: initialSize, file: f})
+	return df, nil
+}
+
+// Write appends the given bytes to the file, growing the reservation if
+// necessary. If the write would exceed the max size, it fails.
+func (df *DiskFile) Write(p []byte) (int, error) {
+	if df == nil || df.f == nil || df.closed {
+		return 0, fmt.Errorf("write on closed DiskFile")
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	// Check max size.
+	neededTotal := df.used + uint64(len(p))
+	if neededTotal > df.maxSpace {
+		return 0, fmt.Errorf(
+			"write exceeds max size: need %s, max %s (over by %s)",
+			humanize.IBytes(neededTotal),
+			humanize.IBytes(df.maxSpace),
+			humanize.IBytes(neededTotal-df.maxSpace),
+		)
+	}
+
+	// Ensure reservation is large enough for this write.
+	if neededTotal > df.reservedSpace {
+		needed := neededTotal - df.reservedSpace
+		increment := max(needed, 2*df.reservedSpace)
+		remaining := df.maxSpace - df.used
+		increment = min(increment, remaining)
+		if err := df.c.reserveSpace(increment); err != nil {
+			return 0, err
+		}
+		df.reservedSpace += increment
+	}
+
+	n, err := df.f.Write(p)
+	if n > 0 {
+		df.used += uint64(n)
+	}
+	if err != nil {
+		return n, fmt.Errorf("failed to write DiskFile: %w", err)
+	}
+	return n, nil
+}
+
+// Close aborts the DiskFile without converting it to a memory map, releasing
+// its reservation and closing the underlying file.
+func (df *DiskFile) Close() error {
+	if df == nil || df.closed {
+		return nil
+	}
+	defer runtime.KeepAlive(df)
+	df.cleanup.Stop()
+	defer func() { df.closed = true }()
+	df.closed = true
+	err := df.f.Close()
+	df.f = nil
+	if df.reservedSpace > 0 {
+		df.c.releaseSpace(df.reservedSpace)
+		df.reservedSpace = 0
+	}
+	df.used = 0
+	return err
+}
+
+// IntoMMap converts the DiskFile into a SectionData backed by a memory map.
+// The DiskFile is closed as part of this operation. The returned SectionData
+// behaves like cachedSectionData and will release its accounting when closed
+// or garbage collected.
+func (df *DiskFile) IntoMMap(flags int) (_ SectionData, retErr error) {
+	defer func() {
+		if retErr != nil {
+			_ = df.Close()
+		}
+	}()
+	if df == nil || df.f == nil || df.closed {
+		return nil, fmt.Errorf("IntoMMap on closed DiskFile")
+	}
+	if df.used == 0 {
+		return nil, fmt.Errorf("cannot mmap empty DiskFile")
+	}
+	if err := df.f.Sync(); err != nil {
+		return nil, fmt.Errorf("failed to sync DiskFile: %w", err)
+	}
+	// Ensure the length fits in an int for syscall.Mmap.
+	maxInt := int(^uint(0) >> 1)
+	if df.used > uint64(maxInt) {
+		return nil, fmt.Errorf("mmap length overflow: %d", df.used)
+	}
+
+	// Map the file as read-only shared mapping.
+	m, err := syscall.Mmap(int(df.f.Fd()), 0, int(df.used), flags, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("failed to mmap DiskFile: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = syscall.Munmap(m)
+		}
+	}()
+	// Close the file descriptor after successful mmap.
+	if err := df.f.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close DiskFile after mmap: %w", err)
+	}
+	df.f = nil
+
+	// TODO: This use of the cachedSectionData is a hack. We should refactor
+	// this package to have two layers of abstraction: one around storing disk
+	// files and one around caching section data.
+
+	// Prepare a unique cache key using random bytes for the htl hash.
+	var randHash htlhash.Hash
+	if _, err := io.ReadFull(rand.Reader, randHash[:]); err != nil {
+		_ = syscall.Munmap(m)
+		return nil, fmt.Errorf("failed to generate random hash: %w", err)
+	}
+	key := cacheKey{
+		htlHash: randHash,
+		compressedSectionMetadata: compressedSectionMetadata{
+			name: df.name,
+			compressedFileRange: compressedFileRange{
+				format:             compressionFormatNone,
+				offset:             0,
+				compressedLength:   int64(df.used),
+				uncompressedLength: int64(df.used),
+			},
+		},
+	}
+
+	// Create the cache entry and adjust accounting: replace reservation with
+	// the actual used size.
+	entry := &cacheEntry{
+		cacheKey: key,
+		cache:    df.c,
+		deleted:  make(chan struct{}),
+	}
+	entry.decompress.data = m
+	// Decompression never ran; but release() expects refCount to be set.
+	df.c.mu.Lock()
+	// Replace reservation with actual usage in totalBytes.
+	if df.reservedSpace > df.c.mu.totalBytes {
+		// Should not happen, but guard against underflow.
+		log.Errorf(
+			"IntoMMap: invariant violation: reservedSpace > totalBytes: %s > %s (delta: %s)",
+			humanize.IBytes(df.reservedSpace),
+			humanize.IBytes(df.c.mu.totalBytes),
+			humanize.IBytes(df.reservedSpace-df.c.mu.totalBytes),
+		)
+		df.c.mu.totalBytes = 0
+	} else {
+		df.c.mu.totalBytes -= df.reservedSpace
+	}
+	df.c.mu.totalBytes += df.used
+	entry.cacheMu.refCount = 1
+	entry.cacheMu.deleting = false
+	df.c.mu.entries[key] = entry
+	df.c.mu.Unlock()
+
+	// Finalize DiskFile state.
+	df.reservedSpace = 0
+	df.closed = true
+	df.cleanup.Stop()
+	runtime.KeepAlive(df)
+
+	sd := new(cachedSectionData)
+	sd.entry = entry
+	sd.cleanup = runtime.AddCleanup(sd, cleanupCacheEntry, entry)
+	return sd, nil
 }
 
 type spaceChecker struct {

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
@@ -178,18 +178,25 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
-		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
@@ -178,25 +178,33 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
-		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
@@ -607,6 +615,8 @@ Package: main
 		Field: i: int
 		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
@@ -190,21 +190,21 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Var: .autotmp_22: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 92, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -189,21 +189,21 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Var: .autotmp_22: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 92, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -177,18 +177,25 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
-		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -177,25 +177,33 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
-		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -594,6 +602,8 @@ Package: main
 		Field: i: int
 		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
@@ -177,17 +177,24 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
@@ -189,20 +189,20 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
@@ -177,24 +177,32 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -593,6 +601,8 @@ Package: main
 		Field: i: int
 		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
@@ -178,18 +178,25 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
-		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
@@ -178,25 +178,33 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
-		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
@@ -607,6 +615,8 @@ Package: main
 		Field: i: int
 		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
@@ -190,21 +190,21 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Var: .autotmp_22: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 92, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -189,21 +189,21 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Var: .autotmp_22: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 92, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -177,18 +177,25 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
-		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -177,25 +177,33 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
-		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -594,6 +602,8 @@ Package: main
 		Field: i: int
 		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
@@ -177,17 +177,24 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
@@ -189,20 +189,20 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
@@ -177,24 +177,32 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -593,6 +601,8 @@ Package: main
 		Field: i: int
 		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -178,18 +178,25 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
-		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -178,25 +178,33 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
-		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
@@ -593,6 +601,8 @@ Package: main
 		Field: wg: sync.WaitGroup
 		Field: a: sync/atomic.Int32
 	Type: main.behavior
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -190,21 +190,21 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Var: .autotmp_22: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 92, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -189,21 +189,21 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Var: .autotmp_22: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 92, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -177,18 +177,25 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
-		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -177,25 +177,33 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
-		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -580,6 +588,8 @@ Package: main
 		Field: wg: sync.WaitGroup
 		Field: a: sync/atomic.Int32
 	Type: main.behavior
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -177,24 +177,32 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -579,6 +587,8 @@ Package: main
 		Field: wg: sync.WaitGroup
 		Field: a: sync/atomic.Int32
 	Type: main.behavior
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -177,17 +177,24 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -189,20 +189,20 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -178,18 +178,25 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
-		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -178,25 +178,33 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
-		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
@@ -593,6 +601,8 @@ Package: main
 		Field: wg: sync.WaitGroup
 		Field: a: sync/atomic.Int32
 	Type: main.behavior
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -190,21 +190,21 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Var: .autotmp_22: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 92, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -189,21 +189,21 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Var: .autotmp_22: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 92, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -177,18 +177,25 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
-		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -177,25 +177,33 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
-		Var: .autotmp_13: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 81, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Var: .autotmp_18: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 87, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -580,6 +588,8 @@ Package: main
 		Field: wg: sync.WaitGroup
 		Field: a: sync/atomic.Int32
 	Type: main.behavior
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -177,24 +177,32 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
-		Arg: b: main.behavior (declared at line 50, available: [51-51])
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
-		Arg: a: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: string (declared at line 55, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
-		Arg: e: error (declared at line 61, available: [61-61])
-	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
-		Arg: a: *interface {} (declared at line 65, available: [65-66])
-		Arg: ~r0: string (declared at line 65, available: )
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
-		Var: &one: *int (declared at line 84, available: [70-102])
-		Var: &foo: *string (declared at line 87, available: [70-102])
-		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
-		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
-		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
-		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
+		Arg: b: main.behavior (declared at line 50, available: [50-50])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55]
+		Arg: a: interface {} (declared at line 54, available: [54-55])
+		Arg: ~r0: string (declared at line 54, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65]
+		Arg: a: *interface {} (declared at line 64, available: [64-65])
+		Arg: ~r0: string (declared at line 64, available: )
+	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
+		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
+		Var: &one: *int (declared at line 90, available: [76-119])
+		Var: &foo: *string (declared at line 93, available: [76-119])
+		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
+		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
+		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
+		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
+		Scope: 112-119
+			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -579,6 +587,8 @@ Package: main
 		Field: wg: sync.WaitGroup
 		Field: a: sync/atomic.Int32
 	Type: main.behavior
+	Type: main.structWithAny
+		Field: a: interface {}
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -177,17 +177,24 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
-		Arg: b: main.behavior (declared at line 50, available: [50-51])
-		Arg: ~r0: string (declared at line 50, available: )
-	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
-		Arg: a: interface {} (declared at line 56, available: [56-57])
-		Arg: ~r0: string (declared at line 56, available: )
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
-		Arg: e: error (declared at line 62, available: [62-62])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
-		Var: &one: *int (declared at line 76, available: [65-83])
-		Var: &foo: *string (declared at line 79, available: [65-83])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [51:51]
+		Arg: b: main.behavior (declared at line 50, available: [51-51])
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [55:56]
+		Arg: a: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: string (declared at line 55, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [61:61]
+		Arg: e: error (declared at line 61, available: [61-61])
+	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:66]
+		Arg: a: *interface {} (declared at line 65, available: [65-66])
+		Arg: ~r0: string (declared at line 65, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [70:102]
+		Var: &one: *int (declared at line 84, available: [70-102])
+		Var: &foo: *string (declared at line 87, available: [70-102])
+		Var: &boxedTypedNil: *interface {} (declared at line 95, available: [70-102])
+		Var: &boxedOne: *interface {} (declared at line 91, available: [70-102])
+		Var: &boxedOnePtr: *interface {} (declared at line 92, available: [70-102])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 93, available: [70-102])
+		Var: &boxedNil: *interface {} (declared at line 94, available: [70-102])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -189,20 +189,20 @@ Package: main
 		Arg: ~r0: string (declared at line 64, available: )
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:119]
-		Var: &one: *int (declared at line 90, available: [76-119])
-		Var: &foo: *string (declared at line 93, available: [76-119])
-		Var: &boxedTypedNil: *interface {} (declared at line 101, available: [76-119])
-		Var: &boxedOne: *interface {} (declared at line 97, available: [76-119])
-		Var: &boxedOnePtr: *interface {} (declared at line 98, available: [76-119])
-		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 99, available: [76-119])
-		Var: &boxedNil: *interface {} (declared at line 100, available: [76-119])
-		Scope: 112-119
-			Var: structWithAny0: main.structWithAny (declared at line 111, available: )
-			Var: structWithAny1: main.structWithAny (declared at line 112, available: )
-			Var: structWithAny2: main.structWithAny (declared at line 113, available: )
-			Var: structWithAny3: main.structWithAny (declared at line 114, available: )
-			Var: structWithAny4: main.structWithAny (declared at line 115, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124]
+		Var: &one: *int (declared at line 95, available: [76-124])
+		Var: &foo: *string (declared at line 98, available: [76-124])
+		Var: &boxedTypedNil: *interface {} (declared at line 106, available: [76-124])
+		Var: &boxedOne: *interface {} (declared at line 102, available: [76-124])
+		Var: &boxedOnePtr: *interface {} (declared at line 103, available: [76-124])
+		Var: &boxedPtrToBoxedOne: *interface {} (declared at line 104, available: [76-124])
+		Var: &boxedNil: *interface {} (declared at line 105, available: [76-124])
+		Scope: 117-124
+			Var: structWithAny0: main.structWithAny (declared at line 116, available: )
+			Var: structWithAny1: main.structWithAny (declared at line 117, available: )
+			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
+			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
+			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -51,8 +51,13 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "main.firstBehavior",
-                "notCapturedReason": "missing type information"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "main.firstBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -113,8 +118,13 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "*main.firstBehavior",
-                "notCapturedReason": "missing type information"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "*main.firstBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -175,8 +185,13 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "main.secondBehavior",
-                "notCapturedReason": "missing type information"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "main.secondBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -237,8 +252,13 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "*main.secondBehavior",
-                "notCapturedReason": "missing type information"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "*main.secondBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -299,8 +319,13 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "lib_v2.V2Type",
-                "notCapturedReason": "missing type information"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "lib_v2.V2Type",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -361,8 +386,13 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "*lib_v2.V2Type",
-                "notCapturedReason": "missing type information"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "*lib_v2.V2Type",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -423,8 +453,13 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "int",
-                "value": "1"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "int",
+                    "value": "1"
+                  }
+                }
               }
             }
           }
@@ -485,9 +520,14 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "*int",
-                "address": "[addr]",
-                "value": "1"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "*int",
+                    "address": "[addr]",
+                    "value": "1"
+                  }
+                }
               }
             }
           }
@@ -548,8 +588,13 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "string",
-                "value": "foo"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "string",
+                    "value": "foo"
+                  }
+                }
               }
             }
           }
@@ -610,9 +655,14 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "*string",
-                "address": "[addr]",
-                "value": "foo"
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "*string",
+                    "address": "[addr]",
+                    "value": "foo"
+                  }
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 70
+            "lineNumber": 77
           },
           {
             "function": "main.main",
@@ -85,12 +85,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 71
+            "lineNumber": 78
           },
           {
             "function": "main.main",
@@ -152,12 +152,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 72
+            "lineNumber": 79
           },
           {
             "function": "main.main",
@@ -219,12 +219,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 73
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -286,12 +286,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 74
+            "lineNumber": 81
           },
           {
             "function": "main.main",
@@ -353,12 +353,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 75
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -420,12 +420,79 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 77
+            "lineNumber": 83
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 55
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 85
           },
           {
             "function": "main.main",
@@ -487,12 +554,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 78
+            "lineNumber": 86
           },
           {
             "function": "main.main",
@@ -555,12 +622,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
+            "lineNumber": 55
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 80
+            "lineNumber": 88
           },
           {
             "function": "main.main",
@@ -592,74 +659,6 @@
                 "fields": {
                   "data": {
                     "type": "string",
-                    "value": "foo"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testAny",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testAny",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 56
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 81
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testAny",
-          "location": {
-            "method": "main.testAny"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "a": {
-                "type": "interface {}",
-                "fields": {
-                  "data": {
-                    "type": "*string",
-                    "address": "[addr]",
                     "value": "foo"
                   }
                 }

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -456,8 +456,7 @@
                 "type": "interface {}",
                 "fields": {
                   "data": {
-                    "type": "",
-                    "notCapturedReason": "missing type information"
+                    "isNull": true
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 77
+            "lineNumber": 83
           },
           {
             "function": "main.main",
@@ -85,12 +85,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 78
+            "lineNumber": 84
           },
           {
             "function": "main.main",
@@ -152,12 +152,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 79
+            "lineNumber": 85
           },
           {
             "function": "main.main",
@@ -219,12 +219,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 80
+            "lineNumber": 86
           },
           {
             "function": "main.main",
@@ -286,12 +286,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 81
+            "lineNumber": 87
           },
           {
             "function": "main.main",
@@ -353,12 +353,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 82
+            "lineNumber": 88
           },
           {
             "function": "main.main",
@@ -420,12 +420,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 83
+            "lineNumber": 89
           },
           {
             "function": "main.main",
@@ -486,12 +486,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 85
+            "lineNumber": 91
           },
           {
             "function": "main.main",
@@ -553,12 +553,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 86
+            "lineNumber": 92
           },
           {
             "function": "main.main",
@@ -621,12 +621,12 @@
           {
             "function": "main.testAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 55
+            "lineNumber": 54
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 88
+            "lineNumber": 94
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -23,341 +23,6 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 83
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testAny",
-          "location": {
-            "method": "main.testAny"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "a": {
-                "type": "interface {}",
-                "fields": {
-                  "data": {
-                    "type": "main.firstBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testAny",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testAny",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 54
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 84
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testAny",
-          "location": {
-            "method": "main.testAny"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "a": {
-                "type": "interface {}",
-                "fields": {
-                  "data": {
-                    "type": "*main.firstBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testAny",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testAny",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 54
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 85
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testAny",
-          "location": {
-            "method": "main.testAny"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "a": {
-                "type": "interface {}",
-                "fields": {
-                  "data": {
-                    "type": "main.secondBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testAny",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testAny",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 54
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 86
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testAny",
-          "location": {
-            "method": "main.testAny"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "a": {
-                "type": "interface {}",
-                "fields": {
-                  "data": {
-                    "type": "*main.secondBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testAny",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testAny",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 54
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 87
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testAny",
-          "location": {
-            "method": "main.testAny"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "a": {
-                "type": "interface {}",
-                "fields": {
-                  "data": {
-                    "type": "lib_v2.V2Type",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testAny",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testAny",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 54
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
             "lineNumber": 88
           },
           {
@@ -389,7 +54,7 @@
                 "type": "interface {}",
                 "fields": {
                   "data": {
-                    "type": "*lib_v2.V2Type",
+                    "type": "main.otherFirstBehavior",
                     "notCapturedReason": "missing type information"
                   }
                 }
@@ -456,7 +121,75 @@
                 "type": "interface {}",
                 "fields": {
                   "data": {
-                    "isNull": true
+                    "type": "*main.otherFirstBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 54
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 90
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "main.otherSecondBehavior",
+                    "notCapturedReason": "missing type information"
                   }
                 }
               }
@@ -492,6 +225,273 @@
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
             "lineNumber": 91
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "*main.otherSecondBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 54
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 92
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "lib_v2.V2Type",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 54
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 93
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "type": "*lib_v2.V2Type",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 54
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 94
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "fields": {
+                  "data": {
+                    "isNull": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 54
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 96
           },
           {
             "function": "main.main",
@@ -558,7 +558,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 92
+            "lineNumber": 97
           },
           {
             "function": "main.main",
@@ -626,7 +626,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 94
+            "lineNumber": 99
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -117,8 +117,7 @@
                 "address": "[addr]",
                 "fields": {
                   "data": {
-                    "type": "",
-                    "notCapturedReason": "missing type information"
+                    "isNull": true
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testInterface",
+      "method": "main.testAnyPtr",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testInterface",
+            "function": "main.testAnyPtr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
+            "lineNumber": 65
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 71
+            "lineNumber": 96
           },
           {
             "function": "main.main",
@@ -42,22 +42,17 @@
           }
         ],
         "probe": {
-          "id": "testInterface",
+          "id": "testAnyPtr",
           "location": {
-            "method": "main.testInterface"
+            "method": "main.testAnyPtr"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.behavior",
-                "fields": {
-                  "data": {
-                    "type": "main.firstBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
+              "a": {
+                "type": "*interface {}",
+                "isNull": true
               }
             }
           }
@@ -71,7 +66,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testInterface",
+      "method": "main.testAnyPtr",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -83,14 +78,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testInterface",
+            "function": "main.testAnyPtr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
+            "lineNumber": 65
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 72
+            "lineNumber": 97
           },
           {
             "function": "main.main",
@@ -109,288 +104,311 @@
           }
         ],
         "probe": {
-          "id": "testInterface",
+          "id": "testAnyPtr",
           "location": {
-            "method": "main.testInterface"
+            "method": "main.testAnyPtr"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.behavior",
-                "fields": {
-                  "data": {
-                    "type": "*main.firstBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testInterface",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testInterface",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 73
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testInterface",
-          "location": {
-            "method": "main.testInterface"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "b": {
-                "type": "main.behavior",
-                "fields": {
-                  "data": {
-                    "type": "main.secondBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testInterface",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testInterface",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 74
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testInterface",
-          "location": {
-            "method": "main.testInterface"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "b": {
-                "type": "main.behavior",
-                "fields": {
-                  "data": {
-                    "type": "*main.secondBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testInterface",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testInterface",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 75
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testInterface",
-          "location": {
-            "method": "main.testInterface"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "b": {
-                "type": "main.behavior",
-                "fields": {
-                  "data": {
-                    "type": "*main.secondBehavior",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "[ts]"
-  },
-  {
-    "service": "sample",
-    "ddsource": "dd_debugger",
-    "logger": {
-      "name": "",
-      "method": "main.testInterface",
-      "version": 0,
-      "thread_id": 0,
-      "thread_name": ""
-    },
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "language": "go",
-        "stack": [
-          {
-            "function": "main.testInterface",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
-          },
-          {
-            "function": "main.executeInterfaceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 76
-          },
-          {
-            "function": "main.main",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
-          },
-          {
-            "function": "runtime.main",
-            "fileName": "runtime/proc.go",
-            "lineNumber": "[lineNumber]"
-          },
-          {
-            "function": "runtime.goexit",
-            "fileName": "runtime/asm_[arch].s",
-            "lineNumber": "[lineNumber]"
-          }
-        ],
-        "probe": {
-          "id": "testInterface",
-          "location": {
-            "method": "main.testInterface"
-          }
-        },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "b": {
-                "type": "main.behavior",
+              "a": {
+                "type": "*interface {}",
+                "address": "[addr]",
                 "fields": {
                   "data": {
                     "type": "",
                     "notCapturedReason": "missing type information"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAnyPtr",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAnyPtr",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 65
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 98
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAnyPtr",
+          "location": {
+            "method": "main.testAnyPtr"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "*interface {}",
+                "address": "[addr]",
+                "fields": {
+                  "data": {
+                    "type": "*int",
+                    "isNull": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAnyPtr",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAnyPtr",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 65
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 99
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAnyPtr",
+          "location": {
+            "method": "main.testAnyPtr"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "*interface {}",
+                "address": "[addr]",
+                "fields": {
+                  "data": {
+                    "type": "int",
+                    "value": "1"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAnyPtr",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAnyPtr",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 65
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 100
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAnyPtr",
+          "location": {
+            "method": "main.testAnyPtr"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "*interface {}",
+                "address": "[addr]",
+                "fields": {
+                  "data": {
+                    "type": "*interface {}",
+                    "address": "[addr]",
+                    "fields": {
+                      "data": {
+                        "type": "int",
+                        "value": "1"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAnyPtr",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAnyPtr",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 65
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 101
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAnyPtr",
+          "location": {
+            "method": "main.testAnyPtr"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "*interface {}",
+                "address": "[addr]",
+                "fields": {
+                  "data": {
+                    "type": "*interface {}",
+                    "address": "[addr]",
+                    "fields": {
+                      "data": {
+                        "type": "*interface {}",
+                        "address": "[addr]",
+                        "fields": {
+                          "data": {
+                            "type": "int",
+                            "value": "1"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 102
+            "lineNumber": 107
           },
           {
             "function": "main.main",
@@ -85,7 +85,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 103
+            "lineNumber": 108
           },
           {
             "function": "main.main",
@@ -152,7 +152,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 104
+            "lineNumber": 109
           },
           {
             "function": "main.main",
@@ -220,7 +220,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 105
+            "lineNumber": 110
           },
           {
             "function": "main.main",
@@ -288,7 +288,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 106
+            "lineNumber": 111
           },
           {
             "function": "main.main",
@@ -362,7 +362,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 107
+            "lineNumber": 112
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testAnyPtr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 65
+            "lineNumber": 64
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 96
+            "lineNumber": 102
           },
           {
             "function": "main.main",
@@ -80,12 +80,12 @@
           {
             "function": "main.testAnyPtr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 65
+            "lineNumber": 64
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 97
+            "lineNumber": 103
           },
           {
             "function": "main.main",
@@ -147,12 +147,12 @@
           {
             "function": "main.testAnyPtr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 65
+            "lineNumber": 64
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 98
+            "lineNumber": 104
           },
           {
             "function": "main.main",
@@ -215,12 +215,12 @@
           {
             "function": "main.testAnyPtr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 65
+            "lineNumber": 64
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 99
+            "lineNumber": 105
           },
           {
             "function": "main.main",
@@ -283,12 +283,12 @@
           {
             "function": "main.testAnyPtr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 65
+            "lineNumber": 64
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 100
+            "lineNumber": 106
           },
           {
             "function": "main.main",
@@ -357,12 +357,12 @@
           {
             "function": "main.testAnyPtr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 65
+            "lineNumber": 64
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 101
+            "lineNumber": 107
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -73,7 +73,7 @@
                     "fields": {
                       "data": {
                         "type": "io.discard",
-                        "notCapturedReason": "missing type information"
+                        "fields": {}
                       }
                     }
                   }

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -69,8 +69,13 @@
                     "value": "5"
                   },
                   "writer": {
-                    "type": "io.discard",
-                    "notCapturedReason": "missing type information"
+                    "type": "io.Writer",
+                    "fields": {
+                      "data": {
+                        "type": "io.discard",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -63,8 +63,13 @@
                         "address": "[addr]",
                         "fields": {
                           "a": {
-                            "type": "*main.deepPtr1",
-                            "notCapturedReason": "missing type information"
+                            "type": "interface {}",
+                            "fields": {
+                              "data": {
+                                "type": "*main.deepPtr1",
+                                "notCapturedReason": "missing type information"
+                              }
+                            }
                           }
                         }
                       }

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -75,8 +75,13 @@
                                     "size": "1",
                                     "elements": [
                                       {
-                                        "type": "*main.deepSlice1",
-                                        "notCapturedReason": "missing type information"
+                                        "type": "interface {}",
+                                        "fields": {
+                                          "data": {
+                                            "type": "*main.deepSlice1",
+                                            "notCapturedReason": "missing type information"
+                                          }
+                                        }
                                       }
                                     ]
                                   }

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -51,8 +51,13 @@
           "entry": {
             "arguments": {
               "e": {
-                "type": "*errors.errorString",
-                "notCapturedReason": "missing type information"
+                "type": "error",
+                "fields": {
+                  "data": {
+                    "type": "*errors.errorString",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testError",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 62
+            "lineNumber": 61
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 82
+            "lineNumber": 90
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -55,7 +55,13 @@
                 "fields": {
                   "data": {
                     "type": "*errors.errorString",
-                    "notCapturedReason": "missing type information"
+                    "address": "[addr]",
+                    "fields": {
+                      "s": {
+                        "type": "string",
+                        "value": "blah"
+                      }
+                    }
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 96
+            "lineNumber": 101
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testError",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 61
+            "lineNumber": 60
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 90
+            "lineNumber": 96
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -79,7 +79,8 @@
                         "fields": {
                           "data": {
                             "type": "*main.somethingImpl",
-                            "notCapturedReason": "missing type information"
+                            "address": "[addr]",
+                            "fields": {}
                           }
                         }
                       },

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -66,12 +66,22 @@
                         "notCapturedReason": "unimplemented"
                       },
                       "val": {
-                        "type": "int",
-                        "value": "42"
+                        "type": "interface {}",
+                        "fields": {
+                          "data": {
+                            "type": "int",
+                            "value": "42"
+                          }
+                        }
                       },
                       "work": {
-                        "type": "*main.somethingImpl",
-                        "notCapturedReason": "missing type information"
+                        "type": "main.something",
+                        "fields": {
+                          "data": {
+                            "type": "*main.somethingImpl",
+                            "notCapturedReason": "missing type information"
+                          }
+                        }
                       },
                       "foo": {
                         "type": "func()",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -62,12 +62,22 @@
                     "notCapturedReason": "unimplemented"
                   },
                   "val": {
-                    "type": "int",
-                    "value": "42"
+                    "type": "interface {}",
+                    "fields": {
+                      "data": {
+                        "type": "int",
+                        "value": "42"
+                      }
+                    }
                   },
                   "work": {
-                    "type": "*main.somethingImpl",
-                    "notCapturedReason": "missing type information"
+                    "type": "main.something",
+                    "fields": {
+                      "data": {
+                        "type": "*main.somethingImpl",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
                   },
                   "foo": {
                     "type": "func()",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -75,7 +75,8 @@
                     "fields": {
                       "data": {
                         "type": "*main.somethingImpl",
-                        "notCapturedReason": "missing type information"
+                        "address": "[addr]",
+                        "fields": {}
                       }
                     }
                   },

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -389,8 +389,7 @@
                 "type": "main.behavior",
                 "fields": {
                   "data": {
-                    "type": "",
-                    "notCapturedReason": "missing type information"
+                    "isNull": true
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
+            "lineNumber": 50
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
@@ -85,12 +85,12 @@
           {
             "function": "main.testInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
+            "lineNumber": 50
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 72
+            "lineNumber": 78
           },
           {
             "function": "main.main",
@@ -152,12 +152,12 @@
           {
             "function": "main.testInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
+            "lineNumber": 50
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 73
+            "lineNumber": 79
           },
           {
             "function": "main.main",
@@ -219,12 +219,12 @@
           {
             "function": "main.testInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
+            "lineNumber": 50
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 74
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -286,12 +286,12 @@
           {
             "function": "main.testInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
+            "lineNumber": 50
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 75
+            "lineNumber": 81
           },
           {
             "function": "main.main",
@@ -353,12 +353,12 @@
           {
             "function": "main.testInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 51
+            "lineNumber": 50
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 76
+            "lineNumber": 82
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -51,8 +51,13 @@
           "entry": {
             "arguments": {
               "b": {
-                "type": "main.firstBehavior",
-                "notCapturedReason": "missing type information"
+                "type": "main.behavior",
+                "fields": {
+                  "data": {
+                    "type": "main.firstBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -113,8 +118,13 @@
           "entry": {
             "arguments": {
               "b": {
-                "type": "*main.firstBehavior",
-                "notCapturedReason": "missing type information"
+                "type": "main.behavior",
+                "fields": {
+                  "data": {
+                    "type": "*main.firstBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -175,8 +185,13 @@
           "entry": {
             "arguments": {
               "b": {
-                "type": "main.secondBehavior",
-                "notCapturedReason": "missing type information"
+                "type": "main.behavior",
+                "fields": {
+                  "data": {
+                    "type": "main.secondBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }
@@ -237,8 +252,13 @@
           "entry": {
             "arguments": {
               "b": {
-                "type": "*main.secondBehavior",
-                "notCapturedReason": "missing type information"
+                "type": "main.behavior",
+                "fields": {
+                  "data": {
+                    "type": "*main.secondBehavior",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -55,7 +55,12 @@
                 "fields": {
                   "data": {
                     "type": "main.firstBehavior",
-                    "notCapturedReason": "missing type information"
+                    "fields": {
+                      "s": {
+                        "type": "string",
+                        "value": "foo"
+                      }
+                    }
                   }
                 }
               }
@@ -122,7 +127,13 @@
                 "fields": {
                   "data": {
                     "type": "*main.firstBehavior",
-                    "notCapturedReason": "missing type information"
+                    "address": "[addr]",
+                    "fields": {
+                      "s": {
+                        "type": "string",
+                        "value": "foo"
+                      }
+                    }
                   }
                 }
               }
@@ -189,7 +200,12 @@
                 "fields": {
                   "data": {
                     "type": "main.secondBehavior",
-                    "notCapturedReason": "missing type information"
+                    "fields": {
+                      "i": {
+                        "type": "int",
+                        "value": "42"
+                      }
+                    }
                   }
                 }
               }
@@ -256,7 +272,13 @@
                 "fields": {
                   "data": {
                     "type": "*main.secondBehavior",
-                    "notCapturedReason": "missing type information"
+                    "address": "[addr]",
+                    "fields": {
+                      "i": {
+                        "type": "int",
+                        "value": "42"
+                      }
+                    }
                   }
                 }
               }
@@ -323,7 +345,7 @@
                 "fields": {
                   "data": {
                     "type": "*main.secondBehavior",
-                    "notCapturedReason": "missing type information"
+                    "isNull": true
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -64,36 +64,7 @@
                             "fields": {
                               "data": {
                                 "type": "main.structWithAny",
-                                "fields": {
-                                  "a": {
-                                    "type": "interface {}",
-                                    "fields": {
-                                      "data": {
-                                        "type": "main.structWithAny",
-                                        "fields": {
-                                          "a": {
-                                            "type": "interface {}",
-                                            "fields": {
-                                              "data": {
-                                                "type": "main.structWithAny",
-                                                "fields": {
-                                                  "a": {
-                                                    "type": "interface {}",
-                                                    "fields": {
-                                                      "data": {
-                                                        "isNull": true
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
+                                "notCapturedReason": "depth"
                               }
                             }
                           }

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 117
+            "lineNumber": 122
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -1,0 +1,113 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testStructWithAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testStructWithAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 73
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 117
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testStructWithAny",
+          "location": {
+            "method": "main.testStructWithAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "main.structWithAny",
+                "fields": {
+                  "a": {
+                    "type": "interface {}",
+                    "fields": {
+                      "data": {
+                        "type": "main.structWithAny",
+                        "fields": {
+                          "a": {
+                            "type": "interface {}",
+                            "fields": {
+                              "data": {
+                                "type": "main.structWithAny",
+                                "fields": {
+                                  "a": {
+                                    "type": "interface {}",
+                                    "fields": {
+                                      "data": {
+                                        "type": "main.structWithAny",
+                                        "fields": {
+                                          "a": {
+                                            "type": "interface {}",
+                                            "fields": {
+                                              "data": {
+                                                "type": "main.structWithAny",
+                                                "fields": {
+                                                  "a": {
+                                                    "type": "interface {}",
+                                                    "fields": {
+                                                      "data": {
+                                                        "isNull": true
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -28,8 +28,45 @@
                 "type": "net/http.ResponseWriter",
                 "fields": {
                   "data": {
-                    "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
-                    "notCapturedReason": "missing type information"
+                    "type": "struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }",
+                    "fields": {
+                      "monitoredResponseWriter": {
+                        "type": "github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1",
+                        "fields": {
+                          "data": {
+                            "type": "*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Flusher": {
+                        "type": "net/http.Flusher",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "CloseNotifier": {
+                        "type": "net/http.CloseNotifier",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Hijacker": {
+                        "type": "net/http.Hijacker",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               },
@@ -225,8 +262,45 @@
                 "type": "net/http.ResponseWriter",
                 "fields": {
                   "data": {
-                    "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
-                    "notCapturedReason": "missing type information"
+                    "type": "struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }",
+                    "fields": {
+                      "monitoredResponseWriter": {
+                        "type": "github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1",
+                        "fields": {
+                          "data": {
+                            "type": "*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Flusher": {
+                        "type": "net/http.Flusher",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "CloseNotifier": {
+                        "type": "net/http.CloseNotifier",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Hijacker": {
+                        "type": "net/http.Hijacker",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               },
@@ -422,8 +496,45 @@
                 "type": "net/http.ResponseWriter",
                 "fields": {
                   "data": {
-                    "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
-                    "notCapturedReason": "missing type information"
+                    "type": "struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }",
+                    "fields": {
+                      "monitoredResponseWriter": {
+                        "type": "github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1",
+                        "fields": {
+                          "data": {
+                            "type": "*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Flusher": {
+                        "type": "net/http.Flusher",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "CloseNotifier": {
+                        "type": "net/http.CloseNotifier",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Hijacker": {
+                        "type": "net/http.Hijacker",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               },

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -43,53 +43,7 @@
                   },
                   "URL": {
                     "type": "*net/url.URL",
-                    "address": "[addr]",
-                    "fields": {
-                      "Scheme": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "Opaque": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "User": {
-                        "type": "*net/url.Userinfo",
-                        "isNull": true
-                      },
-                      "Host": {
-                        "type": "string",
-                        "value": "[host network address]"
-                      },
-                      "Path": {
-                        "type": "string",
-                        "value": "/0"
-                      },
-                      "RawPath": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "OmitHost": {
-                        "type": "bool",
-                        "value": "false"
-                      },
-                      "ForceQuery": {
-                        "type": "bool",
-                        "value": "false"
-                      },
-                      "RawQuery": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "Fragment": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "RawFragment": {
-                        "type": "string",
-                        "value": ""
-                      }
-                    }
+                    "notCapturedReason": "depth"
                   },
                   "Proto": {
                     "type": "string",
@@ -105,41 +59,7 @@
                   },
                   "Header": {
                     "type": "net/http.Header",
-                    "size": "2",
-                    "entries": [
-                      [
-                        {
-                          "type": "string",
-                          "value": "Accept-Encoding"
-                        },
-                        {
-                          "type": "[]string",
-                          "size": "1",
-                          "elements": [
-                            {
-                              "type": "string",
-                              "value": "gzip"
-                            }
-                          ]
-                        }
-                      ],
-                      [
-                        {
-                          "type": "string",
-                          "value": "User-Agent"
-                        },
-                        {
-                          "type": "[]string",
-                          "size": "1",
-                          "elements": [
-                            {
-                              "type": "string",
-                              "value": "Go-http-client/1.1"
-                            }
-                          ]
-                        }
-                      ]
-                    ]
+                    "notCapturedReason": "depth"
                   },
                   "Body": {
                     "type": "io.ReadCloser",
@@ -221,48 +141,7 @@
                   },
                   "pat": {
                     "type": "*net/http.pattern",
-                    "address": "[addr]",
-                    "fields": {
-                      "str": {
-                        "type": "string",
-                        "value": "/"
-                      },
-                      "method": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "host": {
-                        "type": "string",
-                        "value": "/"
-                      },
-                      "segments": {
-                        "type": "[]net/http.segment",
-                        "size": "1",
-                        "elements": [
-                          {
-                            "type": "net/http.segment",
-                            "fields": {
-                              "s": {
-                                "type": "string",
-                                "value": ""
-                              },
-                              "wild": {
-                                "type": "bool",
-                                "value": "true"
-                              },
-                              "multi": {
-                                "type": "bool",
-                                "value": "true"
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "loc": {
-                        "type": "string",
-                        "value": "[datadogagent]pkg/dyninst/testprogs/progs/[binary]/main.go:[line]"
-                      }
-                    }
+                    "notCapturedReason": "depth"
                   },
                   "matches": {
                     "type": "[]string",
@@ -361,53 +240,7 @@
                   },
                   "URL": {
                     "type": "*net/url.URL",
-                    "address": "[addr]",
-                    "fields": {
-                      "Scheme": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "Opaque": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "User": {
-                        "type": "*net/url.Userinfo",
-                        "isNull": true
-                      },
-                      "Host": {
-                        "type": "string",
-                        "value": "[host network address]"
-                      },
-                      "Path": {
-                        "type": "string",
-                        "value": "/1"
-                      },
-                      "RawPath": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "OmitHost": {
-                        "type": "bool",
-                        "value": "false"
-                      },
-                      "ForceQuery": {
-                        "type": "bool",
-                        "value": "false"
-                      },
-                      "RawQuery": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "Fragment": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "RawFragment": {
-                        "type": "string",
-                        "value": ""
-                      }
-                    }
+                    "notCapturedReason": "depth"
                   },
                   "Proto": {
                     "type": "string",
@@ -423,41 +256,7 @@
                   },
                   "Header": {
                     "type": "net/http.Header",
-                    "size": "2",
-                    "entries": [
-                      [
-                        {
-                          "type": "string",
-                          "value": "Accept-Encoding"
-                        },
-                        {
-                          "type": "[]string",
-                          "size": "1",
-                          "elements": [
-                            {
-                              "type": "string",
-                              "value": "gzip"
-                            }
-                          ]
-                        }
-                      ],
-                      [
-                        {
-                          "type": "string",
-                          "value": "User-Agent"
-                        },
-                        {
-                          "type": "[]string",
-                          "size": "1",
-                          "elements": [
-                            {
-                              "type": "string",
-                              "value": "Go-http-client/1.1"
-                            }
-                          ]
-                        }
-                      ]
-                    ]
+                    "notCapturedReason": "depth"
                   },
                   "Body": {
                     "type": "io.ReadCloser",
@@ -539,48 +338,7 @@
                   },
                   "pat": {
                     "type": "*net/http.pattern",
-                    "address": "[addr]",
-                    "fields": {
-                      "str": {
-                        "type": "string",
-                        "value": "/"
-                      },
-                      "method": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "host": {
-                        "type": "string",
-                        "value": "/"
-                      },
-                      "segments": {
-                        "type": "[]net/http.segment",
-                        "size": "1",
-                        "elements": [
-                          {
-                            "type": "net/http.segment",
-                            "fields": {
-                              "s": {
-                                "type": "string",
-                                "value": ""
-                              },
-                              "wild": {
-                                "type": "bool",
-                                "value": "true"
-                              },
-                              "multi": {
-                                "type": "bool",
-                                "value": "true"
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "loc": {
-                        "type": "string",
-                        "value": "[datadogagent]pkg/dyninst/testprogs/progs/[binary]/main.go:[line]"
-                      }
-                    }
+                    "notCapturedReason": "depth"
                   },
                   "matches": {
                     "type": "[]string",
@@ -679,53 +437,7 @@
                   },
                   "URL": {
                     "type": "*net/url.URL",
-                    "address": "[addr]",
-                    "fields": {
-                      "Scheme": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "Opaque": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "User": {
-                        "type": "*net/url.Userinfo",
-                        "isNull": true
-                      },
-                      "Host": {
-                        "type": "string",
-                        "value": "[host network address]"
-                      },
-                      "Path": {
-                        "type": "string",
-                        "value": "/2"
-                      },
-                      "RawPath": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "OmitHost": {
-                        "type": "bool",
-                        "value": "false"
-                      },
-                      "ForceQuery": {
-                        "type": "bool",
-                        "value": "false"
-                      },
-                      "RawQuery": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "Fragment": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "RawFragment": {
-                        "type": "string",
-                        "value": ""
-                      }
-                    }
+                    "notCapturedReason": "depth"
                   },
                   "Proto": {
                     "type": "string",
@@ -741,41 +453,7 @@
                   },
                   "Header": {
                     "type": "net/http.Header",
-                    "size": "2",
-                    "entries": [
-                      [
-                        {
-                          "type": "string",
-                          "value": "Accept-Encoding"
-                        },
-                        {
-                          "type": "[]string",
-                          "size": "1",
-                          "elements": [
-                            {
-                              "type": "string",
-                              "value": "gzip"
-                            }
-                          ]
-                        }
-                      ],
-                      [
-                        {
-                          "type": "string",
-                          "value": "User-Agent"
-                        },
-                        {
-                          "type": "[]string",
-                          "size": "1",
-                          "elements": [
-                            {
-                              "type": "string",
-                              "value": "Go-http-client/1.1"
-                            }
-                          ]
-                        }
-                      ]
-                    ]
+                    "notCapturedReason": "depth"
                   },
                   "Body": {
                     "type": "io.ReadCloser",
@@ -857,48 +535,7 @@
                   },
                   "pat": {
                     "type": "*net/http.pattern",
-                    "address": "[addr]",
-                    "fields": {
-                      "str": {
-                        "type": "string",
-                        "value": "/"
-                      },
-                      "method": {
-                        "type": "string",
-                        "value": ""
-                      },
-                      "host": {
-                        "type": "string",
-                        "value": "/"
-                      },
-                      "segments": {
-                        "type": "[]net/http.segment",
-                        "size": "1",
-                        "elements": [
-                          {
-                            "type": "net/http.segment",
-                            "fields": {
-                              "s": {
-                                "type": "string",
-                                "value": ""
-                              },
-                              "wild": {
-                                "type": "bool",
-                                "value": "true"
-                              },
-                              "multi": {
-                                "type": "bool",
-                                "value": "true"
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "loc": {
-                        "type": "string",
-                        "value": "[datadogagent]pkg/dyninst/testprogs/progs/[binary]/main.go:[line]"
-                      }
-                    }
+                    "notCapturedReason": "depth"
                   },
                   "matches": {
                     "type": "[]string",

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -25,8 +25,13 @@
           "entry": {
             "arguments": {
               "w": {
-                "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
-                "notCapturedReason": "missing type information"
+                "type": "net/http.ResponseWriter",
+                "fields": {
+                  "data": {
+                    "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               },
               "r": {
                 "type": "*net/http.Request",
@@ -137,8 +142,13 @@
                     ]
                   },
                   "Body": {
-                    "type": "http.noBody",
-                    "notCapturedReason": "missing type information"
+                    "type": "io.ReadCloser",
+                    "fields": {
+                      "data": {
+                        "type": "http.noBody",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
                   },
                   "GetBody": {
                     "type": "func() (io.ReadCloser, error)",
@@ -201,8 +211,13 @@
                     "value": "/"
                   },
                   "ctx": {
-                    "type": "*context.valueCtx",
-                    "notCapturedReason": "missing type information"
+                    "type": "context.Context",
+                    "fields": {
+                      "data": {
+                        "type": "*context.valueCtx",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
                   },
                   "pat": {
                     "type": "*net/http.pattern",
@@ -328,8 +343,13 @@
           "entry": {
             "arguments": {
               "w": {
-                "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
-                "notCapturedReason": "missing type information"
+                "type": "net/http.ResponseWriter",
+                "fields": {
+                  "data": {
+                    "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               },
               "r": {
                 "type": "*net/http.Request",
@@ -440,8 +460,13 @@
                     ]
                   },
                   "Body": {
-                    "type": "http.noBody",
-                    "notCapturedReason": "missing type information"
+                    "type": "io.ReadCloser",
+                    "fields": {
+                      "data": {
+                        "type": "http.noBody",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
                   },
                   "GetBody": {
                     "type": "func() (io.ReadCloser, error)",
@@ -504,8 +529,13 @@
                     "value": "/"
                   },
                   "ctx": {
-                    "type": "*context.valueCtx",
-                    "notCapturedReason": "missing type information"
+                    "type": "context.Context",
+                    "fields": {
+                      "data": {
+                        "type": "*context.valueCtx",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
                   },
                   "pat": {
                     "type": "*net/http.pattern",
@@ -631,8 +661,13 @@
           "entry": {
             "arguments": {
               "w": {
-                "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
-                "notCapturedReason": "missing type information"
+                "type": "net/http.ResponseWriter",
+                "fields": {
+                  "data": {
+                    "type": "struct { httptrace.monitoredResponseWriter; http.Flusher; http.CloseNotifier; http.Hijacker }",
+                    "notCapturedReason": "missing type information"
+                  }
+                }
               },
               "r": {
                 "type": "*net/http.Request",
@@ -743,8 +778,13 @@
                     ]
                   },
                   "Body": {
-                    "type": "http.noBody",
-                    "notCapturedReason": "missing type information"
+                    "type": "io.ReadCloser",
+                    "fields": {
+                      "data": {
+                        "type": "http.noBody",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
                   },
                   "GetBody": {
                     "type": "func() (io.ReadCloser, error)",
@@ -807,8 +847,13 @@
                     "value": "/"
                   },
                   "ctx": {
-                    "type": "*context.valueCtx",
-                    "notCapturedReason": "missing type information"
+                    "type": "context.Context",
+                    "fields": {
+                      "data": {
+                        "type": "*context.valueCtx",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
                   },
                   "pat": {
                     "type": "*net/http.pattern",

--- a/pkg/dyninst/testdata/e2e/rc_tester_v1.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester_v1.json
@@ -1,0 +1,704 @@
+[
+  {
+    "service": "rc_tester",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.HandleHTTP",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack]",
+        "probe": {
+          "id": "http_handler",
+          "location": {
+            "method": "main.HandleHTTP"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "w": {
+                "type": "net/http.ResponseWriter",
+                "fields": {
+                  "data": {
+                    "type": "struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }",
+                    "fields": {
+                      "monitoredResponseWriter": {
+                        "type": "gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1",
+                        "fields": {
+                          "data": {
+                            "type": "*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Flusher": {
+                        "type": "net/http.Flusher",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "CloseNotifier": {
+                        "type": "net/http.CloseNotifier",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Hijacker": {
+                        "type": "net/http.Hijacker",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "r": {
+                "type": "*net/http.Request",
+                "address": "[addr]",
+                "fields": {
+                  "Method": {
+                    "type": "string",
+                    "value": "GET"
+                  },
+                  "URL": {
+                    "type": "*net/url.URL",
+                    "notCapturedReason": "depth"
+                  },
+                  "Proto": {
+                    "type": "string",
+                    "value": "HTTP/1.1"
+                  },
+                  "ProtoMajor": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "ProtoMinor": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "Header": {
+                    "type": "net/http.Header",
+                    "notCapturedReason": "depth"
+                  },
+                  "Body": {
+                    "type": "io.ReadCloser",
+                    "fields": {
+                      "data": {
+                        "type": "http.noBody",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
+                  },
+                  "GetBody": {
+                    "type": "func() (io.ReadCloser, error)",
+                    "notCapturedReason": "unimplemented"
+                  },
+                  "ContentLength": {
+                    "type": "int64",
+                    "value": "0"
+                  },
+                  "TransferEncoding": {
+                    "type": "[]string",
+                    "isNull": true
+                  },
+                  "Close": {
+                    "type": "bool",
+                    "value": "false"
+                  },
+                  "Host": {
+                    "type": "string",
+                    "value": "[host network address]"
+                  },
+                  "Form": {
+                    "type": "net/url.Values",
+                    "isNull": true
+                  },
+                  "PostForm": {
+                    "type": "net/url.Values",
+                    "isNull": true
+                  },
+                  "MultipartForm": {
+                    "type": "*mime/multipart.Form",
+                    "isNull": true
+                  },
+                  "Trailer": {
+                    "type": "net/http.Header",
+                    "isNull": true
+                  },
+                  "RemoteAddr": {
+                    "type": "string",
+                    "value": "[remote network address]"
+                  },
+                  "RequestURI": {
+                    "type": "string",
+                    "value": "/0"
+                  },
+                  "TLS": {
+                    "type": "*crypto/tls.ConnectionState",
+                    "isNull": true
+                  },
+                  "Cancel": {
+                    "type": "\u003c-chan struct {}",
+                    "notCapturedReason": "unimplemented"
+                  },
+                  "Response": {
+                    "type": "*net/http.Response",
+                    "isNull": true
+                  },
+                  "Pattern": {
+                    "type": "string",
+                    "value": "/"
+                  },
+                  "ctx": {
+                    "type": "context.Context",
+                    "fields": {
+                      "data": {
+                        "type": "*context.valueCtx",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
+                  },
+                  "pat": {
+                    "type": "*net/http.pattern",
+                    "notCapturedReason": "depth"
+                  },
+                  "matches": {
+                    "type": "[]string",
+                    "isNull": true
+                  },
+                  "otherValues": {
+                    "type": "map[string]string",
+                    "isNull": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "rc_tester",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.LookAtTheRequest",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack]",
+        "probe": {
+          "id": "look_at_the_request",
+          "location": {
+            "method": "main.LookAtTheRequest"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "path": {
+                "type": "string",
+                "value": "/0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "rc_tester",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.HandleHTTP",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack]",
+        "probe": {
+          "id": "http_handler",
+          "location": {
+            "method": "main.HandleHTTP"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "w": {
+                "type": "net/http.ResponseWriter",
+                "fields": {
+                  "data": {
+                    "type": "struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }",
+                    "fields": {
+                      "monitoredResponseWriter": {
+                        "type": "gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1",
+                        "fields": {
+                          "data": {
+                            "type": "*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Flusher": {
+                        "type": "net/http.Flusher",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "CloseNotifier": {
+                        "type": "net/http.CloseNotifier",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Hijacker": {
+                        "type": "net/http.Hijacker",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "r": {
+                "type": "*net/http.Request",
+                "address": "[addr]",
+                "fields": {
+                  "Method": {
+                    "type": "string",
+                    "value": "GET"
+                  },
+                  "URL": {
+                    "type": "*net/url.URL",
+                    "notCapturedReason": "depth"
+                  },
+                  "Proto": {
+                    "type": "string",
+                    "value": "HTTP/1.1"
+                  },
+                  "ProtoMajor": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "ProtoMinor": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "Header": {
+                    "type": "net/http.Header",
+                    "notCapturedReason": "depth"
+                  },
+                  "Body": {
+                    "type": "io.ReadCloser",
+                    "fields": {
+                      "data": {
+                        "type": "http.noBody",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
+                  },
+                  "GetBody": {
+                    "type": "func() (io.ReadCloser, error)",
+                    "notCapturedReason": "unimplemented"
+                  },
+                  "ContentLength": {
+                    "type": "int64",
+                    "value": "0"
+                  },
+                  "TransferEncoding": {
+                    "type": "[]string",
+                    "isNull": true
+                  },
+                  "Close": {
+                    "type": "bool",
+                    "value": "false"
+                  },
+                  "Host": {
+                    "type": "string",
+                    "value": "[host network address]"
+                  },
+                  "Form": {
+                    "type": "net/url.Values",
+                    "isNull": true
+                  },
+                  "PostForm": {
+                    "type": "net/url.Values",
+                    "isNull": true
+                  },
+                  "MultipartForm": {
+                    "type": "*mime/multipart.Form",
+                    "isNull": true
+                  },
+                  "Trailer": {
+                    "type": "net/http.Header",
+                    "isNull": true
+                  },
+                  "RemoteAddr": {
+                    "type": "string",
+                    "value": "[remote network address]"
+                  },
+                  "RequestURI": {
+                    "type": "string",
+                    "value": "/1"
+                  },
+                  "TLS": {
+                    "type": "*crypto/tls.ConnectionState",
+                    "isNull": true
+                  },
+                  "Cancel": {
+                    "type": "\u003c-chan struct {}",
+                    "notCapturedReason": "unimplemented"
+                  },
+                  "Response": {
+                    "type": "*net/http.Response",
+                    "isNull": true
+                  },
+                  "Pattern": {
+                    "type": "string",
+                    "value": "/"
+                  },
+                  "ctx": {
+                    "type": "context.Context",
+                    "fields": {
+                      "data": {
+                        "type": "*context.valueCtx",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
+                  },
+                  "pat": {
+                    "type": "*net/http.pattern",
+                    "notCapturedReason": "depth"
+                  },
+                  "matches": {
+                    "type": "[]string",
+                    "isNull": true
+                  },
+                  "otherValues": {
+                    "type": "map[string]string",
+                    "isNull": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "rc_tester",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.LookAtTheRequest",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack]",
+        "probe": {
+          "id": "look_at_the_request",
+          "location": {
+            "method": "main.LookAtTheRequest"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "path": {
+                "type": "string",
+                "value": "/1"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "rc_tester",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.HandleHTTP",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack]",
+        "probe": {
+          "id": "http_handler",
+          "location": {
+            "method": "main.HandleHTTP"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "w": {
+                "type": "net/http.ResponseWriter",
+                "fields": {
+                  "data": {
+                    "type": "struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }",
+                    "fields": {
+                      "monitoredResponseWriter": {
+                        "type": "gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1",
+                        "fields": {
+                          "data": {
+                            "type": "*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Flusher": {
+                        "type": "net/http.Flusher",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "CloseNotifier": {
+                        "type": "net/http.CloseNotifier",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      },
+                      "Hijacker": {
+                        "type": "net/http.Hijacker",
+                        "fields": {
+                          "data": {
+                            "type": "*net/http.response",
+                            "notCapturedReason": "depth"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "r": {
+                "type": "*net/http.Request",
+                "address": "[addr]",
+                "fields": {
+                  "Method": {
+                    "type": "string",
+                    "value": "GET"
+                  },
+                  "URL": {
+                    "type": "*net/url.URL",
+                    "notCapturedReason": "depth"
+                  },
+                  "Proto": {
+                    "type": "string",
+                    "value": "HTTP/1.1"
+                  },
+                  "ProtoMajor": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "ProtoMinor": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "Header": {
+                    "type": "net/http.Header",
+                    "notCapturedReason": "depth"
+                  },
+                  "Body": {
+                    "type": "io.ReadCloser",
+                    "fields": {
+                      "data": {
+                        "type": "http.noBody",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
+                  },
+                  "GetBody": {
+                    "type": "func() (io.ReadCloser, error)",
+                    "notCapturedReason": "unimplemented"
+                  },
+                  "ContentLength": {
+                    "type": "int64",
+                    "value": "0"
+                  },
+                  "TransferEncoding": {
+                    "type": "[]string",
+                    "isNull": true
+                  },
+                  "Close": {
+                    "type": "bool",
+                    "value": "false"
+                  },
+                  "Host": {
+                    "type": "string",
+                    "value": "[host network address]"
+                  },
+                  "Form": {
+                    "type": "net/url.Values",
+                    "isNull": true
+                  },
+                  "PostForm": {
+                    "type": "net/url.Values",
+                    "isNull": true
+                  },
+                  "MultipartForm": {
+                    "type": "*mime/multipart.Form",
+                    "isNull": true
+                  },
+                  "Trailer": {
+                    "type": "net/http.Header",
+                    "isNull": true
+                  },
+                  "RemoteAddr": {
+                    "type": "string",
+                    "value": "[remote network address]"
+                  },
+                  "RequestURI": {
+                    "type": "string",
+                    "value": "/2"
+                  },
+                  "TLS": {
+                    "type": "*crypto/tls.ConnectionState",
+                    "isNull": true
+                  },
+                  "Cancel": {
+                    "type": "\u003c-chan struct {}",
+                    "notCapturedReason": "unimplemented"
+                  },
+                  "Response": {
+                    "type": "*net/http.Response",
+                    "isNull": true
+                  },
+                  "Pattern": {
+                    "type": "string",
+                    "value": "/"
+                  },
+                  "ctx": {
+                    "type": "context.Context",
+                    "fields": {
+                      "data": {
+                        "type": "*context.valueCtx",
+                        "notCapturedReason": "missing type information"
+                      }
+                    }
+                  },
+                  "pat": {
+                    "type": "*net/http.pattern",
+                    "notCapturedReason": "depth"
+                  },
+                  "matches": {
+                    "type": "[]string",
+                    "isNull": true
+                  },
+                  "otherValues": {
+                    "type": "map[string]string",
+                    "isNull": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "rc_tester",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.LookAtTheRequest",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack]",
+        "probe": {
+          "id": "look_at_the_request",
+          "location": {
+            "method": "main.LookAtTheRequest"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "path": {
+                "type": "string",
+                "value": "/2"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testprogs/progs/sample/interfaces.go
+++ b/pkg/dyninst/testprogs/progs/sample/interfaces.go
@@ -80,10 +80,15 @@ func executeInterfaceFuncs() {
 	testInterface(&secondBehavior{42})
 	testInterface((*secondBehavior)(nil))
 	testInterface(nil)
-	testAny(firstBehavior{"foo"})
-	testAny(&firstBehavior{"foo"})
-	testAny(secondBehavior{42})
-	testAny(&secondBehavior{42})
+	// Use types that don't implement the interface so that we won't sometimes
+	// have the type information if the testInterface probe happens to be
+	// present.
+	type otherFirstBehavior firstBehavior
+	type otherSecondBehavior secondBehavior
+	testAny(otherFirstBehavior{"foo"})
+	testAny(&otherFirstBehavior{"foo"})
+	testAny(otherSecondBehavior{42})
+	testAny(&otherSecondBehavior{42})
 	testAny(lib_v2.V2Type{})
 	testAny(&lib_v2.V2Type{})
 	testAny(nil)

--- a/pkg/dyninst/testprogs/progs/sample/interfaces.go
+++ b/pkg/dyninst/testprogs/progs/sample/interfaces.go
@@ -47,8 +47,7 @@ type itab struct {
 
 //nolint:all
 //go:noinline
-func testInterface(b behavior) {
-}
+func testInterface(b behavior) {}
 
 //nolint:all
 //go:noinline
@@ -65,6 +64,13 @@ func testError(e error) {}
 func testAnyPtr(a *any) string {
 	return fmt.Sprintf("%v", a)
 }
+
+type structWithAny struct {
+	a any
+}
+
+//go:noinline
+func testStructWithAny(s structWithAny) {}
 
 //nolint:all
 func executeInterfaceFuncs() {
@@ -99,4 +105,15 @@ func executeInterfaceFuncs() {
 	testAnyPtr(&boxedOne)
 	testAnyPtr(&boxedOnePtr)
 	testAnyPtr(&boxedPtrToBoxedOne)
+
+	{
+		var (
+			structWithAny0 structWithAny
+			structWithAny1 = structWithAny{a: structWithAny0}
+			structWithAny2 = structWithAny{a: structWithAny1}
+			structWithAny3 = structWithAny{a: structWithAny2}
+			structWithAny4 = structWithAny{a: structWithAny3}
+		)
+		testStructWithAny(structWithAny4)
+	}
 }

--- a/pkg/dyninst/testprogs/progs/sample/interfaces.go
+++ b/pkg/dyninst/testprogs/progs/sample/interfaces.go
@@ -47,8 +47,7 @@ type itab struct {
 
 //nolint:all
 //go:noinline
-func testInterface(b behavior) string {
-	return b.DoSomething()
+func testInterface(b behavior) {
 }
 
 //nolint:all
@@ -62,17 +61,26 @@ func testAny(a any) string {
 func testError(e error) {}
 
 //nolint:all
+//go:noinline
+func testAnyPtr(a *any) string {
+	return fmt.Sprintf("%v", a)
+}
+
+//nolint:all
 func executeInterfaceFuncs() {
 	testInterface(firstBehavior{"foo"})
 	testInterface(&firstBehavior{"foo"})
 	testInterface(secondBehavior{42})
 	testInterface(&secondBehavior{42})
+	testInterface((*secondBehavior)(nil))
+	testInterface(nil)
 	testAny(firstBehavior{"foo"})
 	testAny(&firstBehavior{"foo"})
 	testAny(secondBehavior{42})
 	testAny(&secondBehavior{42})
 	testAny(lib_v2.V2Type{})
 	testAny(&lib_v2.V2Type{})
+	testAny(nil)
 	one := 1
 	testAny(one)
 	testAny(&one)
@@ -80,4 +88,15 @@ func executeInterfaceFuncs() {
 	testAny(foo)
 	testAny(&foo)
 	testError(errors.New("blah"))
+	boxedOne := any(one)
+	boxedOnePtr := any(&boxedOne)
+	boxedPtrToBoxedOne := any(&boxedOnePtr)
+	boxedNil := any(nil)
+	boxedTypedNil := any((*int)(nil))
+	testAnyPtr(nil)
+	testAnyPtr(&boxedNil)
+	testAnyPtr(&boxedTypedNil)
+	testAnyPtr(&boxedOne)
+	testAnyPtr(&boxedOnePtr)
+	testAnyPtr(&boxedPtrToBoxedOne)
 }

--- a/pkg/dyninst/testprogs/testdata/probes/rc_tester.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/rc_tester.yaml
@@ -5,8 +5,12 @@ probes:
     where:
       methodName: main.LookAtTheRequest
     captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1
   - id: http_handler
     type: LOG_PROBE
     where:
       methodName: main.HandleHTTP
     captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1

--- a/pkg/dyninst/testprogs/testdata/probes/rc_tester_v1.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/rc_tester_v1.yaml
@@ -5,9 +5,12 @@ probes:
     where:
       methodName: main.LookAtTheRequest
     captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1
   - id: http_handler
     type: LOG_PROBE
     where:
       methodName: main.HandleHTTP
     captureSnapshot: true
-
+    capture:
+      maxReferenceDepth: 1

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -798,3 +798,10 @@ probes:
   where:
     methodName: main.testEmptyStructPointer
   captureSnapshot: true
+- id: testAnyPtr
+  type: LOG_PROBE
+  where:
+    methodName: main.testAnyPtr
+  captureSnapshot: true
+  sampling:
+    snapshotsPerSecond: 10

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -805,3 +805,10 @@ probes:
   captureSnapshot: true
   sampling:
     snapshotsPerSecond: 10
+- id: testStructWithAny
+  type: LOG_PROBE
+  where:
+    methodName: main.testStructWithAny
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 1


### PR DESCRIPTION
### What does this PR do?

This PR concludes https://datadoghq.atlassian.net/browse/DEBUG-4043. Along the way it fixes some other rough edges in decoding related to interfaces. There's some details related to how the on-disk indexes are implemented that should be refactored in a follow-up, but it gets the job done and avoids using too much RAM.

See individual commits.