### PR TITLE
[Versa] Add Versa check to build tasks

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -84,6 +84,7 @@ AGENT_CORECHECKS = [
     "gpu",
     "wlan",
     "discovery",
+    "versa",
 ]
 
 WINDOWS_CORECHECKS = [


### PR DESCRIPTION
### What does this PR do?
Adds the Versa integration to the build tasks as a core check so the `conf.yaml.example` is included in the build.

### Motivation

### Describe how you validated your changes

### Additional Notes
