### PR TITLE
dyninst/module: clear diagnostic tracker state on exit

### DIFF
--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -241,6 +242,22 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 			assert.False(t, symdbProcStates[proc.ProcessID])
 		}
 	}, 10*time.Second, 100*time.Millisecond, "probes should be removed")
+
+	// Ensure that the diagnostics states are as expected, and get cleared
+	// when the process exits.
+	require.Equal(t,
+		[]map[string][]string{
+			{
+				"look_at_the_request": {"received", "installed", "emitted"},
+				"http_handler":        {"received", "installed", "emitted"},
+			},
+		},
+		slices.Collect(maps.Values(ts.module.Controller().DiagnosticsStates())),
+	)
+	require.NoError(t, ts.serviceCmd.Process.Signal(os.Interrupt))
+	require.NoError(t, ts.serviceCmd.Wait())
+	ts.subscriber.NotifyExit(ts.servicePID)
+	require.Empty(t, ts.module.Controller().DiagnosticsStates())
 }
 
 func makeRemoteConfigUpdate(t *testing.T, probes []ir.ProbeDefinition, addSymdb bool) map[string][]byte {
@@ -825,6 +842,14 @@ func (m *mockSubscriber) NotifyExec(pid uint32) {
 	defer m.mu.Unlock()
 	if m.exec != nil {
 		m.exec(pid)
+	}
+}
+
+func (m *mockSubscriber) NotifyExit(pid uint32) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.exit != nil {
+		m.exit(pid)
 	}
 }
 

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -105,7 +105,7 @@ func (c *Controller) Run(ctx context.Context, interval time.Duration) {
 }
 
 func (c *Controller) handleRemovals(removals []procmon.ProcessID) {
-	c.store.remove(removals)
+	c.store.remove(removals, c.diagnostics)
 	if len(removals) > 0 {
 		c.actuator.HandleUpdate(actuator.ProcessesUpdate{
 			Removals: removals,

--- a/pkg/dyninst/module/diagnostics.go
+++ b/pkg/dyninst/module/diagnostics.go
@@ -107,3 +107,11 @@ func (m *diagnosticsManager) reportError(
 		Message: e.Error(),
 	})
 }
+
+func (m *diagnosticsManager) remove(runtimeID string) {
+	id := any(runtimeID) // only box the string once
+	m.received.byRuntimeID.Delete(id)
+	m.installed.byRuntimeID.Delete(id)
+	m.emitted.byRuntimeID.Delete(id)
+	m.errors.byRuntimeID.Delete(id)
+}

--- a/pkg/dyninst/module/state.go
+++ b/pkg/dyninst/module/state.go
@@ -41,7 +41,7 @@ func newProcessStore() *processStore {
 	}
 }
 
-func (ps *processStore) remove(removals []procmon.ProcessID) {
+func (ps *processStore) remove(removals []procmon.ProcessID, dm *diagnosticsManager) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	for _, pid := range removals {
@@ -52,6 +52,7 @@ func (ps *processStore) remove(removals []procmon.ProcessID) {
 				}
 			}
 			delete(ps.processes, pid)
+			dm.remove(state.procRuntimeID.runtimeID)
 		}
 	}
 }


### PR DESCRIPTION
Before this change, we were leaking this state. It would have been quite a slow leak.
