### PR TITLE
Add generic copies of OTLP attribute translation methods to mapping-go

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/attributes/attributes.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/attributes.go
@@ -17,11 +17,27 @@ package attributes
 
 import (
 	"fmt"
+	"math"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/DataDog/sketches-go/ddsketch"
+	"github.com/DataDog/sketches-go/ddsketch/mapping"
+	"github.com/DataDog/sketches-go/ddsketch/store"
+	"github.com/gogo/protobuf/proto"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv127 "go.opentelemetry.io/otel/semconv/v1.27.0"
-	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	semconv1_12 "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv1_17 "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv1_27 "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv1_6_1 "go.opentelemetry.io/otel/semconv/v1.6.1"
+
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/source"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	normalizeutil "github.com/DataDog/datadog-agent/pkg/util/normalize"
 )
 
 // customContainerTagPrefix defines the prefix for custom container tags.
@@ -33,48 +49,48 @@ var (
 	coreMapping = map[string]string{
 		// Datadog conventions
 		// https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/
-		string(conventions.DeploymentEnvironmentKey):    "env",
-		string(semconv127.ServiceNameKey):               "service",
-		string(semconv127.ServiceVersionKey):            "version",
-		string(semconv127.DeploymentEnvironmentNameKey): "env",
+		string(semconv1_6_1.DeploymentEnvironmentKey):    "env",
+		string(semconv1_27.ServiceNameKey):               "service",
+		string(semconv1_27.ServiceVersionKey):            "version",
+		string(semconv1_27.DeploymentEnvironmentNameKey): "env",
 	}
 
 	// ContainerMappings defines the mapping between OpenTelemetry semantic conventions
 	// and Datadog Agent conventions for containers.
 	ContainerMappings = map[string]string{
 		// Containers
-		string(semconv127.ContainerIDKey):        "container_id",
-		string(semconv127.ContainerNameKey):      "container_name",
-		string(semconv127.ContainerImageNameKey): "image_name",
-		string(conventions.ContainerImageTagKey): "image_tag",
-		string(semconv127.ContainerRuntimeKey):   "runtime",
+		string(semconv1_27.ContainerIDKey):        "container_id",
+		string(semconv1_27.ContainerNameKey):      "container_name",
+		string(semconv1_27.ContainerImageNameKey): "image_name",
+		string(semconv1_6_1.ContainerImageTagKey): "image_tag",
+		string(semconv1_27.ContainerRuntimeKey):   "runtime",
 
 		// Cloud conventions
 		// https://www.datadoghq.com/blog/tagging-best-practices/
-		string(semconv127.CloudProviderKey):         "cloud_provider",
-		string(semconv127.CloudRegionKey):           "region",
-		string(semconv127.CloudAvailabilityZoneKey): "zone",
+		string(semconv1_27.CloudProviderKey):         "cloud_provider",
+		string(semconv1_27.CloudRegionKey):           "region",
+		string(semconv1_27.CloudAvailabilityZoneKey): "zone",
 
 		// ECS conventions
 		// https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/tagger/collectors/ecs_extract.go
-		string(semconv127.AWSECSTaskFamilyKey):   "task_family",
-		string(semconv127.AWSECSTaskARNKey):      "task_arn",
-		string(semconv127.AWSECSClusterARNKey):   "ecs_cluster_name",
-		string(semconv127.AWSECSTaskRevisionKey): "task_version",
-		string(semconv127.AWSECSContainerARNKey): "ecs_container_name",
+		string(semconv1_27.AWSECSTaskFamilyKey):   "task_family",
+		string(semconv1_27.AWSECSTaskARNKey):      "task_arn",
+		string(semconv1_27.AWSECSClusterARNKey):   "ecs_cluster_name",
+		string(semconv1_27.AWSECSTaskRevisionKey): "task_version",
+		string(semconv1_27.AWSECSContainerARNKey): "ecs_container_name",
 
 		// Kubernetes resource name (via semantic conventions)
 		// https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/util/kubernetes/const.go
-		string(semconv127.K8SContainerNameKey):   "kube_container_name",
-		string(semconv127.K8SClusterNameKey):     "kube_cluster_name",
-		string(semconv127.K8SDeploymentNameKey):  "kube_deployment",
-		string(semconv127.K8SReplicaSetNameKey):  "kube_replica_set",
-		string(semconv127.K8SStatefulSetNameKey): "kube_stateful_set",
-		string(semconv127.K8SDaemonSetNameKey):   "kube_daemon_set",
-		string(semconv127.K8SJobNameKey):         "kube_job",
-		string(semconv127.K8SCronJobNameKey):     "kube_cronjob",
-		string(semconv127.K8SNamespaceNameKey):   "kube_namespace",
-		string(semconv127.K8SPodNameKey):         "pod_name",
+		string(semconv1_27.K8SContainerNameKey):   "kube_container_name",
+		string(semconv1_27.K8SClusterNameKey):     "kube_cluster_name",
+		string(semconv1_27.K8SDeploymentNameKey):  "kube_deployment",
+		string(semconv1_27.K8SReplicaSetNameKey):  "kube_replica_set",
+		string(semconv1_27.K8SStatefulSetNameKey): "kube_stateful_set",
+		string(semconv1_27.K8SDaemonSetNameKey):   "kube_daemon_set",
+		string(semconv1_27.K8SJobNameKey):         "kube_job",
+		string(semconv1_27.K8SCronJobNameKey):     "kube_cronjob",
+		string(semconv1_27.K8SNamespaceNameKey):   "kube_namespace",
+		string(semconv1_27.K8SPodNameKey):         "pod_name",
 	}
 
 	// Kubernetes mappings defines the mapping between Kubernetes conventions (both general and Datadog specific)
@@ -174,17 +190,17 @@ var (
 	// HTTPMappings defines the mapping between OpenTelemetry semantic conventions
 	// and Datadog Agent conventions for HTTP attributes.
 	HTTPMappings = map[string]string{
-		string(semconv127.ClientAddressKey):          "http.client_ip",
-		string(semconv127.HTTPResponseBodySizeKey):   "http.response.content_length",
-		string(semconv127.HTTPResponseStatusCodeKey): "http.status_code",
-		string(semconv127.HTTPRequestBodySizeKey):    "http.request.content_length",
-		"http.request.header.referrer":               "http.referrer",
-		string(semconv127.HTTPRequestMethodKey):      "http.method",
-		string(semconv127.HTTPRouteKey):              "http.route",
-		string(semconv127.NetworkProtocolVersionKey): "http.version",
-		string(semconv127.ServerAddressKey):          "http.server_name",
-		string(semconv127.URLFullKey):                "http.url",
-		string(semconv127.UserAgentOriginalKey):      "http.useragent",
+		string(semconv1_27.ClientAddressKey):          "http.client_ip",
+		string(semconv1_27.HTTPResponseBodySizeKey):   "http.response.content_length",
+		string(semconv1_27.HTTPResponseStatusCodeKey): "http.status_code",
+		string(semconv1_27.HTTPRequestBodySizeKey):    "http.request.content_length",
+		"http.request.header.referrer":                "http.referrer",
+		string(semconv1_27.HTTPRequestMethodKey):      "http.method",
+		string(semconv1_27.HTTPRouteKey):              "http.route",
+		string(semconv1_27.NetworkProtocolVersionKey): "http.version",
+		string(semconv1_27.ServerAddressKey):          "http.server_name",
+		string(semconv1_27.URLFullKey):                "http.url",
+		string(semconv1_27.UserAgentOriginalKey):      "http.useragent",
 	}
 )
 
@@ -199,21 +215,21 @@ func TagsFromAttributes(attrs pcommon.Map) []string {
 	attrs.Range(func(key string, value pcommon.Value) bool {
 		switch key {
 		// Process attributes
-		case string(semconv127.ProcessExecutableNameKey):
+		case string(semconv1_27.ProcessExecutableNameKey):
 			processAttributes.ExecutableName = value.Str()
-		case string(semconv127.ProcessExecutablePathKey):
+		case string(semconv1_27.ProcessExecutablePathKey):
 			processAttributes.ExecutablePath = value.Str()
-		case string(semconv127.ProcessCommandKey):
+		case string(semconv1_27.ProcessCommandKey):
 			processAttributes.Command = value.Str()
-		case string(semconv127.ProcessCommandLineKey):
+		case string(semconv1_27.ProcessCommandLineKey):
 			processAttributes.CommandLine = value.Str()
-		case string(semconv127.ProcessPIDKey):
+		case string(semconv1_27.ProcessPIDKey):
 			processAttributes.PID = value.Int()
-		case string(semconv127.ProcessOwnerKey):
+		case string(semconv1_27.ProcessOwnerKey):
 			processAttributes.Owner = value.Str()
 
 		// System attributes
-		case string(semconv127.OSTypeKey):
+		case string(semconv1_27.OSTypeKey):
 			systemAttributes.OSType = value.Str()
 		}
 
@@ -251,9 +267,9 @@ func TagsFromAttributes(attrs pcommon.Map) []string {
 func OriginIDFromAttributes(attrs pcommon.Map) (originID string) {
 	// originID is always empty. Container ID is preferred over Kubernetes pod UID.
 	// Prefixes come from pkg/util/kubernetes/kubelet and pkg/util/containers.
-	if containerID, ok := attrs.Get(string(conventions.ContainerIDKey)); ok {
+	if containerID, ok := attrs.Get(string(semconv1_6_1.ContainerIDKey)); ok {
 		originID = "container_id://" + containerID.AsString()
-	} else if podUID, ok := attrs.Get(string(conventions.K8SPodUIDKey)); ok {
+	} else if podUID, ok := attrs.Get(string(semconv1_6_1.K8SPodUIDKey)); ok {
 		originID = "kubernetes_pod_uid://" + podUID.AsString()
 	}
 	return
@@ -302,4 +318,646 @@ func ContainerTagFromAttributes(attr map[string]string) map[string]string {
 		ddtags[datadogKey] = val
 	}
 	return ddtags
+}
+
+// TODO: Import these from datadog-agent/pkg/opentelemetry-mapping-go
+
+// Agent-style attribute extraction constants
+const (
+	// KeyDatadogService is the key for the service name in the Datadog namespace
+	KeyDatadogService = "datadog.service"
+	// KeyDatadogResource is the key for the resource name in the Datadog namespace
+	KeyDatadogResource = "datadog.resource"
+	// KeyDatadogType is the key for the span type in the Datadog namespace
+	KeyDatadogType = "datadog.type"
+	// KeyDatadogVersion is the key for the version in the Datadog namespace
+	KeyDatadogVersion = "datadog.version"
+	// KeyDatadogHTTPStatusCode is the key for the HTTP status code in the Datadog namespace
+	KeyDatadogHTTPStatusCode = "datadog.http_status_code"
+	// KeyDatadogHost is the key for the host in the Datadog namespace
+	KeyDatadogHost = "datadog.host"
+	// KeyDatadogEnvironment is the key for the environment in the Datadog namespace
+	KeyDatadogEnvironment = "datadog.env"
+	// KeyDatadogContainerID is the key for the container ID in the Datadog namespace
+	KeyDatadogContainerID = "datadog.container_id"
+	// DefaultOTLPServiceName is the default service name for OTel spans when no service name is found in the resource attributes.
+	DefaultOTLPServiceName = "otlpresourcenoservicename"
+	// DefaultOTLPEnvironmentName is the default environment name for OTel spans when no environment name is found in the resource attributes.
+	DefaultOTLPEnvironmentName = "default"
+
+	// Source kinds
+	SourceKindHostname      = "host"
+	SourceKindAWSECSFargate = "task_arn"
+)
+
+// getTimeUnitScaleToNanos returns the scaling factor to convert the given unit to nanoseconds
+func getTimeUnitScaleToNanos(unit string) float64 {
+	switch unit {
+	case "ns":
+		return float64(time.Nanosecond)
+	case "us", "μs":
+		return float64(time.Microsecond)
+	case "ms":
+		return float64(time.Millisecond)
+	case "s":
+		return float64(time.Second)
+	case "min":
+		return float64(time.Minute)
+	case "h":
+		return float64(time.Hour)
+	default:
+		// If unit is unknown, assume seconds (common for duration metrics)
+		return float64(time.Second)
+	}
+}
+
+// getBounds returns the lower and upper bounds for a histogram bucket
+func getBounds(explicitBounds pcommon.Float64Slice, idx int) (lowerBound float64, upperBound float64) {
+	// See https://github.com/open-telemetry/opentelemetry-proto/blob/v0.10.0/opentelemetry/proto/metrics/v1/metrics.proto#L427-L439
+	lowerBound = math.Inf(-1)
+	upperBound = math.Inf(1)
+	if idx > 0 {
+		lowerBound = explicitBounds.At(idx - 1)
+	}
+	if idx < explicitBounds.Len() {
+		upperBound = explicitBounds.At(idx)
+	}
+	return
+}
+
+// createDDSketchFromHistogram creates a DDSketch from regular histogram data point
+func createDDSketchFromHistogram(dp pmetric.HistogramDataPoint, unit string) ([]byte, error) {
+	relativeAccuracy := 0.01 // 1% relative accuracy
+	maxNumBins := 2048
+	newSketch, err := ddsketch.LogCollapsingLowestDenseDDSketch(relativeAccuracy, maxNumBins)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketCounts := dp.BucketCounts()
+	explicitBounds := dp.ExplicitBounds()
+
+	// Get scaling factor to convert unit to nanoseconds
+	scaleToNanos := getTimeUnitScaleToNanos(unit)
+
+	// Find first and last bucket indices with count > 0
+	lowestBucketIndex := -1
+	highestBucketIndex := -1
+	for j := 0; j < bucketCounts.Len(); j++ {
+		count := bucketCounts.At(j)
+		if count > 0 {
+			if lowestBucketIndex == -1 {
+				lowestBucketIndex = j
+			}
+			highestBucketIndex = j
+		}
+	}
+
+	hasMin := dp.HasMin()
+	hasMax := dp.HasMax()
+	minNanoseconds := dp.Min() * scaleToNanos
+	maxNanoseconds := dp.Max() * scaleToNanos
+
+	for j := 0; j < bucketCounts.Len(); j++ {
+		lowerBound, upperBound := getBounds(explicitBounds, j)
+
+		if math.IsInf(upperBound, 1) {
+			upperBound = lowerBound
+		} else if math.IsInf(lowerBound, -1) {
+			lowerBound = upperBound
+		}
+
+		count := bucketCounts.At(j)
+
+		if count > 0 {
+			insertionPoint := 0.0
+			adjustedCount := float64(count)
+			midpoint := (lowerBound + upperBound) / 2 * scaleToNanos
+			// Determine insertion point based on bucket position
+			if j == lowestBucketIndex && j == highestBucketIndex {
+				// Special case: min and max are in the same bucket
+				if hasMin && hasMax {
+					insertionPoint = (minNanoseconds + maxNanoseconds) / 2
+				}
+			} else if j == lowestBucketIndex {
+				// Bottom bucket: insert at min value
+				if hasMin {
+					insertionPoint = minNanoseconds
+				}
+			} else if j == highestBucketIndex {
+				// Top bucket: insert at max value
+				if hasMax {
+					insertionPoint = maxNanoseconds
+				}
+			}
+
+			if insertionPoint == 0.0 {
+				insertionPoint = midpoint
+			}
+
+			newSketch.AddWithCount(insertionPoint, adjustedCount)
+		}
+	}
+
+	// Marshal sketch to protobuf bytes
+	return proto.Marshal(newSketch.ToProto())
+}
+
+// createDDSketchFromExponentialHistogram creates a DDSketch from exponential histogram data point
+func createDDSketchFromExponentialHistogram(dp pmetric.ExponentialHistogramDataPoint, unit string) ([]byte, error) {
+	// Get scaling factor to convert unit to nanoseconds
+	scaleToNanos := getTimeUnitScaleToNanos(unit)
+
+	// Create the DDSketch stores with unit scaling
+	positiveStore := toStoreFromExponentialBucketsWithUnitScale(dp.Positive(), dp.Scale(), scaleToNanos)
+	negativeStore := toStoreFromExponentialBucketsWithUnitScale(dp.Negative(), dp.Scale(), scaleToNanos)
+
+	// Create the DDSketch mapping for nanoseconds (no offset needed since we scaled the stores)
+	gamma := math.Pow(2, math.Pow(2, float64(-dp.Scale())))
+	mapping, err := mapping.NewLogarithmicMappingWithGamma(gamma, 0)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create LogarithmicMapping for DDSketch: %w", err)
+	}
+
+	// Create DDSketch with the above mapping and stores
+	sketch := ddsketch.NewDDSketch(mapping, positiveStore, negativeStore)
+	// Zero count represents values at exactly zero, so we add at zero (no scaling needed for zero)
+	err = sketch.AddWithCount(0, float64(dp.ZeroCount()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to add ZeroCount to DDSketch: %w", err)
+	}
+
+	// Marshal sketch to protobuf bytes
+	return proto.Marshal(sketch.ToProto())
+}
+
+// toStoreFromExponentialBucketsWithUnitScale converts exponential histogram buckets to store with unit scaling
+func toStoreFromExponentialBucketsWithUnitScale(b pmetric.ExponentialHistogramDataPointBuckets, scale int32, scaleToNanos float64) store.Store {
+	offset := b.Offset()
+	bucketCounts := b.BucketCounts()
+
+	// Calculate the base for the exponential histogram
+	base := math.Pow(2, math.Pow(2, float64(-scale)))
+
+	store := store.NewDenseStore()
+	for j := 0; j < bucketCounts.Len(); j++ {
+		bucketIndex := j + int(offset)
+		count := bucketCounts.At(j)
+
+		if count > 0 {
+			// Calculate the actual bucket boundary value
+			bucketValue := math.Pow(base, float64(bucketIndex))
+
+			// Scale the bucket value to nanoseconds
+			scaledValue := bucketValue * scaleToNanos
+
+			// Convert back to the index in the nanosecond space
+			// Using the same gamma since we're keeping the same precision
+			scaledIndex := int(math.Log(scaledValue) / math.Log(base))
+
+			store.AddWithCount(scaledIndex, float64(count))
+		}
+	}
+	return store
+}
+
+// Agent-style attribute extraction functions
+
+// GetOTelAttrFromEitherMap returns the matched value as a string in either attribute map with the given keys.
+// If there are multiple keys present, the first matched one is returned.
+// If the key is present in both maps, map1 takes precedence.
+// If normalize is true, normalize the return value with NormalizeTagValue.
+func GetOTelAttrFromEitherMap(map1 pcommon.Map, map2 pcommon.Map, normalize bool, keys ...string) string {
+	if val := GetOTelAttrVal(map1, normalize, keys...); val != "" {
+		return val
+	}
+	return GetOTelAttrVal(map2, normalize, keys...)
+}
+
+// GetOTelHostname returns the DD hostname based on OTel span and resource attributes, with span taking precedence.
+func GetOTelHostname(signalattrs pcommon.Map, resattrs pcommon.Map, fallbackHost string, ignoreMissingDatadogFields bool, useDatadogNamespaceIfPresent bool, hostFromAttributesHandler HostFromAttributesHandler) string {
+	if useDatadogNamespaceIfPresent {
+		host := GetOTelAttrFromEitherMap(signalattrs, resattrs, true, KeyDatadogHost)
+		if host != "" {
+			return host
+		}
+	}
+	hostname := GetOTelAttrFromEitherMap(signalattrs, resattrs, true, KeyDatadogHost)
+	if hostname == "" && !ignoreMissingDatadogFields {
+		// Try to get source from resource attributes using translator logic
+		src, srcok := SourceFromAttrs(resattrs, hostFromAttributesHandler)
+		if !srcok {
+			if v := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, "_dd.hostname"); v != "" {
+				src = source.Source{Kind: source.HostnameKind, Identifier: v}
+				srcok = true
+			}
+		}
+		if srcok {
+			switch src.Kind {
+			case source.HostnameKind:
+				return src.Identifier
+			default:
+				// We are not on a hostname (serverless), hence the hostname is empty
+				return ""
+			}
+		} else {
+			// fallback hostname from Agent conf.Hostname
+			return fallbackHost
+		}
+	}
+	return hostname
+}
+
+// GetOTelEnv returns the environment based on OTel span and resource attributes, with span taking precedence.
+func GetOTelEnv(signalattr pcommon.Map, resattrs pcommon.Map, ignoreMissingDatadogFields bool, useDatadogNamespaceIfPresent bool) string {
+	if useDatadogNamespaceIfPresent {
+		env := GetOTelAttrFromEitherMap(signalattr, resattrs, true, KeyDatadogEnvironment)
+		if env != "" && !ignoreMissingDatadogFields {
+			return env
+		}
+	}
+	env := GetOTelAttrFromEitherMap(signalattr, resattrs, true, KeyDatadogEnvironment)
+	if env == "" && !ignoreMissingDatadogFields {
+		env = GetOTelAttrFromEitherMap(signalattr, resattrs, true, string(semconv1_27.DeploymentEnvironmentNameKey), string(semconv1_12.DeploymentEnvironmentKey))
+	}
+	if env == "" {
+		env = DefaultOTLPEnvironmentName
+	}
+	return env
+}
+
+// GetOTelService returns the DD service name based on OTel span and resource attributes.
+func GetOTelService(signalattrs pcommon.Map, resattrs pcommon.Map, normalize bool, useDatadogNamespaceIfPresent bool) string {
+	if useDatadogNamespaceIfPresent {
+		svc := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, KeyDatadogService)
+		if svc != "" {
+			return svc
+		}
+	}
+	svc := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_6_1.ServiceNameKey))
+	if svc == "" {
+		svc = DefaultOTLPServiceName
+	}
+	if normalize {
+		newsvc, err := normalizeutil.NormalizeService(svc, "")
+		switch err {
+		case normalizeutil.ErrTooLong:
+			log.Debugf("Fixing malformed trace. Service is too long (reason:service_truncate), truncating span.service to length=%d: %s", normalizeutil.MaxServiceLen, svc) // XXX use a different logger
+		case normalizeutil.ErrInvalid:
+			log.Debugf("Fixing malformed trace. Service is invalid (reason:service_invalid), replacing invalid span.service=%s with fallback span.service=%s", svc, newsvc) // XXX use a different logger
+		}
+		svc = newsvc
+	}
+	return svc
+}
+
+// GetOTelResource returns the DD resource name based on OTel span and resource attributes.
+func GetOTelResource(spanKind ptrace.SpanKind, signalattrs pcommon.Map, resattrs pcommon.Map, fallbackResource string, useDatadogNamespaceIfPresent bool) (resource string) {
+	if useDatadogNamespaceIfPresent {
+		resource = GetOTelAttrFromEitherMap(signalattrs, resattrs, false, KeyDatadogResource)
+		if resource != "" {
+			return resource
+		}
+	}
+	if m := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, "resource.name"); m != "" {
+		return m
+	}
+
+	// HTTP method + route logic
+	if method := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, "http.request.method", string(semconv1_12.HTTPMethodKey)); method != "" {
+		if method == "_OTHER" {
+			method = "HTTP"
+		}
+		resource = method
+		if spanKind == ptrace.SpanKindServer {
+			if route := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_12.HTTPRouteKey)); route != "" {
+				resource = resource + " " + route
+			}
+		}
+		return resource
+	}
+
+	// Messaging operation logic
+	if operation := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_12.MessagingOperationKey)); operation != "" {
+		resource = operation
+		if dest := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_12.MessagingDestinationKey), string(semconv1_17.MessagingDestinationNameKey)); dest != "" {
+			resource = resource + " " + dest
+		}
+		return resource
+	}
+
+	// RPC method logic
+	if method := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_12.RPCMethodKey)); method != "" {
+		resource = method
+		if svc := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_12.RPCServiceKey)); svc != "" {
+			resource = resource + " " + svc
+		}
+		return resource
+	}
+
+	// GraphQL operation logic
+	if opType := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_17.GraphqlOperationTypeKey)); opType != "" {
+		resource = opType
+		if name := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_17.GraphqlOperationNameKey)); name != "" {
+			resource = resource + " " + name
+		}
+		return resource
+	}
+
+	// Database operation logic
+	if dbSystem := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_12.DBSystemKey)); dbSystem != "" {
+		if statement := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_12.DBStatementKey)); statement != "" {
+			return statement
+		}
+		if dbQuery := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, string(semconv1_27.DBQueryTextKey)); dbQuery != "" {
+			return dbQuery
+		}
+	}
+
+	return fallbackResource
+}
+
+// GetOTelSpanType returns the DD span type based on OTel span kind and attributes.
+func GetOTelSpanType(spanKind ptrace.SpanKind, signalattrs pcommon.Map, resattrs pcommon.Map, useDatadogNamespaceIfPresent bool) string {
+	if useDatadogNamespaceIfPresent {
+		typ := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, KeyDatadogType)
+		if typ != "" {
+			return typ
+		}
+	}
+	typ := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, "span.type")
+	if typ != "" {
+		return typ
+	}
+
+	switch spanKind {
+	case ptrace.SpanKindServer:
+		return "web"
+	case ptrace.SpanKindClient:
+		db := GetOTelAttrFromEitherMap(signalattrs, resattrs, true, string(semconv1_6_1.DBSystemKey))
+		if db == "" {
+			typ = "http"
+		} else {
+			typ = checkDBType(db)
+		}
+	default:
+		typ = "custom"
+	}
+	return typ
+}
+
+// Database span type constants (from agent)
+const (
+	spanTypeSQL           = "sql"
+	spanTypeCassandra     = "cassandra"
+	spanTypeRedis         = "redis"
+	spanTypeMemcached     = "memcached"
+	spanTypeMongoDB       = "mongodb"
+	spanTypeElasticsearch = "elasticsearch"
+	spanTypeOpenSearch    = "opensearch"
+	spanTypeDB            = "db"
+)
+
+// dbTypes maps database systems to their corresponding span types (copied from agent)
+var dbTypes = map[string]string{
+	// SQL db types
+	semconv1_12.DBSystemOtherSQL.Value.AsString():    spanTypeSQL,
+	semconv1_12.DBSystemMSSQL.Value.AsString():       spanTypeSQL,
+	semconv1_12.DBSystemMySQL.Value.AsString():       spanTypeSQL,
+	semconv1_12.DBSystemOracle.Value.AsString():      spanTypeSQL,
+	semconv1_12.DBSystemDB2.Value.AsString():         spanTypeSQL,
+	semconv1_12.DBSystemPostgreSQL.Value.AsString():  spanTypeSQL,
+	semconv1_12.DBSystemRedshift.Value.AsString():    spanTypeSQL,
+	semconv1_12.DBSystemCloudscape.Value.AsString():  spanTypeSQL,
+	semconv1_12.DBSystemHSQLDB.Value.AsString():      spanTypeSQL,
+	semconv1_12.DBSystemMaxDB.Value.AsString():       spanTypeSQL,
+	semconv1_12.DBSystemIngres.Value.AsString():      spanTypeSQL,
+	semconv1_12.DBSystemFirstSQL.Value.AsString():    spanTypeSQL,
+	semconv1_12.DBSystemEDB.Value.AsString():         spanTypeSQL,
+	semconv1_12.DBSystemCache.Value.AsString():       spanTypeSQL,
+	semconv1_12.DBSystemFirebird.Value.AsString():    spanTypeSQL,
+	semconv1_12.DBSystemDerby.Value.AsString():       spanTypeSQL,
+	semconv1_12.DBSystemInformix.Value.AsString():    spanTypeSQL,
+	semconv1_12.DBSystemMariaDB.Value.AsString():     spanTypeSQL,
+	semconv1_12.DBSystemSqlite.Value.AsString():      spanTypeSQL,
+	semconv1_12.DBSystemSybase.Value.AsString():      spanTypeSQL,
+	semconv1_12.DBSystemTeradata.Value.AsString():    spanTypeSQL,
+	semconv1_12.DBSystemVertica.Value.AsString():     spanTypeSQL,
+	semconv1_12.DBSystemH2.Value.AsString():          spanTypeSQL,
+	semconv1_12.DBSystemColdfusion.Value.AsString():  spanTypeSQL,
+	semconv1_12.DBSystemCockroachdb.Value.AsString(): spanTypeSQL,
+	semconv1_12.DBSystemProgress.Value.AsString():    spanTypeSQL,
+	semconv1_12.DBSystemHanaDB.Value.AsString():      spanTypeSQL,
+	semconv1_12.DBSystemAdabas.Value.AsString():      spanTypeSQL,
+	semconv1_12.DBSystemFilemaker.Value.AsString():   spanTypeSQL,
+	semconv1_12.DBSystemInstantDB.Value.AsString():   spanTypeSQL,
+	semconv1_12.DBSystemInterbase.Value.AsString():   spanTypeSQL,
+	semconv1_12.DBSystemNetezza.Value.AsString():     spanTypeSQL,
+	semconv1_12.DBSystemPervasive.Value.AsString():   spanTypeSQL,
+	semconv1_12.DBSystemPointbase.Value.AsString():   spanTypeSQL,
+	semconv1_17.DBSystemClickhouse.Value.AsString():  spanTypeSQL, // not in semconv 1.6.1
+
+	// Cassandra db types
+	semconv1_12.DBSystemCassandra.Value.AsString(): spanTypeCassandra,
+
+	// Redis db types
+	semconv1_12.DBSystemRedis.Value.AsString(): spanTypeRedis,
+
+	// Memcached db types
+	semconv1_12.DBSystemMemcached.Value.AsString(): spanTypeMemcached,
+
+	// MongoDB db types
+	semconv1_12.DBSystemMongoDB.Value.AsString(): spanTypeMongoDB,
+
+	// Elasticsearch db types
+	semconv1_12.DBSystemElasticsearch.Value.AsString(): spanTypeElasticsearch,
+
+	// OpenSearch db types, not in semconv1_12 1.6.1
+	semconv1_17.DBSystemOpensearch.Value.AsString(): spanTypeOpenSearch,
+
+	// Generic db types
+	semconv1_12.DBSystemHive.Value.AsString():      spanTypeDB,
+	semconv1_12.DBSystemHBase.Value.AsString():     spanTypeDB,
+	semconv1_12.DBSystemNeo4j.Value.AsString():     spanTypeDB,
+	semconv1_12.DBSystemCouchbase.Value.AsString(): spanTypeDB,
+	semconv1_12.DBSystemCouchDB.Value.AsString():   spanTypeDB,
+	semconv1_12.DBSystemCosmosDB.Value.AsString():  spanTypeDB,
+	semconv1_12.DBSystemDynamoDB.Value.AsString():  spanTypeDB,
+	semconv1_12.DBSystemGeode.Value.AsString():     spanTypeDB,
+}
+
+// checkDBType checks if the dbType is a known db type and returns the corresponding span.Type (from agent)
+func checkDBType(dbType string) string {
+	spanType, ok := dbTypes[dbType]
+	if ok {
+		return spanType
+	}
+	// span type not found, return generic db type
+	return spanTypeDB
+}
+
+// GetOTelVersion returns the version based on OTel span and resource attributes, with span taking precedence.
+func GetOTelVersion(signalattrs pcommon.Map, resattrs pcommon.Map, ignoreMissingDatadogFields bool, useDatadogNamespaceIfPresent bool) string {
+	if useDatadogNamespaceIfPresent {
+		version := GetOTelAttrFromEitherMap(signalattrs, resattrs, false, KeyDatadogVersion)
+		if version != "" {
+			return version
+		}
+	}
+	version := GetOTelAttrFromEitherMap(signalattrs, resattrs, true, KeyDatadogVersion)
+	if version == "" && !ignoreMissingDatadogFields {
+		version = GetOTelAttrFromEitherMap(signalattrs, resattrs, true, string(semconv1_27.ServiceVersionKey))
+	}
+	return version
+}
+
+// GetOTelStatusCode returns the HTTP status code based on OTel span and resource attributes, with span taking precedence.
+func GetOTelStatusCode(signalattrs pcommon.Map, resattrs pcommon.Map, ignoreMissingDatadogFields bool, useDatadogNamespaceIfPresent bool) (uint32, error) {
+	ret := _getOTelStatusCode(signalattrs, resattrs, ignoreMissingDatadogFields, useDatadogNamespaceIfPresent)
+	switch ret.Type() {
+	case pcommon.ValueTypeInt:
+		return uint32(ret.Int()), nil
+	case pcommon.ValueTypeDouble:
+		return uint32(ret.Int()), nil
+	case pcommon.ValueTypeStr:
+		if code, err := strconv.ParseUint(ret.AsString(), 10, 32); err == nil {
+			return uint32(code), nil
+		} else {
+			return 0, fmt.Errorf("invalid status code %s", ret.AsString())
+		}
+	default:
+		return 0, fmt.Errorf("unsupported type %s", ret.Type())
+	}
+}
+
+func _getOTelStatusCode(signalattrs pcommon.Map, resattrs pcommon.Map, ignoreMissingDatadogFields bool, useDatadogNamespaceIfPresent bool) pcommon.Value {
+	if useDatadogNamespaceIfPresent {
+		if code, ok := signalattrs.Get(KeyDatadogHTTPStatusCode); ok {
+			return code
+		}
+		if code, ok := resattrs.Get(KeyDatadogHTTPStatusCode); ok {
+			return code
+		}
+	}
+	if code, ok := signalattrs.Get(KeyDatadogHTTPStatusCode); ok {
+		return code
+	}
+	if code, ok := resattrs.Get(KeyDatadogHTTPStatusCode); ok {
+		return code
+	}
+	if !ignoreMissingDatadogFields {
+		if code, ok := signalattrs.Get(string(semconv1_17.HTTPStatusCodeKey)); ok {
+			return code
+		}
+		if code, ok := signalattrs.Get(string(semconv1_27.HTTPResponseStatusCodeKey)); ok {
+			return code
+		}
+		if code, ok := resattrs.Get(string(semconv1_17.HTTPStatusCodeKey)); ok {
+			return code
+		}
+		if code, ok := resattrs.Get(string(semconv1_27.HTTPResponseStatusCodeKey)); ok {
+			return code
+		}
+	}
+	return pcommon.NewValueInt(0)
+}
+
+// GetOTelContainerID returns the container ID based on OTel span and resource attributes, with span taking precedence.
+func GetOTelContainerID(signalattrs pcommon.Map, resourceattrs pcommon.Map, ignoreMissingDatadogFields bool, useDatadogNamespaceIfPresent bool) string {
+	if useDatadogNamespaceIfPresent {
+		cid := GetOTelAttrFromEitherMap(signalattrs, resourceattrs, true, KeyDatadogContainerID)
+		if cid != "" {
+			return cid
+		}
+	}
+	cid := GetOTelAttrFromEitherMap(signalattrs, resourceattrs, true, KeyDatadogContainerID)
+	if cid == "" && !ignoreMissingDatadogFields {
+		cid = GetOTelAttrFromEitherMap(signalattrs, resourceattrs, true, string(semconv1_27.ContainerIDKey), string(semconv1_27.K8SPodUIDKey))
+	}
+	return cid
+}
+
+// XXX make this take signalattrs as well
+// GetOTelContainerTags returns a list of DD container tags in an OTel map's attributes.
+// Tags are always normalized.
+func GetOTelContainerTags(signalattrs pcommon.Map, rattrs pcommon.Map, tagKeys []string) []string {
+	var containerTags []string
+	containerTagsMap := ContainerTagsFromResourceAttributes(rattrs)
+	for _, key := range tagKeys {
+		if mappedKey, ok := ContainerMappings[key]; ok {
+			// If the key has a mapping in ContainerMappings, use the mapped key
+			if val, ok := containerTagsMap[mappedKey]; ok {
+				t := normalizeutil.NormalizeTag(mappedKey + ":" + val)
+				containerTags = append(containerTags, t)
+			}
+		} else {
+			// Otherwise populate as additional container tags
+			if val := GetOTelAttrVal(rattrs, false, key); val != "" {
+				t := normalizeutil.NormalizeTag(key + ":" + val)
+				containerTags = append(containerTags, t)
+			}
+		}
+	}
+	return containerTags
+}
+
+// GetOTelAttrVal returns the matched value as a string in the input map with the given keys.
+// If there are multiple keys present, the first matched one is returned.
+// If normalize is true, normalize the return value with NormalizeTagValue.
+func GetOTelAttrVal(attrs pcommon.Map, normalize bool, keys ...string) string {
+	val := ""
+	for _, key := range keys {
+		attrval, exists := attrs.Get(key)
+		if exists {
+			val = attrval.AsString()
+			break
+		}
+	}
+
+	if normalize {
+		val = normalizeutil.NormalizeTagValue(val)
+	}
+
+	return val
+}
+
+// normalizeTag normalizes a tag (simplified version of agent's normalizeutil.NormalizeTag)
+func normalizeTag(tag string) string {
+	// Basic validation - must contain colon
+	if !strings.Contains(tag, ":") {
+		return tag
+	}
+
+	// Replace invalid characters with underscores
+	invalidChars := regexp.MustCompile(`[^\w.:/\-]`)
+	tag = invalidChars.ReplaceAllString(tag, "_")
+
+	// Trim and lowercase
+	tag = strings.ToLower(strings.TrimSpace(tag))
+
+	return tag
+}
+
+// GetPeerTagsFromOTelAttributes returns the peer tags based on OTel span and resource attributes, with span taking precedence.
+func GetPeerTagsFromOTelAttributes(signalattrs pcommon.Map, resattrs pcommon.Map, peerTagKeys map[string]struct{}) []string {
+	var peerTagsMap map[string]string
+
+	cb := func(k string, v pcommon.Value) bool {
+		val := v.AsString()
+		if _, ok := peerTagKeys[k]; ok {
+			peerTagsMap[k] = val
+		}
+		return true
+	}
+
+	// Signal overwrites res
+	resattrs.Range(cb)
+	signalattrs.Range(cb)
+
+	peerTags := make([]string, 0, len(peerTagsMap))
+	for k, v := range peerTagsMap {
+		t := normalizeTag(k + ":" + v)
+		peerTags = append(peerTags, t)
+	}
+	return peerTags
 }

--- a/pkg/opentelemetry-mapping-go/otlp/attributes/attributes_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/attributes_test.go
@@ -16,39 +16,44 @@ package attributes
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
-	semconv127 "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv1_17 "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv1_27 "go.opentelemetry.io/otel/semconv/v1.27.0"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+
+	normalizeutil "github.com/DataDog/datadog-agent/pkg/util/normalize"
 )
 
 func TestTagsFromAttributes(t *testing.T) {
 	attributeMap := map[string]interface{}{
-		string(semconv127.ProcessExecutableNameKey):     "otelcol",
-		string(semconv127.ProcessExecutablePathKey):     "/usr/bin/cmd/otelcol",
-		string(semconv127.ProcessCommandKey):            "cmd/otelcol",
-		string(semconv127.ProcessCommandLineKey):        "cmd/otelcol --config=\"/path/to/config.yaml\"",
-		string(semconv127.ProcessPIDKey):                1,
-		string(semconv127.ProcessOwnerKey):              "root",
-		string(semconv127.OSTypeKey):                    "linux",
-		string(semconv127.K8SDaemonSetNameKey):          "daemon_set_name",
-		string(semconv127.AWSECSClusterARNKey):          "cluster_arn",
-		string(semconv127.ContainerRuntimeKey):          "cro",
-		"tags.datadoghq.com/service":                    "service_name",
-		string(semconv127.DeploymentEnvironmentNameKey): "prod",
-		string(semconv127.ContainerNameKey):             "custom",
-		"datadog.container.tag.custom.team":             "otel",
-		"kube_cronjob":                                  "cron",
+		string(semconv1_27.ProcessExecutableNameKey):     "otelcol",
+		string(semconv1_27.ProcessExecutablePathKey):     "/usr/bin/cmd/otelcol",
+		string(semconv1_27.ProcessCommandKey):            "cmd/otelcol",
+		string(semconv1_27.ProcessCommandLineKey):        "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		string(semconv1_27.ProcessPIDKey):                1,
+		string(semconv1_27.ProcessOwnerKey):              "root",
+		string(semconv1_27.OSTypeKey):                    "linux",
+		string(semconv1_27.K8SDaemonSetNameKey):          "daemon_set_name",
+		string(semconv1_27.AWSECSClusterARNKey):          "cluster_arn",
+		string(semconv1_27.ContainerRuntimeKey):          "cro",
+		"tags.datadoghq.com/service":                     "service_name",
+		string(semconv1_27.DeploymentEnvironmentNameKey): "prod",
+		string(semconv1_27.ContainerNameKey):             "custom",
+		"datadog.container.tag.custom.team":              "otel",
+		"kube_cronjob":                                   "cron",
 	}
 	attrs := pcommon.NewMap()
 	attrs.FromRaw(attributeMap)
 
 	assert.ElementsMatch(t, []string{
-		fmt.Sprintf("%s:%s", string(semconv127.ProcessExecutableNameKey), "otelcol"),
-		fmt.Sprintf("%s:%s", string(semconv127.OSTypeKey), "linux"),
+		fmt.Sprintf("%s:%s", string(semconv1_27.ProcessExecutableNameKey), "otelcol"),
+		fmt.Sprintf("%s:%s", string(semconv1_27.OSTypeKey), "linux"),
 		fmt.Sprintf("%s:%s", "kube_daemon_set", "daemon_set_name"),
 		fmt.Sprintf("%s:%s", "ecs_cluster_name", "cluster_arn"),
 		fmt.Sprintf("%s:%s", "service", "service_name"),
@@ -77,20 +82,20 @@ func TestContainerTagFromResourceAttributes(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		attributes := pcommon.NewMap()
 		err := attributes.FromRaw(map[string]interface{}{
-			string(semconv127.ContainerNameKey):         "sample_app",
-			string(conventions.ContainerImageTagKey):    "sample_app_image_tag",
-			string(semconv127.ContainerRuntimeKey):      "cro",
-			string(semconv127.K8SContainerNameKey):      "kube_sample_app",
-			string(semconv127.K8SReplicaSetNameKey):     "sample_replica_set",
-			string(semconv127.K8SDaemonSetNameKey):      "sample_daemonset_name",
-			string(semconv127.K8SPodNameKey):            "sample_pod_name",
-			string(semconv127.CloudProviderKey):         "sample_cloud_provider",
-			string(semconv127.CloudRegionKey):           "sample_region",
-			string(semconv127.CloudAvailabilityZoneKey): "sample_zone",
-			string(semconv127.AWSECSTaskFamilyKey):      "sample_task_family",
-			string(semconv127.AWSECSClusterARNKey):      "sample_ecs_cluster_name",
-			string(semconv127.AWSECSContainerARNKey):    "sample_ecs_container_name",
-			"datadog.container.tag.custom.team":         "otel",
+			string(semconv1_27.ContainerNameKey):         "sample_app",
+			string(conventions.ContainerImageTagKey):     "sample_app_image_tag",
+			string(semconv1_27.ContainerRuntimeKey):      "cro",
+			string(semconv1_27.K8SContainerNameKey):      "kube_sample_app",
+			string(semconv1_27.K8SReplicaSetNameKey):     "sample_replica_set",
+			string(semconv1_27.K8SDaemonSetNameKey):      "sample_daemonset_name",
+			string(semconv1_27.K8SPodNameKey):            "sample_pod_name",
+			string(semconv1_27.CloudProviderKey):         "sample_cloud_provider",
+			string(semconv1_27.CloudRegionKey):           "sample_region",
+			string(semconv1_27.CloudAvailabilityZoneKey): "sample_zone",
+			string(semconv1_27.AWSECSTaskFamilyKey):      "sample_task_family",
+			string(semconv1_27.AWSECSClusterARNKey):      "sample_ecs_cluster_name",
+			string(semconv1_27.AWSECSContainerARNKey):    "sample_ecs_container_name",
+			"datadog.container.tag.custom.team":          "otel",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]string{
@@ -115,7 +120,7 @@ func TestContainerTagFromResourceAttributes(t *testing.T) {
 	t.Run("conventions vs custom", func(t *testing.T) {
 		attributes := pcommon.NewMap()
 		err := attributes.FromRaw(map[string]interface{}{
-			string(semconv127.ContainerNameKey):    "ok",
+			string(semconv1_27.ContainerNameKey):   "ok",
 			"datadog.container.tag.container_name": "nok",
 		})
 		assert.NoError(t, err)
@@ -145,22 +150,22 @@ func TestContainerTagFromResourceAttributes(t *testing.T) {
 
 func TestContainerTagFromAttributes(t *testing.T) {
 	attributeMap := map[string]string{
-		string(semconv127.ContainerNameKey):         "sample_app",
-		string(conventions.ContainerImageTagKey):    "sample_app_image_tag",
-		string(semconv127.ContainerRuntimeKey):      "cro",
-		string(semconv127.K8SContainerNameKey):      "kube_sample_app",
-		string(semconv127.K8SReplicaSetNameKey):     "sample_replica_set",
-		string(semconv127.K8SDaemonSetNameKey):      "sample_daemonset_name",
-		string(semconv127.K8SPodNameKey):            "sample_pod_name",
-		string(semconv127.CloudProviderKey):         "sample_cloud_provider",
-		string(semconv127.CloudRegionKey):           "sample_region",
-		string(semconv127.CloudAvailabilityZoneKey): "sample_zone",
-		string(semconv127.AWSECSTaskFamilyKey):      "sample_task_family",
-		string(semconv127.AWSECSClusterARNKey):      "sample_ecs_cluster_name",
-		string(semconv127.AWSECSContainerARNKey):    "sample_ecs_container_name",
-		"custom_tag":                                "example_custom_tag",
-		"":                                          "empty_string_key",
-		"empty_string_val":                          "",
+		string(semconv1_27.ContainerNameKey):         "sample_app",
+		string(conventions.ContainerImageTagKey):     "sample_app_image_tag",
+		string(semconv1_27.ContainerRuntimeKey):      "cro",
+		string(semconv1_27.K8SContainerNameKey):      "kube_sample_app",
+		string(semconv1_27.K8SReplicaSetNameKey):     "sample_replica_set",
+		string(semconv1_27.K8SDaemonSetNameKey):      "sample_daemonset_name",
+		string(semconv1_27.K8SPodNameKey):            "sample_pod_name",
+		string(semconv1_27.CloudProviderKey):         "sample_cloud_provider",
+		string(semconv1_27.CloudRegionKey):           "sample_region",
+		string(semconv1_27.CloudAvailabilityZoneKey): "sample_zone",
+		string(semconv1_27.AWSECSTaskFamilyKey):      "sample_task_family",
+		string(semconv1_27.AWSECSClusterARNKey):      "sample_ecs_cluster_name",
+		string(semconv1_27.AWSECSContainerARNKey):    "sample_ecs_container_name",
+		"custom_tag":       "example_custom_tag",
+		"":                 "empty_string_key",
+		"empty_string_val": "",
 	}
 
 	assert.Equal(t, map[string]string{
@@ -218,7 +223,7 @@ func TestOriginIDFromAttributes(t *testing.T) {
 			attrs: func() pcommon.Map {
 				attributes := pcommon.NewMap()
 				attributes.FromRaw(map[string]interface{}{
-					string(semconv127.K8SPodUIDKey): "k8s_pod_uid_goes_here",
+					string(semconv1_27.K8SPodUIDKey): "k8s_pod_uid_goes_here",
 				})
 				return attributes
 			}(),
@@ -236,4 +241,699 @@ func TestOriginIDFromAttributes(t *testing.T) {
 			assert.Equal(t, testInstance.originID, originID)
 		})
 	}
+}
+
+func TestGetOTelAttrFromEitherMap(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		map1      map[string]string
+		map2      map[string]string
+		normalize bool
+		keys      []string
+		expected  string
+	}{
+		{
+			name:     "key in map1",
+			map1:     map[string]string{"test.key": "value1"},
+			map2:     map[string]string{"test.key": "value2"},
+			keys:     []string{"test.key"},
+			expected: "value1",
+		},
+		{
+			name:     "key only in map2",
+			map1:     map[string]string{},
+			map2:     map[string]string{"test.key": "value2"},
+			keys:     []string{"test.key"},
+			expected: "value2",
+		},
+		{
+			name:     "multiple keys, first match",
+			map1:     map[string]string{"key1": "value1_map1"},
+			map2:     map[string]string{"key1": "value1_map2", "key2": "value2_map2"},
+			keys:     []string{"key1", "key2"},
+			expected: "value1_map1",
+		},
+		{
+			name:      "normalization enabled",
+			map1:      map[string]string{"test.key": "  VALUE "},
+			map2:      map[string]string{},
+			keys:      []string{"test.key"},
+			normalize: true,
+			expected:  "_value",
+		},
+		{
+			name:     "no match",
+			map1:     map[string]string{"other.key": "value1"},
+			map2:     map[string]string{"another.key": "value2"},
+			keys:     []string{"missing.key"},
+			expected: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pmap1 := pcommon.NewMap()
+			for k, v := range tt.map1 {
+				pmap1.PutStr(k, v)
+			}
+			pmap2 := pcommon.NewMap()
+			for k, v := range tt.map2 {
+				pmap2.PutStr(k, v)
+			}
+			actual := GetOTelAttrFromEitherMap(pmap1, pmap2, tt.normalize, tt.keys...)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetOTelHostname(t *testing.T) {
+	for _, tt := range []struct {
+		name                       string
+		rattrs                     map[string]string
+		sattrs                     map[string]string
+		fallbackHost               string
+		expected                   string
+		ignoreMissingDatadogFields bool
+	}{
+		{
+			name:     "datadog.host.name",
+			rattrs:   map[string]string{"datadog.host.name": "test-host"},
+			expected: "test-host",
+		},
+		{
+			name:     "_dd.hostname",
+			rattrs:   map[string]string{"_dd.hostname": "test-host"},
+			expected: "test-host",
+		},
+		{
+			name:         "fallback hostname",
+			fallbackHost: "test-host",
+			expected:     "test-host",
+		},
+		{
+			name:                       "ignore missing datadog fields",
+			rattrs:                     map[string]string{string(semconv1_17.HostNameKey): "test-host"},
+			expected:                   "",
+			ignoreMissingDatadogFields: true,
+		},
+		{
+			name:     "read from datadog fields",
+			sattrs:   map[string]string{KeyDatadogHost: "test-host", string(semconv1_17.HostNameKey): "test-host-semconv117"},
+			rattrs:   map[string]string{KeyDatadogHost: "test-host", string(semconv1_17.HostNameKey): "test-host-semconv117"},
+			expected: "test-host",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			span := pcommon.NewMap()
+			for k, v := range tt.sattrs {
+				span.PutStr(k, v)
+			}
+			res := pcommon.NewMap()
+			for k, v := range tt.rattrs {
+				res.PutStr(k, v)
+			}
+			actual := GetOTelHostname(span, res, tt.fallbackHost, tt.ignoreMissingDatadogFields, true, nil)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetOTelEnv(t *testing.T) {
+	tests := []struct {
+		name                       string
+		sattrs                     map[string]string
+		rattrs                     map[string]string
+		expected                   string
+		ignoreMissingDatadogFields bool
+	}{
+		{
+			name:     "neither set",
+			expected: "default",
+		},
+		{
+			name:     "only in resource (semconv127)",
+			rattrs:   map[string]string{string(semconv1_27.DeploymentEnvironmentNameKey): "env-res-127"},
+			expected: "env-res-127",
+		},
+		{
+			name:     "only in resource (semconv117)",
+			rattrs:   map[string]string{string(semconv1_17.DeploymentEnvironmentKey): "env-res"},
+			expected: "env-res",
+		},
+		{
+			name:     "only in span (semconv127)",
+			sattrs:   map[string]string{string(semconv1_27.DeploymentEnvironmentNameKey): "env-span-127"},
+			expected: "env-span-127",
+		},
+		{
+			name:     "only in span (semconv117)",
+			sattrs:   map[string]string{string(semconv1_17.DeploymentEnvironmentKey): "env-span"},
+			expected: "env-span",
+		},
+		{
+			name:     "both set (span wins)",
+			sattrs:   map[string]string{string(semconv1_17.DeploymentEnvironmentKey): "env-span"},
+			rattrs:   map[string]string{string(semconv1_17.DeploymentEnvironmentKey): "env-res"},
+			expected: "env-span",
+		},
+		{
+			name:     "normalization",
+			sattrs:   map[string]string{string(semconv1_17.DeploymentEnvironmentKey): "  ENV "},
+			expected: "_env",
+		},
+		{
+			name:                       "ignore missing datadog fields",
+			sattrs:                     map[string]string{string(semconv1_17.DeploymentEnvironmentKey): "env-span"},
+			rattrs:                     map[string]string{string(semconv1_17.DeploymentEnvironmentKey): "env-span"},
+			expected:                   "default",
+			ignoreMissingDatadogFields: true,
+		},
+		{
+			name:     "read from datadog fields",
+			sattrs:   map[string]string{KeyDatadogEnvironment: "env-span", string(semconv1_17.DeploymentEnvironmentKey): "env-span-semconv117"},
+			rattrs:   map[string]string{KeyDatadogEnvironment: "env-res", string(semconv1_17.DeploymentEnvironmentKey): "env-res-semconv117"},
+			expected: "env-span",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := pcommon.NewMap()
+			for k, v := range tt.sattrs {
+				span.PutStr(k, v)
+			}
+			res := pcommon.NewMap()
+			for k, v := range tt.rattrs {
+				res.PutStr(k, v)
+			}
+			assert.Equal(t, tt.expected, GetOTelEnv(span, res, tt.ignoreMissingDatadogFields, true))
+		})
+	}
+}
+
+func TestGetOTelService(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		rattrs    map[string]string
+		sattrs    map[string]string
+		normalize bool
+		expected  string
+	}{
+		{
+			name:     "service not set",
+			expected: "otlpresourcenoservicename",
+		},
+		{
+			name:     "normal service in resource",
+			rattrs:   map[string]string{string(conventions.ServiceNameKey): "svc"},
+			expected: "svc",
+		},
+		{
+			name:     "normal service in span",
+			sattrs:   map[string]string{string(conventions.ServiceNameKey): "svc"},
+			expected: "svc",
+		},
+		{
+			name:     "service in both, span takes precedence",
+			rattrs:   map[string]string{string(conventions.ServiceNameKey): "resource_svc"},
+			sattrs:   map[string]string{string(conventions.ServiceNameKey): "span_svc"},
+			expected: "span_svc",
+		},
+		{
+			name:      "truncate long service",
+			rattrs:    map[string]string{string(conventions.ServiceNameKey): strings.Repeat("a", normalizeutil.MaxServiceLen+1)},
+			normalize: true,
+			expected:  strings.Repeat("a", normalizeutil.MaxServiceLen),
+		},
+		{
+			name:      "invalid service",
+			rattrs:    map[string]string{string(conventions.ServiceNameKey): "%$^"},
+			normalize: true,
+			expected:  normalizeutil.DefaultServiceName,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res := pcommon.NewMap()
+			for k, v := range tt.rattrs {
+				res.PutStr(k, v)
+			}
+			span := pcommon.NewMap()
+			for k, v := range tt.sattrs {
+				span.PutStr(k, v)
+			}
+			actual := GetOTelService(span, res, tt.normalize, true)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetOTelResource(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		rattrs    map[string]string
+		sattrs    map[string]string
+		normalize bool
+		expected  string
+	}{
+		{
+			name:     "resource not set",
+			expected: "span_name",
+		},
+		{
+			name:     "normal resource",
+			sattrs:   map[string]string{"resource.name": "res"},
+			expected: "res",
+		},
+		{
+			name:     "HTTP request method resource",
+			sattrs:   map[string]string{"http.request.method": "GET"},
+			expected: "GET",
+		},
+		{
+			name:     "HTTP method and route resource",
+			sattrs:   map[string]string{string(semconv1_27.HTTPRequestMethodKey): "GET", string(semconv1_27.HTTPRouteKey): "/"},
+			expected: "GET /",
+		},
+		{
+			name:     "GraphQL with no type",
+			sattrs:   map[string]string{"graphql.operation.name": "myQuery"},
+			expected: "span_name",
+		},
+		{
+			name:     "GraphQL with only type",
+			sattrs:   map[string]string{"graphql.operation.type": "query"},
+			expected: "query",
+		},
+		{
+			name:     "GraphQL with type and name",
+			sattrs:   map[string]string{"graphql.operation.type": "query", "graphql.operation.name": "myQuery"},
+			expected: "query myQuery",
+		},
+		{
+			name: "SQL statement resource",
+			rattrs: map[string]string{
+				string(semconv1_27.DBSystemKey):    "mysql",
+				string(semconv1_17.DBStatementKey): "SELECT * FROM table WHERE id = 12345",
+			},
+			sattrs:   map[string]string{"span.name": "span_name"},
+			expected: "SELECT * FROM table WHERE id = 12345",
+		},
+		{
+			name: "Redis command resource",
+			rattrs: map[string]string{
+				string(semconv1_27.DBSystemKey):    "redis",
+				string(semconv1_27.DBQueryTextKey): "SET key value",
+			},
+			sattrs:   map[string]string{"span.name": "span_name"},
+			expected: "SET key value",
+		},
+		{
+			name:     "resource.name in both span and resource (span wins)",
+			rattrs:   map[string]string{"resource.name": "res_resource"},
+			sattrs:   map[string]string{"resource.name": "res_span"},
+			expected: "res_span",
+		},
+		{
+			name:     "http.request.method in both span and resource (span wins)",
+			rattrs:   map[string]string{"http.request.method": "POST"},
+			sattrs:   map[string]string{"http.request.method": "GET"},
+			expected: "GET",
+		},
+		{
+			name:     "messaging.operation in both span and resource (span wins)",
+			rattrs:   map[string]string{"messaging.operation": "receive"},
+			sattrs:   map[string]string{"messaging.operation": "process"},
+			expected: "process",
+		},
+		{
+			name:     "rpc.method in both span and resource (span wins)",
+			rattrs:   map[string]string{"rpc.method": "resource_method", "rpc.service": "resource_service"},
+			sattrs:   map[string]string{"rpc.method": "span_method", "rpc.service": "span_service"},
+			expected: "span_method span_service",
+		},
+		{
+			name:     "GraphQL type in both span and resource (span wins)",
+			rattrs:   map[string]string{"graphql.operation.type": "mutation"},
+			sattrs:   map[string]string{"graphql.operation.type": "query", "graphql.operation.name": "myQuery"},
+			expected: "query myQuery",
+		},
+		{
+			name:     "DB statement in both span and resource (span wins)",
+			rattrs:   map[string]string{"db.system": "mysql", "db.statement": "SELECT * FROM resource"},
+			sattrs:   map[string]string{"db.system": "mysql", "db.statement": "SELECT * FROM span"},
+			expected: "SELECT * FROM span",
+		},
+		{
+			name:     "fallback to span name if nothing set",
+			sattrs:   map[string]string{},
+			rattrs:   map[string]string{},
+			expected: "span_name",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			span := pcommon.NewMap()
+			for k, v := range tt.sattrs {
+				span.PutStr(k, v)
+			}
+			res := pcommon.NewMap()
+			for k, v := range tt.rattrs {
+				res.PutStr(k, v)
+			}
+			actual := GetOTelResource(ptrace.SpanKindServer, span, res, "span_name", true)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetOTelSpanType(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		spanKind ptrace.SpanKind
+		rattrs   map[string]string
+		sattrs   map[string]string
+		expected string
+	}{
+		{
+			name:     "override with span.type attr",
+			spanKind: ptrace.SpanKindInternal,
+			rattrs:   map[string]string{"span.type": "my-type"},
+			expected: "my-type",
+		},
+		{
+			name:     "web span",
+			spanKind: ptrace.SpanKindServer,
+			expected: "web",
+		},
+		{
+			name:     "redis span",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{string(conventions.DBSystemKey): "redis"},
+			expected: spanTypeRedis,
+		},
+		{
+			name:     "memcached span",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{string(conventions.DBSystemKey): "memcached"},
+			expected: spanTypeMemcached,
+		},
+		{
+			name:     "sql db client span",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{string(conventions.DBSystemKey): conventions.DBSystemPostgreSQL.Value.AsString()},
+			expected: spanTypeSQL,
+		},
+		{
+			name:     "elastic db client span",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{string(conventions.DBSystemKey): conventions.DBSystemElasticsearch.Value.AsString()},
+			expected: spanTypeElasticsearch,
+		},
+		{
+			name:     "opensearch db client span",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{string(conventions.DBSystemKey): semconv1_17.DBSystemOpensearch.Value.AsString()},
+			expected: spanTypeOpenSearch,
+		},
+		{
+			name:     "cassandra db client span",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{string(conventions.DBSystemKey): conventions.DBSystemCassandra.Value.AsString()},
+			expected: spanTypeCassandra,
+		},
+		{
+			name:     "other db client span",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{string(conventions.DBSystemKey): conventions.DBSystemCouchDB.Value.AsString()},
+			expected: spanTypeDB,
+		},
+		{
+			name:     "http client span",
+			spanKind: ptrace.SpanKindClient,
+			expected: "http",
+		},
+		{
+			name:     "other custom span",
+			spanKind: ptrace.SpanKindInternal,
+			expected: "custom",
+		},
+		{
+			name:     "span.type in both span and resource (span wins)",
+			rattrs:   map[string]string{"span.type": "resource-type"},
+			sattrs:   map[string]string{"span.type": "span-type"},
+			expected: "span-type",
+		},
+		{
+			name:     "span.type only in span",
+			sattrs:   map[string]string{"span.type": "span-type"},
+			expected: "span-type",
+		},
+		{
+			name:     "span.type only in resource",
+			rattrs:   map[string]string{"span.type": "resource-type"},
+			expected: "resource-type",
+		},
+		{
+			name:     "db.system in both span and resource (span wins)",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{"db.system": "redis"},
+			sattrs:   map[string]string{"db.system": "memcached"},
+			expected: spanTypeMemcached,
+		},
+		{
+			name:     "db.system only in span",
+			spanKind: ptrace.SpanKindClient,
+			sattrs:   map[string]string{"db.system": "redis"},
+			expected: spanTypeRedis,
+		},
+		{
+			name:     "db.system only in resource",
+			spanKind: ptrace.SpanKindClient,
+			rattrs:   map[string]string{"db.system": "redis"},
+			expected: spanTypeRedis,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			span := pcommon.NewMap()
+			for k, v := range tt.sattrs {
+				span.PutStr(k, v)
+			}
+			res := pcommon.NewMap()
+			for k, v := range tt.rattrs {
+				res.PutStr(k, v)
+			}
+			actual := GetOTelSpanType(tt.spanKind, span, res, true)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetOTelVersion(t *testing.T) {
+	tests := []struct {
+		name                       string
+		sattrs                     map[string]string
+		rattrs                     map[string]string
+		expected                   string
+		ignoreMissingDatadogFields bool
+	}{
+		{
+			name:     "neither set",
+			expected: "",
+		},
+		{
+			name:     "only in resource",
+			rattrs:   map[string]string{string(semconv1_27.ServiceVersionKey): "v1"},
+			expected: "v1",
+		},
+		{
+			name:     "only in span",
+			sattrs:   map[string]string{string(semconv1_27.ServiceVersionKey): "v3"},
+			expected: "v3",
+		},
+		{
+			name:     "both set (span wins)",
+			sattrs:   map[string]string{string(semconv1_27.ServiceVersionKey): "v3"},
+			rattrs:   map[string]string{string(semconv1_27.ServiceVersionKey): "v4"},
+			expected: "v3",
+		},
+		{
+			name:     "normalization",
+			sattrs:   map[string]string{string(semconv1_27.ServiceVersionKey): "  V1 "},
+			expected: "_v1",
+		},
+		{
+			name:                       "ignore missing datadog fields",
+			sattrs:                     map[string]string{string(semconv1_27.ServiceVersionKey): "v3"},
+			rattrs:                     map[string]string{string(semconv1_27.ServiceVersionKey): "v4"},
+			expected:                   "",
+			ignoreMissingDatadogFields: true,
+		},
+		{
+			name:     "read from datadog fields",
+			sattrs:   map[string]string{KeyDatadogVersion: "v3", string(semconv1_27.ServiceVersionKey): "v3-semconv127"},
+			rattrs:   map[string]string{KeyDatadogVersion: "v4", string(semconv1_27.ServiceVersionKey): "v4-semconv127"},
+			expected: "v3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := pcommon.NewMap()
+			for k, v := range tt.sattrs {
+				span.PutStr(k, v)
+			}
+			res := pcommon.NewMap()
+			for k, v := range tt.rattrs {
+				res.PutStr(k, v)
+			}
+			assert.Equal(t, tt.expected, GetOTelVersion(span, res, tt.ignoreMissingDatadogFields, true))
+		})
+	}
+}
+
+func TestGetOTelStatusCode(t *testing.T) {
+	tests := []struct {
+		name                       string
+		sattrs                     map[string]uint32
+		rattrs                     map[string]uint32
+		expected                   uint32
+		ignoreMissingDatadogFields bool
+	}{
+		{
+			name:     "neither set",
+			expected: 0,
+		},
+		{
+			name: "only in span, only semconv117.HTTPStatusCodeKey",
+			sattrs: map[string]uint32{
+				string(semconv1_17.HTTPStatusCodeKey): 200,
+			},
+			expected: 200,
+		},
+		{
+			name: "only in span, both semconv117.HTTPStatusCodeKey and http.response.status_code, semconv117.HTTPStatusCodeKey wins",
+			sattrs: map[string]uint32{
+				string(semconv1_17.HTTPStatusCodeKey): 200,
+				"http.response.status_code":           201,
+			},
+			expected: 200,
+		},
+		{
+			name: "only in resource, only semconv117.HTTPStatusCodeKey",
+			rattrs: map[string]uint32{
+				string(semconv1_17.HTTPStatusCodeKey): 201,
+			},
+			expected: 201,
+		},
+		{
+			name: "only in resource, both semconv117.HTTPStatusCodeKey and http.response.status_code, semconv117.HTTPStatusCodeKey wins",
+			rattrs: map[string]uint32{
+				string(semconv1_17.HTTPStatusCodeKey): 201,
+				"http.response.status_code":           202,
+			},
+			expected: 201,
+		},
+		{
+			name:     "both set (span wins)",
+			sattrs:   map[string]uint32{string(semconv1_17.HTTPStatusCodeKey): 203},
+			rattrs:   map[string]uint32{string(semconv1_17.HTTPStatusCodeKey): 204},
+			expected: 203,
+		},
+		{
+			name:                       "ignore missing datadog fields",
+			sattrs:                     map[string]uint32{string(semconv1_17.HTTPStatusCodeKey): 205},
+			expected:                   0,
+			ignoreMissingDatadogFields: true,
+		},
+		{
+			name:     "read from datadog fields",
+			sattrs:   map[string]uint32{KeyDatadogHTTPStatusCode: 206, string(semconv1_17.HTTPStatusCodeKey): 210},
+			rattrs:   map[string]uint32{KeyDatadogHTTPStatusCode: 207, string(semconv1_17.HTTPStatusCodeKey): 211},
+			expected: 206,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := pcommon.NewMap()
+			for k, v := range tt.sattrs {
+				span.PutInt(k, int64(v))
+			}
+			res := pcommon.NewMap()
+			for k, v := range tt.rattrs {
+				res.PutInt(k, int64(v))
+			}
+			actual, err := GetOTelStatusCode(span, res, tt.ignoreMissingDatadogFields, true)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetOTelContainerID(t *testing.T) {
+	tests := []struct {
+		name                       string
+		sattrs                     map[string]string
+		rattrs                     map[string]string
+		expected                   string
+		ignoreMissingDatadogFields bool
+	}{
+		{
+			name:     "neither set",
+			expected: "",
+		},
+		{
+			name:     "only in resource",
+			rattrs:   map[string]string{string(semconv1_17.ContainerIDKey): "cid-res"},
+			expected: "cid-res",
+		},
+		{
+			name:     "only in span",
+			sattrs:   map[string]string{string(semconv1_17.ContainerIDKey): "cid-span"},
+			expected: "cid-span",
+		},
+		{
+			name:     "both set (span wins)",
+			sattrs:   map[string]string{string(semconv1_17.ContainerIDKey): "cid-span"},
+			rattrs:   map[string]string{string(semconv1_17.ContainerIDKey): "cid-res"},
+			expected: "cid-span",
+		},
+		{
+			name:     "normalization",
+			sattrs:   map[string]string{string(semconv1_17.ContainerIDKey): "  CID "},
+			expected: "_cid",
+		},
+		{
+			name:                       "ignore missing datadog fields",
+			sattrs:                     map[string]string{string(semconv1_17.ContainerIDKey): "cid-span"},
+			rattrs:                     map[string]string{string(semconv1_17.ContainerIDKey): "cid-span"},
+			expected:                   "",
+			ignoreMissingDatadogFields: true,
+		},
+		{
+			name:     "read from datadog fields",
+			sattrs:   map[string]string{KeyDatadogContainerID: "cid-span", string(semconv1_17.ContainerIDKey): "cid-span-semconv117"},
+			rattrs:   map[string]string{KeyDatadogContainerID: "cid-res", string(semconv1_17.ContainerIDKey): "cid-res-semconv117"},
+			expected: "cid-span",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := pcommon.NewMap()
+			for k, v := range tt.sattrs {
+				span.PutStr(k, v)
+			}
+			res := pcommon.NewMap()
+			for k, v := range tt.rattrs {
+				res.PutStr(k, v)
+			}
+			assert.Equal(t, tt.expected, GetOTelContainerID(span, res, tt.ignoreMissingDatadogFields, true))
+		})
+	}
+}
+
+func TestGetOTelContainerTags(t *testing.T) {
+	res := pcommon.NewResource()
+	res.Attributes().PutStr(string(semconv1_27.ContainerIDKey), "cid")
+	res.Attributes().PutStr(string(semconv1_27.ContainerNameKey), "cname")
+	res.Attributes().PutStr(string(semconv1_27.ContainerImageNameKey), "ciname")
+	res.Attributes().PutStr(string(conventions.ContainerImageTagKey), "citag")
+	res.Attributes().PutStr("az", "my-az")
+	assert.Contains(t, GetOTelContainerTags(pcommon.NewMap(), res.Attributes(), []string{"az", string(semconv1_27.ContainerIDKey), string(semconv1_27.ContainerNameKey), string(semconv1_27.ContainerImageNameKey), string(conventions.ContainerImageTagKey)}), "container_id:cid", "container_name:cname", "image_name:ciname", "image_tag:citag", "az:my-az")
+	assert.Contains(t, GetOTelContainerTags(pcommon.NewMap(), res.Attributes(), []string{"az"}), "az:my-az")
 }

--- a/pkg/trace/traceutil/otel_util.go
+++ b/pkg/trace/traceutil/otel_util.go
@@ -194,6 +194,7 @@ func GetTopLevelOTelSpans(spanByID map[pcommon.SpanID]ptrace.Span, resByID map[p
 // GetOTelAttrVal returns the matched value as a string in the input map with the given keys.
 // If there are multiple keys present, the first matched one is returned.
 // If normalize is true, normalize the return value with NormalizeTagValue.
+// Deprecated: Use GetOTelAttrVal from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelAttrVal(attrs pcommon.Map, normalize bool, keys ...string) string {
 	val := ""
 	for _, key := range keys {
@@ -215,6 +216,7 @@ func GetOTelAttrVal(attrs pcommon.Map, normalize bool, keys ...string) string {
 // If there are multiple keys present, the first matched one is returned.
 // If the key is present in both maps, map1 takes precedence.
 // If normalize is true, normalize the return value with NormalizeTagValue.
+// Deprecated: Use GetOTelAttrFromEitherMap from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelAttrFromEitherMap(map1 pcommon.Map, map2 pcommon.Map, normalize bool, keys ...string) string {
 	if val := GetOTelAttrVal(map1, normalize, keys...); val != "" {
 		return val
@@ -260,6 +262,7 @@ func SpanKind2Type(span ptrace.Span, res pcommon.Resource) string {
 
 // GetOTelSpanType returns the DD span type based on OTel span kind and attributes.
 // This logic is used in ReceiveResourceSpansV2 logic
+// Deprecated: Use GetOTelSpanType from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelSpanType(span ptrace.Span, res pcommon.Resource) string {
 	sattr := span.Attributes()
 	rattr := res.Attributes()
@@ -285,6 +288,7 @@ func GetOTelSpanType(span ptrace.Span, res pcommon.Resource) string {
 }
 
 // GetOTelService returns the DD service name based on OTel span and resource attributes.
+// Deprecated: Use GetOTelService from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelService(span ptrace.Span, res pcommon.Resource, normalize bool) string {
 	// No need to normalize with NormalizeTagValue since we will do NormalizeService later
 	svc := GetOTelAttrFromEitherMap(span.Attributes(), res.Attributes(), false, string(semconv.ServiceNameKey))
@@ -305,6 +309,7 @@ func GetOTelService(span ptrace.Span, res pcommon.Resource, normalize bool) stri
 }
 
 // GetOTelResourceV1 returns the DD resource name based on OTel span and resource attributes.
+// Deprecated: Use GetOTelResource from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelResourceV1(span ptrace.Span, res pcommon.Resource) (resName string) {
 	resName = GetOTelAttrValInResAndSpanAttrs(span, res, false, "resource.name")
 	if resName == "" {
@@ -345,6 +350,7 @@ func GetOTelResourceV1(span ptrace.Span, res pcommon.Resource) (resName string) 
 }
 
 // GetOTelResourceV2 returns the DD resource name based on OTel span and resource attributes.
+// Deprecated: Use GetOTelResource from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelResourceV2(span ptrace.Span, res pcommon.Resource) (resName string) {
 	defer func() {
 		if len(resName) > normalizeutil.MaxResourceLen {
@@ -563,6 +569,7 @@ func GetOTelOperationNameV1(
 
 // GetOTelContainerTags returns a list of DD container tags in the OTel resource attributes.
 // Tags are always normalized.
+// Deprecated: Use GetOTelContainerTags from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelContainerTags(rattrs pcommon.Map, tagKeys []string) []string {
 	var containerTags []string
 	containerTagsMap := attributes.ContainerTagsFromResourceAttributes(rattrs)

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -251,6 +251,7 @@ func copyAttrToMapIfExists(attributes pcommon.Map, key string, m map[string]stri
 }
 
 // GetOTelEnv returns the environment based on OTel span and resource attributes, with span taking precedence.
+// Deprecated: Use GetOTelEnv from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelEnv(span ptrace.Span, res pcommon.Resource, ignoreMissingDatadogFields bool) string {
 	env := traceutil.GetOTelAttrFromEitherMap(span.Attributes(), res.Attributes(), true, KeyDatadogEnvironment)
 	if env == "" && !ignoreMissingDatadogFields {
@@ -260,6 +261,7 @@ func GetOTelEnv(span ptrace.Span, res pcommon.Resource, ignoreMissingDatadogFiel
 }
 
 // GetOTelHostname returns the DD hostname based on OTel span and resource attributes, with span taking precedence.
+// Deprecated: Use GetOTelHostname from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelHostname(span ptrace.Span, res pcommon.Resource, tr *attributes.Translator, fallbackHost string, ignoreMissingDatadogFields bool) string {
 	hostname := traceutil.GetOTelAttrFromEitherMap(span.Attributes(), res.Attributes(), true, KeyDatadogHost)
 	if hostname == "" && !ignoreMissingDatadogFields {
@@ -288,6 +290,7 @@ func GetOTelHostname(span ptrace.Span, res pcommon.Resource, tr *attributes.Tran
 }
 
 // GetOTelVersion returns the version based on OTel span and resource attributes, with span taking precedence.
+// Deprecated: Use GetOTelVersion from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelVersion(span ptrace.Span, res pcommon.Resource, ignoreMissingDatadogFields bool) string {
 	version := traceutil.GetOTelAttrFromEitherMap(span.Attributes(), res.Attributes(), true, KeyDatadogVersion)
 	if version == "" && !ignoreMissingDatadogFields {
@@ -297,6 +300,7 @@ func GetOTelVersion(span ptrace.Span, res pcommon.Resource, ignoreMissingDatadog
 }
 
 // GetOTelContainerID returns the container ID based on OTel span and resource attributes, with span taking precedence.
+// Deprecated: Use GetOTelContainerID from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelContainerID(span ptrace.Span, res pcommon.Resource, ignoreMissingDatadogFields bool) string {
 	cid := traceutil.GetOTelAttrFromEitherMap(span.Attributes(), res.Attributes(), true, KeyDatadogContainerID)
 	if cid == "" && !ignoreMissingDatadogFields {
@@ -306,6 +310,7 @@ func GetOTelContainerID(span ptrace.Span, res pcommon.Resource, ignoreMissingDat
 }
 
 // GetOTelStatusCode returns the HTTP status code based on OTel span and resource attributes, with span taking precedence.
+// Deprecated: Use GetOTelStatusCode from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelStatusCode(span ptrace.Span, res pcommon.Resource, ignoreMissingDatadogFields bool) uint32 {
 	sattr := span.Attributes()
 	rattr := res.Attributes()
@@ -333,6 +338,7 @@ func GetOTelStatusCode(span ptrace.Span, res pcommon.Resource, ignoreMissingData
 
 // GetOTelContainerTags returns a list of DD container tags in the OTel resource attributes.
 // Tags are always normalized.
+// Deprecated: Use GetOTelContainerTags from pkg/opentelemetry-mapping-go/otlp/attributes instead.
 func GetOTelContainerTags(rattrs pcommon.Map, tagKeys []string) []string {
 	var containerTags []string
 	containerTagsMap := attributes.ContainerTagsFromResourceAttributes(rattrs)

--- a/pkg/util/normalize/fuzz_test.go
+++ b/pkg/util/normalize/fuzz_test.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build go1.18
+
+package normalize
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+var normalizationSeedCorpus = []string{
+	"key:val",
+	"Data🐨dog🐶 繋がっ⛰てて",
+	"Test Conversion Of Weird !@#$%^&**() Characters",
+	"test\x99\x8faaa",
+	"A00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 000000000000",
+}
+
+func FuzzNormalizeTag(f *testing.F) {
+	normalize := func(in, _ string) (string, error) { return NormalizeTag(in), nil }
+	fuzzNormalization(f, normalizationSeedCorpus, maxTagLength, normalize)
+}
+
+func FuzzNormalizeTagValue(f *testing.F) {
+	normalize := func(in, _ string) (string, error) { return NormalizeTagValue(in), nil }
+	fuzzNormalization(f, normalizationSeedCorpus, maxTagLength, normalize)
+}
+
+func FuzzNormalizeName(f *testing.F) {
+	seedCorpus := []string{
+		"good.one",
+		"bad-one",
+		"Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.",
+	}
+	normalize := func(in, _ string) (string, error) { return NormalizeName(in) }
+	fuzzNormalization(f, seedCorpus, MaxNameLen, normalize)
+}
+
+var svcNormalizationSeedCorpus = []string{
+	"good",
+	"bad$",
+	"Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.",
+	"127.0.0.1",
+	":4500",
+	"120.site.platform.com-db.replica1",
+}
+
+func FuzzNormalizeService(f *testing.F) {
+	fuzzNormalization(f, svcNormalizationSeedCorpus, MaxServiceLen, NormalizeService)
+}
+
+func FuzzNormalizePeerService(f *testing.F) {
+	normalize := func(in, _ string) (string, error) { return NormalizePeerService(in) }
+	fuzzNormalization(f, svcNormalizationSeedCorpus, MaxServiceLen, normalize)
+}
+
+func fuzzNormalization(f *testing.F, seedCorpus []string, maxLen int, normalize func(in, lang string) (string, error)) {
+	for _, sc := range seedCorpus {
+		f.Add(sc, "lang")
+	}
+	f.Fuzz(func(t *testing.T, input, lang string) {
+		normalized, err := normalize(input, lang)
+		if err != nil {
+			t.Skipf("Couldn't normalize input (%s): %v", input, err)
+		}
+		normalizedTwice, err := normalize(normalized, lang)
+		if err != nil {
+			t.Fatalf("Normalizing a normalized input returned an error: %v", err)
+		}
+		if normalizedTwice != normalized {
+			t.Fatalf("Normalizing a normalized input didn't return the same input: expected (%s) got (%s)", normalized, normalizedTwice)
+		}
+		runeCount := utf8.RuneCountInString(normalized)
+		if runeCount > maxLen {
+			t.Fatalf("Max length (%d) exceeded: runeCount(%s) == %d", maxLen, normalized, runeCount)
+		}
+	})
+}

--- a/pkg/util/normalize/normalize.go
+++ b/pkg/util/normalize/normalize.go
@@ -1,0 +1,405 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package normalize contains functions for normalizing trace data.
+package normalize
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	// DefaultSpanName is the default name we assign a span if it's missing and we have no reasonable fallback
+	DefaultSpanName = "unnamed_operation"
+	// DefaultServiceName is the default name we assign a service if it's missing and we have no reasonable fallback
+	DefaultServiceName = "unnamed-service"
+)
+
+const (
+	// MaxNameLen the maximum length a name can have
+	MaxNameLen = 100
+	// MaxServiceLen the maximum length a service can have
+	MaxServiceLen = 100
+	// MaxResourceLen the maximum length a resource can have
+	MaxResourceLen = 5000
+)
+
+var (
+	// ErrEmpty specifies that the passed input was empty.
+	ErrEmpty = errors.New("empty")
+	// ErrTooLong signifies that the input was too long.
+	ErrTooLong = errors.New("too long")
+	// ErrInvalid signifies that the input was invalid.
+	ErrInvalid = errors.New("invalid")
+)
+
+var isAlphaLookup = [256]bool{}
+var isAlphaNumLookup = [256]bool{}
+var isValidASCIIStartCharLookup = [256]bool{}
+var isValidASCIITagCharLookup = [256]bool{}
+
+func init() {
+	for i := 0; i < 256; i++ {
+		isAlphaLookup[i] = isAlpha(byte(i))
+		isAlphaNumLookup[i] = isAlphaNum(byte(i))
+		isValidASCIIStartCharLookup[i] = isValidASCIIStartChar(byte(i))
+		isValidASCIITagCharLookup[i] = isValidASCIITagChar(byte(i))
+	}
+}
+
+// NormalizeName normalizes a span name and returns an error describing the reason
+// (if any) why the name was modified.
+//
+//nolint:revive
+func NormalizeName(name string) (string, error) {
+	if name == "" {
+		return DefaultSpanName, ErrEmpty
+	}
+	var err error
+	if len(name) > MaxNameLen {
+		name = TruncateUTF8(name, MaxNameLen)
+		err = ErrTooLong
+	}
+	name, ok := normMetricNameParse(name)
+	if !ok {
+		return DefaultSpanName, ErrInvalid
+	}
+	return name, err
+}
+
+// NormalizeService normalizes a span service and returns an error describing the reason
+// (if any) why the name was modified.
+//
+//nolint:revive
+func NormalizeService(svc string, lang string) (string, error) {
+	if svc == "" {
+		return fallbackService(lang), ErrEmpty
+	}
+	var err error
+	if len(svc) > MaxServiceLen {
+		svc = TruncateUTF8(svc, MaxServiceLen)
+		err = ErrTooLong
+	}
+	// We are normalizing just the tag value.
+	s := NormalizeTagValue(svc)
+	if s == "" {
+		return fallbackService(lang), ErrInvalid
+	}
+	return s, err
+}
+
+// NormalizePeerService normalizes a span's peer.service and returns an error describing the reason
+// (if any) why the name was modified.
+//
+//nolint:revive
+func NormalizePeerService(svc string) (string, error) {
+	if svc == "" {
+		return "", nil
+	}
+	var err error
+	if len(svc) > MaxServiceLen {
+		svc = TruncateUTF8(svc, MaxServiceLen)
+		err = ErrTooLong
+	}
+	// We are normalizing just the tag value.
+	s := NormalizeTagValue(svc)
+	if s == "" {
+		return "", ErrInvalid
+	}
+	return s, err
+}
+
+// fallbackServiceNames is a cache of default service names to use
+// when the span's service is unset or invalid.
+var fallbackServiceNames sync.Map
+
+// fallbackService returns the fallback service name for a service
+// belonging to language lang.
+func fallbackService(lang string) string {
+	if lang == "" {
+		return DefaultServiceName
+	}
+	if v, ok := fallbackServiceNames.Load(lang); ok {
+		return v.(string)
+	}
+	var str strings.Builder
+	str.WriteString("unnamed-")
+	str.WriteString(lang)
+	str.WriteString("-service")
+	fallbackServiceNames.Store(lang, str.String())
+	return str.String()
+}
+
+const maxTagLength = 200
+
+// NormalizeTag applies some normalization to ensure the full tag_key:tag_value string matches the backend requirements.
+//
+//nolint:revive
+func NormalizeTag(v string) string {
+	return normalize(v, true)
+}
+
+// NormalizeTagValue applies some normalization to ensure the tag value matches the backend requirements.
+// It should be used for cases where we have just the tag_value as the input (instead of tag_key:tag_value).
+//
+//nolint:revive
+func NormalizeTagValue(v string) string {
+	return normalize(v, false)
+}
+
+func normalize(v string, removeDigitStartChar bool) string {
+	// Fast path: Check if the tag is valid and only contains ASCII characters,
+	// if yes return it as-is right away. For most use-cases this reduces CPU usage.
+	if isNormalizedASCIITag(v, removeDigitStartChar) {
+		return v
+	}
+	// the algorithm works by creating a set of cuts marking start and end offsets in v
+	// that have to be replaced with underscore (_)
+	if len(v) == 0 {
+		return ""
+	}
+	var (
+		trim  int      // start character (if trimming)
+		cuts  [][2]int // sections to discard: (start, end) pairs
+		chars int      // number of characters processed
+	)
+	var (
+		i    int  // current byte
+		r    rune // current rune
+		jump int  // tracks how many bytes the for range advances on its next iteration
+	)
+	tag := []byte(v)
+	for i, r = range v {
+		jump = utf8.RuneLen(r) // next i will be i+jump
+		if r == utf8.RuneError {
+			// On invalid UTF-8, the for range advances only 1 byte (see: https://golang.org/ref/spec#For_range (point 2)).
+			// However, utf8.RuneError is equivalent to unicode.ReplacementChar so we should rely on utf8.DecodeRune to tell
+			// us whether this is an actual error or just a unicode.ReplacementChar that was present in the string.
+			_, width := utf8.DecodeRune(tag[i:])
+			jump = width
+		}
+		// fast path; all letters (and colons) are ok
+		switch {
+		case r >= 'a' && r <= 'z' || r == ':':
+			chars++
+			goto end
+		case r >= 'A' && r <= 'Z':
+			// lower-case
+			tag[i] += 'a' - 'A'
+			chars++
+			goto end
+		}
+		if unicode.IsUpper(r) {
+			// lowercase this character
+			if low := unicode.ToLower(r); utf8.RuneLen(r) == utf8.RuneLen(low) {
+				// but only if the width of the lowercased character is the same;
+				// there are some rare edge-cases where this is not the case, such
+				// as \u017F (ſ)
+				utf8.EncodeRune(tag[i:], low)
+				r = low
+			}
+		}
+		switch {
+		case unicode.IsLetter(r):
+			chars++
+		// If it's not a unicode letter, and it's the first char, and digits are allowed for the start char,
+		// we should goto end because the remaining cases are not valid for a start char.
+		case removeDigitStartChar && chars == 0:
+			trim = i + jump
+			goto end
+		case unicode.IsDigit(r) || r == '.' || r == '/' || r == '-':
+			chars++
+		default:
+			// illegal character
+			chars++
+			if n := len(cuts); n > 0 && cuts[n-1][1] >= i {
+				// merge intersecting cuts
+				cuts[n-1][1] += jump
+			} else {
+				// start a new cut
+				cuts = append(cuts, [2]int{i, i + jump})
+			}
+		}
+	end:
+		if i+jump >= 2*maxTagLength {
+			// bail early if the tag contains a lot of non-letter/digit characters.
+			// If a tag is test🍣🍣[...]🍣, then it's unlikely to be a properly formatted tag
+			break
+		}
+		if chars >= maxTagLength {
+			// we've reached the maximum
+			break
+		}
+	}
+
+	tag = tag[trim : i+jump] // trim start and end
+	if len(cuts) == 0 {
+		// tag was ok, return it as it is
+		return string(tag)
+	}
+	delta := trim // cut offsets delta
+	for _, cut := range cuts {
+		// start and end of cut, including delta from previous cuts:
+		start, end := cut[0]-delta, cut[1]-delta
+
+		if end >= len(tag) {
+			// this cut includes the end of the string; discard it
+			// completely and finish the loop.
+			tag = tag[:start]
+			break
+		}
+		// replace the beginning of the cut with '_'
+		tag[start] = '_'
+		if end-start == 1 {
+			// nothing to discard
+			continue
+		}
+		// discard remaining characters in the cut
+		copy(tag[start+1:], tag[end:])
+
+		// shorten the slice
+		tag = tag[:len(tag)-(end-start)+1]
+
+		// count the new delta for future cuts
+		delta += cut[1] - cut[0] - 1
+	}
+	return string(tag)
+}
+
+// This code is borrowed from dd-go metric normalization
+
+// fast isAlpha for ascii
+func isAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// fast isAlphaNumeric for ascii
+func isAlphaNum(b byte) bool {
+	return isAlpha(b) || (b >= '0' && b <= '9')
+}
+
+func isValidNormalizedMetricName(name string) bool {
+	if name == "" {
+		return false
+	}
+	if !isAlphaLookup[name[0]] {
+		return false
+	}
+	for j := 1; j < len(name); j++ {
+		b := name[j]
+		if !(isAlphaNumLookup[b] || (b == '.' && !(name[j-1] == '_')) || (b == '_' && !(name[j-1] == '_'))) {
+			return false
+		}
+	}
+	return true
+}
+
+// normMetricNameParse normalizes metric names with a parser instead of using
+// garbage-creating string replacement routines.
+func normMetricNameParse(name string) (string, bool) {
+	if name == "" || len(name) > MaxNameLen {
+		return name, false
+	}
+
+	var i, ptr int
+	var resa [MaxNameLen]byte
+	res := resa[:0]
+
+	// skip non-alphabetic characters
+	for ; i < len(name) && !isAlphaLookup[name[i]]; i++ {
+		continue
+	}
+
+	// if there were no alphabetic characters it wasn't valid
+	if i == len(name) {
+		return "", false
+	}
+
+	if isValidNormalizedMetricName(name[i:]) {
+		normalized := name[i:]
+		if normalized[len(normalized)-1] == '_' {
+			normalized = normalized[:len(normalized)-1]
+		}
+		return normalized, true
+	}
+
+	for ; i < len(name); i++ {
+		switch {
+		case isAlphaNumLookup[name[i]]:
+			res = append(res, name[i])
+			ptr++
+		case name[i] == '.':
+			// we skipped all non-alpha chars up front so we have seen at least one
+			switch res[ptr-1] {
+			// overwrite underscores that happen before periods
+			case '_':
+				res[ptr-1] = '.'
+			default:
+				res = append(res, '.')
+				ptr++
+			}
+		default:
+			// we skipped all non-alpha chars up front so we have seen at least one
+			switch res[ptr-1] {
+			// no double underscores, no underscores after periods
+			case '.', '_':
+			default:
+				res = append(res, '_')
+				ptr++
+			}
+		}
+	}
+
+	if res[ptr-1] == '_' {
+		res = res[:ptr-1]
+	}
+
+	return string(res), true
+}
+
+func isNormalizedASCIITag(tag string, checkValidStartChar bool) bool {
+	if len(tag) == 0 {
+		return true
+	}
+	if len(tag) > maxTagLength {
+		return false
+	}
+	i := 0
+	if checkValidStartChar {
+		if !isValidASCIIStartCharLookup[tag[0]] {
+			return false
+		}
+		i++
+	}
+	for ; i < len(tag); i++ {
+		b := tag[i]
+		// TODO: Attempt to optimize this check using SIMD/vectorization.
+		if isValidASCIITagCharLookup[b] {
+			continue
+		}
+		if b == '_' {
+			// an underscore is only okay if followed by a valid non-underscore character
+			i++
+			if i == len(tag) || !isValidASCIITagCharLookup[tag[i]] {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidASCIIStartChar(c byte) bool {
+	return ('a' <= c && c <= 'z') || c == ':'
+}
+
+func isValidASCIITagChar(c byte) bool {
+	return isValidASCIIStartChar(c) || ('0' <= c && c <= '9') || c == '.' || c == '/' || c == '-'
+}

--- a/pkg/util/normalize/normalize_test.go
+++ b/pkg/util/normalize/normalize_test.go
@@ -1,0 +1,287 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package normalize
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTag(t *testing.T) {
+	for _, tt := range []struct{ in, out string }{
+		{in: "#test_starting_hash", out: "test_starting_hash"},
+		{in: "TestCAPSandSuch", out: "testcapsandsuch"},
+		{in: "Test Conversion Of Weird !@#$%^&**() Characters", out: "test_conversion_of_weird_characters"},
+		{in: "$#weird_starting", out: "weird_starting"},
+		{in: "allowed:c0l0ns", out: "allowed:c0l0ns"},
+		{in: "1love", out: "love"},
+		{in: "ünicöde", out: "ünicöde"},
+		{in: "ünicöde:metäl", out: "ünicöde:metäl"},
+		{in: "Data🐨dog🐶 繋がっ⛰てて", out: "data_dog_繋がっ_てて"},
+		{in: " spaces   ", out: "spaces"},
+		{in: " #hashtag!@#spaces #__<>#  ", out: "hashtag_spaces"},
+		{in: ":testing", out: ":testing"},
+		{in: "_foo", out: "foo"},
+		{in: ":::test", out: ":::test"},
+		{in: "contiguous_____underscores", out: "contiguous_underscores"},
+		{in: "foo_", out: "foo"},
+		{in: "\u017Fodd_\u017Fcase\u017F", out: "\u017Fodd_\u017Fcase\u017F"}, // edge-case
+		{in: "", out: ""},
+		{in: " ", out: ""},
+		{in: "ok", out: "ok"},
+		{in: "™Ö™Ö™™Ö™", out: "ö_ö_ö"},
+		{in: "AlsO:ök", out: "also:ök"},
+		{in: ":still_ok", out: ":still_ok"},
+		{in: "___trim", out: "trim"},
+		{in: "12.:trim@", out: ":trim"},
+		{in: "12.:trim@@", out: ":trim"},
+		{in: "fun:ky__tag/1", out: "fun:ky_tag/1"},
+		{in: "fun:ky@tag/2", out: "fun:ky_tag/2"},
+		{in: "fun:ky@@@tag/3", out: "fun:ky_tag/3"},
+		{in: "tag:1/2.3", out: "tag:1/2.3"},
+		{in: "---fun:k####y_ta@#g/1_@@#", out: "fun:k_y_ta_g/1"},
+		{in: "AlsO:œ#@ö))œk", out: "also:œ_ö_œk"},
+		{in: "test\x99\x8faaa", out: "test_aaa"},
+		{in: "test\x99\x8f", out: "test"},
+		{in: strings.Repeat("a", 888), out: strings.Repeat("a", 200)},
+		{
+			in: func() string {
+				b := bytes.NewBufferString("a")
+				for i := 0; i < 799; i++ {
+					_, err := b.WriteRune('🐶')
+					assert.NoError(t, err)
+				}
+				_, err := b.WriteRune('b')
+				assert.NoError(t, err)
+				return b.String()
+			}(),
+			out: "a", // 'b' should have been truncated
+		},
+		{"a" + string(unicode.ReplacementChar), "a"},
+		{"a" + string(unicode.ReplacementChar) + string(unicode.ReplacementChar), "a"},
+		{"a" + string(unicode.ReplacementChar) + string(unicode.ReplacementChar) + "b", "a_b"},
+		{
+			in:  "A00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 000000000000",
+			out: "a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000_0",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tt.out, NormalizeTag(tt.in), tt.in)
+		})
+	}
+}
+
+func benchNormalize(tag string, normFn func(string) string) func(b *testing.B) {
+	return func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			normFn(tag)
+		}
+	}
+}
+
+type benchCase struct {
+	caseName string
+	caseVal  string
+}
+
+var benchCases = []benchCase{
+	{caseName: "ok", caseVal: "good_tag"},
+	{caseName: "trim", caseVal: "___trim_left"},
+	{caseName: "trim-both", caseVal: "___trim_right@@#!"},
+	{caseName: "plenty", caseVal: "fun:ky_ta@#g/1"},
+	{caseName: "more", caseVal: "fun:k####y_ta@#g/1_@@#"},
+}
+
+func BenchmarkNormalizeTag(b *testing.B) {
+	for _, c := range benchCases {
+		b.Run(c.caseName, benchNormalize(c.caseVal, NormalizeTag))
+	}
+}
+
+func BenchmarkNormalizeTagValue(b *testing.B) {
+	cases := append(benchCases, benchCase{caseName: "digit", caseVal: "1service-name"})
+	for _, c := range cases {
+		b.Run(c.caseName, benchNormalize(c.caseVal, NormalizeTagValue))
+	}
+}
+
+func TestNormalizeName(t *testing.T) {
+	testCases := []struct {
+		name       string
+		normalized string
+		err        error
+	}{
+		{
+			name:       "",
+			normalized: DefaultSpanName,
+			err:        ErrEmpty,
+		},
+		{
+			name:       "good",
+			normalized: "good",
+			err:        nil,
+		},
+		{
+			name:       "last.underscore_trunc_",
+			normalized: "last.underscore_trunc",
+			err:        nil,
+		},
+		{
+			name:       "last.double_underscore_trunc__",
+			normalized: "last.double_underscore_trunc",
+			err:        nil,
+		},
+		{
+			name:       "Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.",
+			normalized: "Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.",
+			err:        ErrTooLong,
+		},
+		{
+			name:       "double..point",
+			normalized: "double..point",
+			err:        nil,
+		},
+		{
+			name:       "other_^.character^^_than_underscore",
+			normalized: "other.character_than_underscore",
+			err:        nil,
+		},
+		{
+			name:       "bad-name",
+			normalized: "bad_name",
+			err:        nil,
+		},
+		{
+			name:       "^^_.non_alpha.prefix",
+			normalized: "non_alpha.prefix",
+			err:        nil,
+		},
+		{
+			name:       "_",
+			normalized: "unnamed_operation",
+			err:        ErrInvalid,
+		},
+	}
+	for _, testCase := range testCases {
+		out, err := NormalizeName(testCase.name)
+		assert.Equal(t, testCase.normalized, out)
+		assert.Equal(t, testCase.err, err)
+	}
+}
+
+func BenchmarkNormalizeName(b *testing.B) {
+	cases := []struct {
+		caseName string
+		caseVal  string
+	}{
+
+		{
+			caseName: "ok",
+			caseVal:  "good",
+		},
+		{
+			caseName: "truncate",
+			caseVal:  "Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.",
+		},
+		{
+			caseName: "remap",
+			caseVal:  "bad-name",
+		},
+	}
+	for _, c := range cases {
+		b.Run(c.caseName, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				NormalizeName(c.caseVal)
+			}
+		})
+	}
+}
+
+type serviceNormalizationCase struct {
+	service    string
+	normalized string
+	err        error
+}
+
+var svcNormCases = []serviceNormalizationCase{
+	{
+		service:    "good",
+		normalized: "good",
+		err:        nil,
+	},
+	{
+		service:    "127.0.0.1",
+		normalized: "127.0.0.1",
+		err:        nil,
+	},
+	{
+		service:    "127.site.platform-db-replica1",
+		normalized: "127.site.platform-db-replica1",
+		err:        nil,
+	},
+	{
+		service:    "hyphenated-service-name",
+		normalized: "hyphenated-service-name",
+		err:        nil,
+	},
+	{
+		service:    "🐨animal-db🐶",
+		normalized: "_animal-db",
+		err:        nil,
+	},
+	{
+		service:    "🐨1animal-db🐶",
+		normalized: "_1animal-db",
+		err:        nil,
+	},
+	{
+		service:    "1🐨1animal-db🐶",
+		normalized: "1_1animal-db",
+		err:        nil,
+	},
+	{
+		service:    "Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.",
+		normalized: "too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.",
+		err:        ErrTooLong,
+	},
+	{
+		service:    "bad$service",
+		normalized: "bad_service",
+		err:        nil,
+	},
+}
+
+func TestNormalizeService(t *testing.T) {
+	cases := append(svcNormCases, serviceNormalizationCase{
+		service:    "",
+		normalized: DefaultServiceName,
+		err:        ErrEmpty,
+	})
+	for _, testCase := range cases {
+		out, err := NormalizeService(testCase.service, "")
+		assert.Equal(t, testCase.normalized, out)
+		assert.Equal(t, testCase.err, err)
+	}
+}
+
+func TestNormalizePeerService(t *testing.T) {
+	cases := append(svcNormCases, serviceNormalizationCase{
+		service:    "",
+		normalized: "",
+		err:        nil,
+	})
+	for _, testCase := range cases {
+		out, err := NormalizePeerService(testCase.service)
+		assert.Equal(t, testCase.normalized, out)
+		assert.Equal(t, testCase.err, err)
+	}
+}

--- a/pkg/util/normalize/truncate.go
+++ b/pkg/util/normalize/truncate.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package normalize
+
+import "unicode/utf8"
+
+// TruncateUTF8 truncates the given string to make sure it uses less than limit bytes.
+// If the last character is an utf8 character that would be splitten, it removes it
+// entirely to make sure the resulting string is not broken.
+func TruncateUTF8(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	s = s[:limit]
+	// The max length of a valid code point is 4 bytes, therefore if we see all valid
+	// code points in the last 4 bytes we know we have a fully valid utf-8 string
+	// If not we can truncate one byte at a time until the end of the string is valid utf-8
+	for len(s) >= 1 {
+		if len(s) >= 4 && utf8.Valid([]byte(s[len(s)-4:])) {
+			break
+		}
+		if len(s) >= 3 && utf8.Valid([]byte(s[len(s)-3:])) {
+			break
+		}
+		if len(s) >= 2 && utf8.Valid([]byte(s[len(s)-2:])) {
+			break
+		}
+		if len(s) >= 1 && utf8.Valid([]byte(s[len(s)-1:])) {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/pkg/util/normalize/truncate_test.go
+++ b/pkg/util/normalize/truncate_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package normalize
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateString(t *testing.T) {
+	assert.Equal(t, "", TruncateUTF8("", 5))
+	assert.Equal(t, "tél", TruncateUTF8("télé", 5))
+	assert.Equal(t, "t", TruncateUTF8("télé", 2))
+	assert.Equal(t, "éé", TruncateUTF8("ééééé", 5))
+	assert.Equal(t, "ééééé", TruncateUTF8("ééééé", 18))
+	assert.Equal(t, "ééééé", TruncateUTF8("ééééé", 10))
+	assert.Equal(t, "ééé", TruncateUTF8("ééééé", 6))
+	assert.Equal(t, "", TruncateUTF8("肋", 2))
+	// Testing 4 character split
+	assert.Equal(t, "🠠", TruncateUTF8("🠠a", 4))
+	// Testing 3 character split
+	assert.Equal(t, "⃠⃠", TruncateUTF8("⃠⃠a", 6))
+	// Testing 2 character split
+	assert.Equal(t, "à", TruncateUTF8("àa", 2))
+}
+
+func FuzzTruncateString(f *testing.F) {
+	f.Add("télé", 5)
+	f.Add("肋", 2)
+	f.Fuzz(func(t *testing.T, s string, limit int) {
+		if !utf8.Valid([]byte(s)) || limit <= 0 { // This function previously assumed these invariants so let's keep them for fuzzing.
+			t.Skip()
+		}
+		result := TruncateUTF8(s, limit)
+		if len(result) > limit {
+			t.Errorf("%s was truncated to %s which is %d long. Longer than limit %d", s, result, len(result), limit)
+		}
+		assert.True(t, utf8.Valid([]byte(result)), "%s became invalid utf8 %s", s, result)
+	})
+}
+
+func BenchmarkTruncateString(b *testing.B) {
+	s := strings.Repeat("télé", 100)
+	for i := 0; i < b.N; i++ {
+		TruncateUTF8(s, 100)
+	}
+}

--- a/releasenotes/notes/new-mapping-go-functions-8fa3f2a66c3323a4.yaml
+++ b/releasenotes/notes/new-mapping-go-functions-8fa3f2a66c3323a4.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add new methods to pkg/opentelemetry-mapping-go/attributes that translate attributes from OpenTelemetry to Datadog semantics.
+    Add new methods to pkg/opentelemetry-mapping-go/otlp/attributes that translate attributes from OpenTelemetry to Datadog semantics.

--- a/releasenotes/notes/new-mapping-go-functions-8fa3f2a66c3323a4.yaml
+++ b/releasenotes/notes/new-mapping-go-functions-8fa3f2a66c3323a4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add new methods to pkg/opentelemetry-mapping-go/attributes that translate attributes from OpenTelemetry to Datadog semantics.


### PR DESCRIPTION
### What does this PR do?

Add generic copies of OTLP attribute translation methods to mapping-go that can be used with all signal types via pcommon.Map (instead of just traces). These are copied from transform.go and otel_util.go, whose versions are now marked as deprecated. In a future PR, will replace these in the agent codebase.

### Motivation

### Describe how you validated your changes

### Additional Notes
