### PR TITLE
[ AGNTLOG-303 ] Fix logs agent incompatibility with systemd >= 256

### DIFF
--- a/omnibus/config/software/zstd.rb
+++ b/omnibus/config/software/zstd.rb
@@ -15,7 +15,7 @@
 #
 
 name "zstd"
-default_version "1.5.5"
+default_version "1.5.6"
 
 license "BSD"
 license_file "LICENSE"
@@ -23,7 +23,7 @@ skip_transitive_dependency_licensing true
 
 dependency "libarchive"
 
-version("1.5.5") { source sha256: "9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4" }
+version("1.5.6") { source sha256: "8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1" }
 
 source url: "https://github.com/facebook/zstd/releases/download/v#{version}/zstd-#{version}.tar.gz"
 

--- a/releasenotes/notes/systemd-libzstd-bug-fix-e0572443e5b19761.yaml
+++ b/releasenotes/notes/systemd-libzstd-bug-fix-e0572443e5b19761.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Resolved possible segfault when running zstd-compressed journald log collection on systemd versions >= 256.
+


### PR DESCRIPTION
### What does this PR do?
A libzstd version mismatch within the agent code is causing issues with newer versions of systemd, namely the [datadog/zstd](https://github.com/DataDog/zstd) go dependency is set [within the agent](https://github.com/DataDog/datadog-agent/blob/1db7ec98d4f91cca55b21f1f616094ac9efeb723/go.mod#L54) to v1.5.6 but the embedded libzstd.so.1 we're packaging with the agent is set to v1.5.5. This can cause a segfault on all versions of systemd >= 256, because [version 256](https://github.com/systemd/systemd/releases/tag/v256-rc1) introduced a change to how the systemd library dynamically links to local libzstd libraries.

In order to resolve this issue, this MR seeks to align the two versions of libzstd together onto version 1.5.6

### Motivation

### Describe how you validated your changes
Agent versions deployed with this change onto journald-enabled systems that reliably experience the segfault resolve the segfault. 

Additionally, the expectation is that all libraries currently attempting to load version 1.5.5 via dynamic linking are actually getting the statically compiled 1.5.6 in its entirety. Any library attempting to dynamically load 1.5.5 is expected to break in the same manner that systemd does. Correspondingly, updating the 1.5.5 version to 1.5.6 is locked to be either a fix or a no-op, rather than a potential avenue for expected version mismatch.

### Additional Notes
resolves #40416
