### PR TITLE
dyninst/object: do not munmap nil

### DIFF
--- a/pkg/dyninst/object/disk_cache.go
+++ b/pkg/dyninst/object/disk_cache.go
@@ -753,11 +753,14 @@ func (e *cacheEntry) release() error {
 			e.cache.mu.totalBytes -= length
 		}
 	}()
+	// If the entry was never actually mmapped, we don't need to munmap.
 	var munmapErr error
-	if err := syscall.Munmap(e.decompress.data); err != nil {
-		munmapErr = fmt.Errorf("failed to munmap decompressed data: %w", err)
+	if e.decompress.data != nil {
+		if err := syscall.Munmap(e.decompress.data); err != nil {
+			munmapErr = fmt.Errorf("failed to munmap decompressed data: %w", err)
+		}
+		e.decompress.data = nil
 	}
-	e.decompress.data = nil
 	return munmapErr
 }
 


### PR DESCRIPTION
Before this change, if an error occurred during decompression but before we had mmapped the file, we would end up hitting this code path and logging about it. We don't need to do that.

We were hitting the error because of https://github.com/DataDog/datadog-agent/pull/40765, so I don't expect to need to backport this (no harm was caused by it), but still worth merging.