### PR TITLE
fix(fleet): Properly remove Squid proxy

### DIFF
--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -526,6 +526,12 @@ func (h *Host) RemoveProxy() {
 	// Check proxy removed
 	_, err := h.remote.Execute("curl https://google.com")
 	require.NoError(h.t(), err)
+
+	// Remove Docker container
+	_, err = h.remote.Execute("sudo docker rm -f squid-proxy")
+	if err != nil {
+		h.t().Logf("warn: failed to remove Docker container: %v", err)
+	}
 }
 
 // LoadState is the load state of a systemd unit.


### PR DESCRIPTION
### What does this PR do?
Fixes Fleet Automation tests retries where the Squid proxy would not be properly removed

### Motivation
No E2E flakes

### Describe how you validated your changes
E2E pipeline

### Additional Notes
