### PR TITLE
Revert "[CXP-2599] Enable WLM for process collection by default on linux (#40403)"

### DIFF
--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -51,26 +51,6 @@ import (
 
 const defaultWaitInterval = time.Second
 
-func waitForWorkloadMeta(logger log.Component, wm workloadmeta.Component) {
-	logger.Info("Waiting for workloadmeta to be initialized...")
-	timeout := time.After(10 * time.Second)
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-timeout:
-			logger.Warn("Workloadmeta is not ready after 10 seconds, proceeding anyway")
-			return
-		case <-ticker.C:
-			if wm.IsInitialized() {
-				logger.Info("Workloadmeta is ready, proceeding with checks")
-				return
-			}
-		}
-	}
-}
-
 type CliParams struct {
 	*command.GlobalParams
 	checkName       string
@@ -205,10 +185,6 @@ func RunCheckCmd(deps Dependencies) error {
 			c()
 		}
 	}()
-
-	// Wait for Workloadmeta to be initialized otherwise results may be empty as this is a hard dependency
-	// for some checks
-	waitForWorkloadMeta(deps.Log, deps.WorkloadMeta)
 
 	names := make([]string, 0, len(deps.Checks))
 	for _, checkComponent := range deps.Checks {

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -195,7 +195,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 		return errors.NewDisabled(componentName, "wlm process collection disabled")
 	}
 
-	if !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() && !c.isLanguageCollectionEnabled() {
+	if !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() {
 		return errors.NewDisabled(componentName, "wlm process collection and service discovery are disabled")
 	}
 
@@ -208,7 +208,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 	}
 	c.store = store
 
-	if c.isProcessCollectionEnabled() || c.isLanguageCollectionEnabled() {
+	if c.isProcessCollectionEnabled() {
 		go c.collectProcesses(ctx, c.clock.Ticker(c.processCollectionIntervalConfig()))
 	}
 
@@ -222,7 +222,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 			telemetry.DefaultOptions,
 		)
 
-		if c.isProcessCollectionEnabled() || c.isLanguageCollectionEnabled() {
+		if c.isProcessCollectionEnabled() {
 			log.Debug("Starting cached service collection (process collection enabled)")
 			go c.collectServicesCached(ctx, c.clock.Ticker(serviceCollectionInterval))
 		} else {

--- a/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector_test.go
@@ -93,7 +93,6 @@ func TestProcessCollector(t *testing.T) {
 		"language_detection.enabled":                true,
 		"process_config.process_collection.enabled": true,
 		"process_config.run_in_core_agent.enabled":  true,
-		"process_config.process_collection.use_wlm": false,
 	}
 
 	c := setUpCollectorTest(t, configOverrides)
@@ -258,7 +257,6 @@ func TestProcessCollectorWithoutProcessCheck(t *testing.T) {
 		"language_detection.enabled":                true,
 		"process_config.process_collection.enabled": false,
 		"process_config.run_in_core_agent.enabled":  true,
-		"process_config.process_collection.use_wlm": false,
 	}
 
 	c := setUpCollectorTest(t, configOverrides)

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
@@ -151,7 +151,7 @@ func (s *streamHandler) IsEnabled() bool {
 		return false
 	}
 
-	return s.Reader.GetBool("language_detection.enabled") && !util.ProcessLanguageCollectorIsEnabled() && !pkgconfigsetup.Datadog().GetBool("process_config.process_collection.use_wlm")
+	return s.Reader.GetBool("language_detection.enabled") && !util.ProcessLanguageCollectorIsEnabled()
 }
 
 func (s *streamHandler) NewClient(cc grpc.ClientConnInterface) remote.GrpcClient {

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
@@ -256,9 +256,8 @@ func TestCollection(t *testing.T) {
 				fx.Provide(func(t testing.TB) log.Component { return logmock.New(t) }),
 				fx.Provide(func(t testing.TB) config.Component {
 					return config.NewMockWithOverrides(t, map[string]interface{}{
-						"language_detection.enabled":                true,
-						"process_config.run_in_core_agent.enabled":  false,
-						"process_config.process_collection.use_wlm": false,
+						"language_detection.enabled":               true,
+						"process_config.run_in_core_agent.enabled": false,
 					})
 				}),
 				workloadmetafxmock.MockModule(workloadmeta.Params{AgentType: workloadmeta.Remote}),

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -115,7 +115,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	procBindEnv(config, "process_config.enabled")
 	procBindEnvAndSetDefault(config, "process_config.container_collection.enabled", true)
 	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
-	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", runtime.GOOS == "linux")
+	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", false)
 
 	// This allows for the process check to run in the core agent but is for linux only
 	procBindEnvAndSetDefault(config, "process_config.run_in_core_agent.enabled", runtime.GOOS == "linux")

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -141,7 +141,7 @@ func TestProcessDefaultConfig(t *testing.T) {
 		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
 		{
 			key:          "process_config.process_collection.use_wlm",
-			defaultValue: runtime.GOOS == "linux",
+			defaultValue: false,
 		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -722,9 +722,6 @@ func (c *Client) GetLastProcessPayloadAPIKey() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(payloads) == 0 {
-		return "", errors.New("no process payloads found")
-	}
 	return payloads[len(payloads)-1].APIKey, nil
 }
 
@@ -734,10 +731,6 @@ func (c *Client) GetAllProcessPayloadAPIKeys() ([]string, error) {
 	payloads, err := c.getFakePayloads(processesEndpoint)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(payloads) == 0 {
-		return nil, errors.New("no process payloads found")
 	}
 
 	keysFound := make(map[string]struct{})

--- a/test/new-e2e/tests/discovery/testdata/config/agent_config.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/agent_config.yaml
@@ -1,4 +1,1 @@
 log_level: DEBUG
-process_config:
-  process_collection:
-    use_wlm: false

--- a/test/new-e2e/tests/discovery/testdata/config/agent_process_config.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/agent_process_config.yaml
@@ -4,6 +4,7 @@ language_detection:
 process_config:
   process_collection:
     enabled: true
+    use_wlm: true
   run_in_core_agent:
     enabled: true
 

--- a/test/new-e2e/tests/language-detection/node_test.go
+++ b/test/new-e2e/tests/language-detection/node_test.go
@@ -40,5 +40,5 @@ func (s *languageDetectionSuite) TestNodeDetection() {
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf(`echo "%s" > prog.js`, nodeProg))
 	s.Env().RemoteHost.MustExecute("nohup node prog.js >myscript.log 2>&1 </dev/null &")
 
-	s.checkDetectedLanguage("node", "node", "process_collector")
+	s.checkDetectedLanguage("node", "node", "remote_process_collector")
 }

--- a/test/new-e2e/tests/language-detection/php_test.go
+++ b/test/new-e2e/tests/language-detection/php_test.go
@@ -23,7 +23,7 @@ func (s *languageDetectionSuite) installPHP() {
 func (s *languageDetectionSuite) TestPHPDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
 	s.runPHP()
-	s.checkDetectedLanguage("php", "php", "process_collector")
+	s.checkDetectedLanguage("php", "php", "process_language_collector")
 }
 
 func (s *languageDetectionSuite) runPHP() {

--- a/test/new-e2e/tests/language-detection/python_test.go
+++ b/test/new-e2e/tests/language-detection/python_test.go
@@ -23,25 +23,25 @@ func (s *languageDetectionSuite) installPython() {
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_collector")
+	s.checkDetectedLanguage("python3", "python", "process_language_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgentNoCheck() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigNoCheckStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_collector")
+	s.checkDetectedLanguage("python3", "python", "process_language_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionProcessAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(processConfigStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_collector")
+	s.checkDetectedLanguage("python3", "python", "remote_process_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionProcessAgentNoCheck() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(processConfigNoCheckStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_collector")
+	s.checkDetectedLanguage("python3", "python", "remote_process_collector")
 }
 
 func (s *languageDetectionSuite) runPython() {

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -350,7 +350,6 @@ func (s *linuxTestSuite) TestProcessChecksWithNPM() {
 }
 
 func (s *linuxTestSuite) TestManualProcessCheck() {
-	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr))))
 	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
 
 	assertManualProcessCheck(s.T(), check, false, "stress")


### PR DESCRIPTION
### What does this PR do?
This reverts commit 31aa5ddb1d82a4f0136d0d3207afea557055d6a0.

### Motivation
#incident-42726

### Describe how you validated your changes
CI [passed](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1115129300) on the concerned job, and also on a [retry](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1115307090), whereas the [failure rate](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40ci.job.name%3Anew-e2e-process%20%40git.branch%3Amain&agg_m=%40ci.job.name&agg_m_source=base&agg_t=cardinality&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cipipeline_explorer_sort=time%2Cdesc&colorByAttr=meta%5B%27ci.stage.name%27%5D&cols=%40git.branch%2C%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40ci.stage.name%2C%40ci.job.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name&currentTab=trace&fromUser=true&graphType=flamegraph&index=cipipeline&mode=sliding&saved-view-id=2643993&sort=time&spanViewType=metadata&tab=overview&viz=stream&start=1757037094048&end=1757065894048&paused=false) is >85% recently

### Additional Notes
