### PR TITLE
Reduce lengthy output when running test with error

### DIFF
--- a/tasks/libs/testing/result_json.py
+++ b/tasks/libs/testing/result_json.py
@@ -58,6 +58,7 @@ class ResultJson:
     def from_file(cls, file: str) -> "ResultJson":
         """Load a ResultJson from a file."""
         res = []
+        warning_logged = False
         with open(file) as f:
             for line in f:
                 data = json.loads(line)
@@ -65,7 +66,10 @@ class ResultJson:
                     res.append(ResultJsonLine.from_dict(data))
                 except ValueError:
                     # TODO(@agent-devx): Use a proper logging mechanism instead of print
-                    print(f"WARNING: Invalid line in result json file, skipping: {line.strip()}")
+                    if not warning_logged:
+                        print("WARNING: Invalid line in result json file, skipping")
+                        warning_logged = True
+                    print(data.get("Output", line).strip())
         return cls(res)
 
     def _sort_into_packages_and_tests(self) -> dict[str, dict[str, list[ResultJsonLine]]]:

--- a/tasks/unit_tests/json_result_tests.py
+++ b/tasks/unit_tests/json_result_tests.py
@@ -140,10 +140,9 @@ class TestJSONResult(TestCase):
         file = str(Path(__file__).parent / "testdata" / "test_output_with_invalid.json")
         res = ResultJson.from_file(file)
         self.assertGreater(p.call_count, 0, f"Expected at least one warning for invalid lines in {file}")
-        last_print_call = p.call_args_list[-1]
         self.assertIn(
-            "WARNING: Invalid line in result json file, skipping:",
-            last_print_call[0][0],
+            "WARNING: Invalid line in result json file, skipping",
+            p.call_args_list[0][0][0],
             f"Expected a warning about the invalid line in {file}",
         )
 


### PR DESCRIPTION
### What does this PR do?

Running test with compiling error produce a tedious output to read. This PR improve the user experience by reducing repeated information.

Examnple, before:
```
DONE 0 tests, 1 failure, 3 errors in 0.000s
WARNING: Invalid line in result json file, skipping: {"ImportPath":"github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]","Action":"build-output","Output":"# github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]\n"}
WARNING: Invalid line in result json file, skipping: {"ImportPath":"github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]","Action":"build-output","Output":"comp/core/secrets/impl/secrets_test.go:344:26: cannot use \"\" (untyped string constant) as handleToContext value in struct literal\n"}
WARNING: Invalid line in result json file, skipping: {"ImportPath":"github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]","Action":"build-output","Output":"comp/core/secrets/impl/secrets_test.go:486:20: not enough arguments in call to assert.Equal\n"}
WARNING: Invalid line in result json file, skipping: {"ImportPath":"github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]","Action":"build-output","Output":"\thave (*testing.T, string)\n"}
WARNING: Invalid line in result json file, skipping: {"ImportPath":"github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]","Action":"build-output","Output":"\twant (assert.TestingT, interface{}, interface{}, ...interface{})\n"}
WARNING: Invalid line in result json file, skipping: {"ImportPath":"github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]","Action":"build-output","Output":"comp/core/secrets/impl/secrets_test.go:642:28: cannot use 123 (untyped int constant) as string value in array or slice literal\n"}
WARNING: Invalid line in result json file, skipping: {"ImportPath":"github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]","Action":"build-fail"}
Tests failed (base flavor)
Test failures:
- github.com/DataDog/datadog-agent/comp/core/secrets/impl package failed due to panic / race condition
```

after:
```
DONE 0 tests, 1 failure, 3 errors in 0.000s
WARNING: Invalid line in result json file, skipping
# github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]
comp/core/secrets/impl/secrets_test.go:344:26: cannot use "" (untyped string constant) as handleToContext value in struct literal
comp/core/secrets/impl/secrets_test.go:486:20: not enough arguments in call to assert.Equal
have (*testing.T, string)
want (assert.TestingT, interface{}, interface{}, ...interface{})
comp/core/secrets/impl/secrets_test.go:642:28: cannot use 123 (untyped int constant) as string value in array or slice literal
{"ImportPath":"github.com/DataDog/datadog-agent/comp/core/secrets/impl [github.com/DataDog/datadog-agent/comp/core/secrets/impl.test]","Action":"build-fail"}
Tests failed (base flavor)
Test failures:
- github.com/DataDog/datadog-agent/comp/core/secrets/impl package failed due to panic / race condition
```

### Describe how you validated your changes

Running the CI is enough.