### PR TITLE
[CWS] Fail tests on `newDockerCmdWrapper` errors

### DIFF
--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -372,6 +372,10 @@ func TestCGroupSnapshot(t *testing.T) {
 func TestCGroupVariables(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_cgroup_set_variable",
@@ -410,10 +414,8 @@ func TestCGroupVariables(t *testing.T) {
 
 	dockerWrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "ubuntu", "")
 	if err != nil {
-		t.Skip("Skipping created time in containers tests: Docker not available")
-		return
+		t.Fatalf("failed to start docker wrapper: %v", err)
 	}
-	defer dockerWrapper.stop()
 
 	dockerWrapper.Run(t, "cgroup-variables", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -47,7 +47,7 @@ var dockerImageLibrary = map[string][]string{
 	},
 	"busybox": {
 		"busybox:1.36.1",
-		"docker.io/busybox:1.36.1", // before changing the version make sure that the new version behaves as previously (hardlink vs symlink)
+		"public.ecr.aws/docker/library/busybox:1.36.1", // before changing the version make sure that the new version behaves as previously (hardlink vs symlink)
 	},
 }
 

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -13,14 +13,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestContainerCreatedAt(t *testing.T) {
 	SkipIfNotAvailable(t)
+
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
 
 	checkKernelCompatibility(t, "OpenSUSE 15.3 kernel", func(kv *kernel.Version) bool {
 		// because of some strange btrfs subvolume error
@@ -55,10 +60,8 @@ func TestContainerCreatedAt(t *testing.T) {
 
 	dockerWrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "ubuntu", "")
 	if err != nil {
-		t.Skip("Skipping created time in containers tests: Docker not available")
-		return
+		t.Fatalf("failed to start docker wrapper: %v", err)
 	}
-	defer dockerWrapper.stop()
 
 	dockerWrapper.Run(t, "container-created-at", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
@@ -98,6 +101,10 @@ func TestContainerCreatedAt(t *testing.T) {
 func TestContainerVariables(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_container_set_variable",
@@ -135,10 +142,8 @@ func TestContainerVariables(t *testing.T) {
 
 	dockerWrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "ubuntu", "")
 	if err != nil {
-		t.Skip("Skipping created time in containers tests: Docker not available")
-		return
+		t.Fatalf("failed to start docker wrapper: %v", err)
 	}
-	defer dockerWrapper.stop()
 
 	dockerWrapper.Run(t, "container-variables", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -943,8 +943,7 @@ func TestFilterInUpperLayerApprover(t *testing.T) {
 
 	wrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "busybox", "")
 	if err != nil {
-		t.Skip("docker not available")
-		return
+		t.Fatalf("failed to start docker wrapper: %v", err)
 	}
 
 	wrapper.Run(t, "cat", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -165,10 +165,13 @@ func TestRawPacket(t *testing.T) {
 	})
 
 	t.Run("icmp", func(t *testing.T) {
+		if _, err := whichNonFatal("docker"); err != nil {
+			t.Skip("Skip test where docker is unavailable")
+		}
+
 		wrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "busybox", "")
 		if err != nil {
-			t.Skip("docker not available")
-			return
+			t.Fatalf("failed to start docker wrapper: %v", err)
 		}
 
 		waitSignal := test.WaitSignalWithoutProcessContext

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -641,9 +641,9 @@ func TestOverlayOpOverride(t *testing.T) {
 		t.Fatalf("failed to start docker wrapper: %v", err)
 	}
 	t.Cleanup(func() {
-		_, err := dockerWrapper.stop()
+		output, err := dockerWrapper.stop()
 		if err != nil {
-			t.Errorf("failed to stop docker wrapper: %v", err)
+			t.Errorf("failed to stop docker wrapper: %v\n%s", err, string(output))
 		}
 	})
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1911,6 +1911,10 @@ func TestProcessExit(t *testing.T) {
 func TestProcessBusyboxSymlink(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_busybox_1",
@@ -1938,8 +1942,7 @@ func TestProcessBusyboxSymlink(t *testing.T) {
 
 	wrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "alpine", "")
 	if err != nil {
-		t.Skip("docker not available")
-		return
+		t.Fatalf("failed to start docker wrapper: %v", err)
 	}
 
 	wrapper.Run(t, "busybox-1", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -1994,6 +1997,10 @@ func TestProcessBusyboxSymlink(t *testing.T) {
 func TestProcessBusyboxHardlink(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+
 	checkKernelCompatibility(t, "Not supported on kernels < 5.12", func(kv *kernel.Version) bool {
 		return kv.Code < kernel.Kernel5_12
 	})
@@ -2018,8 +2025,7 @@ func TestProcessBusyboxHardlink(t *testing.T) {
 	// busybox uses hardlinks
 	wrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "busybox", "")
 	if err != nil {
-		t.Skip("docker not available")
-		return
+		t.Fatalf("failed to create docker wrapper: %v", err)
 	}
 
 	wrapper.Run(t, "busybox-1", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -24,6 +24,10 @@ import (
 func TestSBOM(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+
 	if testEnvironment == DockerEnvironment {
 		t.Skip("Skip test spawning docker containers on docker")
 	}
@@ -53,10 +57,8 @@ func TestSBOM(t *testing.T) {
 
 	dockerWrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "ubuntu", "")
 	if err != nil {
-		t.Skip("Skipping sbom tests: Docker not available")
-		return
+		t.Fatalf("failed to create docker wrapper: %v", err)
 	}
-	defer dockerWrapper.stop()
 
 	dockerWrapper.Run(t, "package-rule", func(t *testing.T, _ wrapperType, cmdFunc func(bin string, args, env []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {

--- a/pkg/security/tests/snapshot_test.go
+++ b/pkg/security/tests/snapshot_test.go
@@ -68,16 +68,24 @@ func TestSnapshot(t *testing.T) {
 			},
 		}
 
+		if _, err := whichNonFatal("docker"); err != nil {
+			t.Skip("Skip test where docker is unavailable")
+		}
+
 		dockerWrapper, err := newDockerCmdWrapper("/tmp", "/tmp", "ubuntu", "")
 		if err != nil {
-			t.Skip("Skipping created time in containers tests: Docker not available")
-			return
+			t.Fatalf("failed to create docker wrapper: %v", err)
 		}
 
 		if _, err := dockerWrapper.start(); err != nil {
 			t.Fatal(err)
 		}
-		defer dockerWrapper.stop()
+		t.Cleanup(func() {
+			output, err := dockerWrapper.stop()
+			if err != nil {
+				t.Errorf("failed to stop docker wrapper: %v\n%s", err, string(output))
+			}
+		})
 
 		sleepCtx, cancel := context.WithCancel(context.Background())
 
@@ -123,16 +131,24 @@ func TestSnapshot(t *testing.T) {
 			},
 		}
 
+		if _, err := whichNonFatal("docker"); err != nil {
+			t.Skip("Skip test where docker is unavailable")
+		}
+
 		dockerWrapper, err := newDockerCmdWrapper("/tmp", "/tmp", "ubuntu", "")
 		if err != nil {
-			t.Skip("Skipping created time in containers tests: Docker not available")
-			return
+			t.Fatalf("failed to create docker wrapper: %v", err)
 		}
 
 		if _, err := dockerWrapper.start(); err != nil {
 			t.Fatal(err)
 		}
-		defer dockerWrapper.stop()
+		t.Cleanup(func() {
+			output, err := dockerWrapper.stop()
+			if err != nil {
+				t.Errorf("failed to stop docker wrapper: %v\n%s", err, string(output))
+			}
+		})
 
 		var cmd *exec.Cmd
 		go func() {

--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -18,6 +18,10 @@ import (
 func TestUserGroup(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+
 	if testEnvironment == DockerEnvironment {
 		t.Skip("Skip test spawning docker containers on docker")
 	}
@@ -135,7 +139,12 @@ func TestUserGroup(t *testing.T) {
 			if _, err := dockerWrapper.start(); err != nil {
 				t.Fatal(err)
 			}
-			defer dockerWrapper.stop()
+			t.Cleanup(func() {
+				output, err := dockerWrapper.stop()
+				if err != nil {
+					t.Errorf("failed to stop docker wrapper: %v\n%s", err, string(output))
+				}
+			})
 
 			for _, testCommand := range distroTest.testCommands {
 				i := 0


### PR DESCRIPTION
### What does this PR do?

- Call `t.Fatal` on newDockerCmdWrapper errors to avoid hiding unexpected errors.
- Use `whichNonFatal("docker")` instead to skip tests that require docker to run.
- Add AWS ECR fallback for busybox image to avoid rate-limiting image errors when pulling the image.

### Motivation

Do not skip tests on real errors.

### Describe how you validated your changes

### Additional Notes
