### PR TITLE
[CWS-5084] Fix hardlinks dentry resolution (old)

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -30,7 +30,7 @@ int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_
 
     syscall->exec.file.path_key.ino = inode ? get_inode_ino(inode) : get_path_ino(path);
     syscall->exec.file.path_key.mount_id = mount_id;
-    syscall->exec.file.path_key.path_id = get_path_id(mount_id, 0);
+    set_file_inode(syscall->exec.dentry, &syscall->exec.file, 0);
 
     inc_mount_ref(mount_id);
 

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -184,15 +184,23 @@ void __attribute__((always_inline)) fill_file(struct dentry *dentry, struct file
     }
 
 static __attribute__((always_inline)) void set_file_inode(struct dentry *dentry, struct file_t *file, int invalidate) {
-    file->path_key.path_id = get_path_id(file->path_key.mount_id, invalidate);
     if (!file->path_key.ino) {
         file->path_key.ino = get_dentry_ino(dentry);
+    }
+
+    int nlink = get_dentry_nlink(dentry);
+    if (nlink > file->metadata.nlink) {
+        file->metadata.nlink = nlink;
     }
 
     if (is_overlayfs(dentry)) {
         set_overlayfs_inode(dentry, file);
         set_overlayfs_nlink(dentry, file);
     }
+
+    invalidate |= file->metadata.nlink > 1;
+
+    file->path_key.path_id = get_path_id(file->path_key.mount_id, invalidate);
 }
 
 #endif


### PR DESCRIPTION
### What does this PR do?

Hardlinks share the same inode and (potentially) the same mount ID.
This means that any hardlink path resolution will override any previous path components of a different link for the same file, which makes the resolution of hardlink paths racy and might lead to inconsistent path resolutions.

For example executing the following: `/bin/cat /bin/gunzip` on busybox (where both paths point to the same file) sometimes causes the exec event path to be resolved to `/bin/gunzip` because the open syscall for `/bin/gunzip` had already overwritten the dentry entries in the kernel map at the time system-probe performs the dentry resolution of the exec event.

One solution to fix this is to bump the path_id of path keys every time a file has hardlinks (nlink > 1).

Other solution in this PR: https://github.com/DataDog/datadog-agent/pull/40812

### Motivation

### Describe how you validated your changes

### Additional Notes
