### PR TITLE
(fleet) fix cross-experiment bug

### DIFF
--- a/pkg/fleet/installer/config/file.go
+++ b/pkg/fleet/installer/config/file.go
@@ -11,6 +11,18 @@ import (
 	"path/filepath"
 )
 
+func isSameFile(file1, file2 string) bool {
+	stat1, err := os.Stat(file1)
+	if err != nil {
+		return false
+	}
+	stat2, err := os.Stat(file2)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(stat1, stat2)
+}
+
 // replaceConfigDirectory replaces the contents of two directories.
 func replaceConfigDirectory(oldDir, newDir string) (err error) {
 	backupPath := filepath.Clean(oldDir) + ".bak"

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -110,11 +110,6 @@ func NewInstaller(env *env.Env) (Installer, error) {
 		userConfigsDir: paths.DefaultUserConfigsDir,
 		packagesDir:    paths.PackagesPath,
 	}
-
-	err = i.ensureConfigSymlink()
-	if err != nil {
-		return nil, fmt.Errorf("could not ensure packages are configured: %w", err)
-	}
 	return i, nil
 }
 
@@ -408,6 +403,10 @@ func (i *installerImpl) InstallExperiment(ctx context.Context, url string) error
 			fmt.Errorf("could not set experiment: %w", err),
 		)
 	}
+	err = i.config.RemoveExperiment(ctx)
+	if err != nil {
+		return fmt.Errorf("could not remove config experiment: %w", err)
+	}
 	// HACK: close so package can be updated as watchdog runs
 	if pkg.Name == packageDatadogAgent && runtime.GOOS == "windows" {
 		i.db.Close()
@@ -515,7 +514,11 @@ func (i *installerImpl) InstallConfigExperiment(ctx context.Context, pkg string,
 	i.m.Lock()
 	defer i.m.Unlock()
 
-	err := i.config.WriteExperiment(ctx, operations)
+	err := i.packages.Get(pkg).DeleteExperiment(ctx)
+	if err != nil {
+		return fmt.Errorf("could not delete experiment: %w", err)
+	}
+	err = i.config.WriteExperiment(ctx, operations)
 	if err != nil {
 		return fmt.Errorf("could not write experiment: %w", err)
 	}
@@ -730,20 +733,6 @@ func (i *installerImpl) Close() error {
 	i.m.Lock()
 	defer i.m.Unlock()
 	return i.close()
-}
-
-func (i *installerImpl) ensureConfigSymlink() (err error) {
-	_, err = os.Stat(i.config.ExperimentPath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("could not stat experiment path: %w", err)
-	}
-	if os.IsNotExist(err) && runtime.GOOS != "windows" {
-		err = os.Symlink(i.config.StablePath, i.config.ExperimentPath)
-		if err != nil {
-			return fmt.Errorf("could not symlink experiment path: %w", err)
-		}
-	}
-	return nil
 }
 
 const (

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/config"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/db"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/fixtures"
@@ -45,13 +46,19 @@ func newTestPackageManager(t *testing.T, s *fixtures.Server, rootPath string) *t
 	db, err := db.New(filepath.Join(rootPath, "packages.db"))
 	assert.NoError(t, err)
 	hooks := &testHooks{}
+	userConfigsDir := t.TempDir()
+	config := &config.Directories{
+		StablePath:     filepath.Join(userConfigsDir, "stable"),
+		ExperimentPath: filepath.Join(userConfigsDir, "experiment"),
+	}
 	return &testPackageManager{
 		installerImpl: installerImpl{
 			env:            &env.Env{},
 			db:             db,
 			downloader:     oci.NewDownloader(&env.Env{}, s.Client()),
 			packages:       packages,
-			userConfigsDir: t.TempDir(),
+			userConfigsDir: userConfigsDir,
+			config:         config,
 			packagesDir:    rootPath,
 			hooks:          hooks,
 		},

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/symlink"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -470,7 +471,7 @@ type link struct {
 }
 
 func newLink(linkPath string) (*link, error) {
-	linkExists, err := linkExists(linkPath)
+	linkExists, err := symlink.Exist(linkPath)
 	if err != nil {
 		return nil, fmt.Errorf("could check if link exists: %w", err)
 	}
@@ -479,7 +480,7 @@ func newLink(linkPath string) (*link, error) {
 			linkPath: linkPath,
 		}, nil
 	}
-	packagePath, err := linkRead(linkPath)
+	packagePath, err := symlink.Read(linkPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read link: %w", err)
 	}
@@ -510,7 +511,7 @@ func (l *link) Target() string {
 }
 
 func (l *link) Set(path string) error {
-	err := linkSet(l.linkPath, path)
+	err := symlink.Set(l.linkPath, path)
 	if err != nil {
 		return fmt.Errorf("could not set link: %w", err)
 	}
@@ -519,7 +520,7 @@ func (l *link) Set(path string) error {
 }
 
 func (l *link) Delete() error {
-	err := linkDelete(l.linkPath)
+	err := symlink.Delete(l.linkPath)
 	if err != nil {
 		return fmt.Errorf("could not delete link: %w", err)
 	}

--- a/pkg/fleet/installer/repository/repository_test.go
+++ b/pkg/fleet/installer/repository/repository_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/symlink"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,7 +41,7 @@ func createTestDownloadedPackage(t *testing.T, dir string, packageName string) s
 func assertLinkTarget(t *testing.T, repository *Repository, link string, target string) {
 	linkPath := path.Join(repository.rootPath, link)
 	assert.FileExists(t, linkPath)
-	linkTarget, err := linkRead(linkPath)
+	linkTarget, err := symlink.Read(linkPath)
 	assert.NoError(t, err)
 	assert.Equal(t, target, filepath.Base(linkTarget))
 }

--- a/pkg/fleet/installer/symlink/link.go
+++ b/pkg/fleet/installer/symlink/link.go
@@ -3,18 +3,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package repository
+// Package symlink contains the logic to manage symlinks.
+package symlink
 
 import (
 	"errors"
 	"os"
 )
 
-func linkRead(linkPath string) (string, error) {
+// Read reads the target of a link.
+func Read(linkPath string) (string, error) {
 	return os.Readlink(linkPath)
 }
 
-func linkExists(linkPath string) (bool, error) {
+// Exists checks if a link exists.
+func Exist(linkPath string) (bool, error) {
 	_, err := os.Stat(linkPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
@@ -24,10 +27,12 @@ func linkExists(linkPath string) (bool, error) {
 	return true, nil
 }
 
-func linkSet(linkPath string, targetPath string) error {
+// Set creates a link.
+func Set(linkPath string, targetPath string) error {
 	return atomicSymlink(targetPath, linkPath)
 }
 
-func linkDelete(linkPath string) error {
+// Delete removes a link.
+func Delete(linkPath string) error {
 	return os.Remove(linkPath)
 }

--- a/pkg/fleet/installer/symlink/link.go
+++ b/pkg/fleet/installer/symlink/link.go
@@ -16,7 +16,7 @@ func Read(linkPath string) (string, error) {
 	return os.Readlink(linkPath)
 }
 
-// Exists checks if a link exists.
+// Exist checks if a link exists.
 func Exist(linkPath string) (bool, error) {
 	_, err := os.Stat(linkPath)
 	if errors.Is(err, os.ErrNotExist) {

--- a/pkg/fleet/installer/symlink/link_nix.go
+++ b/pkg/fleet/installer/symlink/link_nix.go
@@ -5,7 +5,7 @@
 
 //go:build !windows
 
-package repository
+package symlink
 
 import (
 	"os"

--- a/pkg/fleet/installer/symlink/link_test.go
+++ b/pkg/fleet/installer/symlink/link_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package repository
+package symlink
 
 import (
 	"os"
@@ -14,7 +14,7 @@ import (
 )
 
 func createLink(t *testing.T, linkPath string, targetPath string) {
-	err := linkSet(linkPath, targetPath)
+	err := Set(linkPath, targetPath)
 	assert.NoError(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestLinkRead(t *testing.T) {
 	createTarget(t, targetPath)
 	createLink(t, linkPath, targetPath)
 
-	actualTargetPath, err := linkRead(linkPath)
+	actualTargetPath, err := Read(linkPath)
 	assert.NoError(t, err)
 
 	// the following cleanup is required on darwin because t.TempDir returns a symlinked path.
@@ -55,14 +55,14 @@ func TestLinkExists(t *testing.T) {
 	linkPath := filepath.Join(tmpDir, "link")
 	targetPath := filepath.Join(tmpDir, "target")
 
-	exists, err := linkExists(linkPath)
+	exists, err := Exist(linkPath)
 	assert.NoError(t, err)
 	assert.False(t, exists)
 
 	createTarget(t, targetPath)
 	createLink(t, linkPath, targetPath)
 
-	exists, err = linkExists(linkPath)
+	exists, err = Exist(linkPath)
 	assert.NoError(t, err)
 	assert.True(t, exists)
 }
@@ -73,10 +73,10 @@ func TestLinkSet(t *testing.T) {
 	targetPath := filepath.Join(tmpDir, "target")
 	createTarget(t, targetPath)
 
-	err := linkSet(linkPath, targetPath)
+	err := Set(linkPath, targetPath)
 	assert.NoError(t, err)
 
-	exists, err := linkExists(linkPath)
+	exists, err := Exist(linkPath)
 	assert.NoError(t, err)
 	assert.True(t, exists)
 }
@@ -88,15 +88,15 @@ func TestLinkSetWhenExists(t *testing.T) {
 	linkPath := filepath.Join(tmpDir, "stable")
 
 	createTarget(t, stablePath)
-	err := linkSet(linkPath, stablePath)
+	err := Set(linkPath, stablePath)
 	assert.NoError(t, err)
 
-	exists, err := linkExists(linkPath)
+	exists, err := Exist(linkPath)
 	assert.NoError(t, err)
 	assert.True(t, exists)
 
 	createTarget(t, experimentPath)
-	err = linkSet(linkPath, experimentPath)
+	err = Set(linkPath, experimentPath)
 	assert.NoError(t, err)
 }
 
@@ -107,10 +107,10 @@ func TestLinkDelete(t *testing.T) {
 	createTarget(t, targetPath)
 	createLink(t, linkPath, targetPath)
 
-	err := linkDelete(linkPath)
+	err := Delete(linkPath)
 	assert.NoError(t, err)
 
-	exists, err := linkExists(linkPath)
+	exists, err := Exist(linkPath)
 	assert.NoError(t, err)
 	assert.False(t, exists)
 }

--- a/pkg/fleet/installer/symlink/link_win.go
+++ b/pkg/fleet/installer/symlink/link_win.go
@@ -11,15 +11,16 @@
 
 //go:build windows
 
-package repository
+package symlink
 
 import (
 	"fmt"
-	"golang.org/x/sys/windows"
 	"os"
 	"runtime"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 const (


### PR DESCRIPTION
This PR fixes a bug found during QA where leftover config/package experiments could be picked up during unrelated package/config experiments. 

This should ensure a config experiment always uses the stable package and a package experiment always uses the stable config.