### PR TITLE
Orchestrion version should come from go.mod

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -130,7 +130,7 @@ go_e2e_test_binaries:
     - !reference [.retrieve_linux_go_e2e_deps]
   script:
     - pushd test/new-e2e
-    - go install github.com/DataDog/orchestrion@v1.4.0
+    - go install github.com/DataDog/orchestrion
     - popd
     - dda inv -- -e new-e2e-tests.build-binaries --output-dir test-binaries -p $KUBERNETES_CPU_REQUEST --manifest-file-path manifest.json
     - tar czf test-binaries.tar.gz test-binaries


### PR DESCRIPTION
### What does this PR do?

Remove the explicit pinning in `go install`. The version installed should be the one in the go.mod

### Motivation

Have orchestrion version automatically bumped if there are updates in go.mod. Also make sure we benefit from go_e2e_deps caching

### Describe how you validated your changes

### Additional Notes
