### PR TITLE
ndm: Send agent_host tag by default

### DIFF
--- a/pkg/collector/corechecks/snmp/integration_profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/integration_profile_metadata_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
@@ -30,7 +31,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 )
 
+func setupHostname(t *testing.T) {
+	mockConfig := configmock.New(t)
+	cache.Cache.Delete(cache.BuildAgentKey("hostname"))
+	mockConfig.SetWithoutSource("hostname", "my-hostname")
+}
+
 func TestProfileMetadata_f5(t *testing.T) {
+	setupHostname(t)
 	cfg := configmock.New(t)
 	timeNow = common.MockTimeNow
 	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
@@ -349,6 +357,7 @@ profiles:
         "snmp_device:1.2.3.4"
       ],
       "tags": [
+		"agent_host:my-hostname",
         "agent_version:%s",
 		"device_id:profile-metadata:1.2.3.4",
 		"device_ip:1.2.3.4",

--- a/pkg/collector/corechecks/snmp/integration_topology_test.go
+++ b/pkg/collector/corechecks/snmp/integration_topology_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestTopologyPayload_LLDP(t *testing.T) {
+	setupHostname(t)
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
 	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
@@ -659,6 +660,7 @@ profiles:
         "snmp_device:1.2.3.4"
       ],
       "tags": [
+	    "agent_host:my-hostname",
         "agent_version:%s",
 		"device_id:profile-metadata:1.2.3.4",
 		"device_ip:1.2.3.4",
@@ -1429,6 +1431,7 @@ profiles:
         "snmp_device:1.2.3.4"
       ],
       "tags": [
+		"agent_host:my-hostname",
         "agent_version:%s",
 		"device_id:profile-metadata:1.2.3.4",
 		"device_ip:1.2.3.4",
@@ -2189,6 +2192,7 @@ profiles:
         "snmp_device:1.2.3.4"
       ],
       "tags": [
+		"agent_host:my-hostname",
         "agent_version:%s",
 		"device_id:profile-metadata:1.2.3.4",
 		"device_ip:1.2.3.4",
@@ -2950,6 +2954,7 @@ profiles:
         "snmp_device:1.2.3.4"
       ],
       "tags": [
+		"agent_host:my-hostname",
         "agent_version:%s",
 		"device_id:profile-metadata:1.2.3.4",
 		"device_ip:1.2.3.4",

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -9,13 +9,14 @@ package checkconfig
 import (
 	"context"
 	"fmt"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"hash/fnv"
 	"net"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 
 	"gopkg.in/yaml.v2"
 
@@ -224,13 +225,11 @@ func (c *CheckConfig) GetStaticTags() []string {
 		tags = append(tags, deviceIDTagKey+":"+c.DeviceID)
 	}
 
-	if c.UseDeviceIDAsHostname {
-		hname, err := hostname.Get(context.TODO())
-		if err != nil {
-			log.Warnf("Error getting the hostname: %v", err)
-		} else {
-			tags = append(tags, "agent_host:"+hname)
-		}
+	hname, err := hostname.Get(context.TODO())
+	if err != nil {
+		log.Warnf("Error getting the hostname: %v", err)
+	} else {
+		tags = append(tags, "agent_host:"+hname)
 	}
 	return tags
 }

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -25,9 +25,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 )
 
+func setupHostname(t *testing.T) {
+	mockConfig := configmock.New(t)
+	cache.Cache.Delete(cache.BuildAgentKey("hostname"))
+	mockConfig.SetWithoutSource("hostname", "my-hostname")
+}
+
 func TestConfigurations(t *testing.T) {
+	setupHostname(t)
+
 	profile.SetConfdPathAndCleanProfiles()
 	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
 
@@ -158,7 +167,7 @@ bulk_max_repetitions: 20
 	assert.Equal(t, "aes", config.PrivProtocol)
 	assert.Equal(t, "my-privKey", config.PrivKey)
 	assert.Equal(t, "my-contextName", config.ContextName)
-	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}, config.GetStaticTags())
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4", "agent_host:my-hostname"}, config.GetStaticTags())
 	assert.True(t, config.ProfileProvider.HasProfile("f5-big-ip"))
 	assert.Equal(t, "default:1.2.3.4", config.DeviceID)
 	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4"}, config.DeviceIDTags)
@@ -268,6 +277,7 @@ bulk_max_repetitions: 20
 }
 
 func TestDiscoveryConfigurations(t *testing.T) {
+	setupHostname(t)
 	// language=yaml
 	rawInstanceConfig := []byte(`
 network_address: 127.0.0.0/24
@@ -297,6 +307,7 @@ workers: 30
 }
 
 func TestProfileNormalizeMetrics(t *testing.T) {
+	setupHostname(t)
 	profile.SetConfdPathAndCleanProfiles()
 
 	// language=yaml
@@ -319,7 +330,7 @@ profiles:
 	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"device_namespace:default", "snmp_device:172.26.0.2", "device_ip:172.26.0.2", "device_id:default:172.26.0.2"}, config.GetStaticTags())
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:172.26.0.2", "device_ip:172.26.0.2", "device_id:default:172.26.0.2", "agent_host:my-hostname"}, config.GetStaticTags())
 
 	profile, err := config.BuildProfile("")
 	require.NoError(t, err)
@@ -337,6 +348,7 @@ profiles:
 }
 
 func TestInlineProfileConfiguration(t *testing.T) {
+	setupHostname(t)
 	profile.SetConfdPathAndCleanProfiles()
 	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
 
@@ -371,7 +383,7 @@ profiles:
 	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}, config.GetStaticTags())
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4", "agent_host:my-hostname"}, config.GetStaticTags())
 	assert.Equal(t, "123", config.CommunityString)
 	assert.True(t, config.ProfileProvider.HasProfile("f5-big-ip"))
 	assert.True(t, config.ProfileProvider.HasProfile("inline-profile"))
@@ -397,6 +409,7 @@ profiles:
 }
 
 func TestDefaultConfigurations(t *testing.T) {
+	setupHostname(t)
 	profile.SetConfdPathAndCleanProfiles()
 
 	// language=yaml
@@ -700,6 +713,7 @@ network_address: 10.0.0.0/xx
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			setupHostname(t)
 			_, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig, nil)
 			for _, errStr := range tt.expectedErrors {
 				require.NotNil(t, err, "expected error %q", errStr)
@@ -776,6 +790,7 @@ retries: "5"
 }
 
 func TestExtraTags(t *testing.T) {
+	setupHostname(t)
 	profile.SetConfdPathAndCleanProfiles()
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -784,7 +799,7 @@ community_string: abc
 `)
 	config, err := NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}, config.GetStaticTags())
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4", "agent_host:my-hostname"}, config.GetStaticTags())
 
 	// language=yaml
 	rawInstanceConfigWithExtraTags := []byte(`
@@ -794,7 +809,7 @@ extra_tags: "extratag1:val1,extratag2:val2"
 `)
 	config, err = NewCheckConfig(rawInstanceConfigWithExtraTags, []byte(``), nil)
 	assert.Nil(t, err)
-	assert.ElementsMatch(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4", "extratag1:val1", "extratag2:val2"}, config.GetStaticTags())
+	assert.ElementsMatch(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4", "agent_host:my-hostname", "extratag1:val1", "extratag2:val2"}, config.GetStaticTags())
 }
 
 func Test_snmpConfig_getDeviceIDTags(t *testing.T) {
@@ -1531,6 +1546,9 @@ ip_address: 1.2.3.4
 }
 
 func TestCheckConfig_DiscoveryDigest(t *testing.T) {
+	mockConfig := configmock.New(t)
+	cache.Cache.Delete(cache.BuildAgentKey("hostname"))
+	mockConfig.SetWithoutSource("hostname", "my-hostname")
 	baseCaseHash := DeviceDigest("a1d0f0237ee2fe8f")
 	tests := []struct {
 		name         string
@@ -1860,6 +1878,7 @@ func TestCheckConfig_GetStaticTags(t *testing.T) {
 				"device_namespace:default",
 				"snmp_device:1.2.3.4",
 				"device_ip:1.2.3.4",
+				"agent_host:my-hostname",
 			},
 		},
 		{
@@ -1878,6 +1897,7 @@ func TestCheckConfig_GetStaticTags(t *testing.T) {
 				"device_namespace:default",
 				"snmp_device:1.2.3.4",
 				"device_ip:1.2.3.4",
+				"agent_host:my-hostname",
 			},
 		},
 		{
@@ -1906,6 +1926,7 @@ func TestCheckConfig_GetStaticTags(t *testing.T) {
 				"device_namespace:default",
 				"snmp_device:1.2.3.4",
 				"device_ip:1.2.3.4",
+				"agent_host:my-hostname",
 			},
 		},
 	}

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -877,6 +877,7 @@ profiles:
         "snmp_device:1.2.3.4"
       ],
       "tags": [
+        "agent_host:my-hostname",
         "agent_version:%s",
         "autodiscovery_subnet:127.0.0.0/30",
 		"device_id:default:1.2.3.4",
@@ -1312,6 +1313,7 @@ metrics:
 }
 
 func TestReportDeviceMetadataEvenOnProfileError(t *testing.T) {
+	setupHostname(t)
 	mockConfig := configmock.New(t)
 	testDir := t.TempDir()
 	mockConfig.SetWithoutSource("run_path", testDir)
@@ -1547,6 +1549,7 @@ tags:
         "snmp_device:1.2.3.4"
       ],
       "tags": [
+        "agent_host:my-hostname",
         "agent_version:%s",
         "autodiscovery_subnet:127.0.0.0/30",
 		"device_id:default:1.2.3.4",
@@ -1697,6 +1700,7 @@ tags:
         "snmp_device:1.2.3.5"
       ],
       "tags": [
+        "agent_host:my-hostname",
         "agent_version:%s",
         "autodiscovery_subnet:127.0.0.0/30",
 		"device_id:default:1.2.3.5",
@@ -2015,6 +2019,7 @@ metric_tags:
         "snmp_device:%s"
       ],
       "tags": [
+        "agent_host:my-hostname",
         "agent_version:%s",
         "autodiscovery_subnet:10.10.0.0/30",
 		"device_id:%s",


### PR DESCRIPTION
Always send the agent_host tag on ndm metadata payloads regardless of `use_device_id_as_hostname`.
It's always useful to be able to get back to the Agent from the device metadata, and this is needed for triggering device scan from the profile manager