### PR TITLE
[CWS-5081] Fix wrong kill status when process failed to be killed

### DIFF
--- a/pkg/security/probe/actions.go
+++ b/pkg/security/probe/actions.go
@@ -32,6 +32,8 @@ const (
 	KillActionStatusRuleDismantled KillActionStatus = "rule_dismantled"
 	// KillActionStatusQueued indicates the kill action was queued until the end of the first rule period
 	KillActionStatusQueued KillActionStatus = "kill_queued"
+	// KillActionStatusPartiallyPerformed indicates the kill action was performed on some processes but not all
+	KillActionStatusPartiallyPerformed = "partially_performed"
 )
 
 // KillActionReport defines a kill action reports

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -119,14 +119,6 @@ func (p *ProcessKiller) getRuleStats(ruleID string) *processKillerStats {
 func (p *ProcessKiller) updatePendingReportKillPerformed(now time.Time, killQueue *[]killContext, failedToBeKilled []uint32, nbOfKilled int64) {
 	p.Lock()
 	defer p.Unlock()
-
-	for _, pid := range failedToBeKilled {
-		// First we remove them from the killQueue
-		*killQueue = slices.DeleteFunc(*killQueue, func(kc killContext) bool {
-			return kc.pid == int(pid)
-		})
-	}
-	// Then we update the status
 	for _, report := range p.pendingReports {
 		report.Lock()
 		func() {

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -409,7 +409,7 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.exited_at =~ /20.*/)]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
-				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed || @.status == 'partially_performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
 			})

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -409,7 +409,7 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.exited_at =~ /20.*/)]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
-				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed || @.status == 'partially_performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
 			})


### PR DESCRIPTION
### What does this PR do?
**This PR fixes a bug.**
During a kill action, if the kill failed, the action was still flagged as "performed".

**Details of the bug fix:**

1) When a process needs to be killed but the kill action must be delayed (by the disarmer), it is placed in the KillQueue.

2) When the process is allowed to be killed, the kill is attempted on all processes in the queue.

3) The algorithm then assumed that every process in this map was successfully killed (and flagged the actions as "performed"), without checking the return value of the actual kill.

This PR introduces a mechanism to check whether the kill was successful.
If the kill fails, the process is removed from the queue and its status is properly updated to "error".
### Motivation

### Describe how you validated your changes

### Additional Notes
