### PR TITLE
[CWS] make `USE_SYSCALL_WRAPPER` and `USE_FENTRY` definition based

### DIFF
--- a/pkg/security/ebpf/c/include/constants/syscall_macro.h
+++ b/pkg/security/ebpf/c/include/constants/syscall_macro.h
@@ -2,7 +2,7 @@
 #define _CONSTANTS_SYSCALL_MACRO_H_
 
 #if defined(__x86_64__)
-#if USE_SYSCALL_WRAPPER == 1
+#ifdef USE_SYSCALL_WRAPPER
 #define SYSCALL64_PREFIX "__x64_"
 #define SYSCALL32_PREFIX "__ia32_"
 #else
@@ -13,7 +13,7 @@
 #define SYSCALL64_PT_REGS_PARM1(x) ((x)->di)
 #define SYSCALL64_PT_REGS_PARM2(x) ((x)->si)
 #define SYSCALL64_PT_REGS_PARM3(x) ((x)->dx)
-#if USE_SYSCALL_WRAPPER == 1
+#ifdef USE_SYSCALL_WRAPPER
 #define SYSCALL64_PT_REGS_PARM4(x) ((x)->r10)
 #else
 #define SYSCALL64_PT_REGS_PARM4(x) ((x)->cx)
@@ -29,7 +29,7 @@
 #define SYSCALL32_PT_REGS_PARM6(x) ((x)->bp)
 
 #elif defined(__aarch64__)
-#if USE_SYSCALL_WRAPPER == 1
+#ifdef USE_SYSCALL_WRAPPER
 #define SYSCALL64_PREFIX "__arm64_"
 #define SYSCALL32_PREFIX "__arm32_"
 #else
@@ -107,7 +107,7 @@
     if (!rctx) return 0;                               \
     __MAP(x, m, __VA_ARGS__)
 
-#if USE_SYSCALL_WRAPPER == 1
+#ifdef USE_SYSCALL_WRAPPER
 #define __SC_64_PARAM(n, t, a) \
     t a;                       \
     bpf_probe_read(&a, sizeof(t), (void *)&SYSCALL64_PT_REGS_PARM##n(rctx));

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -22,13 +22,11 @@ func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useFen
 	var cflags []string
 
 	if useFentry {
-		cflags = append(cflags, "-DUSE_FENTRY=1")
+		cflags = append(cflags, "-DUSE_FENTRY")
 	}
 
 	if useSyscallWrapper {
-		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=1")
-	} else {
-		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=0")
+		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER")
 	}
 
 	if !config.NetworkEnabled {

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -229,7 +229,7 @@ def ninja_security_ebpf_programs(
         infile=infile,
         outfile=outfile,
         variables={
-            "flags": security_flags + " -DUSE_SYSCALL_WRAPPER=0",
+            "flags": security_flags,
             "kheaders": kheaders,
         },
     )
@@ -243,7 +243,7 @@ def ninja_security_ebpf_programs(
         infile=infile,
         outfile=syscall_wrapper_outfile,
         variables={
-            "flags": security_flags + " -DUSE_SYSCALL_WRAPPER=1",
+            "flags": security_flags + " -DUSE_SYSCALL_WRAPPER",
             "kheaders": kheaders,
         },
     )
@@ -257,7 +257,7 @@ def ninja_security_ebpf_programs(
         infile=infile,
         outfile=syscall_wrapper_outfile,
         variables={
-            "flags": security_flags + " -DUSE_SYSCALL_WRAPPER=1 -DUSE_FENTRY=1",
+            "flags": security_flags + " -DUSE_SYSCALL_WRAPPER -DUSE_FENTRY",
             "kheaders": kheaders,
         },
     )


### PR DESCRIPTION
### What does this PR do?

This PR cleans up a bit the way we use `USE_SYSCALL_WRAPPER` and `USE_FENTRY` to align them both on: if the macro is defined then the feature is enabled.

### Motivation

### Describe how you validated your changes

### Additional Notes
