### PR TITLE
add exponential backoff to the sending of the host metadata payload

### DIFF
--- a/comp/metadata/host/hostimpl/host_test.go
+++ b/comp/metadata/host/hostimpl/host_test.go
@@ -7,11 +7,14 @@ package hostimpl
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"go.uber.org/fx"
 	"golang.org/x/exp/maps"
 
@@ -24,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/resources/resourcesimpl"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	serializermock "github.com/DataDog/datadog-agent/pkg/serializer/mocks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -40,7 +44,7 @@ func TestNewHostProviderDefaultInterval(t *testing.T) {
 		),
 	)
 
-	assert.Equal(t, defaultCollectInterval, ret.Comp.(*host).collectInterval)
+	assert.Equal(t, defaultCollectInterval, ret.Comp.(*host).backoffPolicy.MaxInterval)
 }
 
 func TestNewHostProviderCustomInterval(t *testing.T) {
@@ -65,7 +69,7 @@ func TestNewHostProviderCustomInterval(t *testing.T) {
 		),
 	)
 
-	assert.Equal(t, time.Duration(1000)*time.Second, ret.Comp.(*host).collectInterval)
+	assert.Equal(t, time.Duration(1000)*time.Second, ret.Comp.(*host).backoffPolicy.MaxInterval)
 }
 
 func TestNewHostProviderInvalidCustomInterval(t *testing.T) {
@@ -90,7 +94,7 @@ func TestNewHostProviderInvalidCustomInterval(t *testing.T) {
 		),
 	)
 
-	assert.Equal(t, defaultCollectInterval, ret.Comp.(*host).collectInterval)
+	assert.Equal(t, defaultCollectInterval, ret.Comp.(*host).backoffPolicy.MaxInterval)
 }
 
 func TestFlareProvider(t *testing.T) {
@@ -166,4 +170,74 @@ func TestStatusHeaderProvider(t *testing.T) {
 			test.assertFunc(t)
 		})
 	}
+}
+
+func TestExponentialBackoffIntervals(t *testing.T) {
+	mockSerializer := serializermock.NewMetricSerializer(t)
+	mockSerializer.On("SendHostMetadata", mock.Anything).Return(nil)
+
+	ret := newHostProvider(
+		fxutil.Test[dependencies](
+			t,
+			fx.Provide(func() log.Component { return logmock.New(t) }),
+			fx.Provide(func() config.Component { return config.NewMock(t) }),
+			resourcesimpl.MockModule(),
+			fx.Replace(resources.MockParams{Data: nil}),
+			fx.Provide(func() serializer.MetricSerializer { return mockSerializer }),
+			hostnameimpl.MockModule(),
+		),
+	)
+
+	hostProvider := ret.Comp.(*host)
+
+	hostProvider.backoffPolicy = &backoff.ExponentialBackOff{
+		InitialInterval:     5 * time.Minute,
+		RandomizationFactor: 0.0,
+		Multiplier:          3.0,
+		MaxInterval:         defaultCollectInterval,
+		MaxElapsedTime:      0,
+		Clock:               backoff.SystemClock,
+	}
+	hostProvider.backoffPolicy.Reset()
+
+	ctx := context.Background()
+
+	expectedIntervals := []time.Duration{
+		5 * time.Minute,
+		15 * time.Minute,
+		defaultCollectInterval,
+		defaultCollectInterval,
+	}
+
+	for i, expected := range expectedIntervals {
+		actual := hostProvider.collect(ctx)
+		assert.Equal(t, expected, actual, "Interval %d should be exactly %v, got %v", i, expected, actual)
+	}
+
+	for i := 0; i < 3; i++ {
+		actual := hostProvider.collect(ctx)
+		assert.Equal(t, defaultCollectInterval, actual, "Stabilized interval %d should be exactly %v, got %v", i, defaultCollectInterval, actual)
+	}
+}
+
+func TestExponentialBackoffInitialization(t *testing.T) {
+	ret := newHostProvider(
+		fxutil.Test[dependencies](
+			t,
+			fx.Provide(func() log.Component { return logmock.New(t) }),
+			fx.Provide(func() config.Component { return config.NewMock(t) }),
+			resourcesimpl.MockModule(),
+			fx.Replace(resources.MockParams{Data: nil}),
+			fx.Provide(func() serializer.MetricSerializer { return serializermock.NewMetricSerializer(t) }),
+			hostnameimpl.MockModule(),
+		),
+	)
+
+	hostProvider := ret.Comp.(*host)
+
+	assert.NotNil(t, hostProvider.backoffPolicy, "Backoff policy should be initialized")
+	assert.Equal(t, 5*time.Minute, hostProvider.backoffPolicy.InitialInterval, "Initial interval should be 5 minutes")
+	assert.Equal(t, defaultCollectInterval, hostProvider.backoffPolicy.MaxInterval, "Max interval should match configured interval")
+	assert.Equal(t, 3.0, hostProvider.backoffPolicy.Multiplier, "Multiplier should be 3.0")
+	assert.Equal(t, 0.0, hostProvider.backoffPolicy.RandomizationFactor, "Randomization factor should be 0.0")
 }

--- a/pkg/config/utils/metadata_providers.go
+++ b/pkg/config/utils/metadata_providers.go
@@ -14,8 +14,9 @@ import (
 
 // MetadataProviders helps unmarshalling `metadata_providers` config param
 type MetadataProviders struct {
-	Name     string        `mapstructure:"name"`
-	Interval time.Duration `mapstructure:"interval"`
+	Name          string        `mapstructure:"name"`
+	Interval      time.Duration `mapstructure:"interval"`
+	EarlyInterval time.Duration `mapstructure:"early_interval"`
 }
 
 // GetMetadataProviders returns the "metadata_providers" set in the configuration

--- a/releasenotes/notes/exponential-host-metadata-backoff-d44838bd71c4b80a.yaml
+++ b/releasenotes/notes/exponential-host-metadata-backoff-d44838bd71c4b80a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added exponential backoff to host metadata collection at startup to increase early host-payload frequency and speed up node-level tag availability.


### PR DESCRIPTION
### What does this PR do?

Front-loads host-payload attempts exponentially during the start to speed up node-level tag availability. Attempts are then stabilized at a normal collection interval. 

### Motivation

Customers noticed that they sometimes have to wait a considerable amount before node-level tags are available during fresh deployments due to the host payload only being sent every 30 minutes, so a miss early on could push tag availability back significantly.

### Describe how you validated your changes

1. Unit Tests to test proper intervals
2. Running the binary with custom configured interval times and grep-ing for the debug line showing when the next run should be
```
metadata_providers:
  - name: host
    interval: 1800
    early_interval: 600
```
```
dda inv agent.build && DD_LOG_LEVEL=debug stdbuf -oL -eL ./bin/agent/agent run -c ./dev/dist 2>&1 \
| grep -F --line-buffered --color=always 'Next host metadata collection scheduled'
```