### PR TITLE
Default replacement value to $1

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils.go
@@ -66,7 +66,11 @@ func processValueUsingSymbolConfig(value valuestore.ResultValue, symbol profiled
 		}
 
 		if symbol.MatchPatternCompiled.MatchString(strValue) {
-			replacedVal := checkconfig.RegexReplaceValue(strValue, symbol.MatchPatternCompiled, symbol.MatchValue)
+			replacement := symbol.MatchValue
+			if replacement == "" {
+				replacement = "$1"
+			}
+			replacedVal := checkconfig.RegexReplaceValue(strValue, symbol.MatchPatternCompiled, replacement)
 			if replacedVal == "" {
 				return valuestore.ResultValue{}, fmt.Errorf("the pattern `%v` matched value `%v`, but template `%s` is not compatible", symbol.MatchPattern, strValue, symbol.MatchValue)
 			}

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
@@ -66,6 +66,19 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			expectedError: "extract value extractValuePattern does not match (extractValuePattern=abc, srcValue=value1)",
 		},
 		{
+			name:   "OK match pattern with default replacement value",
+			values: mockValues,
+			symbol: profiledefinition.SymbolConfig{
+				OID:                  "1.2.3.4",
+				Name:                 "mySymbol",
+				MatchPatternCompiled: regexp.MustCompile(`[a-z]+(\d)`),
+			},
+			expectedValue: valuestore.ResultValue{
+				Value: "1",
+			},
+			expectedError: "",
+		},
+		{
 			name:   "OK match pattern without replace",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{


### PR DESCRIPTION
### What does this PR do?

This makes the `match_value` default to `"$1"` when `match_pattern` is set, instead of defaulting to `""`.

### Motivation

Without this, the behavior of `match_pattern` without `match_value` is to silently discard the entire value; I don't believe this is ever something a customer would do intentionally.

With this change, setting `match_pattern` without `match_value` is exactly the same as setting `extract_value` (and if we want, we could deprecate `extract_value` entirely in the future).

### Describe how you validated your changes

I added a test for it and confirmed all the tests still pass. This shouldn't change the behavior of the agent in any case except the pathological one where someone has forgotten to set `match_value`.
