### PR TITLE
[netpath] Fix spurious error from Recvfrom finishing synchronously

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -147,6 +147,8 @@ core,github.com/DataDog/datadog-traceroute/common,Apache-2.0,"Copyright 2016-pre
 core,github.com/DataDog/datadog-traceroute/icmp,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/log,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/packets,Apache-2.0,"Copyright 2016-present Datadog, Inc"
+core,github.com/DataDog/datadog-traceroute/result,Apache-2.0,"Copyright 2016-present Datadog, Inc"
+core,github.com/DataDog/datadog-traceroute/reversedns,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/sack,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/tcp,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/udp,Apache-2.0,"Copyright 2016-present Datadog, Inc"

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	// TODO: pin to an operator released version once there is a release that includes the api module
 	github.com/DataDog/datadog-operator/api v0.0.0-20250417130148-1aa8dc0fc964
-	github.com/DataDog/datadog-traceroute v0.1.5
+	github.com/DataDog/datadog-traceroute v0.1.5-hotfix1
 	github.com/DataDog/ebpf-manager v0.7.14
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.12

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20250417130148-1aa8dc0fc964 h1:3EH1aRTHY22KbCYYhPZCaXTo1swWsi2DEyZNFAuTrt0=
 github.com/DataDog/datadog-operator/api v0.0.0-20250417130148-1aa8dc0fc964/go.mod h1:J6wMbBik2dRZfv+XYIrOwHyWi9+T6lRZSxTmEQ8bWNU=
-github.com/DataDog/datadog-traceroute v0.1.5 h1:ka2D5XicwDjnSyQh1mudEG2OilkMp2D8JJ8sD7ORxd8=
-github.com/DataDog/datadog-traceroute v0.1.5/go.mod h1:uBhYAQTsxnhOC/rbh5B3rs4A1Gk4YWa/dqdSN+lScfM=
+github.com/DataDog/datadog-traceroute v0.1.5-hotfix1 h1:Zfb29/dtwvZxFDbb1LItdC8z5XpS6ApcfrYqq83IOIc=
+github.com/DataDog/datadog-traceroute v0.1.5-hotfix1/go.mod h1:axG/S4dflSNuxcDt9xbjzs5JBvAHHSYzRyuEm/yTiRk=
 github.com/DataDog/dd-trace-go/v2 v2.0.0 h1:cHMEzD0Wcgtu+Rec9d1GuVgpIN5f+4vCaNzuFHJ0v+Y=
 github.com/DataDog/dd-trace-go/v2 v2.0.0/go.mod h1:WBtf7TA9bWr5uA8DjOyw1qlSKe3bw9gN5nc0Ta9dHFE=
 github.com/DataDog/ebpf-manager v0.7.14 h1:k08TW46xdUEHggumRmbs9y+ymcZIJ1LKrRcXEq7EgIM=


### PR DESCRIPTION
### What does this PR do?
This fixes a missing nil check by pulling in the datadog-traceroute PR [\[filters\] Check for nil in SetBPFAndDrain](https://github.com/DataDog/datadog-traceroute/pull/28). Normally this almost always has an error, but occasionally `MSG_DONTWAIT` can finish synchronously.
### Motivation
Rarely we get this error running netpath at scale in staging:
```
SYS-PROBE | ERROR | (cmd/system-probe/modules/traceroute.go:72 in func1) | unable to run traceroute for host: 10.128.11.211: UDP traceroute failed to set packet filter: SetPacketFilter failed to apply BPF filter: SetBPFAndDrain failed to drain: %!w(<nil>)
```

Apparently this syscall can occasionally finish synchronously which results in a nil error. I think it happens on hosts with barely any network traffic.

### Describe how you validated your changes
In datadog-traceroute, I ran the packet filtering suite 100 times:
```
sudo env PATH="$PATH" go test -v -tags linux,test,root github.com/DataDog/datadog-traceroute/packets -count 100
```
(I had to make a few extra changes to get the root privileged test suite compiling: [\[packets\] Use os.File to close all fds](https://github.com/DataDog/datadog-traceroute/pull/25))