### PR TITLE
add ec2_prioritize_instance_id_as_hostname option to template config

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -450,10 +450,12 @@ api_key:
 
 ## @param ec2_prioritize_instance_id_as_hostname - boolean - optional - default: false
 ## @env DD_EC2_PRIORITIZE_INSTANCE_ID_AS_HOSTNAME - boolean - optional - default: false
-## Force the use of EC2 instance ID as hostname even when the hostname is not one of the
-## default EC2 hostnames. When set to true, this bypasses the standard hostname detection
-## logic and forces the EC2 instance ID to be used as the canonical hostname.
-## Only takes effect on EC2 instances.
+## On EC2, prefer the instance ID as the Agent hostname even when the OS hostname does not match
+## the known generic EC2 prefixes. Normal hostname detection still applies, and a hostname set in
+## datadog.yaml takes precedence. By default, the Agent uses the instance ID if the OS hostname
+## has a generic EC2 prefix to avoid merging multiple instances under one host. When this option
+## is true, the instance ID is used even if no prefix is detected. This is useful in cases such as
+## when custom images overwrite the system hostname, causing multiple instances to share the same hostname.
 #
 # ec2_prioritize_instance_id_as_hostname: false
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -451,11 +451,9 @@ api_key:
 ## @param ec2_prioritize_instance_id_as_hostname - boolean - optional - default: false
 ## @env DD_EC2_PRIORITIZE_INSTANCE_ID_AS_HOSTNAME - boolean - optional - default: false
 ## On EC2, prefer the instance ID as the Agent hostname even when the OS hostname does not match
-## the known generic EC2 prefixes. Normal hostname detection still applies, and a hostname set in
-## datadog.yaml takes precedence. By default, the Agent uses the instance ID if the OS hostname
-## has a generic EC2 prefix to avoid merging multiple instances under one host. When this option
-## is true, the instance ID is used even if no prefix is detected. This is useful in cases such as
-## when custom images overwrite the system hostname, causing multiple instances to share the same hostname.
+## the known generic EC2 prefixes. By default, the Agent uses the instance ID if the OS hostname
+## has a generic EC2 prefix to avoid merging multiple instances under one host. This is useful 
+## when using custom images that share the same system hostname.
 #
 # ec2_prioritize_instance_id_as_hostname: false
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -448,6 +448,15 @@ api_key:
 #
 # ec2_prefer_imdsv2: false
 
+## @param ec2_prioritize_instance_id_as_hostname - boolean - optional - default: false
+## @env DD_EC2_PRIORITIZE_INSTANCE_ID_AS_HOSTNAME - boolean - optional - default: false
+## Force the use of EC2 instance ID as hostname even when the hostname is not one of the
+## default EC2 hostnames. When set to true, this bypasses the standard hostname detection
+## logic and forces the EC2 instance ID to be used as the canonical hostname.
+## Only takes effect on EC2 instances.
+#
+# ec2_prioritize_instance_id_as_hostname: false
+
 ## @param collect_gce_tags - boolean - optional - default: true
 ## @env DD_COLLECT_GCE_TAGS - boolean - optional - default: true
 ## Collect Google Cloud Engine metadata as host tags


### PR DESCRIPTION
### What does this PR do?
Adds `ec2_prioritize_instance_id_as_hostname` to the config template as it's a feature that can be configured.
 
### Motivation
configuration options we want the customer to potentially use for the agent should be on the example datadog.yaml template file. 

### Describe how you validated your changes
No code was changed.
