### PR TITLE
fix(assign_issue): Add a missing dependency at runtime

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Install yq
+      run: |
+        sudo add-apt-repository ppa:rmescandon/yq
+        sudo apt update
+        sudo apt install yq -y
     - name: Install dda
       uses: ./.github/actions/install-dda
       with:


### PR DESCRIPTION
### What does this PR do?
- Add `yq` at runtime during the `assign_issue` workflow

### Motivation
- `yq` is used by `dda` and the workflow is currently [failing](https://github.com/DataDog/datadog-agent/actions/runs/17498675682/job/49705999064)
- We install it at runtime because modification of the image is not [straightforward](https://datadoghq.atlassian.net/wiki/x/IQM0CQE)
- This is intended to be temporary. We should get yq in a better way in the future.

### Describe how you validated your changes
I need this to be merged before I can retrigger the workflow on an issue. The modification is quite simple.

### Additional Notes
