### PR TITLE
[CSPM] import full pkg/compliance in system-probe module

### DIFF
--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -16,6 +16,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	// import the full compliance code in the system-probe (including the rego evaluator)
+	// this allows us to reserve the package size while we work on pluging things out
+	_ "github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"


### PR DESCRIPTION
### What does this PR do?

This PR does nothing except importing the `pkg/compliance` code in system-probe. This allows to reserve the package size while we merge the different win, without being blocked by static quality gates later.

### Motivation

### Describe how you validated your changes

### Additional Notes
