### PR TITLE
[CWS] Try to fix TestFilterOpenLeafDiscarderActivityDump flackyness

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/activity_dump.h
+++ b/pkg/security/ebpf/c/include/helpers/activity_dump.h
@@ -34,6 +34,11 @@ __attribute__((always_inline)) bool is_cgroup_mount_id_filter_valid(u32 cgroup_f
 
     // handle special case for CENTOS7 where we can't retrieve the mount_id of traced cgroup
     if (key->mount_id == 0) {
+        if (key->ino == 0) {
+            // can happen on CentOS7 with systemd pid 1 being not part of any cgroup
+            return false;
+        }
+
         u32 cgroup_write_type = get_cgroup_write_type();
         if (cgroup_write_type == CGROUP_CENTOS_7) {
             return true;

--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -590,9 +590,11 @@ func (m *Manager) SnapshotTracedCgroups() {
 		cgroupContext, _, err := m.resolvers.ResolveCGroupContext(cgroupFile)
 		if err != nil {
 			seclog.Warnf("couldn't resolve cgroup context for (%v): %v", cgroupFile, err)
+			_ = m.tracedCgroupsMap.Delete(cgroupFile)
 			continue
 		}
 		event.CGroupContext = *cgroupContext
+		event.ContainerContext.ContainerID = containerutils.FindContainerID(event.CGroupContext.CGroupID)
 
 		m.HandleCGroupTracingEvent(&event)
 	}

--- a/pkg/security/tests/activity_dumps_common.go
+++ b/pkg/security/tests/activity_dumps_common.go
@@ -23,7 +23,7 @@ import (
 const (
 	dedicatedADNodeForTestsEnv         = "DEDICATED_ACTIVITY_DUMP_NODE"
 	testActivityDumpRateLimiter        = 200
-	testActivityDumpTracedCgroupsCount = 3
+	testActivityDumpTracedCgroupsCount = 5
 )
 
 var (

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -1363,12 +1363,24 @@ func (tm *testModule) GetDumpFromDocker(dockerInstance *dockerCmdWrapper) (*acti
 	}
 	dump := findLearningContainerID(dumps, containerutils.ContainerID(dockerInstance.containerID))
 	if dump == nil {
-		return nil, errors.New("ContainerID not found on activity dump list")
+		return nil, fmt.Errorf("ContainerID %s not found on activity dump list (%+v)", dockerInstance.containerID, dumps)
 	}
 	return dump, nil
 }
 
 func (tm *testModule) StartADockerGetDump() (*dockerCmdWrapper, *activityDumpIdentifier, error) {
+	// before starting the docker, we need to make sure the traced cgroup map is not filled with
+	// entries waiting to be evicted
+	p, ok := tm.probe.PlatformProbe.(*sprobe.EBPFProbe)
+	if !ok {
+		return nil, nil, errors.New("not supported")
+	}
+	managers := p.GetProfileManager()
+	if managers == nil {
+		return nil, nil, errors.New("No manager")
+	}
+	managers.SnapshotTracedCgroups()
+
 	dockerInstance, err := tm.StartADocker()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
### What does this PR do?

It does fix the test flackyness by calling the lost event traced cgroup cleanup func (`SnapshotTracedCgroups`) when we call `StartADockerGetDump`. The issue was that, at module startup the traced cgroup maps was filled with running cgroups, then when the test started trying to start a docker and get it traced it happen often that the map was already full and not cleaned up yet to evict cgroups to let the containers been traced.
At the end it was a test issue, as on a living system-probe the cleanup callback will eventually be called to evict unwanted entries in the map.

PLUS:
* Fix some trace cgroup map poisoning on CentOS7 where pid 1 has no cgroup.
* Fix some data races around the cgroup resolver saving/sharing pointers, now it stores/gives a copy.
* Fix the cleanup of lost cgroup tracing events where, if any, as the containerID was not filled .. it evicted running container from the traced cgroup map.

### Motivation

Fix test `TestFilterOpenLeafDiscarderActivityDump`  flackyness

### Describe how you validated your changes

### Additional Notes
