### PR TITLE
Mark installer build as `always_build` to not attempt to cache it

### DIFF
--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -14,6 +14,8 @@ source path: '..',
        }
 relative_path 'src/github.com/DataDog/datadog-agent'
 
+always_build true
+
 build do
   license :project_license
 


### PR DESCRIPTION
### What does this PR do?

Marks installer build as `always_build` to not attempt to cache it.

### Motivation

We're being spammed by [this monitor](https://app.datadoghq.com/monitors/174328890?event_id=AwAAAZkzdodwzjnSNQAAABhBWmt6ZC1xNkFBRDdNZ2hCb3RfN3JIQ0QAAAAkMDE5OTMzN2EtMjkyMC00MDAxLThlMTctNmQxMGYzYWRhY2I4AAAwJw&link_source=monitor_notif&from_ts=1757504130000&to_ts=1757505330000&live=false) which checks for "cache mutations". The logs report `installer` dirtying the cache (as it can't be effectively be cached). It's mostly innocuous, but noisy.

https://github.com/DataDog/datadog-agent/pull/39721 introduced the `installer` dependency to the omnibus build, which caused this.

### Describe how you validated your changes

Not needed.

### Additional Notes
