### PR TITLE
ignore late service does not exist

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
@@ -79,6 +79,8 @@
     <Compile Include="ProcessUserCustomActions\TestDelegate.cs" />
     <Compile Include="Process\ProcessConfigTests.cs" />
     <Compile Include="Proxy\ProcessConfigTests.cs" />
+    <Compile Include="Service\ServiceCustomActionTests.cs" />
+    <Compile Include="Service\ServiceCustomActionsTestSetup.cs" />
     <Compile Include="Telemetry\TelemetryUnitTests.cs" />
     <Compile Include="SessionTestBaseSetup.cs" />
     <Compile Include="ProcessUserCustomActions\ProcessUserCustomActionsDomainClientTests.cs" />

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ServiceCustomActionTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ServiceCustomActionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Deployment.WindowsInstaller;
 using Moq;
 using System;
 using System.ComponentModel;
+using System.ServiceProcess;
 using Xunit;
 
 namespace CustomActions.Tests.Service
@@ -17,7 +18,7 @@ namespace CustomActions.Tests.Service
         public void ReturnsTrue_ForWin32Exception1060()
         {
             var ex = new Win32Exception(1060); // ERROR_SERVICE_DOES_NOT_EXIST
-            Assert.True(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+            Assert.True(ServiceCustomAction.IsServiceDoesNotExistError(ex));
         }
 
         [Fact]
@@ -25,28 +26,28 @@ namespace CustomActions.Tests.Service
         {
             var inner = new Win32Exception(1060);
             var ex = new Exception("wrapper", inner);
-            Assert.True(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+            Assert.True(ServiceCustomAction.IsServiceDoesNotExistError(ex));
         }
 
         [Fact]
         public void ReturnsTrue_ForInvalidOperationMessage()
         {
             var ex = new InvalidOperationException("The specified service does not exist as an installed service");
-            Assert.True(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+            Assert.True(ServiceCustomAction.IsServiceDoesNotExistError(ex));
         }
 
         [Fact]
         public void ReturnsFalse_ForOtherWin32Exception()
         {
             var ex = new Win32Exception(5); // Access denied
-            Assert.False(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+            Assert.False(ServiceCustomAction.IsServiceDoesNotExistError(ex));
         }
 
         [Fact]
         public void ReturnsFalse_ForUnrelatedException()
         {
             var ex = new InvalidOperationException("Some other message");
-            Assert.False(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+            Assert.False(ServiceCustomAction.IsServiceDoesNotExistError(ex));
         }
 
         [Fact]
@@ -59,7 +60,7 @@ namespace CustomActions.Tests.Service
             {
                 throw new InvalidOperationException("error message", new Win32Exception(1060));
             }
-            catch (Exception ex) when (Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex))
+            catch (Exception ex) when (ServiceCustomAction.IsServiceDoesNotExistError(ex))
             {
                 handledByFilter = true;
             }
@@ -82,7 +83,7 @@ namespace CustomActions.Tests.Service
             {
                 throw new Win32Exception(5);
             }
-            catch (Exception ex) when (Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex))
+            catch (Exception ex) when (ServiceCustomAction.IsServiceDoesNotExistError(ex))
             {
                 handledByFilter = true;
             }
@@ -108,7 +109,7 @@ namespace CustomActions.Tests.Service
             var serviceMock = new Mock<IWindowsService>();
             serviceMock.SetupGet(s => s.ServiceName).Returns(Constants.AgentServiceName);
             serviceMock.SetupGet(s => s.DisplayName).Returns("Datadog Agent");
-            serviceMock.SetupGet(s => s.Status).Returns(System.ServiceProcess.ServiceControllerStatus.Running);
+            serviceMock.SetupGet(s => s.Status).Returns(ServiceControllerStatus.Running);
             serviceMock.Setup(s => s.Refresh());
 
             Test.ServiceController.SetupGet(c => c.Services).Returns(new[] { serviceMock.Object });
@@ -130,7 +131,7 @@ namespace CustomActions.Tests.Service
             var serviceMock = new Mock<IWindowsService>();
             serviceMock.SetupGet(s => s.ServiceName).Returns(Constants.AgentServiceName);
             serviceMock.SetupGet(s => s.DisplayName).Returns("Datadog Agent");
-            serviceMock.SetupGet(s => s.Status).Returns(System.ServiceProcess.ServiceControllerStatus.Running);
+            serviceMock.SetupGet(s => s.Status).Returns(ServiceControllerStatus.Running);
             serviceMock.Setup(s => s.Refresh());
 
             Test.ServiceController.SetupGet(c => c.Services).Returns(new[] { serviceMock.Object });
@@ -152,7 +153,7 @@ namespace CustomActions.Tests.Service
             var serviceMock = new Mock<IWindowsService>();
             serviceMock.SetupGet(s => s.ServiceName).Returns(Constants.AgentServiceName);
             serviceMock.SetupGet(s => s.DisplayName).Returns("Datadog Agent");
-            serviceMock.SetupGet(s => s.Status).Returns(System.ServiceProcess.ServiceControllerStatus.Running);
+            serviceMock.SetupGet(s => s.Status).Returns(ServiceControllerStatus.Running);
             serviceMock.Setup(s => s.Refresh());
 
             Test.ServiceController.SetupGet(c => c.Services).Returns(new[] { serviceMock.Object });

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ServiceCustomActionTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ServiceCustomActionTests.cs
@@ -1,0 +1,186 @@
+using Datadog.CustomActions;
+using Datadog.CustomActions.Interfaces;
+using FluentAssertions;
+using Microsoft.Deployment.WindowsInstaller;
+using Moq;
+using System;
+using System.ComponentModel;
+using Xunit;
+
+namespace CustomActions.Tests.Service
+{
+    public class ServiceCustomActionTests : ServiceCustomActionsTestSetup
+    {
+        public ServiceCustomActionsTestSetup Test { get; } = new();
+
+        [Fact]
+        public void ReturnsTrue_ForWin32Exception1060()
+        {
+            var ex = new Win32Exception(1060); // ERROR_SERVICE_DOES_NOT_EXIST
+            Assert.True(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+        }
+
+        [Fact]
+        public void ReturnsTrue_ForWrappedWin32Exception1060()
+        {
+            var inner = new Win32Exception(1060);
+            var ex = new Exception("wrapper", inner);
+            Assert.True(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+        }
+
+        [Fact]
+        public void ReturnsTrue_ForInvalidOperationMessage()
+        {
+            var ex = new InvalidOperationException("The specified service does not exist as an installed service");
+            Assert.True(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+        }
+
+        [Fact]
+        public void ReturnsFalse_ForOtherWin32Exception()
+        {
+            var ex = new Win32Exception(5); // Access denied
+            Assert.False(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+        }
+
+        [Fact]
+        public void ReturnsFalse_ForUnrelatedException()
+        {
+            var ex = new InvalidOperationException("Some other message");
+            Assert.False(Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex));
+        }
+
+        [Fact]
+        public void ExceptionFilter_Catches1060AndSkipsFallback()
+        {
+            var handledByFilter = false;
+            var handledByFallback = false;
+
+            try
+            {
+                throw new InvalidOperationException("error message", new Win32Exception(1060));
+            }
+            catch (Exception ex) when (Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex))
+            {
+                handledByFilter = true;
+            }
+            catch (Exception)
+            {
+                handledByFallback = true;
+            }
+
+            Assert.True(handledByFilter);
+            Assert.False(handledByFallback);
+        }
+
+        [Fact]
+        public void ExceptionFilter_SkipsForOtherExceptions()
+        {
+            var handledByFilter = false;
+            var handledByFallback = false;
+
+            try
+            {
+                throw new Win32Exception(5);
+            }
+            catch (Exception ex) when (Datadog.CustomActions.ServiceCustomAction.IsServiceDoesNotExistError(ex))
+            {
+                handledByFilter = true;
+            }
+            catch (Exception)
+            {
+                handledByFallback = true;
+            }
+
+            Assert.False(handledByFilter);
+            Assert.True(handledByFallback);
+        }
+
+        /// <summary>
+        /// Tests that a late "service does not exist" error is ignored 
+        /// </summary>
+        /// <remarks>
+        /// We had an instance where the Agent service somehow got returned from Enum but then raised a "not found" error
+        /// when trying to send the stop signal, see https://datadoghq.atlassian.net/browse/WINA-1776
+        /// </remarks>
+        [Fact]
+        public void StopDDServices_Treats1060AsSuccess()
+        {
+            var serviceMock = new Mock<IWindowsService>();
+            serviceMock.SetupGet(s => s.ServiceName).Returns(Constants.AgentServiceName);
+            serviceMock.SetupGet(s => s.DisplayName).Returns("Datadog Agent");
+            serviceMock.SetupGet(s => s.Status).Returns(System.ServiceProcess.ServiceControllerStatus.Running);
+            serviceMock.Setup(s => s.Refresh());
+
+            Test.ServiceController.SetupGet(c => c.Services).Returns(new[] { serviceMock.Object });
+            Test.ServiceController
+                .Setup(c => c.StopService(Constants.AgentServiceName, It.IsAny<TimeSpan>()))
+                .Throws(new InvalidOperationException("error", new Win32Exception(1060)));
+
+            Test.Create()
+                .StopDDServices(false)
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.ServiceController.Verify(c => c.StopService(Constants.AgentServiceName, It.IsAny<TimeSpan>()), Times.Once);
+        }
+
+        [Fact]
+        public void StopDDServices_ContinuesOnNon1060WhenContinueOnErrorTrue()
+        {
+            var serviceMock = new Mock<IWindowsService>();
+            serviceMock.SetupGet(s => s.ServiceName).Returns(Constants.AgentServiceName);
+            serviceMock.SetupGet(s => s.DisplayName).Returns("Datadog Agent");
+            serviceMock.SetupGet(s => s.Status).Returns(System.ServiceProcess.ServiceControllerStatus.Running);
+            serviceMock.Setup(s => s.Refresh());
+
+            Test.ServiceController.SetupGet(c => c.Services).Returns(new[] { serviceMock.Object });
+            Test.ServiceController
+                .Setup(c => c.StopService(Constants.AgentServiceName, It.IsAny<TimeSpan>()))
+                .Throws(new Exception("boom"));
+
+            Test.Create()
+                .StopDDServices(true)
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.ServiceController.Verify(c => c.StopService(Constants.AgentServiceName, It.IsAny<TimeSpan>()), Times.Once);
+        }
+
+        [Fact]
+        public void StopDDServices_FailsOnNon1060WhenContinueOnErrorFalse()
+        {
+            var serviceMock = new Mock<IWindowsService>();
+            serviceMock.SetupGet(s => s.ServiceName).Returns(Constants.AgentServiceName);
+            serviceMock.SetupGet(s => s.DisplayName).Returns("Datadog Agent");
+            serviceMock.SetupGet(s => s.Status).Returns(System.ServiceProcess.ServiceControllerStatus.Running);
+            serviceMock.Setup(s => s.Refresh());
+
+            Test.ServiceController.SetupGet(c => c.Services).Returns(new[] { serviceMock.Object });
+            Test.ServiceController
+                .Setup(c => c.StopService(Constants.AgentServiceName, It.IsAny<TimeSpan>()))
+                .Throws(new Exception("boom"));
+
+            Test.Create()
+                .StopDDServices(false)
+                .Should()
+                .Be(ActionResult.Failure);
+
+            Test.ServiceController.Verify(c => c.StopService(Constants.AgentServiceName, It.IsAny<TimeSpan>()), Times.Once);
+        }
+
+        [Fact]
+        public void StopDDServices_DoesNotCallStopWhenServiceNotFound()
+        {
+            Test.ServiceController.SetupGet(c => c.Services).Returns(Array.Empty<IWindowsService>());
+
+            Test.Create()
+                .StopDDServices(false)
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.ServiceController.Verify(c => c.StopService(It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.Never);
+        }
+    }
+}
+
+

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ServiceCustomActionsTestSetup.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ServiceCustomActionsTestSetup.cs
@@ -1,0 +1,37 @@
+using Datadog.CustomActions.Interfaces;
+using Moq;
+using System;
+
+namespace CustomActions.Tests.Service
+{
+    public class ServiceCustomActionsTestSetup : SessionTestBaseSetup
+    {
+        public Mock<INativeMethods> NativeMethods { get; } = new();
+        public Mock<IServiceController> ServiceController { get; } = new();
+        public Mock<IRegistryServices> RegistryServices { get; } = new();
+        public Mock<IDirectoryServices> DirectoryServices { get; } = new();
+        public Mock<IFileServices> FileServices { get; } = new();
+        public Mock<IFileSystemServices> FileSystemServices { get; } = new();
+
+        public ServiceCustomActionsTestSetup()
+        {
+            // No services by default
+            ServiceController.SetupGet(s => s.Services).Returns(Array.Empty<IWindowsService>());
+        }
+
+        public Datadog.CustomActions.ServiceCustomAction Create()
+        {
+            return new Datadog.CustomActions.ServiceCustomAction(
+                Session.Object,
+                rollbackDataName: null,
+                nativeMethods: NativeMethods.Object,
+                registryServices: RegistryServices.Object,
+                directoryServices: DirectoryServices.Object,
+                fileServices: FileServices.Object,
+                serviceController: ServiceController.Object,
+                fileSystemServices: FileSystemServices.Object);
+        }
+    }
+}
+
+

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ServiceCustomActionsTestSetup.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ServiceCustomActionsTestSetup.cs
@@ -1,3 +1,4 @@
+using Datadog.CustomActions;
 using Datadog.CustomActions.Interfaces;
 using Moq;
 using System;
@@ -19,9 +20,9 @@ namespace CustomActions.Tests.Service
             ServiceController.SetupGet(s => s.Services).Returns(Array.Empty<IWindowsService>());
         }
 
-        public Datadog.CustomActions.ServiceCustomAction Create()
+        public ServiceCustomAction Create()
         {
-            return new Datadog.CustomActions.ServiceCustomAction(
+            return new ServiceCustomAction(
                 Session.Object,
                 rollbackDataName: null,
                 nativeMethods: NativeMethods.Object,


### PR DESCRIPTION
### What does this PR do?
ignores "service not found" error when stopping services in the MSI

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1776

### Describe how you validated your changes
added unit tests

### Additional Notes
Seems like it shouldn't occur because we only try to stop services that are returned to us from `ServiceController.GetServices()`, but we saw it happen in telemetry.