### PR TITLE
add linter to disallow uses of RevertFinishedBackToBuilder

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -627,7 +627,7 @@ linters-settings:
         pkg: ^github.com/DataDog/datadog-agent/pkg/config/setup$
         msg: use pkg/config/mock instead for tests or the config component
       - p: RevertFinishedBackToBuilder
-        msg: RevertFinishedBackToBuilder is deprecated and should not be used in any new code. Only existing OTel usage is allowed.
+        msg: RevertFinishedBackToBuilder is typically not needed, so using it is discouraged. Only existing OTel usage is allowed.
     analyze-types: true
   custom:
     pkgconfigusage:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -626,6 +626,8 @@ linters-settings:
       - p: ^setup.SetSystemProbe.*$
         pkg: ^github.com/DataDog/datadog-agent/pkg/config/setup$
         msg: use pkg/config/mock instead for tests or the config component
+      - p: RevertFinishedBackToBuilder
+        msg: RevertFinishedBackToBuilder is deprecated and should not be used in any new code. Only existing OTel usage is allowed.
     analyze-types: true
   custom:
     pkgconfigusage:

--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -100,8 +100,7 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	// Get the global agent config, build on top of it some more
 	// NOTE: This pattern should not be used by other callsites, it is needed here
 	// specifically because of the unique requirements of OTel's configuration.
-	pkgconfig := pkgconfigsetup.Datadog().RevertFinishedBackToBuilder()
-
+	pkgconfig := pkgconfigsetup.Datadog().RevertFinishedBackToBuilder() //nolint:forbidigo // legitimate use for OTel configuration
 	pkgconfig.SetConfigName("OTel")
 	pkgconfig.SetEnvPrefix("DD")
 	pkgconfig.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -42,8 +42,8 @@ func NewTeeConfig(baseline, compare model.BuildableConfig) model.BuildableConfig
 // current config, instead of treating it as sealed
 // NOTE: Only used by OTel, no new uses please!
 func (t *teeConfig) RevertFinishedBackToBuilder() model.BuildableConfig {
-	t.baseline.RevertFinishedBackToBuilder()
-	t.compare.RevertFinishedBackToBuilder()
+	t.baseline.RevertFinishedBackToBuilder() //nolint:forbidigo // legitimate use within interface implementation
+	t.compare.RevertFinishedBackToBuilder()  //nolint:forbidigo // legitimate use within interface implementation
 	return t
 }
 


### PR DESCRIPTION
### What does this PR do?
linter to disallow uses of pkgconfigmodel.RevertFinishedBackToBuilder

### Motivation
OTel uses the method RevertFinishedBackToBuilder, because they build on top of the already finished configuration however this method should not be used by other calls. 

### Describe how you validated your changes
Using `RevertFinishedBackToBuilder` with and without `//nolint:forbidigo` when running the linter