### PR TITLE
dyninst/rcscrape: gracefully handle decoding failures

### DIFF
--- a/pkg/dyninst/output/event.go
+++ b/pkg/dyninst/output/event.go
@@ -19,10 +19,29 @@ const (
 	dataItemHeaderSize = int(unsafe.Sizeof(DataItemHeader{}))
 )
 
+const (
+	// DataItemFailedReadMask is a mask on the type field of a data item header that
+	// can be used to check if a data item was marked as a failed read.
+	DataItemFailedReadMask = uint32(1 << 31)
+	// DataItemTypeMask is a mask on the type field of a data item header that can be
+	// used to get the type of a data item without the failed read mask.
+	DataItemTypeMask = ^DataItemFailedReadMask
+)
+
 // DataItem represents a single data item in an event.
 type DataItem struct {
 	header *DataItemHeader
 	data   []byte
+}
+
+// IsFailedRead returns true if the data item was marked as a failed read.
+func (d *DataItem) IsFailedRead() bool {
+	return d.header.Type&DataItemFailedReadMask != 0
+}
+
+// Type returns the type of the data item without the failed read mask.
+func (d *DataItem) Type() uint32 {
+	return d.header.Type & DataItemTypeMask
 }
 
 // Header returns the header of the data item.

--- a/pkg/dyninst/rcscrape/decoder.go
+++ b/pkg/dyninst/rcscrape/decoder.go
@@ -335,10 +335,9 @@ func processDataItems(
 		if i == 0 {
 			rootData = dataItem.Data()
 		} else {
-			header := dataItem.Header()
 			key := dataItemKey{
-				typeID:  header.Type,
-				address: header.Address,
+				typeID:  dataItem.Type(),
+				address: dataItem.Header().Address,
 			}
 			dataItems[key] = dataItem
 		}
@@ -368,7 +367,15 @@ func (d *stringDecoder) decodeStringExpression(
 		address: strAddr,
 	}]
 	if !ok {
-		return "", 0, fmt.Errorf("string data item not found")
+		return "", 0, fmt.Errorf(
+			"string data item not found at address %#x with len %d",
+			strAddr, strLen,
+		)
+	}
+	if dataItem.IsFailedRead() {
+		return "", 0, fmt.Errorf(
+			"string data read failed at address %#x with len %d", strAddr, strLen,
+		)
 	}
 	return string(dataItem.Data()), strLen, nil
 }

--- a/pkg/dyninst/rcscrape/scraper_handleevent_test.go
+++ b/pkg/dyninst/rcscrape/scraper_handleevent_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package rcscrape
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
+)
+
+// Test that scraperSink.HandleEvent swallows errors and clears debouncer state.
+func TestHandleEventErrorClearsDebouncer(t *testing.T) {
+	// Minimal scraper with initialized internals.
+	s := &Scraper{}
+	s.mu.debouncer = makeDebouncer(1 * time.Millisecond)
+	s.mu.sinks = make(map[ir.ProgramID]*scraperSink)
+	s.mu.processes = make(map[actuator.ProcessID]*trackedProcess)
+
+	pid := actuator.ProcessID{PID: 123}
+	s.mu.processes[pid] = &trackedProcess{}
+
+	// Prepopulate debouncer state for pid.
+	now := time.Now()
+	s.mu.debouncer.addUpdate(now, pid, remoteConfigFile{
+		RuntimeID:     "rid",
+		ConfigPath:    "path",
+		ConfigContent: "content",
+	})
+
+	// Build a sink with a zero-value decoder and an invalid event to force an error
+	// from getEventDecoder (no data items in the event).
+	sink := &scraperSink{
+		scraper:   s,
+		decoder:   &decoder{},
+		processID: pid,
+	}
+	var ev output.Event // zero-length event triggers header parse error
+
+	// HandleEvent should not return an error (it is swallowed) and should clear
+	// the debouncer for this process.
+	err := sink.HandleEvent(ev)
+	require.NoError(t, err)
+
+	updates := s.mu.debouncer.getUpdates(now.Add(1 * time.Hour))
+	require.Len(t, updates, 0, "debouncer state was not cleared on error")
+}


### PR DESCRIPTION
#### dyninst/rcscrape: mark if a data item had a failed read

We've seen data items missing related to a runtime ID. Perhaps we
failed to read those memory addresses. We'd like to know about that.

Note that this same treatment should get applied to regular decoding
(perhaps in a more principled way). That's left for a different change
that won't be backported.


#### dyninst/rcscrape: gracefully handle decoding failures

If we can't decode a message, we don't want to shut down the entire
dyninst subsystem. The fact that that's what happens when decoding
fails is not great, but it's not for this change we intend to backport.

There's an upcoming refactor to address that.

Fixes [DEBUG-4455](https://datadoghq.atlassian.net/browse/DEBUG-4455).


[DEBUG-4455]: https://datadoghq.atlassian.net/browse/DEBUG-4455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ