### PR TITLE
[CWS] tests: ignore no such process errors when checking for zombie processes

### DIFF
--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -1890,6 +1890,9 @@ func (tm *testModule) CheckZombieProcesses() error {
 
 				comm, err := os.ReadFile(filepath.Join("/proc", pidStr, "comm"))
 				if err != nil {
+					if errors.Is(err, syscall.ESRCH) {
+						continue
+					}
 					return fmt.Errorf("failed to read comm for PID %d: %w", pid, err)
 				}
 				commStr := strings.TrimSpace(string(comm))
@@ -1900,8 +1903,8 @@ func (tm *testModule) CheckZombieProcesses() error {
 				}
 			}
 		}
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("error reading status file for PPID %d: %w", pid, err)
+		if err := scanner.Err(); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return fmt.Errorf("error reading status file for PID %d: %w", pid, err)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

A process can exit while we walk `/proc` to check for zombie processes, which will cause tests to fail based on legitimate behavior. This PR ignores `syscall.ESRCH` errors to avoid this.

```
module_tester_linux.go:1029: failed checking for zombie processes: error reading status file for PPID 214901: read /proc/214901/status: no such process
```

### Motivation

### Describe how you validated your changes

### Additional Notes
