### PR TITLE
[CWS] add CWS template content to system-probe status section

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -60,6 +60,7 @@ func createEventMonitorModule(sysconfig *sysconfigtypes.Config, deps module.Fact
 			return nil, err
 		}
 		evm.RegisterEventConsumer(cws)
+		evm.SetCWSStatusProvider(cws)
 		log.Info("event monitoring cws consumer initialized")
 	}
 

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
@@ -55,6 +56,8 @@ type EventMonitor struct {
 	sendStatsChan  chan chan bool
 	eventConsumers []EventConsumer
 	wg             sync.WaitGroup
+
+	cwsStatusProvider CWSStatusProvider
 }
 
 var _ module.Module = &EventMonitor{}
@@ -82,6 +85,16 @@ func (m *EventMonitor) AddEventConsumerHandler(consumer EventConsumerHandler) er
 // RegisterEventConsumer registers an event consumer
 func (m *EventMonitor) RegisterEventConsumer(consumer EventConsumer) {
 	m.eventConsumers = append(m.eventConsumers, consumer)
+}
+
+// CWSStatusProvider defines an interface to get CWS status
+type CWSStatusProvider interface {
+	GetStatus(ctx context.Context) (*api.Status, error)
+}
+
+// SetCWSStatusProvider sets the CWS status provider
+func (m *EventMonitor) SetCWSStatusProvider(provider CWSStatusProvider) {
+	m.cwsStatusProvider = provider
 }
 
 // Init initializes the module
@@ -213,6 +226,15 @@ func (m *EventMonitor) GetStats() map[string]interface{} {
 		debug["probe"] = m.Probe.GetDebugStats()
 	} else {
 		debug["probe"] = "not_running"
+	}
+
+	if m.cwsStatusProvider != nil {
+		cwsStatus, err := m.cwsStatusProvider.GetStatus(context.Background())
+		if err != nil {
+			debug["cws"] = fmt.Sprintf("failed to get CWS status: %v", err)
+		} else {
+			debug["cws"] = cwsStatus
+		}
 	}
 
 	return debug

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -391,3 +391,8 @@ func (c *CWSConsumer) PrepareForFunctionalTests() {
 	// no need for container running telemetry in functional tests
 	c.crtelemetry = nil
 }
+
+// GetStatus returns the status of the module
+func (c *CWSConsumer) GetStatus(ctx context.Context) (*api.Status, error) {
+	return c.apiServer.GetStatus(ctx, &api.GetStatusParams{})
+}

--- a/pkg/status/systemprobe/status_templates/systemprobe.tmpl
+++ b/pkg/status/systemprobe/status_templates/systemprobe.tmpl
@@ -78,6 +78,108 @@
   {{- else }}
     Status: Running
   {{- end }}
+
+  {{- with .event_monitor.cws }}
+
+  CWS (runtime security)
+  ======================
+
+    Endpoints
+    =========
+
+    {{ if .DirectSenderStatus }}
+    {{- range $endpoint := .DirectSenderStatus.Endpoints }}
+    {{ $endpoint }}
+    {{- end }}
+    {{- end }}
+
+    Self Tests
+    ==========
+
+      Last execution: {{ .SelfTests.LastTimestamp }}
+      {{ if .SelfTests.Success }}
+      Succeeded:
+        {{- range $test := .SelfTests.Success }}
+        - {{ $test }}
+        {{- end }}
+      {{- else }}
+      Succeeded: none
+      {{- end }}
+      {{ if .SelfTests.Fails }}
+      Failed:
+        {{- range $test := .SelfTests.Fails }}
+        - {{ $test }}
+        {{- end }}
+      {{- else }}
+      Failed: none
+      {{- end }}
+
+    Policies
+    ========
+      {{ range $policy := .PoliciesStatus }}
+        {{ $policy.Name }}:
+          source: {{ $policy.Source }}
+          rules:
+            {{- range $status := $policy.Status }}
+              - {{ $status.ID }}: {{ $status.Status }}{{- if $status.Error }} ({{- $status.Error }}){{- end }}
+            {{- end }}
+      {{ end }}
+
+
+    SECL Variables
+    ==============
+
+    Global variables:
+    {{ range $variable := .GlobalVariables }}
+      - {{ $variable.Name }}: {{ $variable.Value }}
+    {{- end }}
+    {{- if not .GlobalVariables }}
+        No variable found
+    {{- end }}
+
+    Scoped variables:
+    {{ range $scope, $vars := .ScopedVariables }}
+      {{ $scope }}:
+      {{ range $key, $variables := $vars.KeyValues }}
+        {{ $key }}:
+        {{- range $variable := $variables.Variables }}
+          - {{ $variable.Name }}: {{ $variable.Value }}
+        {{- end }}
+      {{ end }}
+    {{- end }}
+    {{- if not .ScopedVariables }}
+        No variable found
+    {{- end }}
+
+    {{- with .Environment }}
+
+    Environment
+    ===========
+      {{- if .Warnings }}
+      Warnings:
+        {{- range $warning := .Warnings }}
+        - {{ $warning }}
+        {{- end }}
+      {{- end }}
+      Kernel lockdown: {{ .KernelLockdown }}
+      Use eBPF mmapable maps: {{ .UseMmapableMaps }}
+      Use eBPF ring buffer: {{ .UseRingBuffer }}
+      Use fentry: {{ .UseFentry }}
+      {{ if .Constants }}
+      Available constant fetchers
+      ===========================
+        {{ range $fetcher := .Constants.Fetchers }}
+        {{ $fetcher }}
+        {{- end }}
+
+      Constants
+      =========
+        {{ range $constant := .Constants.Values }}
+        {{ $constant.ID }} = {{ $constant.Value }} (from {{ $constant.Source }})
+        {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if .process }}
 


### PR DESCRIPTION
### What does this PR do?

This PR allows the event monitor module to forward the CWS (which is only an event monitor consumer, not a top level module) status when fetching the status from all modules.

This allows the core agent status to include the CWS status, similarly to how it's done for USM for example. The status content is currently copied from the security agent status and looks like:
```
  CWS (runtime security)
  ======================

    Self Tests
    ==========

      Last execution: 01 Jan 01 00:00 UTC

      Succeeded: none

      Failed: none

    Policies
    ========

        default.policy:
          source: file
          rules:
              - pci_11_5_critical_binaries_unlink: loaded
              - kernel_module_link: loaded
              - nsswitch_conf_mod_chmod: loaded
              - ssh_authorized_keys_chmod: loaded
              - offensive_k8s_tool: loaded
              - open_msr_writes: loaded
              - auditd_rule_file_modified: loaded
              - passwd_execution: "********"
              - sensitive_tracing: loaded
              - suspicious_container_client: loaded
              - user_created_tty: loaded
              - ssl_certificate_tampering_utimes: loaded
              - compiler_in_container: loaded
              - mount_proc_hide: loaded
              - dirty_pipe_exploitation: loaded
              - ssh_authorized_keys_open: loaded
              - sudoers_policy_modified_unlink: loaded
              - cron_at_job_creation_utimes: loaded
              - pci_11_5_critical_binaries_chmod: loaded
              - network_sniffing_tool: loaded
              - nsswitch_conf_mod_unlink: loaded
              - kernel_module_load_from_memory: loaded
              - sudoers_policy_modified_chmod: loaded
              - cron_at_job_creation_chown: loaded
              - shell_history_symlink: loaded
              - redis_sandbox_escape: loaded
              - perl_shell: loaded
              - dynamic_linker_config_unlink: loaded
              - systemd_modification_unlink: loaded
              - nsswitch_conf_mod_link: loaded
              - net_file_download: loaded
              - pam_modification_rename: loaded
              - shell_net_connection: loaded
              - nsswitch_conf_mod_open_v2: loaded
              - exec_wrmsr: loaded
              - devshm_execution: loaded
              - systemd_modification_chmod: loaded
              - executable_bit_added: loaded
              - credential_modified_link: loaded
              - user_deleted_tty: loaded
              - ssh_it_tool_config_write: loaded
              - modified_file_requesting_imds_creds: loaded
              - tar_execution: loaded
              - cryptominer_envs: loaded
              - cups_spawned_shell: loaded
              - potential_web_shell_parent: loaded
              - memfd_create: loaded
              - runc_modification: loaded
              - read_kubeconfig: loaded
              - hidden_file_executed: loaded
              - tunnel_traffic: loaded
              - service_stop: loaded
              - net_util: loaded
              - mining_pool_lookup: loaded
              - gcp_imds: loaded
              - nsswitch_conf_mod_chown: loaded
              - openssl_backdoor: loaded
              - pam_modification_unlink: loaded
              - netcat_shell: loaded
              - python_cli_code: loaded
              - net_util_exfiltration: loaded
              - runc_leaky_fd: loaded
              - auditd_config_modified: loaded
              - dirty_pipe_attempt: loaded
              - ssl_certificate_tampering_open_v2: loaded
              - delete_system_log: loaded
              - common_net_intrusion_util: loaded
              - credential_modified_unlink: loaded
              - credential_modified_utimes: loaded
              - kubernetes_dns_enumeration: loaded
              - credential_modified_chown: loaded
              - dynamic_linker_config_write: loaded
              - systemd_modification_open: loaded
              - ransomware_note: loaded
              - paste_site: loaded
              - azure_imds: loaded
              - kernel_module_load: loaded
              - debugfs_in_container: loaded
              - kernel_module_load_container: loaded
              - cron_at_job_creation_chmod: loaded
              - iptables_egress_allowed: loaded
              - pci_11_5_critical_binaries_link: loaded
              - systemd_modification_rename: loaded
              - cryptominer_args: loaded
              - credential_modified_open_v2: loaded
              - deploy_priv_container: loaded
              - kernel_module_unlink: loaded
              - webdriver_spawned_shell: loaded
              - kernel_module_rename: loaded
              - libpam_ebpf_hook: loaded
              - sudoers_policy_modified_rename: loaded
              - pam_modification_link: loaded
              - auditctl_usage: loaded
              - base64_decode: loaded
              - shell_history_truncated: loaded
              - tty_shell_in_container: loaded
              - kernel_module_chmod: loaded
              - pam_modification_utimes: loaded
              - jupyter_shell_execution: loaded
              - shell_profile_modification: loaded
              - sudoers_policy_modified_chown: loaded
              - cron_at_job_creation_unlink: loaded
              - net_unusual_request: loaded
              - file_sync_exfil: loaded
              - pci_11_5_critical_binaries_open_v2: loaded
              - ptrace_antidebug: loaded
              - nsenter_in_container: loaded
              - ssl_certificate_tampering_chmod: loaded
              - cron_at_job_creation_open: loaded
              - ssh_authorized_keys_unlink: loaded
              - kmod_list: loaded
              - kernel_module_utimes: loaded
              - aws_eks_service_account_token_accessed: loaded
              - interactive_shell_in_container: loaded
              - pci_11_5_critical_binaries_chown: loaded
              - ptrace_injection: loaded
              - ssl_certificate_tampering_unlink: loaded
              - nsswitch_conf_mod_utimes: loaded
              - ssl_certificate_tampering_link: loaded
              - release_agent_escape: loaded
              - find_credentials: loaded
              - kernel_module_open: loaded
              - sudoers_policy_modified_open: loaded
              - suid_file_execution: loaded
              - compile_after_delivery: loaded
              - nsswitch_conf_mod_open: loaded
              - k8s_pod_service_account_token_accessed: loaded
              - cron_at_job_creation_rename: loaded
              - ip_check_domain: loaded
              - systemd_modification_link: loaded
              - kernel_module_load_from_memory_container: loaded
              - apparmor_modified_tty: loaded
              - p2pinfect_connection: loaded
              - pam_modification_chown: loaded
              - redis_save_module: loaded
              - udev_modification: loaded
              - ssh_authorized_keys_open_v2: loaded
              - aws_imds: loaded
              - mount_host_fs: loaded
              - java_shell_execution_parent: loaded
              - ssh_outbound_connection: loaded
              - net_util_in_container: loaded
              - php_shell: loaded
              - sudoers_policy_modified_link: loaded
              - ssl_certificate_tampering_chown: loaded
              - mount_in_container: loaded
              - selinux_disable_enforcement: loaded
              - sudoers_policy_modified_utimes: loaded
              - kernel_module_chown: loaded
              - nsswitch_conf_mod_rename: loaded
              - suspicious_suid_execution: loaded
              - systemd_modification_chown: loaded
              - credential_modified_rename: loaded
              - unshare_in_container: loaded
              - exec_whoami: loaded
              - ld_preload_unusual_library_path: loaded
              - overwrite_entrypoint: loaded
              - rc_scripts_modified: loaded
              - ssh_nonstandard_connection: loaded
              - cron_at_job_creation_link: loaded
              - exec_lsmod: loaded
              - curl_docker_socket: loaded
              - pam_modification_open: loaded
              - socat_shell: loaded
              - ssh_authorized_keys_chown: loaded
              - database_shell_execution: loaded
              - ssh_authorized_keys_utimes: loaded
              - package_management_in_container: loaded
              - ssh_authorized_keys_link: loaded
              - aws_cli_usage: loaded
              - chatroom_request: loaded
              - irc_connection: loaded
              - shell_history_deleted: loaded
              - pci_11_5_critical_binaries_rename: loaded
              - ssl_certificate_tampering_rename: loaded
              - pci_11_5_critical_binaries_open: loaded
              - pci_11_5_critical_binaries_utimes: loaded
              - new_binary_execution_in_container: loaded
              - ssl_certificate_tampering_open: loaded
              - credential_modified_chmod: loaded
              - pwnkit_privilege_escalation: loaded
              - systemd_modification_utimes: loaded
              - webapp_imds_V1_request: loaded
              - kernel_msr_write: loaded
              - ssh_authorized_keys_rename: loaded
              - looney_tunables_exploit: loaded
              - pam_modification_chmod: loaded
              - suspicious_bitsadmin_usage: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_firewall_configuration_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - powershell_empire_uac_bypass: "********"
              - sliver_c2_implant_execution: filtered (none of the rule filters matched the host or configuration of this agent)
              - certutil_usage: filtered (none of the rule filters matched the host or configuration of this agent)
              - registry_hives_file_path_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - suspicious_ntdsutil_usage: filtered (none of the rule filters matched the host or configuration of this agent)
              - critical_registry_export: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_explorer_executable_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_system_enviroment_variable_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - crackmap_exec_executed: filtered (none of the rule filters matched the host or configuration of this agent)
              - critical_windows_files_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - safeboot_modification: filtered (none of the rule filters matched the host or configuration of this agent)
              - procdump_execution: filtered (none of the rule filters matched the host or configuration of this agent)
              - inveigh_tool_usage: filtered (none of the rule filters matched the host or configuration of this agent)
              - registry_runkey_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - rubeus_execution: filtered (none of the rule filters matched the host or configuration of this agent)
              - sharpup_tool_usage: filtered (none of the rule filters matched the host or configuration of this agent)
              - suspicious_dll_write: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_hosts_file_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - known_dll_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - ntds_in_commandline: filtered (none of the rule filters matched the host or configuration of this agent)
              - relay_attack_tool_execution: filtered (none of the rule filters matched the host or configuration of this agent)
              - scheduled_task_creation: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_security_essentials_executable_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_boot_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - wmi_spawning_shell: filtered (none of the rule filters matched the host or configuration of this agent)
              - php_spawning_shell: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_cryptominer_process: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_shell_folders_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_update_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - registry_service_runkey_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_com_rpc_debugging_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - windows_cryptographic_blocking_policy_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)
              - dotnet_dump_execution: filtered (none of the rule filters matched the host or configuration of this agent)
              - minidump_usage: filtered (none of the rule filters matched the host or configuration of this agent)
              - winlogon_registry_key_modified: filtered (none of the rule filters matched the host or configuration of this agent)



    SECL Variables
    ==============

    Global variables:

        No variable found

    Scoped variables:

        No variable found

    Environment
    ===========
      Kernel lockdown: none
      Use eBPF mmapable maps: true
      Use eBPF ring buffer: true
      Use fentry: <no value>

      Available constant fetchers
      ===========================

        btf co-re
        btfhub
        offset-guesser
        fallback

      Constants
      =========

        file_f_inode_offset = 168 (from btf co-re)
        bpf_prog_aux_name_offset = 920 (from btf co-re)
        pid_level_offset = 4 (from btf co-re)
        flowi6_saddr_offset = 56 (from btf co-re)
        flowi6_uli_offset = 76 (from btf co-re)
        sock_sk_protocol_offset = 516 (from btf co-re)
        sizeof_pipe_buffer = 40 (from btf co-re)
        pipe_inode_info_head_offset = 80 (from btf co-re)
        super_block_s_type_offset = 40 (from btf co-re)
        path_dentry_offset = 8 (from btf co-re)
        mount_mnt_mountpoint_offset = 24 (from btf co-re)
        linux_binprm_p_offset = 24 (from btf co-re)
        dentry_d_sb_offset = 112 (from btf co-re)
        net_device_name_offset = 304 (from btf co-re)
        flowi4_saddr_offset = 40 (from btf co-re)
        kernel_clone_args_exit_signal_offset = 40 (from btf co-re)
        sizeof_upid = 16 (from btf co-re)
        pipe_buffer_flags_offset = 24 (from btf co-re)
        net_device_ifindex_offset = 224 (from btf co-re)
        sock_common_skc_family_offset = 16 (from btf co-re)
        flowi6_proto_offset = 18 (from fallback)
        iokiocb_ctx_offset = 88 (from btf co-re)
        sb_dev_offset = 16 (from btf co-re)
        nf_conn_ct_net_offset = 136 (from btf co-re)
        sizeof_inode = 632 (from btf co-re)
        creds_uid_offset = 8 (from btf co-re)
        flowi4_uli_offset = 48 (from btf co-re)
        inode_gid_offset = 8 (from btf co-re)
        mountpoint_dentry_offset = 16 (from btf co-re)
        vfsmount_mnt_flags_offset = 16 (from btf co-re)
        vfsmount_mnt_root_offset = <no value> (from btf co-re)
        sb_flags_offset = 80 (from btf co-re)
        vm_area_struct_flags_offset = 32 (from btf co-re)
        pid_numbers_offset = 96 (from btf co-re)
        sock_common_skc_num_offset = 14 (from btf co-re)
        vfsmount_mnt_sb_offset = 8 (from btf co-re)
        bpf_prog_attach_type_offset = 8 (from btf co-re)
        tty_name_offset = 352 (from btf co-re)
        creds_cap_inheritable_offset = 48 (from btf co-re)
        task_struct_pid_offset = 1672 (from btf co-re)
        sock_common_skc_net_offset = 48 (from btf co-re)
        dentry_d_name_offset = 32 (from btf co-re)
        bpf_prog_tag_offset = 20 (from btf co-re)
        bpf_prog_aux_offset = 56 (from btf co-re)
        vfs_rename_src_dentry_offset = 16 (from btf co-re)
        dentry_d_inode_offset = 48 (from btf co-re)
        inode_nlink_offset = 72 (from btf co-re)
        tty_offset = 416 (from btf co-re)
        linux_binprm_envc_offset = 92 (from btf co-re)
        bpf_map_name_offset = 96 (from btf co-re)
        bpf_prog_type_offset = 4 (from btf co-re)
        pipe_inode_info_ring_size_offset = 92 (from btf co-re)
        device_nd_net_net_offset = 280 (from btf co-re)
        inode_mtime_offset = 104 (from btf co-re)
        vfs_rename_target_dentry_offset = 40 (from btf co-re)
        bpf_map_id_offset = 52 (from btf co-re)
        socket_sock_offset = 24 (from btf co-re)
        inode_sb_offset = 40 (from btf co-re)
        linux_binprm_argc_offset = 88 (from btf co-re)
        mount_id_offset = 300 (from btf co-re)
        pipe_inode_info_bufs_offset = 152 (from btf co-re)
        inode_ctime_offset = 120 (from btf co-re)
        path_mnt_offset = <no value> (from btf co-re)
        inode_ino_offset = 64 (from btf co-re)
        sb_magic_offset = 96 (from btf co-re)
        file_f_path_offset = 152 (from btf co-re)
        bpf_prog_aux_id_offset = 32 (from btf co-re)
        net_ns_offset = 120 (from btf co-re)
        binprm_file_offset = 64 (from btf co-re)
        dentry_sb_offset = 112 (from btf co-re)
        bpf_map_type_offset = 24 (from btf co-re)
        flowi4_proto_offset = 18 (from fallback)
```

### Motivation

### Describe how you validated your changes

### Additional Notes
