### PR TITLE
codeowners: Mark USM as owners of usm files in /pkg/network/config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -589,6 +589,7 @@
 /pkg/network/*usm*                      @DataDog/universal-service-monitoring
 /pkg/network/*_windows*.go              @DataDog/windows-products
 /pkg/network/config/config_test.go      @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring @DataDog/windows-products
+/pkg/network/config/usm*.go             @DataDog/universal-service-monitoring
 /pkg/network/driver_*.go                @DataDog/windows-products
 /pkg/network/dns/*_windows*.go          @DataDog/windows-products
 /pkg/network/driver/                    @DataDog/windows-products


### PR DESCRIPTION
### What does this PR do?

Adds Universal Service Monitoring team as code owners for USM-related configuration files in `/pkg/network/config/usm*.go`.

### Motivation

The USM team should own and review changes to their configuration files to ensure proper oversight and maintenance of USM-specific functionality.

### Describe how you validated your changes

### Additional Notes

🤖 Generated with [Claude Code](https://claude.ai/code)