### PR TITLE
Implement listmount

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1280,6 +1280,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("failed to decode open event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
+		//fmt.Printf("LISMNT fileOpen: %+v\n", event.Open)
 	case model.FileMkdirEventType:
 		if _, err = event.Mkdir.UnmarshalBinary(data[offset:]); err != nil {
 			seclog.Errorf("failed to decode mkdir event: %s (offset %d, len %d)", err, offset, dataLen)

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1280,7 +1280,6 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("failed to decode open event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
-		//fmt.Printf("LISMNT fileOpen: %+v\n", event.Open)
 	case model.FileMkdirEventType:
 		if _, err = event.Mkdir.UnmarshalBinary(data[offset:]); err != nil {
 			seclog.Errorf("failed to decode mkdir event: %s (offset %d, len %d)", err, offset, dataLen)

--- a/pkg/security/resolvers/mount/interface.go
+++ b/pkg/security/resolvers/mount/interface.go
@@ -17,6 +17,8 @@ import (
 type ResolverInterface interface {
 	IsMountIDValid(mountID uint32) (bool, error)
 	SyncCache(pid uint32) error
+	HasListMount() bool
+	SyncCacheFromListMount() error
 	Delete(mountID uint32) error
 	ResolveFilesystem(mountID uint32, device uint32, pid uint32, containerID containerutils.ContainerID) (string, error)
 	Insert(m model.Mount, pid uint32) error

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux
+
+// Package mount holds mount related files
 package mount
 
 import (

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -1,0 +1,297 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package mount
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+// Adjust for your arch/kernel if needed (these match your current file)
+const (
+	SysStatmount = 457
+	SysListmount = 458
+
+	LSMTRoot = ^uint64(0)
+
+	StatmountSbBasic       = 0x00000001
+	StatmountMntBasic      = 0x00000002
+	StatmountPropagateFrom = 0x00000004
+	StatmountMntRoot       = 0x00000008
+	StatmountMntPoint      = 0x00000010
+	StatmountFsType        = 0x00000020
+)
+
+type mntIDReq struct {
+	Size  uint32
+	Spare uint32
+	MntID uint64
+	Param uint64
+}
+
+type statmountFixed struct {
+	Size           uint32
+	Spare1         uint32
+	Mask           uint64
+	SbDevMajor     uint32
+	SbDevMinor     uint32
+	SbMagic        uint64
+	SbFlags        uint32
+	FsType         uint32
+	MntID          uint64
+	MntParentID    uint64
+	MntIDOld       uint32
+	MntParentIDOld uint32
+	MntAttr        uint64
+	MntPropagation uint64
+	MntPeerGroup   uint64
+	MntMaster      uint64
+	PropagateFrom  uint64
+	MntRoot        uint32
+	MntPoint       uint32
+	Spare2         [50]uint64
+}
+
+// Statmount represents the data obtained from the syscall statmount()
+type Statmount struct {
+	NamespaceInode uint64
+	Mask           uint64
+	SbDevMajor     uint32
+	SbDevMinor     uint32
+	SbMagic        uint64
+	SbFlags        uint32
+	FsType         string
+	MntID          uint64
+	MntParentID    uint64
+	MntIDOld       uint32
+	MntParentIDOld uint32
+	MntAttr        uint64
+	MntPropagation uint64
+	MntPeerGroup   uint64
+	MntMaster      uint64
+	PropagateFrom  uint64
+	MntRoot        string
+	MntPoint       string
+}
+
+func ztToString(b []byte) string {
+	for i, v := range b {
+		if v == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}
+
+func parseStatmount(buf []byte) Statmount {
+	var hdr statmountFixed
+	_ = binary.Read(bytes.NewReader(buf), binary.NativeEndian, &hdr)
+	base := uint32(unsafe.Sizeof(statmountFixed{}))
+	return Statmount{
+		Mask:           hdr.Mask,
+		SbDevMajor:     hdr.SbDevMajor,
+		SbDevMinor:     hdr.SbDevMinor,
+		SbMagic:        hdr.SbMagic,
+		SbFlags:        hdr.SbFlags,
+		FsType:         ztToString(buf[base+hdr.FsType:]),
+		MntID:          hdr.MntID,
+		MntParentID:    hdr.MntParentID,
+		MntIDOld:       hdr.MntIDOld,
+		MntParentIDOld: hdr.MntParentIDOld,
+		MntAttr:        hdr.MntAttr,
+		MntPropagation: hdr.MntPropagation,
+		MntPeerGroup:   hdr.MntPeerGroup,
+		MntMaster:      hdr.MntMaster,
+		PropagateFrom:  hdr.PropagateFrom,
+		MntPoint:       ztToString(buf[base+hdr.MntPoint:]),
+		MntRoot:        ztToString(buf[base+hdr.MntRoot:]),
+	}
+}
+
+func listmount(req *mntIDReq, ids []uint64) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	r1, _, e := unix.RawSyscall6(
+		SysListmount,
+		uintptr(unsafe.Pointer(req)),
+		uintptr(unsafe.Pointer(&ids[0])),
+		uintptr(len(ids)),
+		0, 0, 0,
+	)
+	if e != 0 {
+		return 0, e
+	}
+	return int(r1), nil
+}
+
+func statmount(req *mntIDReq, buf []byte) error {
+	_, _, e := unix.RawSyscall6(
+		SysStatmount,
+		uintptr(unsafe.Pointer(req)),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		0, 0, 0,
+	)
+	if e != 0 {
+		return e
+	}
+	return nil
+}
+
+type mountNsInoFd struct {
+	ino uint64
+	fd  int
+}
+
+func collectUniqueMountNSFDs(procfs string) ([]mountNsInoFd, error) {
+	seen := make(map[uint64]struct{})
+	var fds []mountNsInoFd
+
+	ents, err := os.ReadDir(procfs)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		pid := e.Name()
+		if _, err := strconv.Atoi(pid); err != nil {
+			continue
+		}
+		p := filepath.Join(procfs, pid, "ns", "mnt")
+		info, err := os.Lstat(p)
+		if err != nil {
+			continue
+		}
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			continue
+		}
+		ino := st.Ino
+		if _, ok := seen[ino]; ok {
+			continue
+		}
+		fd, err := unix.Open(p, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			continue
+		}
+		seen[ino] = struct{}{}
+		fdElem := mountNsInoFd{
+			ino: ino,
+			fd:  fd,
+		}
+		fds = append(fds, fdElem)
+	}
+	return fds, nil
+}
+
+// GetAll Retrieves all the mountpoints from all the mount namespaces present in the procfs path
+func GetAll(procfs string) ([]Statmount, error) {
+	nsFDs, err := collectUniqueMountNSFDs(procfs)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		for _, inoFd := range nsFDs {
+			unix.Close(inoFd.fd)
+		}
+	}()
+
+	done := make(chan error, 1)
+	ret := make([]Statmount, 0, 255)
+	go func() {
+		runtime.LockOSThread()
+		// Lock but don't unlock, because as per go's runtime package documentation,
+		// "If the calling goroutine exits without unlocking the thread, the thread will be terminated."
+
+		if err := unix.Unshare(unix.CLONE_FS); err != nil {
+			done <- err
+			return
+		}
+
+		ids := make([]uint64, 2048)
+		buf := make([]byte, 4096)
+		mask := uint64(StatmountSbBasic |
+			StatmountMntBasic |
+			StatmountPropagateFrom |
+			StatmountMntRoot |
+			StatmountMntPoint |
+			StatmountFsType)
+
+		for _, inoFd := range nsFDs {
+			firstIteration := true
+			lastMountID := uint64(0)
+
+			for {
+				req := mntIDReq{
+					Size:  uint32(unsafe.Sizeof(mntIDReq{})),
+					Spare: 0,
+					MntID: LSMTRoot,
+					Param: 0,
+				}
+				if firstIteration {
+					if err := unix.Setns(inoFd.fd, unix.CLONE_NEWNS); err != nil {
+						done <- fmt.Errorf("failed to setns: %v", err)
+						return
+					}
+				} else {
+					req.Param = lastMountID
+				}
+
+				n, err := listmount(&req, ids)
+
+				if err != nil || n < 0 {
+					done <- fmt.Errorf("failed to listmount: %v", err)
+					return
+				}
+
+				for i := 0; i < n; i++ {
+					req2 := mntIDReq{
+						Size:  uint32(unsafe.Sizeof(mntIDReq{})),
+						Spare: 0,
+						MntID: ids[i],
+						Param: mask,
+					}
+					if err := statmount(&req2, buf); err != nil {
+						done <- fmt.Errorf("failed to statmount: %v", err)
+						return
+					}
+					sm := parseStatmount(buf)
+					sm.NamespaceInode = inoFd.ino
+					ret = append(ret, sm)
+					lastMountID = req2.MntID
+				}
+
+				if n == len(ids) {
+					// Not all mounts were obtained yet
+					firstIteration = false
+					continue
+				}
+
+				if n < len(ids) {
+					// All mounts for this namespace were obtained
+					break
+				}
+			}
+		}
+		done <- nil
+	}()
+	err = <-done
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -217,8 +217,9 @@ func GetAll(procfs string) ([]Statmount, error) {
 	ret := make([]Statmount, 0, 255)
 	go func() {
 		runtime.LockOSThread()
-		// Lock but don't unlock, because as per go's runtime package documentation,
+		// Lock but don't unlock, in order to force the runtime to remove this thread from the pool
 		// "If the calling goroutine exits without unlocking the thread, the thread will be terminated."
+		// Afterward, the runtime will detect this and spawn a new clean thread to replace it.
 
 		if err := unix.Unshare(unix.CLONE_FS); err != nil {
 			done <- fmt.Errorf("unshare error: %w", err)

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -268,7 +268,8 @@ func GetAll(procfs string) ([]Statmount, error) {
 						MntID: ids[i],
 						Param: mask,
 					}
-					if err := statmount(&req2, buf); err != nil {
+					// Ignore ENOENT, sometimes the mountpoint might have been unmounted between listmount and this call
+					if err := statmount(&req2, buf); err != nil && err != unix.ENOENT {
 						done <- fmt.Errorf("failed to statmount: %v", err)
 						return
 					}

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -23,9 +23,6 @@ import (
 
 // Adjust for your arch/kernel if needed (these match your current file)
 const (
-	SysStatmount = 457
-	SysListmount = 458
-
 	LSMTRoot = ^uint64(0)
 
 	StatmountSbBasic       = 0x00000001
@@ -127,7 +124,7 @@ func listmount(req *mntIDReq, ids []uint64) (int, error) {
 		return 0, nil
 	}
 	r1, _, e := unix.RawSyscall6(
-		SysListmount,
+		unix.SYS_LISTMOUNT,
 		uintptr(unsafe.Pointer(req)),
 		uintptr(unsafe.Pointer(&ids[0])),
 		uintptr(len(ids)),
@@ -141,7 +138,7 @@ func listmount(req *mntIDReq, ids []uint64) (int, error) {
 
 func statmount(req *mntIDReq, buf []byte) error {
 	_, _, e := unix.RawSyscall6(
-		SysStatmount,
+		unix.SYS_STATMOUNT,
 		uintptr(unsafe.Pointer(req)),
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(len(buf)),

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -205,7 +205,7 @@ func collectUniqueMountNSFDs(procfs string) ([]mountNsInoFd, error) {
 func GetAll(procfs string) ([]Statmount, error) {
 	nsFDs, err := collectUniqueMountNSFDs(procfs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error collecting unique mount namespace file descriptors: %w", err)
 	}
 	defer func() {
 		for _, inoFd := range nsFDs {
@@ -221,7 +221,7 @@ func GetAll(procfs string) ([]Statmount, error) {
 		// "If the calling goroutine exits without unlocking the thread, the thread will be terminated."
 
 		if err := unix.Unshare(unix.CLONE_FS); err != nil {
-			done <- err
+			done <- fmt.Errorf("unshare error: %w", err)
 			return
 		}
 

--- a/pkg/security/resolvers/mount/no_op_resolver.go
+++ b/pkg/security/resolvers/mount/no_op_resolver.go
@@ -29,6 +29,7 @@ func (mr *NoOpResolver) SyncCache(_ uint32) error {
 	return nil
 }
 
+// HasListMount returns true if the kernel has the listmount() syscall, false otherwise
 func (mr *NoOpResolver) HasListMount() bool {
 	return false
 }

--- a/pkg/security/resolvers/mount/no_op_resolver.go
+++ b/pkg/security/resolvers/mount/no_op_resolver.go
@@ -29,6 +29,15 @@ func (mr *NoOpResolver) SyncCache(_ uint32) error {
 	return nil
 }
 
+func (mr *NoOpResolver) HasListMount() bool {
+	return false
+}
+
+// SyncCacheFromListMount Snapshots the current mount points of the system by calling `listmount`
+func (mr *NoOpResolver) SyncCacheFromListMount() error {
+	return nil
+}
+
 // Delete a mount from the cache
 func (mr *NoOpResolver) Delete(_ uint32) error {
 	return nil

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -55,23 +55,23 @@ type redemptionEntry struct {
 func newMountFromMountInfo(mnt *mountinfo.Info) *model.Mount {
 	root := mnt.Root
 
-	if mnt.FSType == "btrfs" {
-		var subvol string
-		for _, opt := range strings.Split(mnt.VFSOptions, ",") {
-			name, val, ok := strings.Cut(opt, "=")
-			if ok && name == "subvol" {
-				subvol = val
-			}
-		}
-
-		if subvol != "" {
-			root = strings.TrimPrefix(root, subvol)
-		}
-
-		if root == "" {
-			root = "/"
-		}
-	}
+	//if mnt.FSType == "btrfs" {
+	//	var subvol string
+	//	for _, opt := range strings.Split(mnt.VFSOptions, ",") {
+	//		name, val, ok := strings.Cut(opt, "=")
+	//		if ok && name == "subvol" {
+	//			subvol = val
+	//		}
+	//	}
+	//
+	//	if subvol != "" {
+	//		root = strings.TrimPrefix(root, subvol)
+	//	}
+	//
+	//	if root == "" {
+	//		root = "/"
+	//	}
+	//}
 
 	if mnt.FSType == "cgroup2" && strings.HasPrefix(root, "/..") {
 		cfs := utils.DefaultCGroupFS()
@@ -133,7 +133,7 @@ func (mr *Resolver) IsMountIDValid(mountID uint32) (bool, error) {
 	return true, nil
 }
 
-// newMountFromMountInfo - Creates a new Mount from parsed MountInfo data
+// newMountFromStatmount - Creates a new Mount from parsed MountInfo data
 func newMountFromStatmount(sm *Statmount) *model.Mount {
 	root := sm.MntRoot
 
@@ -178,7 +178,7 @@ func newMountFromStatmount(sm *Statmount) *model.Mount {
 	}
 }
 
-// HasListMount returns true if the kernel has the listmount() sycall, false otherwise
+// HasListMount returns true if the kernel has the listmount() syscall, false otherwise
 func (mr *Resolver) HasListMount() bool {
 	_, _, errno := unix.Syscall(SysListmount, 0, 0, 0)
 	return errno != unix.ENOSYS

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -166,12 +166,11 @@ func newMountFromStatmount(sm *Statmount) *model.Mount {
 		Device:        utils.Mkdev(sm.SbDevMajor, sm.SbDevMinor),
 		ParentPathKey: model.PathKey{
 			MountID: sm.MntParentIDOld,
-			//UniqueMountID: sm.MntParentID,
 		},
 		FSType:        sm.FsType,
 		MountPointStr: sm.MntPoint,
 		Path:          sm.MntPoint,
-		RootStr:       sm.MntRoot,
+		RootStr:       root,
 		Origin:        model.MountOriginListmount,
 		Visible:       true,
 		Detached:      false,

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -165,8 +165,8 @@ func newMountFromStatmount(sm *Statmount) *model.Mount {
 		MountIDUnique: sm.MntID,
 		Device:        utils.Mkdev(sm.SbDevMajor, sm.SbDevMinor),
 		ParentPathKey: model.PathKey{
-			MountID:       sm.MntParentIDOld,
-			UniqueMountID: sm.MntParentID,
+			MountID: sm.MntParentIDOld,
+			//UniqueMountID: sm.MntParentID,
 		},
 		FSType:        sm.FsType,
 		MountPointStr: sm.MntPoint,

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -173,7 +173,7 @@ func (mr *Resolver) SyncCacheFromListMount() error {
 		return fmt.Errorf("error synchronizing cache: %v", err)
 	}
 
-	seclog.Warnf("listmount sync cache found %d entries", len(mounts))
+	seclog.Infof("listmount sync cache found %d entries", len(mounts))
 
 	mr.lock.Lock()
 	defer mr.lock.Unlock()

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -162,13 +162,13 @@ func newMountFromStatmount(sm *Statmount) *model.Mount {
 
 // HasListMount returns true if the kernel has the listmount() syscall, false otherwise
 func (mr *Resolver) HasListMount() bool {
-	_, _, errno := unix.Syscall(SysListmount, 0, 0, 0)
+	_, _, errno := unix.Syscall(unix.SYS_LISTMOUNT, 0, 0, 0)
 	return errno != unix.ENOSYS
 }
 
 // SyncCacheFromListMount Snapshots the current mountpoints using the listmount api
 func (mr *Resolver) SyncCacheFromListMount() error {
-	mounts, err := GetAll("/proc")
+	mounts, err := GetAll(kernel.ProcFSRoot())
 	if err != nil {
 		return fmt.Errorf("error synchronizing cache: %v", err)
 	}

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dentry"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"golang.org/x/sys/unix"
 	"path"
 	"path/filepath"
 	"slices"
@@ -185,15 +186,15 @@ func (mr *Resolver) HasListMount() bool {
 
 // SyncCacheFromListMount Snapshots the current mountpoints using the listmount api
 func (mr *Resolver) SyncCacheFromListMount() error {
-	mr.lock.Lock()
-	defer mr.lock.Unlock()
+	seclog.Infof("listmount sync cache")
 
-	fmt.Println("LISMNT - synchronizing cache from listmount")
 	mounts, err := GetAll("/proc")
 	if err != nil {
-		fmt.Println("LISMNT - Error synchronizing cache")
 		return fmt.Errorf("error synchronizing cache: %v", err)
 	}
+
+	mr.lock.Lock()
+	defer mr.lock.Unlock()
 
 	for _, mnt := range mounts {
 		mr.insert(newMountFromStatmount(&mnt), 0)

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -179,7 +179,7 @@ func (mr *Resolver) SyncCacheFromListMount() error {
 	defer mr.lock.Unlock()
 
 	for _, mnt := range mounts {
-		mr.insert(newMountFromStatmount(&mnt), 0)
+		mr.insert(newMountFromStatmount(&mnt), 0, false)
 	}
 
 	return nil

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -215,13 +215,13 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		SyscallCtxResolver:     syscallctx.NewResolver(),
 		DNSResolver:            dnsResolver,
 		FileMetadataResolver:   fileMetadataResolver,
-		SnapshotUsingListmount: false,
+		SnapshotUsingListmount: true,
 	}
 
-	//if !mountResolver.HasListMount() {
-	//	seclog.Warnf("listmount not found in this system, will default to procfs")
-	//	resolvers.SnapshotUsingListmount = false
-	//}
+	if !mountResolver.HasListMount() {
+		seclog.Warnf("listmount not found in this system, will default to procfs")
+		resolvers.SnapshotUsingListmount = false
+	}
 
 	return resolvers, nil
 }
@@ -330,7 +330,7 @@ func (r *EBPFResolvers) snapshot() error {
 	if r.SnapshotUsingListmount {
 		err = r.MountResolver.SyncCacheFromListMount()
 		if err != nil {
-			seclog.Errorf("failed to sync cache from listmount: %v", err)
+			seclog.Errorf("Failed to sync cache from listmount: %v", err)
 			r.SnapshotUsingListmount = false
 		}
 	}

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -215,11 +215,12 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		SyscallCtxResolver:     syscallctx.NewResolver(),
 		DNSResolver:            dnsResolver,
 		FileMetadataResolver:   fileMetadataResolver,
-		SnapshotUsingListmount: false,
+		SnapshotUsingListmount: true,
 	}
 
-	if mountResolver.HasListMount() {
-		resolvers.SnapshotUsingListmount = true
+	if !mountResolver.HasListMount() {
+		seclog.Warnf("listmount not found in this system, will default to procfs")
+		resolvers.SnapshotUsingListmount = false
 	}
 
 	return resolvers, nil
@@ -329,7 +330,7 @@ func (r *EBPFResolvers) snapshot() error {
 	if r.SnapshotUsingListmount {
 		err = r.MountResolver.SyncCacheFromListMount()
 		if err != nil {
-			seclog.Errorf("failed to sync cache from list mount: %v", err)
+			seclog.Errorf("failed to sync cache from listmount: %v", err)
 			r.SnapshotUsingListmount = false
 		}
 	}

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -215,13 +215,13 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		SyscallCtxResolver:     syscallctx.NewResolver(),
 		DNSResolver:            dnsResolver,
 		FileMetadataResolver:   fileMetadataResolver,
-		SnapshotUsingListmount: true,
+		SnapshotUsingListmount: false,
 	}
 
-	if !mountResolver.HasListMount() {
-		seclog.Warnf("listmount not found in this system, will default to procfs")
-		resolvers.SnapshotUsingListmount = false
-	}
+	//if !mountResolver.HasListMount() {
+	//	seclog.Warnf("listmount not found in this system, will default to procfs")
+	//	resolvers.SnapshotUsingListmount = false
+	//}
 
 	return resolvers, nil
 }

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -326,7 +326,6 @@ func (r *EBPFResolvers) snapshot() error {
 		return createA < createB
 	})
 
-	r.SnapshotUsingListmount = false
 	if r.SnapshotUsingListmount {
 		err = r.MountResolver.SyncCacheFromListMount()
 		if err != nil {
@@ -349,7 +348,6 @@ func (r *EBPFResolvers) snapshot() error {
 
 		// Start with the mount resolver because the process resolver might need it to resolve paths
 		if !r.SnapshotUsingListmount {
-			fmt.Println("Snapshotting")
 			if err = r.MountResolver.SyncCache(pid); err != nil {
 				if !os.IsNotExist(err) {
 					log.Debugf("snapshot failed for %d: couldn't sync mount points: %s", proc.Pid, err)

--- a/pkg/security/secl/model/model_helpers_unix.go
+++ b/pkg/security/secl/model/model_helpers_unix.go
@@ -245,12 +245,13 @@ func (e *FileEvent) GetPathResolutionError() string {
 type MountOrigin = uint32
 
 const (
-	MountOriginUnknown  MountOrigin = iota // MountOriginUnknown unknown mount origin
-	MountOriginProcfs                      // MountOriginProcfs mount point info from procfs
-	MountOriginEvent                       // MountOriginEvent mount point info from an event
-	MountOriginUnshare                     // MountOriginUnshare mount point info from an event
-	MountOriginFsmount                     // MountOriginFsmount mount point info from the fsmount syscall
-	MountOriginOpenTree                    // MountOriginOpenTree mount point created from the open_tree syscall
+	MountOriginUnknown   MountOrigin = iota // MountOriginUnknown unknown mount origin
+	MountOriginProcfs                       // MountOriginProcfs mount point info from procfs
+	MountOriginEvent                        // MountOriginEvent mount point info from an event
+	MountOriginUnshare                      // MountOriginUnshare mount point info from an event
+	MountOriginFsmount                      // MountOriginFsmount mount point info from the fsmount syscall
+	MountOriginOpenTree                     // MountOriginOpenTree mount point created from the open_tree syscall
+	MountOriginListmount                    // MountOriginListmount mount point obtained by calling `listmount`
 )
 
 // MountSource source of the mount
@@ -294,6 +295,7 @@ var MountOrigins = [...]string{
 	"unshare",
 	"fsmount",
 	"open_tree",
+	"listmount",
 }
 
 // MountOriginToString returns the string corresponding to a mount origin

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -847,8 +847,7 @@ type SyscallsEvent struct {
 type PathKey struct {
 	Inode   uint64 `field:"inode"`    // SECLDoc[inode] Definition:`Inode of the file`
 	MountID uint32 `field:"mount_id"` // SECLDoc[mount_id] Definition:`Mount ID of the file`
-	//UniqueMountID uint64 `field:"-"`
-	PathID uint32 `field:"-"`
+	PathID  uint32 `field:"-"`
 }
 
 // OnDemandPerArgSize is the size of each argument in Data in the on-demand event

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -510,7 +510,7 @@ type ArgsEnvsEvent struct {
 // Mount represents a mountpoint (used by MountEvent, FsmountEvent and UnshareMountNSEvent)
 type Mount struct {
 	MountID        uint32   `field:"-"`
-	MountIDUnique  uint64  `field:"-"`
+	MountIDUnique  uint64   `field:"-"`
 	Device         uint32   `field:"-"`
 	ParentPathKey  PathKey  `field:"-"`
 	Children       []uint32 `field:"-"`

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -510,6 +510,7 @@ type ArgsEnvsEvent struct {
 // Mount represents a mountpoint (used by MountEvent, FsmountEvent and UnshareMountNSEvent)
 type Mount struct {
 	MountID        uint32   `field:"-"`
+	MountIDUnique  uint64  `field:"-"`
 	Device         uint32   `field:"-"`
 	ParentPathKey  PathKey  `field:"-"`
 	Children       []uint32 `field:"-"`
@@ -844,9 +845,10 @@ type SyscallsEvent struct {
 
 // PathKey identifies an entry in the dentry cache
 type PathKey struct {
-	Inode   uint64 `field:"inode"`    // SECLDoc[inode] Definition:`Inode of the file`
-	MountID uint32 `field:"mount_id"` // SECLDoc[mount_id] Definition:`Mount ID of the file`
-	PathID  uint32 `field:"-"`
+	Inode         uint64 `field:"inode"`    // SECLDoc[inode] Definition:`Inode of the file`
+	MountID       uint32 `field:"mount_id"` // SECLDoc[mount_id] Definition:`Mount ID of the file`
+	UniqueMountID uint64 `field:"-"`
+	PathID        uint32 `field:"-"`
 }
 
 // OnDemandPerArgSize is the size of each argument in Data in the on-demand event

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -845,10 +845,10 @@ type SyscallsEvent struct {
 
 // PathKey identifies an entry in the dentry cache
 type PathKey struct {
-	Inode         uint64 `field:"inode"`    // SECLDoc[inode] Definition:`Inode of the file`
-	MountID       uint32 `field:"mount_id"` // SECLDoc[mount_id] Definition:`Mount ID of the file`
-	UniqueMountID uint64 `field:"-"`
-	PathID        uint32 `field:"-"`
+	Inode   uint64 `field:"inode"`    // SECLDoc[inode] Definition:`Inode of the file`
+	MountID uint32 `field:"mount_id"` // SECLDoc[mount_id] Definition:`Mount ID of the file`
+	//UniqueMountID uint64 `field:"-"`
+	PathID uint32 `field:"-"`
 }
 
 // OnDemandPerArgSize is the size of each argument in Data in the on-demand event

--- a/pkg/security/secl/schemas/file.schema.json
+++ b/pkg/security/secl/schemas/file.schema.json
@@ -49,7 +49,7 @@
         },
         "mount_origin": {
             "type": "string",
-            "enum": ["procfs", "event", "unshare", "fsmount", "open_tree"]
+            "enum": ["procfs", "event", "unshare", "fsmount", "open_tree", "listmount"]
         }
     },
     "required": [

--- a/pkg/security/secl/schemas/process.schema.json
+++ b/pkg/security/secl/schemas/process.schema.json
@@ -176,7 +176,8 @@
                         "event",
                         "unshare",
                         "fsmount",
-                        "open_tree"
+                        "open_tree",
+                        "listmount"
                     ]
                 }
             },


### PR DESCRIPTION
### What does this PR do?

Implement the new syscalls `listmount` and `statmount` instead of procfs for the mount resolver.

### Motivation

To have better visibility of all the mountpoints we have, and speed up synchronization

### Describe how you validated your changes

Locally, deployed to several clusters
