### PR TITLE
[Cisco SD-WAN] Do not send uptime metric when the device is unreachable

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/devices.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/devices.go
@@ -43,7 +43,7 @@ func GetDevicesTags(namespace string, devices []client.Device) map[string][]stri
 func GetDevicesUptime(devices []client.Device) map[string]float64 {
 	uptimes := make(map[string]float64)
 	for _, device := range devices {
-		if device.UptimeDate != 0 {
+		if device.UptimeDate != 0 && device.Reachability == "reachable" {
 			uptimes[device.SystemIP] = computeUptime(device)
 		}
 	}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/devices_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/payload/devices_test.go
@@ -41,7 +41,7 @@ var testDevices = []client.Device{
 		SystemIP:     "10.0.0.2",
 		HostName:     "test-2",
 		SiteID:       "102",
-		Reachability: "reachable",
+		Reachability: "unreachable",
 		DeviceModel:  "vbond",
 		DeviceOs:     "vbond-os",
 		Version:      "20.12",
@@ -80,7 +80,7 @@ func TestProcessDevicesMetadata(t *testing.T) {
 			Name:         "test-2",
 			Tags:         []string{"device_vendor:cisco", "device_namespace:test-ns", "hostname:test-2", "system_ip:10.0.0.2", "site_id:102", "type:vbond", "device_ip:10.0.0.2", "device_hostname:test-2", "device_id:test-ns:10.0.0.2", "source:cisco-sdwan"},
 			IDTags:       []string{"device_namespace:test-ns", "system_ip:10.0.0.2"},
-			Status:       devicemetadata.DeviceStatusReachable,
+			Status:       devicemetadata.DeviceStatusUnreachable,
 			Model:        "vbond",
 			OsName:       "vbond-os",
 			Version:      "20.12",
@@ -128,10 +128,9 @@ func TestProcessDevicesUptime(t *testing.T) {
 	TimeNow = mockTimeNow
 
 	uptimes := GetDevicesUptime(testDevices)
-	require.Len(t, uptimes, 2)
+	require.Len(t, uptimes, 1)
 	require.Equal(t, map[string]float64{
 		"10.0.0.1": 360000,
-		"10.0.0.2": 720000,
 	}, uptimes)
 }
 


### PR DESCRIPTION
### What does this PR do?
Do not send uptime metric when the device is unreachable

### Motivation

### Describe how you validated your changes

### Additional Notes
