### PR TITLE
Scrub exact secret key

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -151,9 +151,9 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	)
 	tokenReplacer.LastUpdated = defaultVersion
 
-	secretReplacer := matchYAMLKeyPart(
-		`secret`,
-		[]string{"secret"},
+	secretReplacer := matchYAMLKey(
+		`(token_secret|consumer_secret)`,
+		[]string{"token_secret", "consumer_secret"},
 		[]byte(`$1 "********"`),
 	)
 	secretReplacer.LastUpdated = parseVersion("7.70.0") // https://github.com/DataDog/datadog-agent/pull/40345


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/DataDog/datadog-agent/pull/40345, the scrubber was scrubbing debugging information, this PR aims to solve this issue

### Motivation

Avoid decreasing support efficiency by not be able to read configuration for secret feature:
```
root@datadog-qn879:/tmp# ./agent config | grep secret_       
    secret_name: "********"
secret_audit_file_max_size: "********"
secret_backend_arguments: "********"
secret_backend_command: "********"
secret_backend_command_allow_group_exec_perm: "********"
secret_backend_config: "********"
secret_backend_output_max_size: "********"
secret_backend_remove_trailing_line_break: "********"
secret_backend_skip_checks: "********"
secret_backend_timeout: "********"
secret_backend_type: "********"
secret_image_to_secret: "********"
secret_kubernetes: "********"
secret_refresh_interval: "********"
secret_refresh_scatter: "********"
```

### Describe how you validated your changes

CI

### Additional Notes
