### PR TITLE
dyninst: remove with-depth-limits tests

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/rcjson"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 )
@@ -373,26 +372,6 @@ func runIntegrationTestSuite(
 			}
 		})
 	}
-}
-
-func probeConfigsWithMaxReferenceDepth(
-	probesCfgs []ir.ProbeDefinition, limit int,
-) []ir.ProbeDefinition {
-	for _, cfg := range probesCfgs {
-		switch cfg := cfg.(type) {
-		case *rcjson.LogProbe:
-			if cfg.Capture == nil {
-				cfg.Capture = new(rcjson.Capture)
-			}
-			cfg.Capture.MaxReferenceDepth = limit
-		case *rcjson.SnapshotProbe:
-			if cfg.Capture == nil {
-				cfg.Capture = new(rcjson.Capture)
-			}
-			cfg.Capture.MaxReferenceDepth = limit
-		}
-	}
-	return probesCfgs
 }
 
 // validateAndSaveOutputs ensures that the outputs for the same probe are consistent


### PR DESCRIPTION
These tests were poorly conceived. I wanted to make sure that the tests still ran with a low depth limit, but I wasn't validating much. The way to get the test to avoid having expectations was to tell it it was in rewrite mode. The downside of being in rewrite mode is we do not know how many events to expect, so we just wait a while. This turns out to be problematic and can cause flakes in production. We do exercise a bunch of depth limits explicitly. For now, just remove this bad subtest.
