### PR TITLE
[AGENTRUN-691] Increase the timeout for the flakey test assertion condition

### DIFF
--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -115,7 +115,7 @@ func newScheduler() *scheduler.Scheduler {
 func assertAsyncWorkerCount(t *testing.T, count int) {
 	require.Eventually(t, func() bool {
 		return expvars.GetWorkerCount() == count
-	}, 750*time.Millisecond, 10*time.Millisecond)
+	}, 1*time.Second, 10*time.Millisecond)
 }
 
 func assertAsyncBool(t *testing.T, actualValueFunc func() bool, expectedValue bool) {


### PR DESCRIPTION
### What does this PR do?

We saw this test assertion flake twice in the last month ([link](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1116089162)), lets increase the timeout and see if it fixes the issue.

### Motivation

### Describe how you validated your changes

### Additional Notes
