### PR TITLE
[CWS] remove extra import from `pkg/security/api`

### DIFF
--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -34,7 +34,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/clihelpers"
-	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api/transform"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -380,7 +380,7 @@ func checkPoliciesLoaded(client secagent.SecurityModuleClientWrapper, writer io.
 	}
 
 	// extract and report the filters
-	transformedOutput := api.FromProtoToFilterReport(output.GetRuleSetReportMessage().GetFilters())
+	transformedOutput := transform.FromProtoToFilterReport(output.GetRuleSetReportMessage().GetFilters())
 
 	content, _ := json.MarshalIndent(transformedOutput, "", "\t")
 	_, err = fmt.Fprintf(writer, "%s\n", string(content))

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -34,6 +34,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/clihelpers"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -379,7 +380,7 @@ func checkPoliciesLoaded(client secagent.SecurityModuleClientWrapper, writer io.
 	}
 
 	// extract and report the filters
-	transformedOutput := output.GetRuleSetReportMessage().GetFilters().FromProtoToFilterReport()
+	transformedOutput := api.FromProtoToFilterReport(output.GetRuleSetReportMessage().GetFilters())
 
 	content, _ := json.MarshalIndent(transformedOutput, "", "\t")
 	_, err = fmt.Fprintf(writer, "%s\n", string(content))

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/selftests"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api/transform"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/monitor"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -581,7 +582,7 @@ func (a *APIServer) GetRuleSetReport(_ context.Context, _ *api.GetRuleSetReportP
 	}
 
 	return &api.GetRuleSetReportMessage{
-		RuleSetReportMessage: api.FromFilterReportToProtoRuleSetReportMessage(report),
+		RuleSetReportMessage: transform.FromFilterReportToProtoRuleSetReportMessage(report),
 	}, nil
 }
 

--- a/pkg/security/proto/api/transform_functions.go
+++ b/pkg/security/proto/api/transform_functions.go
@@ -15,7 +15,7 @@ import (
 )
 
 // FromProtoToFilterReport transforms a proto to a kfilter filter report
-func (p *FilterReport) FromProtoToFilterReport() *kfilters.FilterReport {
+func FromProtoToFilterReport(p *FilterReport) *kfilters.FilterReport {
 	approverReports := make(map[eval.EventType]*kfilters.ApproverReport)
 
 	toAcceptModeRules := func(r []*AcceptModeRule) []kfilters.AcceptModeRule {

--- a/pkg/security/proto/api/transform_functions.go
+++ b/pkg/security/proto/api/transform_functions.go
@@ -29,7 +29,7 @@ func (p *FilterReport) FromProtoToFilterReport() *kfilters.FilterReport {
 	}
 
 	for _, report := range p.GetApprovers() {
-		approversToPrint := *report.GetApprovers().FromProtoToApprovers()
+		approversToPrint := *report.GetApprovers().fromProtoToApprovers()
 		if len(approversToPrint) == 0 {
 			approversToPrint = nil // This is here to ensure that the printed result is `"Approvers": null` and not `"Approvers": {}`
 		}
@@ -45,8 +45,8 @@ func (p *FilterReport) FromProtoToFilterReport() *kfilters.FilterReport {
 	return wholeReport
 }
 
-// FromProtoToApprovers transforms a proto to a kfilter approvers
-func (p *Approvers) FromProtoToApprovers() *rules.Approvers {
+// fromProtoToApprovers transforms a proto to a kfilter approvers
+func (p *Approvers) fromProtoToApprovers() *rules.Approvers {
 	approvers := make(rules.Approvers)
 
 	for _, approver := range p.GetApproverDetails() {
@@ -79,8 +79,8 @@ func FromFilterReportToProtoRuleSetReportMessage(filterReport *kfilters.FilterRe
 		protoReport := &ApproverReport{
 			EventType:       key,
 			Mode:            uint32(report.Mode),
-			Approvers:       FromApproversToProto(report.Approvers),
-			AcceptModeRules: FromAcceptModeRulesToProto(report.AcceptModeRules),
+			Approvers:       fromApproversToProto(report.Approvers),
+			AcceptModeRules: fromAcceptModeRulesToProto(report.AcceptModeRules),
 		}
 
 		reports = append(reports, protoReport)
@@ -93,8 +93,8 @@ func FromFilterReportToProtoRuleSetReportMessage(filterReport *kfilters.FilterRe
 	}
 }
 
-// FromAcceptModeRulesToProto transforms a kfilter to a proto accept mode rules
-func FromAcceptModeRulesToProto(acceptModeRules []kfilters.AcceptModeRule) []*AcceptModeRule {
+// fromAcceptModeRulesToProto transforms a kfilter to a proto accept mode rules
+func fromAcceptModeRulesToProto(acceptModeRules []kfilters.AcceptModeRule) []*AcceptModeRule {
 	protoAcceptModeRules := make([]*AcceptModeRule, len(acceptModeRules))
 	for i, rule := range acceptModeRules {
 		protoAcceptModeRules[i] = &AcceptModeRule{
@@ -104,8 +104,8 @@ func FromAcceptModeRulesToProto(acceptModeRules []kfilters.AcceptModeRule) []*Ac
 	return protoAcceptModeRules
 }
 
-// FromApproversToProto transforms a kfilter to a proto approvers
-func FromApproversToProto(approvers rules.Approvers) *Approvers {
+// fromApproversToProto transforms a kfilter to a proto approvers
+func fromApproversToProto(approvers rules.Approvers) *Approvers {
 	protoApprovers := new(Approvers)
 
 	for field, filterValues := range approvers {


### PR DESCRIPTION
### What does this PR do?

This PR extracts the transformation between kfilters model types and associated protobuf versions in order to let the security agent imports `pkg/security/api` without bringing the whole CWS code with it.

### Motivation

### Describe how you validated your changes

### Additional Notes
