### PR TITLE
Update dogstatsd load

### DIFF
--- a/test/regression/cases/quality_gate_metrics_logs/README.md
+++ b/test/regression/cases/quality_gate_metrics_logs/README.md
@@ -21,8 +21,8 @@ This combination is intended to model a high-end production scenario.
 
 ### DogStatsD Configuration
 
-- **Throughput**: 100 MiB/s is chosen to represent a high-end production use
-  case
+- **Throughput**: 20 MiB/s is chosen to represent a high-end production use
+  case. This translates to 6k messages/sec.
 - **Message Composition**:
   - 90% metrics (87% counters, 8% gauges, 5% distributions)
   - 5% events

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -30,7 +30,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total collector memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: 1100 MiB
+      upper_bound: 490 MiB
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."

--- a/test/regression/cases/quality_gate_metrics_logs/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/lading/lading.yaml
@@ -43,7 +43,7 @@ generator:
       # `bytes_per_second` is understood to be a high-end use case,
       # however Agent's internal telemetry differs from lading's units: UDS
       # packets per second versus bytes per second.
-      bytes_per_second: "100 MiB"
+      bytes_per_second: "20 MiB"
       maximum_prebuild_cache_size_bytes: "500 MiB"
 
   # Log rotation file system for logs collection (following quality_gate_logs pattern)


### PR DESCRIPTION
### What does this PR do?

Reduce the dogstatsd load applied in the `quality_gate_metrics_logs` experiment. This translates to 6k dogstatsd messages per second, which is in line with the load one might expect on an individual host.

Manual quality gates run for this change: [summary](https://github.com/DataDog/single-machine-performance/actions/runs/17558261543), [dashboard](https://app.datadoghq.com/dashboard/ykh-ua8-vcu/SMP-Regression-Detector-Metrics?fromUser=false&refresh_mode=paused&tpl_var_experiment%5B0%5D=quality_gate_metrics_logs&tpl_var_run-id%5B0%5D=9fcb93ee-8d95-4d57-8a8f-888abe3ba4a5&view=spans&from_ts=1757352693000&to_ts=1757353293000&live=false).

### Motivation

Align quality gate experiment with expected real world use.

### Describe how you validated your changes

Manual quality gate run.
