### PR TITLE
remove dependency on lint jobs from binary build jobs

### DIFF
--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -3,7 +3,7 @@ build_dogstatsd_static-binary_x64:
   stage: binary_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
-  needs: ["lint_linux-x64", "go_deps"]
+  needs: ["go_deps"]
   variables:
     ARCH: amd64
   before_script:
@@ -20,7 +20,7 @@ build_dogstatsd_static-binary_arm64:
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
-  needs: ["lint_linux-arm64", "go_deps"]
+  needs: ["go_deps"]
   variables:
     ARCH: arm64
   before_script:
@@ -37,7 +37,7 @@ build_dogstatsd-binary_x64:
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
-  needs: ["lint_linux-x64", "go_deps"]
+  needs: ["go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
@@ -52,7 +52,7 @@ build_dogstatsd-binary_arm64:
   stage: binary_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
-  needs: ["lint_linux-arm64", "go_deps"]
+  needs: ["go_deps"]
   variables:
     ARCH: arm64
   before_script:
@@ -70,7 +70,7 @@ build_iot_agent-binary_x64:
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
-  needs: ["lint_linux-x64", "go_deps"]
+  needs: ["go_deps"]
   variables:
     KUBERNETES_CPU_REQUEST: 4
   before_script:
@@ -85,7 +85,7 @@ build_iot_agent-binary_arm64:
   stage: binary_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
-  needs: ["lint_linux-arm64", "go_deps"]
+  needs: ["go_deps"]
   variables:
     ARCH: arm64
     KUBERNETES_CPU_REQUEST: 4


### PR DESCRIPTION
### What does this PR do?

There is no actual dependency between the lint jobs and the dogstatsd/iot-agent binary build jobs. In addition this can prevent a PR failing some lints to progress forward and give additional errors in one pipeline (especially this blocks the static quality gates from running).

This PR removes the dependency link.

### Motivation

### Describe how you validated your changes

### Additional Notes
