### PR TITLE
[CWS] re-use event and context when fetching list of SECL variables

### DIFF
--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -399,9 +399,8 @@ func (e *RuleEngine) notifyAPIServer(ruleIDs []rules.RuleID, policies []*monitor
 	e.apiServer.ApplyPolicyStates(policies)
 }
 
-func (e *RuleEngine) getCommonSECLVariables(rs *rules.RuleSet) map[string]*api.SECLVariableState {
-	var seclVariables = make(map[string]*api.SECLVariableState)
-	for name, value := range rs.GetVariables() {
+func (e *RuleEngine) fillCommonSECLVariables(rsVariables map[string]eval.SECLVariable, seclVariables map[string]*api.SECLVariableState) {
+	for name, value := range rsVariables {
 		if strings.HasPrefix(name, "process.") {
 			scopedVariable := value.(eval.ScopedVariable)
 			if !scopedVariable.IsMutable() {
@@ -441,7 +440,6 @@ func (e *RuleEngine) getCommonSECLVariables(rs *rules.RuleSet) map[string]*api.S
 			}
 		}
 	}
-	return seclVariables
 }
 
 func (e *RuleEngine) gatherDefaultPolicyProviders() []rules.PolicyProvider {

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -414,12 +414,12 @@ func (e *RuleEngine) fillCommonSECLVariables(rsVariables map[string]eval.SECLVar
 				event := e.probe.PlatformProbe.NewEvent()
 				event.ProcessCacheEntry = entry
 				ctx := eval.NewContext(event)
-				scopedName := fmt.Sprintf("%s.%d", name, entry.Pid)
 				value, found := scopedVariable.GetValue(ctx)
 				if !found {
 					return
 				}
 
+				scopedName := fmt.Sprintf("%s.%d", name, entry.Pid)
 				scopedValue := fmt.Sprintf("%+v", value)
 				seclVariables[scopedName] = &api.SECLVariableState{
 					Name:  scopedName,

--- a/pkg/security/rules/engine_linux.go
+++ b/pkg/security/rules/engine_linux.go
@@ -23,8 +23,12 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 		return nil
 	}
 
-	seclVariables := e.getCommonSECLVariables(rs)
-	for name, value := range rs.GetVariables() {
+	rsVariables := rs.GetVariables()
+	seclVariables := make(map[string]*api.SECLVariableState, len(rsVariables))
+
+	e.fillCommonSECLVariables(rsVariables, seclVariables)
+
+	for name, value := range rsVariables {
 		if strings.HasPrefix(name, "container.") {
 			scopedVariable := value.(eval.ScopedVariable)
 			ebpfProbe, ok := e.probe.PlatformProbe.(*probe.EBPFProbe)

--- a/pkg/security/rules/engine_linux.go
+++ b/pkg/security/rules/engine_linux.go
@@ -47,12 +47,12 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 				event := e.probe.PlatformProbe.NewEvent()
 				event.ContainerContext = &cgce.ContainerContext
 				ctx := eval.NewContext(event)
-				scopedName := fmt.Sprintf("%s.%s", name, cgce.ContainerContext.ContainerID)
 				value, found := scopedVariable.GetValue(ctx)
 				if !found {
 					return
 				}
 
+				scopedName := fmt.Sprintf("%s.%s", name, cgce.ContainerContext.ContainerID)
 				scopedValue := fmt.Sprintf("%v", value)
 				seclVariables[scopedName] = &api.SECLVariableState{
 					Name:  scopedName,
@@ -70,12 +70,12 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 				event := e.probe.PlatformProbe.NewEvent()
 				event.CGroupContext = &cgce.CGroupContext
 				ctx := eval.NewContext(event)
-				scopedName := fmt.Sprintf("%s.%s", name, cgce.CGroupID)
 				value, found := scopedVariable.GetValue(ctx)
 				if !found {
 					return
 				}
 
+				scopedName := fmt.Sprintf("%s.%s", name, cgce.CGroupID)
 				scopedValue := fmt.Sprintf("%v", value)
 				seclVariables[scopedName] = &api.SECLVariableState{
 					Name:  scopedName,

--- a/pkg/security/rules/engine_others.go
+++ b/pkg/security/rules/engine_others.go
@@ -19,10 +19,12 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 		return nil
 	}
 
+	preparator := e.newSECLVariableEventPreparator()
+
 	rsVariables := rs.GetVariables()
 	seclVariables := make(map[string]*api.SECLVariableState, len(rsVariables))
 
-	e.fillCommonSECLVariables(rsVariables, seclVariables)
+	e.fillCommonSECLVariables(rsVariables, seclVariables, preparator)
 
 	return seclVariables
 }

--- a/pkg/security/rules/engine_others.go
+++ b/pkg/security/rules/engine_others.go
@@ -19,5 +19,10 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 		return nil
 	}
 
-	return e.getCommonSECLVariables(rs)
+	rsVariables := rs.GetVariables()
+	seclVariables := make(map[string]*api.SECLVariableState, len(rsVariables))
+
+	e.fillCommonSECLVariables(rsVariables, seclVariables)
+
+	return seclVariables
 }


### PR DESCRIPTION
### What does this PR do?

This PR optimizes the way we collect SECL variables by re-using the fake event, and using a context pool, in order to not create a new fake event for each (variable, scope) tuple.

[Here is a profile](https://app.datadoghq.com/profiling/explorer?query=env%3Asingle-machine-performance%20service%3Asystem-probe%20job_id%3A08196009-a8e3-4079-aad8-fa5c9c3414fc%20version%3A7.72.0-devel_git.82.1e07097&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZky68MC72L36wAAABhBWmt5NjhZMUFBQ1BTdUtwT0xrMDJ3QUEAAAAkZjE5OTMyZjAtMGI1OC00ZDk3LWI3ZjYtY2Q3M2Y0YmVhM2M4AAZEFQ&fromUser=false&my_code=disabled&op_filter=focus_on%28function%3A%22updateStats%22%29&profile_type=alloc-size&profileId=AZky68Y1AACPSuKpOLk02wAA&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&start=1757487954000&end=1757499354000&paused=true) showing the impact of the fake event call with a frequent status query.

### Motivation

### Describe how you validated your changes

### Additional Notes
