### PR TITLE
[chore] remove crio from windows build

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -260,7 +260,12 @@ AGENT_TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
 LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "nvml", "pcap", "podman", "trivy"}
 
 # List of tags to always remove when building on Windows
-WINDOWS_EXCLUDE_TAGS = {"linux_bpf", "nvml", "requirefips"}
+WINDOWS_EXCLUDE_TAGS = {
+    "linux_bpf",
+    "nvml",
+    "requirefips",
+    "crio",
+}
 
 # List of tags to always remove when building on Darwin/macOS
 DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "no_dynamic_plugins", "nvml", "cri", "crio"}


### PR DESCRIPTION
### What does this PR do?
attempts to exclude crio from windows builds.

### Motivation
this will reduce the size of Agent MSI and windows binaries, as seen below.
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1123193297
### Describe how you validated your changes

- Existing test coverage

### Additional Notes
will also unblock https://github.com/DataDog/datadog-agent/pull/40778 which is based on the target branch