### PR TITLE
[ AGNTLOG-266 ] Improve documentation for the logs_dd_url configuration option

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1009,8 +1009,9 @@ api_key:
 
 #   # @param logs_dd_url - string - optional
 #   # @env DD_LOGS_CONFIG_LOGS_DD_URL - string - optional
-#   # Define the endpoint and port to hit when using a proxy for logs. The logs are forwarded in TCP
-#   # therefore the proxy must be able to handle TCP connections.
+#   # Define the endpoint and port to hit when using a proxy for logs. 
+#   # As of agent version 7.70.0, proxy paths are supported. To forward logs to a 
+#   # specific proxy path, the URL scheme must be specified: https://proxy.example.com:443/logs
 #
 #   logs_dd_url: <ENDPOINT>:<PORT>
 


### PR DESCRIPTION
### What does this PR do?
Update documentation for logs_config.logs_dd_url. 

This documentation is referenced in https://docs.datadoghq.com/agent/logs/?tab=tailfiles#activate-log-collection and https://docs.datadoghq.com/getting_started/logs/#server

### Motivation

### Describe how you validated your changes

### Additional Notes
