### PR TITLE
Add package interaction metadata and config file to ddot-byoc builds

### DIFF
--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -118,6 +118,12 @@ ddot_byoc_package_build_test_deb:
         exit 1
       fi
       dpkg -c "$DEB_PATH" | grep /opt/datadog-agent/embedded/bin/otel-agent || { echo "ERROR: otel-agent binary not found in DEB package"; exit 1; }
+    # Check conflicts field for generated package
+    - |
+      [ "$(dpkg -f ${DEB_PATH} Conflicts)" = "datadog-agent-ddot" ] || { echo "ERROR: missing expected value for 'Conflicts'"; exit 1; }
+    # Check runtime dependencies for generated package
+    - |
+      dpkg -f "${DEB_PATH}" Depends | grep datadog-agent || { echo "ERROR: package should depend on datadog-agent"; exit 1; }
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -106,9 +106,10 @@ description: "Datadog Distribution of OpenTelemetry Collector (Custom)"
 contents:
   - src: bin/otel-agent/otel-agent
     dst: /opt/datadog-agent/embedded/bin/otel-agent
-    type: file
     file_info:
       mode: 0755
+  - src: bin/otel-agent/dist/otel-config.yaml
+    dst: /etc/datadog-agent/otel-config.yaml.example
 EOF
   nfpm package --config nfpm.yaml --target /dist --packager "${PACKAGE_TYPE}"
 else

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -110,6 +110,15 @@ contents:
       mode: 0755
   - src: bin/otel-agent/dist/otel-config.yaml
     dst: /etc/datadog-agent/otel-config.yaml.example
+conflicts:
+  - datadog-agent-ddot
+overrides:
+  deb:
+    depends:
+      - "datadog-agent (= 1:${AGENT_VERSION}-1)"
+  rpm:
+    depends:
+      - "datadog-agent = 1:${AGENT_VERSION}-1"
 EOF
   nfpm package --config nfpm.yaml --target /dist --packager "${PACKAGE_TYPE}"
 else


### PR DESCRIPTION
### What does this PR do?

- Adds a depends relationship from the ddot-byoc to the datadog-agent in a way similar to what our official ddot package does.
- Adds a conflict from ddot-byoc towards our official ddot package to have package managers generally prevent having the default and the custom ddot installed on the same system.
- It adds the config file that's generated by the build command to the package.

### Motivation

[ABLD-102](https://datadoghq.atlassian.net/browse/ABLD-102)

### Describe how you validated your changes

- Some extra assertions added to test build job.
- Manually tested some basic installation scenarios.

### Additional Notes

Note that the version provided as AGENT_VERSION and which is used as the version for the "depends" field as well as for the version given to the ddot-byoc package itself is arbitrary and holds no direct relationship currently to the actual code checkout that the build is based on. But this is consistent with what is currently done for the container BYOC (where the agent image where the custom ddot is injected can be a different version from the code used to build it). Therefore, I'm leaving that for a possible follow up where this is "corrected" for both containers and packages, to be discussed.

In addition, this currently doesn't properly support non-release versions of the Agent (such as `devel`, `rc`s and the like). If we want to support that, it would be a matter of sanitizing versions in the same way as omnibus does.

[ABLD-102]: https://datadoghq.atlassian.net/browse/ABLD-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ