### PR TITLE
[backport] [netpath] Fix file descriptor handling on linux (#40639)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	// TODO: pin to an operator released version once there is a release that includes the api module
 	github.com/DataDog/datadog-operator/api v0.0.0-20250417130148-1aa8dc0fc964
-	github.com/DataDog/datadog-traceroute v0.1.4
+	github.com/DataDog/datadog-traceroute v0.1.5
 	github.com/DataDog/ebpf-manager v0.7.14
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.12

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20250417130148-1aa8dc0fc964 h1:3EH1aRTHY22KbCYYhPZCaXTo1swWsi2DEyZNFAuTrt0=
 github.com/DataDog/datadog-operator/api v0.0.0-20250417130148-1aa8dc0fc964/go.mod h1:J6wMbBik2dRZfv+XYIrOwHyWi9+T6lRZSxTmEQ8bWNU=
-github.com/DataDog/datadog-traceroute v0.1.4 h1:02pZpt8DcE7TI4b4fTAGDuSwXQXo4KLPPfaTCJDWa1g=
-github.com/DataDog/datadog-traceroute v0.1.4/go.mod h1:uBhYAQTsxnhOC/rbh5B3rs4A1Gk4YWa/dqdSN+lScfM=
+github.com/DataDog/datadog-traceroute v0.1.5 h1:ka2D5XicwDjnSyQh1mudEG2OilkMp2D8JJ8sD7ORxd8=
+github.com/DataDog/datadog-traceroute v0.1.5/go.mod h1:uBhYAQTsxnhOC/rbh5B3rs4A1Gk4YWa/dqdSN+lScfM=
 github.com/DataDog/dd-trace-go/v2 v2.0.0 h1:cHMEzD0Wcgtu+Rec9d1GuVgpIN5f+4vCaNzuFHJ0v+Y=
 github.com/DataDog/dd-trace-go/v2 v2.0.0/go.mod h1:WBtf7TA9bWr5uA8DjOyw1qlSKe3bw9gN5nc0Ta9dHFE=
 github.com/DataDog/ebpf-manager v0.7.14 h1:k08TW46xdUEHggumRmbs9y+ymcZIJ1LKrRcXEq7EgIM=


### PR DESCRIPTION
This is a manual backport of #40639 to 7.71.x due to merge conflicts.

### What does this PR do?
This PR fixes an issue where datadog-traceroute was potentially incorrectly handling file descriptors on linux. More details on the datadog-traceroute PR: [\[linux\] Fix linuxSink file descriptor handling](https://github.com/DataDog/datadog-traceroute/pull/24)

### Motivation
Errors from the current 7.71 RC

### Describe how you validated your changes
This was triggered by the finalizer of `*os.File` -- the datadog traceroute library now has zero manual calls to unix.Close() on linux which was the source of this issue. It purely uses os.File's handling to close files