### PR TITLE
Strictly parse yaml in normalize_cmd

### DIFF
--- a/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
+++ b/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
@@ -9,6 +9,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -42,9 +43,14 @@ var rootCmd = &cobra.Command{
 			fmt.Printf("parse failure %v, unable to generate output\n", err)
 		}
 		for _, filePath := range args {
-			filename := filepath.Base(filePath)
-			name := filename[:len(filename)-len(filepath.Ext(filename))] // remove extension
-			def, errors := GetProfile(filePath)
+			var name string
+			if filePath == "-" {
+				name = "stdin"
+			} else {
+				filename := filepath.Base(filePath)
+				name = filename[:len(filename)-len(filepath.Ext(filename))] // remove extension
+			}
+			def, errors := GetProfile(filePath, strict)
 			if len(errors) > 0 {
 				fmt.Printf("*** %d error(s) in profile %q ***\n", len(errors), filePath)
 				for _, e := range errors {
@@ -62,14 +68,23 @@ var rootCmd = &cobra.Command{
 
 // GetProfile parses a profile from a file path and validates it.
 func GetProfile(filePath string, strict bool) (*profiledefinition.ProfileDefinition, []string) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, []string{fmt.Sprintf("unable to read file: %v", err)}
+	var inFile io.Reader
+	if filePath == "-" {
+		inFile = os.Stdin
+	} else {
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, []string{fmt.Sprintf("unable to read file: %v", err)}
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		inFile = f
 	}
 	def := profiledefinition.NewProfileDefinition()
-	dec := yaml.NewDecoder(file)
+	dec := yaml.NewDecoder(inFile)
 	dec.SetStrict(strict)
-	err = dec.Decode(&def)
+	err := dec.Decode(&def)
 	if err != nil {
 		return nil, []string{fmt.Sprintf("unable to parse profile: %v", err)}
 	}
@@ -85,11 +100,11 @@ func WriteProfile(def *profiledefinition.ProfileDefinition, name string, outdir 
 	if outdir == "" {
 		return nil
 	}
-	var filename string
+	var outPath string
 	var data []byte
 	if useJSON {
 		var err error
-		filename = name + ".json"
+		outPath = filepath.Join(outdir, name+".json")
 		data, err = json.Marshal(def)
 		if err != nil {
 			return fmt.Errorf("unable to marshal profile %s: %w", name, err)
@@ -97,22 +112,28 @@ func WriteProfile(def *profiledefinition.ProfileDefinition, name string, outdir 
 	} else {
 		var err error
 		data, err = yaml.Marshal(def)
-		filename = name + ".yaml"
+		outPath = filepath.Join(outdir, name+".yaml")
 		if err != nil {
 			return fmt.Errorf("unable to marshal profile %s: %w", name, err)
 		}
 	}
-	outfile := filepath.Join(outdir, filename)
-	f, err := os.Create(outfile)
-	if err != nil {
-		return fmt.Errorf("unable to create file %s: %w", outfile, err)
+	var writer io.Writer
+	if outdir == "-" {
+		writer = os.Stdout
+		outPath = "stdout"
+	} else {
+		f, err := os.Create(outPath)
+		if err != nil {
+			return fmt.Errorf("unable to create file %s: %w", outPath, err)
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		writer = f
 	}
-	defer func() {
-		_ = f.Close()
-	}()
-	_, err = f.Write(data)
+	_, err := writer.Write(data)
 	if err != nil {
-		return fmt.Errorf("unable to write to file %s: %w", outfile, err)
+		return fmt.Errorf("unable to write to %s: %w", outPath, err)
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This improves the output and flexibility of `normalize_cmd`, as well as the quality of the errors produced by profile parsing:
 1. (general profile parsing) If a structure has a legacy format, but parsing fails both for the expected type and the legacy type, the profile parser will now return the error for the expected type instead of the error from the legacy type (e.g. `field constant_value not found in type profiledefinition.MetricTagConfig` instead of `cannot unmarsal !!map into string`).
 2. The `normalize_cmd` CLI tool now supports
   *  a `-s` or `--strict` flag that parses in strict mode so that unrecognized fields will be reported as errors instead of silently ignored
   * The ability to specify `-` as an input path to read from stdin
   * The ability to specify `-o -` as the output path to cause the resulting profile to be printed to stdout instead of to a file on disk.

### Motivation

These are small issues that came up while I was dealing with various support tickets and wanted to validate that their profiles were properly structured. Now I can just run `normalize_cmd etc/confd/snmp.d/profiles/*.yaml` from within a flare and immediately get a list of all the things that might be wrong in those profiles, or paste a profile segment copied from a ticket directly into stdout and validate it.

Strict parsing *does* introduce some false positives - e.g. we frequently put `MIB` or `table` fields in handwritten profiles even though those aren't recognized fields in the profile data structure, so they'll be reported as unrecognized fields with this change, but since this is only when `-s` is set it shouldn't affect any existing use cases.

### Describe how you validated your changes

I ran the CLI tool on various profiles and confirmed that I was now getting useful error messages out of it.

### Additional Notes
