### PR TITLE
[CWS] cleanup import of security config from the security agent

### DIFF
--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 )
 
@@ -187,7 +187,7 @@ func NewRuntimeSecurityClient() (*RuntimeSecurityClient, error) {
 		return nil, errors.New("runtime_security_config.socket must be set")
 	}
 
-	family := config.GetFamilyAddress(socketPath)
+	family := common.GetFamilyAddress(socketPath)
 	if family == "unix" {
 		if runtime.GOOS == "windows" {
 			return nil, fmt.Errorf("unix sockets are not supported on Windows")

--- a/pkg/security/common/address_utils.go
+++ b/pkg/security/common/address_utils.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package common holds common related files
+package common
+
+import "strings"
+
+// GetFamilyAddress returns the address famility to use for system-probe <-> security-agent communication
+func GetFamilyAddress(path string) string {
+	if strings.HasPrefix(path, "/") {
+		return "unix"
+	}
+	return "tcp"
+}

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -15,11 +15,9 @@ import (
 	"strings"
 	"time"
 
-	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -759,28 +757,6 @@ func (c *RuntimeSecurityConfig) sanitizeRuntimeSecurityConfigActivityDump() erro
 	}
 
 	return nil
-}
-
-// ActivityDumpRemoteStorageEndpoints returns the list of activity dump remote storage endpoints parsed from the agent config
-func ActivityDumpRemoteStorageEndpoints(endpointPrefix string, intakeTrackType logsconfig.IntakeTrackType, intakeProtocol logsconfig.IntakeProtocol, intakeOrigin logsconfig.IntakeOrigin) (*logsconfig.Endpoints, error) {
-	logsConfig := logsconfig.NewLogsConfigKeys("runtime_security_config.activity_dump.remote_storage.endpoints.", pkgconfigsetup.Datadog())
-	endpoints, err := logsconfig.BuildHTTPEndpointsWithConfig(pkgconfigsetup.Datadog(), logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
-	if err != nil {
-		endpoints, err = logsconfig.BuildHTTPEndpoints(pkgconfigsetup.Datadog(), intakeTrackType, intakeProtocol, intakeOrigin)
-		if err == nil {
-			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main, pkgconfigsetup.Datadog())
-			endpoints, err = logsconfig.BuildEndpoints(pkgconfigsetup.Datadog(), httpConnectivity, intakeTrackType, intakeProtocol, intakeOrigin)
-		}
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("invalid endpoints: %w", err)
-	}
-
-	for _, status := range endpoints.GetStatus() {
-		seclog.Infof("activity dump remote storage endpoint: %v\n", status)
-	}
-	return endpoints, nil
 }
 
 // parseEventTypeDurations converts a map of durations indexed by event types

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	"net"
 	"slices"
-	"strings"
 	"time"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -785,12 +784,4 @@ func parseHashAlgorithmStringSlice(algorithms []string) []model.HashAlgorithm {
 		}
 	}
 	return output
-}
-
-// GetFamilyAddress returns the address famility to use for system-probe <-> security-agent communication
-func GetFamilyAddress(path string) string {
-	if strings.HasPrefix(path, "/") {
-		return "unix"
-	}
-	return "tcp"
 }

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -20,6 +20,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
@@ -86,7 +87,7 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		}
 	}
 
-	family := config.GetFamilyAddress(cfg.SocketPath)
+	family := common.GetFamilyAddress(cfg.SocketPath)
 
 	apiServer, err := NewAPIServer(cfg, evm.Probe, opts.MsgSender, evm.StatsdClient, selfTester, compression, ipc)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR does 2 things to remove edges between `pkg/security/agent` and `pkg/security/config`:
- it moves the `ActivityDumpRemoteStorageEndpoints` to the same package where it's used (removing one import edge)
- it moves `GetFamilyAddress` to `pkg/security/common`

The end goal, when all edges are removed, is to remove a lot of indirect dependencies pulled through the configuration such as the ebpf-manager, cilium/ebpf etc.

### Motivation

### Describe how you validated your changes

### Additional Notes
