### PR TITLE
[incident-42773] Fix cache errors on git merge-base operations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,7 +243,7 @@ variables:
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job cloning strategy
-  GIT_STRATEGY: "s3"
+  # GIT_STRATEGY: "s3"
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)
   ARTIFACT_DOWNLOAD_ATTEMPTS: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,7 +243,7 @@ variables:
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job cloning strategy
-  # GIT_STRATEGY: "s3"
+  GIT_STRATEGY: "s3"
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)
   ARTIFACT_DOWNLOAD_ATTEMPTS: 2

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -119,7 +119,7 @@ def diff(
         commit_sha = get_commit_sha(ctx)
 
     if not baseline_ref:
-        base_branch = _get_release_json_value("base_branch")
+        base_branch = f'origin/{_get_release_json_value("base_branch")}'
         baseline_ref = get_common_ancestor(ctx, commit_sha, base_branch)
 
     diffs = {}

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -14,7 +14,7 @@ from tasks.go import GOARCH_MAPPING, GOOS_MAPPING
 from tasks.go import version as dot_go_version
 from tasks.libs.common.color import color_message
 from tasks.libs.common.datadog_api import create_gauge, send_metrics
-from tasks.libs.common.git import check_uncommitted_changes, get_commit_sha, get_current_branch
+from tasks.libs.common.git import check_uncommitted_changes, get_commit_sha, get_common_ancestor, get_current_branch
 from tasks.release import _get_release_json_value
 
 METRIC_GO_DEPS_ALL_NAME = "datadog.agent.go_dependencies.all"
@@ -120,7 +120,7 @@ def diff(
 
     if not baseline_ref:
         base_branch = _get_release_json_value("base_branch")
-        baseline_ref = ctx.run(f"git merge-base {commit_sha} origin/{base_branch}").stdout.strip()
+        baseline_ref = get_common_ancestor(ctx, commit_sha, base_branch)
 
     diffs = {}
     dep_cmd = "go list -f '{{ range .Deps }}{{ printf \"%s\\n\" . }}{{end}}'"

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -162,10 +162,10 @@ def get_common_ancestor(ctx, branch, base=None, try_fetch=True) -> str:
         The common ancestor between two branches.
     """
 
-    base = 'origin/' + (base or get_default_branch()).removeprefix("origin/")
+    base = (base or get_default_branch()).removeprefix("origin/")
 
     try:
-        return ctx.run(f"git merge-base {branch} {base}", hide=True).stdout.strip()
+        return ctx.run(f"git merge-base {branch} origin/{base}", hide=True).stdout.strip()
     except Exception:
         if not try_fetch:
             raise
@@ -173,7 +173,7 @@ def get_common_ancestor(ctx, branch, base=None, try_fetch=True) -> str:
         # With S3 caching, it's possible that the base branch is not fetched
         ctx.run(f"git fetch origin {base}")
 
-        return ctx.run(f"git merge-base {branch} {base}", hide=True).stdout.strip()
+        return ctx.run(f"git merge-base {branch} origin/{base}", hide=True).stdout.strip()
 
 
 def check_uncommitted_changes(ctx):

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -93,6 +93,7 @@ def get_file_modifications(
 
     base_branch = base_branch or _get_release_json_value('base_branch')
 
+    ctx.run(f"git fetch origin {base_branch}")
     last_main_commit = ctx.run(f"git merge-base HEAD origin/{base_branch}", hide=True).stdout.strip()
 
     flags = '--no-renames' if no_renames else ''

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -71,7 +71,6 @@ def get_untracked_files(ctx, re_filter=None) -> Iterable[str]:
             yield file
 
 
-
 def get_file_modifications(
     ctx, base_branch=None, added=False, modified=False, removed=False, only_names=False, no_renames=False
 ) -> list[tuple[str, str]]:
@@ -163,7 +162,7 @@ def get_common_ancestor(ctx, branch, base=None, try_fetch=True) -> str:
         The common ancestor between two branches.
     """
 
-    base = base or f"origin/{get_default_branch()}"
+    base = base or f'origin/{get_default_branch()}'
 
     try:
         return ctx.run(f"git merge-base {branch} {base}", hide=True).stdout.strip()
@@ -205,7 +204,7 @@ def get_main_parent_commit(ctx) -> str:
     """
     Get the commit sha your current branch originated from
     """
-    return get_common_ancestor(ctx, "HEAD", get_default_branch())
+    return get_common_ancestor(ctx, "HEAD", f'origin/{get_default_branch()}')
 
 
 def check_base_branch(branch, release_version):
@@ -364,7 +363,7 @@ def create_tree(ctx, base_branch):
     """
     Create a tree on all the local staged files
     """
-    base = get_common_ancestor(ctx, "HEAD", base_branch)
+    base = get_common_ancestor(ctx, "HEAD", f'origin/{base_branch}')
     tree = {"base_tree": base, "tree": []}
     template = {"path": None, "mode": "100644", "type": "blob", "content": None}
     for file in get_staged_files(ctx, include_deleted_files=True, relative_path=True):

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -162,7 +162,7 @@ def get_common_ancestor(ctx, branch, base=None, try_fetch=True) -> str:
         The common ancestor between two branches.
     """
 
-    base = base or f'origin/{get_default_branch()}'
+    base = 'origin/' + (base or get_default_branch()).removeprefix("origin/")
 
     try:
         return ctx.run(f"git merge-base {branch} {base}", hide=True).stdout.strip()


### PR DESCRIPTION
### Motivation

This fixes issues with S3 cache by fetching the target branch when doing `git merge-base` operations.

### Describe how you validated your changes

### Additional Notes

#incident-42773 
