### PR TITLE
[CWS] Skip `TestFilterInUpperLayerApprover` when overlay fs isn't used

### DIFF
--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -922,6 +922,14 @@ func TestFilterOpenFlagsApprover(t *testing.T) {
 func TestFilterInUpperLayerApprover(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+
+	checkDockerCompatibility(t, "this test requires docker to use overlayfs", func(docker *dockerInfo) bool {
+		return docker.Info["Storage Driver"] != "overlay2"
+	})
+
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.file.in_upper_layer`,


### PR DESCRIPTION
### What does this PR do?

Skip `TestFilterInUpperLayerApprover` test when overlay fs isn't used (e.g. docker on opensuse 15.3 uses btrfs).

### Motivation

### Describe how you validated your changes

### Additional Notes
