### PR TITLE
add a change log for load-more-gui-fix

### DIFF
--- a/releasenotes/notes/load-more-gui-fix-bff84f0212617313.yaml
+++ b/releasenotes/notes/load-more-gui-fix-bff84f0212617313.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed the "Load more" button in the Agent GUI log page which was failing to load additional log lines after the initial load.

--- a/releasenotes/notes/load-more-gui-fix-bff84f0212617313.yaml
+++ b/releasenotes/notes/load-more-gui-fix-bff84f0212617313.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixed the "Load more" button in the Agent GUI log page which was failing to load additional log lines after the initial load.
+    Fixed the "Load more" button in the Agent GUI log page, which was failing to load additional log lines after the initial load.


### PR DESCRIPTION
### What does this PR do?
addresses [PR](https://github.com/DataDog/datadog-agent/pull/40698#discussion_r2331077275) which did not have a changelog added. 

### Motivation
Maintain a changelog for customer facing changes.

### Additional Notes
The original PR discussion suggested leaving out a changelog, but that was decided against on.