### PR TITLE
Reapply "[CXP-2599] Enable WLM for process collection by default on linux"

### DIFF
--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -30,7 +30,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
+	wmcatalogremote "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
@@ -45,7 +45,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -145,6 +144,8 @@ func MakeCommand(globalParamsGetter func() *command.GlobalParams, name string, a
 			return fxutil.OneShot(RunCheckCmd,
 				fx.Supply(cliParams, bundleParams),
 				core.Bundle(),
+				// Provide workloadmeta module
+
 				// Provide eventplatformimpl module
 				eventplatformreceiverimpl.Module(),
 				eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
@@ -155,20 +156,9 @@ func MakeCommand(globalParamsGetter func() *command.GlobalParams, name string, a
 				// Provide npcollector module
 				npcollectorimpl.Module(),
 				// Provide the corresponding workloadmeta Params to configure the catalog
-				wmcatalog.GetCatalog(),
-
-				// Provide workloadmeta module
-				workloadmetafx.ModuleWithProvider(func(c config.Component) workloadmeta.Params {
-					var catalog workloadmeta.AgentType
-
-					// This command can be run from both process-agent and core-agent
-					if flavor.GetFlavor() == flavor.ProcessAgent {
-						catalog = workloadmeta.Remote
-					} else {
-						catalog = workloadmeta.NodeAgent
-					}
-
-					return workloadmeta.Params{AgentType: catalog}
+				wmcatalogremote.GetCatalog(),
+				workloadmetafx.Module(workloadmeta.Params{
+					AgentType: workloadmeta.Remote,
 				}),
 
 				// Tagger must be initialized after agent config has been setup

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -195,7 +195,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 		return errors.NewDisabled(componentName, "wlm process collection disabled")
 	}
 
-	if !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() {
+	if !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() && !c.isLanguageCollectionEnabled() {
 		return errors.NewDisabled(componentName, "wlm process collection and service discovery are disabled")
 	}
 
@@ -208,7 +208,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 	}
 	c.store = store
 
-	if c.isProcessCollectionEnabled() {
+	if c.isProcessCollectionEnabled() || c.isLanguageCollectionEnabled() {
 		go c.collectProcesses(ctx, c.clock.Ticker(c.processCollectionIntervalConfig()))
 	}
 
@@ -222,7 +222,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 			telemetry.DefaultOptions,
 		)
 
-		if c.isProcessCollectionEnabled() {
+		if c.isProcessCollectionEnabled() || c.isLanguageCollectionEnabled() {
 			log.Debug("Starting cached service collection (process collection enabled)")
 			go c.collectServicesCached(ctx, c.clock.Ticker(serviceCollectionInterval))
 		} else {

--- a/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector_test.go
@@ -93,6 +93,7 @@ func TestProcessCollector(t *testing.T) {
 		"language_detection.enabled":                true,
 		"process_config.process_collection.enabled": true,
 		"process_config.run_in_core_agent.enabled":  true,
+		"process_config.process_collection.use_wlm": false,
 	}
 
 	c := setUpCollectorTest(t, configOverrides)
@@ -257,6 +258,7 @@ func TestProcessCollectorWithoutProcessCheck(t *testing.T) {
 		"language_detection.enabled":                true,
 		"process_config.process_collection.enabled": false,
 		"process_config.run_in_core_agent.enabled":  true,
+		"process_config.process_collection.use_wlm": false,
 	}
 
 	c := setUpCollectorTest(t, configOverrides)

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
@@ -151,7 +151,7 @@ func (s *streamHandler) IsEnabled() bool {
 		return false
 	}
 
-	return s.Reader.GetBool("language_detection.enabled") && !util.ProcessLanguageCollectorIsEnabled()
+	return s.Reader.GetBool("language_detection.enabled") && !util.ProcessLanguageCollectorIsEnabled() && !pkgconfigsetup.Datadog().GetBool("process_config.process_collection.use_wlm")
 }
 
 func (s *streamHandler) NewClient(cc grpc.ClientConnInterface) remote.GrpcClient {

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
@@ -256,8 +256,9 @@ func TestCollection(t *testing.T) {
 				fx.Provide(func(t testing.TB) log.Component { return logmock.New(t) }),
 				fx.Provide(func(t testing.TB) config.Component {
 					return config.NewMockWithOverrides(t, map[string]interface{}{
-						"language_detection.enabled":               true,
-						"process_config.run_in_core_agent.enabled": false,
+						"language_detection.enabled":                true,
+						"process_config.run_in_core_agent.enabled":  false,
+						"process_config.process_collection.use_wlm": false,
 					})
 				}),
 				workloadmetafxmock.MockModule(workloadmeta.Params{AgentType: workloadmeta.Remote}),

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -115,7 +115,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	procBindEnv(config, "process_config.enabled")
 	procBindEnvAndSetDefault(config, "process_config.container_collection.enabled", true)
 	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
-	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", false)
+	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", runtime.GOOS == "linux")
 
 	// This allows for the process check to run in the core agent but is for linux only
 	procBindEnvAndSetDefault(config, "process_config.run_in_core_agent.enabled", runtime.GOOS == "linux")

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -141,7 +141,7 @@ func TestProcessDefaultConfig(t *testing.T) {
 		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
 		{
 			key:          "process_config.process_collection.use_wlm",
-			defaultValue: false,
+			defaultValue: runtime.GOOS == "linux",
 		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -722,6 +722,9 @@ func (c *Client) GetLastProcessPayloadAPIKey() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if len(payloads) == 0 {
+		return "", errors.New("no process payloads found")
+	}
 	return payloads[len(payloads)-1].APIKey, nil
 }
 
@@ -731,6 +734,10 @@ func (c *Client) GetAllProcessPayloadAPIKeys() ([]string, error) {
 	payloads, err := c.getFakePayloads(processesEndpoint)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(payloads) == 0 {
+		return nil, errors.New("no process payloads found")
 	}
 
 	keysFound := make(map[string]struct{})

--- a/test/new-e2e/tests/discovery/testdata/config/agent_config.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/agent_config.yaml
@@ -1,1 +1,4 @@
 log_level: DEBUG
+process_config:
+  process_collection:
+    use_wlm: false

--- a/test/new-e2e/tests/discovery/testdata/config/agent_process_config.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/agent_process_config.yaml
@@ -4,7 +4,6 @@ language_detection:
 process_config:
   process_collection:
     enabled: true
-    use_wlm: true
   run_in_core_agent:
     enabled: true
 

--- a/test/new-e2e/tests/language-detection/node_test.go
+++ b/test/new-e2e/tests/language-detection/node_test.go
@@ -40,5 +40,5 @@ func (s *languageDetectionSuite) TestNodeDetection() {
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf(`echo "%s" > prog.js`, nodeProg))
 	s.Env().RemoteHost.MustExecute("nohup node prog.js >myscript.log 2>&1 </dev/null &")
 
-	s.checkDetectedLanguage("node", "node", "remote_process_collector")
+	s.checkDetectedLanguage("node", "node", "process_collector")
 }

--- a/test/new-e2e/tests/language-detection/php_test.go
+++ b/test/new-e2e/tests/language-detection/php_test.go
@@ -23,7 +23,7 @@ func (s *languageDetectionSuite) installPHP() {
 func (s *languageDetectionSuite) TestPHPDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
 	s.runPHP()
-	s.checkDetectedLanguage("php", "php", "process_language_collector")
+	s.checkDetectedLanguage("php", "php", "process_collector")
 }
 
 func (s *languageDetectionSuite) runPHP() {

--- a/test/new-e2e/tests/language-detection/python_test.go
+++ b/test/new-e2e/tests/language-detection/python_test.go
@@ -23,25 +23,25 @@ func (s *languageDetectionSuite) installPython() {
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_language_collector")
+	s.checkDetectedLanguage("python3", "python", "process_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgentNoCheck() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigNoCheckStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_language_collector")
+	s.checkDetectedLanguage("python3", "python", "process_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionProcessAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(processConfigStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "remote_process_collector")
+	s.checkDetectedLanguage("python3", "python", "process_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionProcessAgentNoCheck() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(processConfigNoCheckStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "remote_process_collector")
+	s.checkDetectedLanguage("python3", "python", "process_collector")
 }
 
 func (s *languageDetectionSuite) runPython() {

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -350,6 +350,7 @@ func (s *linuxTestSuite) TestProcessChecksWithNPM() {
 }
 
 func (s *linuxTestSuite) TestManualProcessCheck() {
+	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr))))
 	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
 
 	assertManualProcessCheck(s.T(), check, false, "stress")

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -351,15 +351,18 @@ func (s *linuxTestSuite) TestProcessChecksWithNPM() {
 
 func (s *linuxTestSuite) TestManualProcessCheck() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr))))
-	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
 
-	assertManualProcessCheck(s.T(), check, false, "stress")
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
+		assertManualProcessCheck(c, check, false, "stress")
+	}, 2*time.Minute, 10*time.Second)
 }
 
 func (s *linuxTestSuite) TestManualProcessDiscoveryCheck() {
-	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process_discovery --json")
-
-	assertManualProcessDiscoveryCheck(s.T(), check, "stress")
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process_discovery --json")
+		assertManualProcessDiscoveryCheck(c, check, "stress")
+	}, 2*time.Minute, 10*time.Second)
 }
 
 func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
@@ -367,7 +370,8 @@ func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
 		agentparams.WithAgentConfig(processCheckConfigStr),
 		agentparams.WithSystemProbeConfig(systemProbeConfigStr))))
 
-	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
-
-	assertManualProcessCheck(s.T(), check, true, "stress")
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
+		assertManualProcessCheck(c, check, true, "stress")
+	}, 2*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
@@ -350,6 +351,7 @@ func (s *linuxTestSuite) TestProcessChecksWithNPM() {
 }
 
 func (s *linuxTestSuite) TestManualProcessCheck() {
+	flake.Mark(s.T())
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr))))
 
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
@@ -366,6 +368,7 @@ func (s *linuxTestSuite) TestManualProcessDiscoveryCheck() {
 }
 
 func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
+	flake.Mark(s.T())
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(
 		agentparams.WithAgentConfig(processCheckConfigStr),
 		agentparams.WithSystemProbeConfig(systemProbeConfigStr))))

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -382,13 +382,7 @@ func assertManualContainerCheck(t require.TestingT, check string, expectedContai
 
 // assertManualProcessDiscoveryCheck asserts that the given process is collected and reported in
 // the output of the manual process_discovery check
-func assertManualProcessDiscoveryCheck(t *testing.T, check string, process string) {
-	defer func() {
-		if t.Failed() {
-			t.Logf("Check output:\n%s\n", check)
-		}
-	}()
-
+func assertManualProcessDiscoveryCheck(t require.TestingT, check string, process string) {
 	var checkOutput struct {
 		ProcessDiscoveries []*agentmodel.ProcessDiscovery `json:"processDiscoveries"`
 	}


### PR DESCRIPTION
### What does this PR do?
The initial [PR](https://github.com/DataDog/datadog-agent/pull/40403) was reverted due to introducing flakes on the `TestLinuxTestSuite/TestManualProcessCheckWithIO` e2e test. Since the change resulted in the process-agent using remote WLM for process data, there is a race condition between the run of the check command on the process agent and whether the collectors actually ran on the core agent. The `workloadmeta.IsInitialized()` will only check if the collectors were started in the current runtime not across others, so we can't rely on it. To fix this, we introduce retries in the test since the race condition has more impact on agent startup.

### Motivation
Fix test flakes + original motivations from https://github.com/DataDog/datadog-agent/pull/40403
### Describe how you validated your changes
e2e tests + unit tests

e2e tests were run multiple times in the hopes of catching flakes. The problematic tests are also marked as flaky to prevent issues on main while we determine if the fix works.

### Additional Notes
