### PR TITLE
[incident-42773] Fix cache errors on git merge-base operations (main)

### DIFF
--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -14,7 +14,7 @@ from tasks.go import GOARCH_MAPPING, GOOS_MAPPING
 from tasks.go import version as dot_go_version
 from tasks.libs.common.color import color_message
 from tasks.libs.common.datadog_api import create_gauge, send_metrics
-from tasks.libs.common.git import check_uncommitted_changes, get_commit_sha, get_current_branch
+from tasks.libs.common.git import check_uncommitted_changes, get_commit_sha, get_common_ancestor, get_current_branch
 from tasks.release import _get_release_json_value
 
 METRIC_GO_DEPS_ALL_NAME = "datadog.agent.go_dependencies.all"
@@ -119,8 +119,8 @@ def diff(
         commit_sha = get_commit_sha(ctx)
 
     if not baseline_ref:
-        base_branch = _get_release_json_value("base_branch")
-        baseline_ref = ctx.run(f"git merge-base {commit_sha} origin/{base_branch}").stdout.strip()
+        base_branch = f'origin/{_get_release_json_value("base_branch")}'
+        baseline_ref = get_common_ancestor(ctx, commit_sha, base_branch)
 
     diffs = {}
     dep_cmd = "go list -f '{{ range .Deps }}{{ printf \"%s\\n\" . }}{{end}}'"

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -148,7 +148,7 @@ def get_default_branch(major: int | None = None):
     return '6.53.x' if major is None and is_agent6(ctx) or major == 6 else 'main'
 
 
-def get_common_ancestor(ctx, branch, base=None, try_fetch=True) -> str:
+def get_common_ancestor(ctx, branch, base=None, try_fetch=True, hide=True) -> str:
     """
     Get the common ancestor between two branches.
 
@@ -165,15 +165,15 @@ def get_common_ancestor(ctx, branch, base=None, try_fetch=True) -> str:
     base = (base or get_default_branch()).removeprefix("origin/")
 
     try:
-        return ctx.run(f"git merge-base {branch} origin/{base}", hide=True).stdout.strip()
+        return ctx.run(f"git merge-base {branch} origin/{base}", hide=hide).stdout.strip()
     except Exception:
         if not try_fetch:
             raise
 
         # With S3 caching, it's possible that the base branch is not fetched
-        ctx.run(f"git fetch origin {base}")
+        ctx.run(f"git fetch origin {base}", hide=hide)
 
-        return ctx.run(f"git merge-base {branch} origin/{base}", hide=True).stdout.strip()
+        return ctx.run(f"git merge-base {branch} origin/{base}", hide=hide).stdout.strip()
 
 
 def check_uncommitted_changes(ctx):
@@ -202,7 +202,7 @@ def get_commit_sha(ctx, commit="HEAD", short=False) -> str:
 
 def get_main_parent_commit(ctx) -> str:
     """
-    Get the commit sha your current branch originated from
+    Get the commit sha from the LCA between main and the current branch
     """
     return get_common_ancestor(ctx, "HEAD", f'origin/{get_default_branch()}')
 

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -155,7 +155,7 @@ def get_common_ancestor(ctx, branch, base=None, try_fetch=True) -> str:
     Args:
         ctx: The invoke context.
         branch: The branch to get the common ancestor with.
-        base: The base branch to get the common ancestor with.
+        base: The base branch to get the common ancestor with. Defaults to the default branch.
         try_fetch: Try to fetch the base branch if it's not found (to avoid S3 caching issues).
 
     Returns:

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -93,7 +93,7 @@ def get_file_modifications(
 
     base_branch = base_branch or _get_release_json_value('base_branch')
 
-    last_main_commit = ctx.run(f"git merge-base HEAD origin/{base_branch}", hide=True).stdout.strip()
+    last_main_commit = get_common_ancestor(ctx, "HEAD", base_branch)
 
     flags = '--no-renames' if no_renames else ''
 
@@ -148,10 +148,32 @@ def get_default_branch(major: int | None = None):
     return '6.53.x' if major is None and is_agent6(ctx) or major == 6 else 'main'
 
 
-def get_common_ancestor(ctx, branch, base=None) -> str:
-    base = base or f"origin/{get_default_branch()}"
+def get_common_ancestor(ctx, branch, base=None, try_fetch=True) -> str:
+    """
+    Get the common ancestor between two branches.
 
-    return ctx.run(f"git merge-base {branch} {base}", hide=True).stdout.strip()
+    Args:
+        ctx: The invoke context.
+        branch: The branch to get the common ancestor with.
+        base: The base branch to get the common ancestor with.
+        try_fetch: Try to fetch the base branch if it's not found (to avoid S3 caching issues).
+
+    Returns:
+        The common ancestor between two branches.
+    """
+
+    base = (base or get_default_branch()).removeprefix("origin/")
+
+    try:
+        return ctx.run(f"git merge-base {branch} origin/{base}", hide=True).stdout.strip()
+    except Exception:
+        if not try_fetch:
+            raise
+
+        # With S3 caching, it's possible that the base branch is not fetched
+        ctx.run(f"git fetch origin {base}")
+
+        return ctx.run(f"git merge-base {branch} origin/{base}", hide=True).stdout.strip()
 
 
 def check_uncommitted_changes(ctx):
@@ -182,7 +204,7 @@ def get_main_parent_commit(ctx) -> str:
     """
     Get the commit sha your current branch originated from
     """
-    return ctx.run(f"git merge-base HEAD origin/{get_default_branch()}", hide=True).stdout.strip()
+    return get_common_ancestor(ctx, "HEAD", f'origin/{get_default_branch()}')
 
 
 def check_base_branch(branch, release_version):
@@ -341,7 +363,7 @@ def create_tree(ctx, base_branch):
     """
     Create a tree on all the local staged files
     """
-    base = get_common_ancestor(ctx, "HEAD", base_branch)
+    base = get_common_ancestor(ctx, "HEAD", f'origin/{base_branch}')
     tree = {"base_tree": base, "tree": []}
     template = {"path": None, "mode": "100644", "type": "blob", "content": None}
     for file in get_staged_files(ctx, include_deleted_files=True, relative_path=True):


### PR DESCRIPTION
### What does this PR do?

This fixes issues with S3 cache by fetching the target branch when doing `git merge-base` operations.

### Motivation

### Describe how you validated your changes

### Additional Notes
