### PR TITLE
[ABLD-150] Minor: fix too broad `buildifier` exclusions

### DIFF
--- a/bazel/buildifier/BUILD.bazel
+++ b/bazel/buildifier/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
 
 exclude_patterns = [
-    "**/.bazelbsp/**",
-    "**/.cache/**",
+    "./.bazelbsp/**",
+    "./.cache/**",
 ]
 
 buildifier(


### PR DESCRIPTION
### Motivation
Since `buildifier-prebuilt` relies on [`find .`'s output](https://github.com/keith/buildifier-prebuilt/blob/225bf6acef5f9944393e4cc623f450eeb25696f3/runner.bash.template#L33), there's no need for excluding files other than at the workspace root.