### PR TITLE
[CWS] use our own implementation to fetch CPU flags

### DIFF
--- a/pkg/security/probe/sysctl/cpu_flags.go
+++ b/pkg/security/probe/sysctl/cpu_flags.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package sysctl is used to process and analyze sysctl data
+package sysctl
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+func parseCPUFlags() ([]string, error) {
+	// no need for host proc path here, the cpuinfo file is always exposed
+	f, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key != "flags" && key != "Features" {
+			continue
+		}
+
+		value = strings.TrimSpace(value)
+
+		flags := strings.FieldsFunc(value, func(r rune) bool {
+			return r == ',' || r == ' '
+		})
+		return flags, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}

--- a/pkg/security/probe/sysctl/cpu_flags_test.go
+++ b/pkg/security/probe/sysctl/cpu_flags_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package sysctl is used to process and analyze sysctl data
+package sysctl
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCPUFlags(t *testing.T) {
+	ours, err := parseCPUFlags()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	theirs, err := gopsutilVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, ours, theirs)
+}
+
+func gopsutilVersion() ([]string, error) {
+	info, err := cpu.Info()
+	if err != nil {
+		return nil, err
+	}
+	if len(info) == 0 {
+		return nil, nil
+	}
+
+	return info[0].Flags, nil
+}

--- a/pkg/security/probe/sysctl/snapshot.go
+++ b/pkg/security/probe/sysctl/snapshot.go
@@ -22,8 +22,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/shirou/gopsutil/v4/cpu"
-
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -233,17 +231,12 @@ func (s *Snapshot) snapshotSys(ignoredBaseNames []string) error {
 
 // snapshotCPUFlags fetches the current CPU flags and adds them to the snapshot
 func (s *Snapshot) snapshotCPUFlags() error {
-	// no need for host proc path here, the cpuinfo file is always exposed
-	info, err := cpu.Info()
+	flags, err := parseCPUFlags()
 	if err != nil {
-		return err
+		return fmt.Errorf("error parsing CPU features/flags: %w", err)
 	}
-	if len(info) == 0 {
-		return nil
-	}
-
-	s.CPUFlags = info[0].Flags
-	slices.Sort(s.CPUFlags)
+	slices.Sort(flags)
+	s.CPUFlags = flags
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

We recently got some reports of the following panic:
```
panic: runtime error: index out of range [0] with length 0
goroutine 1139 [running]:
github.com/shirou/gopsutil/v4/cpu.finishCPUInfo({0x26c7458, 0x3e77f00}, 0x4005349cd0)
	github.com/shirou/gopsutil/v4@v4.25.8-0.20250809033336-ffcdc2b7662f/cpu/cpu_linux.go:141 +0x140
github.com/shirou/gopsutil/v4/cpu.InfoWithContext({0x26c7458, 0x3e77f00})
	github.com/shirou/gopsutil/v4@v4.25.8-0.20250809033336-ffcdc2b7662f/cpu/cpu_linux.go:196 +0x79c
github.com/shirou/gopsutil/v4/cpu.Info(...)
	github.com/shirou/gopsutil/v4@v4.25.8-0.20250809033336-ffcdc2b7662f/cpu/cpu_linux.go:172
github.com/DataDog/datadog-agent/pkg/security/probe/sysctl.(*Snapshot).snapshotCPUFlags(0x4006166280)
	github.com/DataDog/datadog-agent/pkg/security/probe/sysctl/snapshot.go:237 +0x34
github.com/DataDog/datadog-agent/pkg/security/probe/sysctl.(*Snapshot).Snapshot(0x4006166280, {0x4000795820, 0x2, 0x2}, 0x4001cc91d0)
	github.com/DataDog/datadog-agent/pkg/security/probe/sysctl/snapshot.go:102 +0xcc
github.com/DataDog/datadog-agent/pkg/security/probe/sysctl.NewSnapshotEvent({0x4000795820, 0x2, 0x2}, 0x4001cc91d0)
	github.com/DataDog/datadog-agent/pkg/security/probe/sysctl/snapshot.go:58 +0xcc
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).startSysCtlSnapshotLoop(0x400237d808)
	github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:2107 +0xc8
created by github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).Start in goroutine 1
	github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:778 +0xc0
```

the issue is that the gopsutil is reading `/sys/devices/system/cpu/cpu[0-9]+/topology/core_id` and the file is empty, triggering the condition `lines = nil, err = nil` in https://github.com/shirou/gopsutil/blob/a98291f13d6c213eee463ed6daff49df08f0fff7/cpu/cpu_linux.go#L152 triggering the panic.

It's not entirely clear how it's possible the core_id file is empty, but what is clear is that we don't actually need to read this file, a simple parsing of `/proc/cpuinfo` is enough to parse the flags/features. 

This PR drops the call to gopsutil altogether, and re-implements the needed logic (with correct error handling) in our own code. 

### Motivation

### Describe how you validated your changes

### Additional Notes
