### PR TITLE
usm: http: Use dynamic tags as a set for HTTP monitoring

### DIFF
--- a/pkg/network/encoding/marshal/usm_http.go
+++ b/pkg/network/encoding/marshal/usm_http.go
@@ -87,7 +87,7 @@ func (e *httpEncoder) encodeData(connectionData *USMConnectionData[http.Key, *ht
 				})
 
 				staticTags |= stats.StaticTags
-				for _, dynamicTag := range stats.DynamicTags {
+				for dynamicTag := range stats.DynamicTags {
 					dynamicTags[dynamicTag] = struct{}{}
 				}
 			}

--- a/pkg/network/encoding/marshal/usm_http2.go
+++ b/pkg/network/encoding/marshal/usm_http2.go
@@ -86,7 +86,7 @@ func (e *http2Encoder) encodeData(connectionData *USMConnectionData[http.Key, *h
 				})
 
 				staticTags |= stats.StaticTags
-				for _, dynamicTag := range stats.DynamicTags {
+				for dynamicTag := range stats.DynamicTags {
 					dynamicTags[dynamicTag] = struct{}{}
 				}
 			}

--- a/pkg/network/protocols/http/debugging/debugging.go
+++ b/pkg/network/protocols/http/debugging/debugging.go
@@ -65,7 +65,7 @@ func HTTP(stats map[http.Key]*http.RequestStats, dns map[util.Address][]dns.Host
 
 		for status, stat := range v.Data {
 			debug.StaticTags = stat.StaticTags
-			debug.DynamicTags = stat.DynamicTags
+			debug.DynamicTags = stat.DynamicTags.GetAll()
 
 			debug.ByStatus[status] = Stats{
 				Count:              stat.Count,

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -196,7 +197,11 @@ func (h *StatKeeper) add(tx Transaction) {
 		h.stats[key] = stats
 	}
 
-	stats.AddRequest(tx.StatusCode(), latency, tx.StaticTags(), tx.DynamicTags())
+	dynamicTagsSet := common.StringSet(nil)
+	if dynamicTags := tx.DynamicTags(); len(dynamicTags) > 0 {
+		dynamicTagsSet = common.NewStringSet(dynamicTags...)
+	}
+	stats.AddRequest(tx.StatusCode(), latency, tx.StaticTags(), dynamicTagsSet)
 }
 
 func pathIsMalformed(fullPath []byte) bool {

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/intern"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -123,7 +124,7 @@ type RequestStat struct {
 	StaticTags uint64
 
 	// Dynamic tags (if attached)
-	DynamicTags []string
+	DynamicTags common.StringSet
 }
 
 func (r *RequestStat) initSketch() error {
@@ -199,7 +200,7 @@ func (r *RequestStats) CombineWith(newStats *RequestStats) {
 }
 
 // AddRequest takes information about a HTTP transaction and adds it to the request stats
-func (r *RequestStats) AddRequest(statusCode uint16, latency float64, staticTags uint64, dynamicTags []string) {
+func (r *RequestStats) AddRequest(statusCode uint16, latency float64, staticTags uint64, dynamicTags common.StringSet) {
 	if !isValidStatusCode(statusCode) {
 		return
 	}
@@ -212,7 +213,12 @@ func (r *RequestStats) AddRequest(statusCode uint16, latency float64, staticTags
 
 	stats.StaticTags |= staticTags
 	if len(dynamicTags) != 0 {
-		stats.DynamicTags = append(stats.DynamicTags, dynamicTags...)
+		if stats.DynamicTags == nil {
+			stats.DynamicTags = common.NewStringSet()
+		}
+		for tag := range dynamicTags {
+			stats.DynamicTags.Add(tag)
+		}
 	}
 
 	stats.Count++


### PR DESCRIPTION
### What does this PR do?

Updates HTTP and HTTP2 monitoring to use dynamic tags as a set data structure instead of individual tag variables for improved performance and memory efficiency.

### Motivation

The current implementation stores dynamic tags individually which can lead to inefficient memory usage and performance overhead. Using a set data structure provides better performance and memory management for HTTP monitoring operations.

### Describe how you validated your changes

### Additional Notes

This change affects the following components:
- HTTP and HTTP2 marshaling (`pkg/network/encoding/marshal/`)
- HTTP debugging (`pkg/network/protocols/http/debugging/`)
- HTTP statkeeper and stats (`pkg/network/protocols/http/`)

🤖 Generated with [Claude Code](https://claude.ai/code)