### PR TITLE
[CWS] do not recompute offsets/constants when querying the status of the fetcher

### DIFF
--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -188,10 +188,7 @@ func (a *APIServer) SaveSecurityProfile(_ context.Context, params *api.SecurityP
 func (a *APIServer) fillStatusPlatform(apiStatus *api.Status) error {
 	p, ok := a.probe.PlatformProbe.(*probe.EBPFProbe)
 	if ok {
-		status, err := p.GetConstantFetcherStatus()
-		if err != nil {
-			return err
-		}
+		status := p.GetConstantFetcherStatus()
 
 		constants := make([]*api.ConstantValueAndSource, 0, len(status.Values))
 		for _, v := range status.Values {

--- a/pkg/security/probe/model_ebpf.go
+++ b/pkg/security/probe/model_ebpf.go
@@ -23,12 +23,12 @@ func NewEBPFModel(probe *EBPFProbe) *model.Model {
 		ExtraValidateFieldFnc: func(field eval.Field, value eval.FieldValue) error {
 			switch field {
 			case "bpf.map.name":
-				if offset, found := probe.constantOffsets[constantfetch.OffsetNameBPFMapStructName]; !found || offset == constantfetch.ErrorSentinel {
+				if !probe.constantOffsets.IsPresent(constantfetch.OffsetNameBPFMapStructName) {
 					return fmt.Errorf("%s is not available on this kernel version", field)
 				}
 
 			case "bpf.prog.name":
-				if offset, found := probe.constantOffsets[constantfetch.OffsetNameBPFProgAuxStructName]; !found || offset == constantfetch.ErrorSentinel {
+				if !probe.constantOffsets.IsPresent(constantfetch.OffsetNameBPFProgAuxStructName) {
 					return fmt.Errorf("%s is not available on this kernel version", field)
 				}
 			case "packet.filter":

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2832,7 +2832,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, ipc ipc.Component, opts O
 		return nil, fmt.Errorf("failed to parse CPU count: %w", err)
 	}
 
-	p.constantOffsets, err = p.GetOffsetConstants()
+	p.constantOffsets, err = p.getOffsetConstants()
 	if err != nil {
 		seclog.Warnf("constant fetcher failed: %v", err)
 		return nil, err
@@ -3037,8 +3037,8 @@ func getCGroupWriteConstants() manager.ConstantEditor {
 	}
 }
 
-// GetOffsetConstants returns the offsets and struct sizes constants
-func (p *EBPFProbe) GetOffsetConstants() (map[string]uint64, error) {
+// getOffsetConstants returns the offsets and struct sizes constants
+func (p *EBPFProbe) getOffsetConstants() (map[string]uint64, error) {
 	constantFetcher := constantfetch.ComposeConstantFetchers(constantfetch.GetAvailableConstantFetchers(p.config.Probe, p.kernelVersion))
 	AppendProbeRequestsToFetcher(constantFetcher, p.kernelVersion)
 	return constantFetcher.FinishAndGetResults()

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -162,7 +162,7 @@ type EBPFProbe struct {
 	processKiller         *ProcessKiller
 
 	isRuntimeDiscarded bool
-	constantOffsets    map[string]uint64
+	constantOffsets    *constantfetch.ConstantFetcherStatus
 	runtimeCompiled    bool
 	useSyscallWrapper  bool
 	useFentry          bool
@@ -3038,17 +3038,15 @@ func getCGroupWriteConstants() manager.ConstantEditor {
 }
 
 // getOffsetConstants returns the offsets and struct sizes constants
-func (p *EBPFProbe) getOffsetConstants() (map[string]uint64, error) {
-	constantFetcher := constantfetch.ComposeConstantFetchers(constantfetch.GetAvailableConstantFetchers(p.config.Probe, p.kernelVersion))
-	AppendProbeRequestsToFetcher(constantFetcher, p.kernelVersion)
-	return constantFetcher.FinishAndGetResults()
-}
-
-// GetConstantFetcherStatus returns the status of the constant fetcher associated with this probe
-func (p *EBPFProbe) GetConstantFetcherStatus() (*constantfetch.ConstantFetcherStatus, error) {
+func (p *EBPFProbe) getOffsetConstants() (*constantfetch.ConstantFetcherStatus, error) {
 	constantFetcher := constantfetch.ComposeConstantFetchers(constantfetch.GetAvailableConstantFetchers(p.config.Probe, p.kernelVersion))
 	AppendProbeRequestsToFetcher(constantFetcher, p.kernelVersion)
 	return constantFetcher.FinishAndGetStatus()
+}
+
+// GetConstantFetcherStatus returns the status of the constant fetcher associated with this probe
+func (p *EBPFProbe) GetConstantFetcherStatus() *constantfetch.ConstantFetcherStatus {
+	return p.constantOffsets
 }
 
 // AppendProbeRequestsToFetcher returns the offsets and struct sizes constants, from a constant fetcher


### PR DESCRIPTION
### What does this PR do?

Currently, when we query the CWS status, we end up recomputing all the constants. This is an issue because on recent kernels this means reloading the kernel BTF. This PR re-organizes this to re-use the currently used constants from the probe, without recomputing anything.

### Motivation

### Describe how you validated your changes

### Additional Notes
