### PR TITLE
[CWS-5084] Fix hardlinks dentry resolution

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -30,7 +30,7 @@ int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_
 
     syscall->exec.file.path_key.ino = inode ? get_inode_ino(inode) : get_path_ino(path);
     syscall->exec.file.path_key.mount_id = mount_id;
-    syscall->exec.file.path_key.path_id = get_path_id(mount_id, 0);
+    set_file_inode(syscall->exec.dentry, &syscall->exec.file, 0);
 
     inc_mount_ref(mount_id);
 

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -20,7 +20,8 @@ static __attribute__((always_inline)) void bump_path_id(u32 mount_id) {
     }
 }
 
-#define PATH_ID_MASK 0xFFFFFF
+#define PATH_ID_LOW_MASK 0xFFFFFF
+#define PATH_ID(high, low) ((u32)((high << 24) | (low & PATH_ID_LOW_MASK)))
 
 static __attribute__((always_inline)) u64 get_path_id(u64 ino, u32 mount_id, int nlink, int invalidate) {
     u32 key = mount_id % PATH_ID_MAP_SIZE;
@@ -52,7 +53,7 @@ static __attribute__((always_inline)) u64 get_path_id(u64 ino, u32 mount_id, int
         link_id_value = 0;
     }
 
-    id_value = (id_value & PATH_ID_MASK) | (link_id_value << 24);
+    id_value = PATH_ID(link_id_value, id_value);
 
     return id_value;
 }

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -184,15 +184,23 @@ void __attribute__((always_inline)) fill_file(struct dentry *dentry, struct file
     }
 
 static __attribute__((always_inline)) void set_file_inode(struct dentry *dentry, struct file_t *file, int invalidate) {
-    file->path_key.path_id = get_path_id(file->path_key.mount_id, invalidate);
     if (!file->path_key.ino) {
         file->path_key.ino = get_dentry_ino(dentry);
+    }
+
+    int nlink = get_dentry_nlink(dentry);
+    if (nlink > file->metadata.nlink) {
+        file->metadata.nlink = nlink;
     }
 
     if (is_overlayfs(dentry)) {
         set_overlayfs_inode(dentry, file);
         set_overlayfs_nlink(dentry, file);
     }
+
+    invalidate |= file->metadata.nlink > 1;
+
+    file->path_key.path_id = get_path_id(file->path_key.mount_id, invalidate);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -23,7 +23,7 @@ static __attribute__((always_inline)) void bump_path_id(u32 mount_id) {
 #define PATH_ID_LOW_MASK 0xFFFFFF
 #define PATH_ID(high, low) ((u32)((high << 24) | (low & PATH_ID_LOW_MASK)))
 
-static __attribute__((always_inline)) u64 get_path_id(u64 ino, u32 mount_id, int nlink, int invalidate) {
+static __attribute__((always_inline)) u32 get_path_id(u64 ino, u32 mount_id, int nlink, int invalidate) {
     u32 key = mount_id % PATH_ID_MAP_SIZE;
 
     u32 *id = bpf_map_lookup_elem(&path_id, &key);

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -69,7 +69,7 @@ int __attribute__((always_inline)) handle_interpreted_exec_event(void *ctx, stru
     bpf_probe_read(&interpreter_inode, sizeof(interpreter_inode), get_file_f_inode_addr(file));
 
     syscall->exec.linux_binprm.interpreter = get_inode_key_path(interpreter_inode, get_file_f_path_addr(file));
-    syscall->exec.linux_binprm.interpreter.path_id = get_path_id(syscall->exec.linux_binprm.interpreter.mount_id, 0);
+    syscall->exec.linux_binprm.interpreter.path_id = get_path_id(syscall->exec.linux_binprm.interpreter.ino, syscall->exec.linux_binprm.interpreter.mount_id, 1, 0);
 
 #if defined(DEBUG_INTERPRETER)
     bpf_printk("interpreter file: %llx", file);

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -180,13 +180,13 @@ void __attribute__((always_inline)) handle_new_mount(void *ctx, struct syscall_c
     struct dentry *root_dentry = get_vfsmount_dentry(get_mount_vfsmount(syscall->mount.newmnt));
     syscall->mount.root_key.mount_id = get_mount_mount_id(syscall->mount.newmnt);
     syscall->mount.root_key.ino = get_dentry_ino(root_dentry);
-    update_path_id(&syscall->mount.root_key, 0);
+    update_path_id(&syscall->mount.root_key, 0, 0);
 
     if(!detached) {
         // populate the mountpoint dentry key
         syscall->mount.mountpoint_key.mount_id = get_mount_mount_id(syscall->mount.parent);
         syscall->mount.mountpoint_key.ino = get_dentry_ino(syscall->mount.mountpoint_dentry);
-        update_path_id(&syscall->mount.mountpoint_key, 0);
+        update_path_id(&syscall->mount.mountpoint_key, 0, 0);
     }
 
     // populate the device of the new mount

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -90,6 +90,7 @@ BPF_LRU_MAP(sock_meta, void *, struct sock_meta_t, 4096);
 BPF_LRU_MAP(dns_responses_sent_to_userspace, u16, struct dns_responses_sent_to_userspace_lru_entry_t, 1024)
 BPF_LRU_MAP(capabilities_usage, struct capabilities_usage_key_t, struct capabilities_usage_entry_t, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(sock_cookie_pid, u64, u32, 1); // max entries will be overridden at runtime
+BPF_LRU_MAP(hardlink_ids, u64, u8, 10240);
 
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime

--- a/pkg/security/ebpf/c/include/tests/path_id_test.h
+++ b/pkg/security/ebpf/c/include/tests/path_id_test.h
@@ -1,8 +1,8 @@
 #ifndef _PATH_ID_TEST_H_
 #define _PATH_ID_TEST_H_
 
-SEC("test/path_id")
-int test_path_id() {
+SEC("test/path_id_mount_bump")
+int test_path_id_mount_bump() {
     u32 mount_id1 = 123;
     u32 mount_id2 = 456;
 
@@ -18,6 +18,28 @@ int test_path_id() {
 
     u32 mount_2_path_id_after_mount_1_invalidation = get_path_id(0, mount_id2, 1, 0);
     assert_equals(mount_2_path_id_after_mount_1_invalidation, initial_mount_2_path_id, "path id for mount 2 should be left unchanged");
+
+    return 1;
+}
+
+SEC("test/path_id_link_bump")
+int test_path_id_link_bump() {
+    const u32 mount_id = 32;
+
+    u64 inode_1 = 1;
+    u64 inode_2 = 2;
+
+    u32 initial_inode1_path_id = get_path_id(inode_1, mount_id, 1, 0);
+    u32 initial_inode2_path_id = get_path_id(inode_2, mount_id, 1, 0);
+
+    u32 inode1_path_id_no_link = get_path_id(inode_1, mount_id, 1, 0);
+    assert_equals(inode1_path_id_no_link, initial_inode1_path_id, "path id should be the same");
+
+    u32 inode1_path_id_with_link = get_path_id(inode_1, mount_id, 2, 0);
+    assert_equals(inode1_path_id_with_link, PATH_ID(1, 0), "path id should be incremented");
+
+    u32 inode2_path_id_with_link = get_path_id(inode_2, mount_id, 1, 0);
+    assert_equals(inode2_path_id_with_link, initial_inode2_path_id, "path id for inode 2 should be left unchanged");
 
     return 1;
 }

--- a/pkg/security/ebpf/c/include/tests/path_id_test.h
+++ b/pkg/security/ebpf/c/include/tests/path_id_test.h
@@ -6,17 +6,17 @@ int test_path_id() {
     u32 mount_id1 = 123;
     u32 mount_id2 = 456;
 
-    u32 initial_mount_1_path_id = get_path_id(mount_id1, 0);
-    u32 initial_mount_2_path_id = get_path_id(mount_id2, 0);
+    u32 initial_mount_1_path_id = get_path_id(0, mount_id1, 1, 0);
+    u32 initial_mount_2_path_id = get_path_id(0, mount_id2, 1, 0);
 
     // get path id mount 1 and invalidate the path
-    u32 mount_1_path_id_after_invalidation = get_path_id(mount_id1, 1);
+    u32 mount_1_path_id_after_invalidation = get_path_id(0, mount_id1, 1, 1);
     assert_equals(mount_1_path_id_after_invalidation, initial_mount_1_path_id, "path id should be the same");
     
-    u32 mount_1_next_path_id = get_path_id(mount_id1, 0);
+    u32 mount_1_next_path_id = get_path_id(0, mount_id1, 1, 0);
     assert_equals(mount_1_next_path_id, mount_1_path_id_after_invalidation + 1, "path id should be incremented");
 
-    u32 mount_2_path_id_after_mount_1_invalidation = get_path_id(mount_id2, 0);
+    u32 mount_2_path_id_after_mount_1_invalidation = get_path_id(0, mount_id2, 1, 0);
     assert_equals(mount_2_path_id_after_mount_1_invalidation, initial_mount_2_path_id, "path id for mount 2 should be left unchanged");
 
     return 1;

--- a/pkg/security/ebpf/tests/path_id_test.go
+++ b/pkg/security/ebpf/tests/path_id_test.go
@@ -15,9 +15,19 @@ import (
 )
 
 func TestPathID(t *testing.T) {
-	var ctx baloum.StdContext
-	code, err := newVM(t).RunProgram(&ctx, "test/path_id")
-	if err != nil || code != 1 {
-		t.Errorf("unexpected error: %v, %d", err, code)
-	}
+	t.Run("mount-bump", func(t *testing.T) {
+		var ctx baloum.StdContext
+		code, err := newVM(t).RunProgram(&ctx, "test/path_id_mount_bump")
+		if err != nil || code != 1 {
+			t.Errorf("unexpected error: %v, %d", err, code)
+		}
+	})
+
+	t.Run("link-bump", func(t *testing.T) {
+		var ctx baloum.StdContext
+		code, err := newVM(t).RunProgram(&ctx, "test/path_id_link_bump")
+		if err != nil || code != 1 {
+			t.Errorf("unexpected error: %v, %d", err, code)
+		}
+	})
 }

--- a/pkg/security/secl/model/consts_map_names_linux.go
+++ b/pkg/security/secl/model/consts_map_names_linux.go
@@ -51,6 +51,7 @@ var bpfMapNames = []string{
 	"filtered_dns_rc",
 	"flow_pid",
 	"global_rate_lim",
+	"hardlink_ids",
 	"imds_event",
 	"in_upper_layer_",
 	"inet_bind_args",


### PR DESCRIPTION
### What does this PR do?

Hardlinks share the same inode and (potentially) the same mount ID.
This means that any hardlink path resolution will override any previous path components of a different link for the same file, which makes the resolution of hardlink paths racy and might lead to inconsistent path resolutions.

For example executing the following: `/bin/cat /bin/gunzip` on busybox (where both paths point to the same file) sometimes causes the exec event path to be resolved to `/bin/gunzip` because the open syscall for `/bin/gunzip` had already overwritten the dentry entries in the kernel map at the time system-probe performs the dentry resolution of the exec event.

To solve this, this PR introduces a new ID that is incremented every time an inode with hardlinks is accessed.
This ID is merged in the existing path_id field to avoid increasing the size of all kernel events.

Using a new ID avoids bumping the path_id map every time an inode with hardlinks is accessed, meaning previous (non-hardlink) userspace cache entries remain valid. This is at the downside of using less bits for the path_id to account for dentry renaming and others.

### Motivation

### Describe how you validated your changes

### Additional Notes
