### PR TITLE
pkg/util/funcs/cache: make sure the get function is only called once

### DIFF
--- a/pkg/util/funcs/cache.go
+++ b/pkg/util/funcs/cache.go
@@ -34,6 +34,11 @@ func (mf *cachedFunc[T]) Do() (*T, error) {
 	mf.mtx.Lock()
 	defer mf.mtx.Unlock()
 
+	// check again, after acquiring the lock
+	if mf.result != nil {
+		return mf.result, nil
+	}
+
 	var err error
 	res, err = mf.fn()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

If you have 2 threads:
- they both take the read lock, check that the value has not yet been computed and then release it
- they both reach the point where they try to take the write lock, at this point the decision has already be taken to call `fn()`, for both threads

This PR fixes this by checking again if the result is present after taking the write lock, this way the first thread will do the computation, release the write lock, and the second thread will see the value and return it directly, without computing it again.

### Motivation

### Describe how you validated your changes

### Additional Notes
