### PR TITLE
fix(github): Update the policies

### DIFF
--- a/.github/chainguard/self.ask-review-bot-pr.label-pr.sts.yaml
+++ b/.github/chainguard/self.ask-review-bot-pr.label-pr.sts.yaml
@@ -1,12 +1,12 @@
 ---
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/datadog-agent:ref:refs/heads/main
+subject: repo:DataDog/datadog-agent:environment:main
 
 claim_pattern:
   event_name: workflow_run
   ref: refs/heads/main
-  ref_protected: true
+  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/ask_review_bot_pr\.yml@refs/heads/main
 
 permissions:

--- a/.github/chainguard/self.update-dependencies.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-dependencies.create-pr.sts.yaml
@@ -1,11 +1,12 @@
 ---
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/datadog-agent:ref:refs/heads/main
+subject: repo:DataDog/datadog-agent:environment:main
 
 claim_pattern:
-  event_name: workflow_dispatch
+  event_name: workflow_dispatch|schedule
   ref: refs/heads/main
+  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/update_dependencies\.yml@refs/heads/main
 
 permissions:


### PR DESCRIPTION
### What does this PR do?
- Update the policy for the ask_review workflow
- Update as well for the Update golang.org/x/... dependencies workflow

### Motivation
Despite #39060, the policy is incorrect and the workflow is [failing](https://github.com/DataDog/datadog-agent/actions/runs/17592123062/job/49975181930). Similar failure on [Update golang.org/x/... dependencies](https://github.com/DataDog/datadog-agent/actions/runs/17604755578/job/50013227845#logs)

### Describe how you validated your changes
Applied the suggestion from the log, and validated the change locally
```
DDOCTOSTS_ID_TOKEN=$(cat claims.json) dd-octo-sts check --scope \"DataDog/datadog-agent\" --policy self.ask-review-bot-pr.label-pr
DDOCTOSTS_ID_TOKEN=$(cat claims.json) dd-octo-sts check --scope \"DataDog/datadog-agent\" --policy self.update-dependencies.create-pr
```
