### PR TITLE
Re-document path needs to be valid

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2310,6 +2310,7 @@ api_key:
 ## @param dogstatsd_socket - string - optional - default: "/var/run/datadog/dsd.socket"
 ## @env DD_DOGSTATSD_SOCKET - string - optional - default: "/var/run/datadog/dsd.socket"
 ## Listen for Dogstatsd metrics on a Unix Socket (*nix only).
+## Set to a valid and existing filesystem path to enable.
 ## Set to "" to disable this feature.
 #
 # dogstatsd_socket: "/var/run/datadog/dsd.socket"


### PR DESCRIPTION
### What does this PR do?

- Mention that the path for `dogstatsd_socket` needs to be valid and existing
- This is already documented [here](https://github.com/DataDog/documentation/blob/master/content/en/developers/dogstatsd/unix_socket.md?plain=1#L58) bot got removed from [this commit](https://github.com/DataDog/datadog-agent/commit/b31fbf53498a2ce21726b8e8286b8b71228590ed#diff-a77843a3a2d99bdc21000210a1c6a0fc99871774b33d15b6779389e8299aa794L2020)

- Note that DD Agent has not been responsible for creating `/var/run/datadog/`.
- In OS that uses SystemD, this path gets created by the SystemD as per unit file configuration; there are scenarios where this does not get created and would result in `no such file or directory` which is expected

### Motivation

### Describe how you validated your changes

### Additional Notes

- APMS-15981
- AGENT-13813
