### PR TITLE
[AGNTLOG-281] Logs Agent fingerprint configuration at source and global level

### DIFF
--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -179,7 +179,12 @@ func ValidateFingerprintConfig(config *types.FingerprintConfig) error {
 	}
 
 	if err := config.FingerprintStrategy.Validate(); err != nil {
-		return fmt.Errorf("fingerprintStrategy must be one of: line_checksum, byte_checksum, got: %s", config.FingerprintStrategy)
+		return fmt.Errorf("fingerprintStrategy must be one of: line_checksum, byte_checksum, disabled. Got: %s", config.FingerprintStrategy)
+	}
+
+	// Skip validation if fingerprinting is disabled
+	if config.FingerprintStrategy == types.FingerprintStrategyDisabled {
+		return nil
 	}
 
 	// Validate Count (must be positive if set)

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -173,7 +173,6 @@ func (suite *ConfigTestSuite) TestTaggerWarmupDuration() {
 }
 
 func (suite *ConfigTestSuite) TestGlobalFingerprintConfigShouldReturnConfigWithValidMap() {
-	suite.config.SetWithoutSource("logs_config.fingerprint_enabled_experimental", true)
 	suite.config.SetWithoutSource("logs_config.fingerprint_config", map[string]interface{}{
 		"fingerprint_strategy": "line_checksum",
 		"count":                10,
@@ -190,8 +189,20 @@ func (suite *ConfigTestSuite) TestGlobalFingerprintConfigShouldReturnConfigWithV
 	suite.Equal(1024, config.MaxBytes)
 }
 
+func (suite *ConfigTestSuite) TestGlobalFingerprintConfigShouldReturnStrategyDisabled() {
+	suite.config.SetWithoutSource("logs_config.fingerprint_config", map[string]interface{}{
+		"fingerprint_strategy": "disabled",
+		"count":                10,
+		"count_to_skip":        5,
+		"max_bytes":            1024,
+	})
+
+	config, err := GlobalFingerprintConfig(suite.config)
+	suite.Nil(err)
+	suite.Equal(types.FingerprintStrategyDisabled, config.FingerprintStrategy)
+}
+
 func (suite *ConfigTestSuite) TestGlobalFingerprintConfigShouldReturnErrorWithInvalidConfig() {
-	suite.config.SetWithoutSource("logs_config.fingerprint_enabled_experimental", true)
 	suite.config.SetWithoutSource("logs_config.fingerprint_config", map[string]interface{}{
 		"fingerprint_strategy": "invalid_strategy", // Invalid: unknown strategy
 		"count":                -1,                 // Invalid: negative value

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -98,9 +98,8 @@ type LogsConfig struct {
 	AutoMultiLineOptions *SourceAutoMultiLineOptions `mapstructure:"auto_multi_line" json:"auto_multi_line" yaml:"auto_multi_line"`
 	// CustomSamples holds the raw string content of the 'auto_multi_line_detection_custom_samples' YAML block.
 	// Downstream code will be responsible for parsing this string.
-	AutoMultiLineSamples           []*AutoMultilineSample   `mapstructure:"auto_multi_line_detection_custom_samples" json:"auto_multi_line_detection_custom_samples" yaml:"auto_multi_line_detection_custom_samples"`
-	FingerprintConfig              *types.FingerprintConfig `mapstructure:"fingerprint_config" json:"fingerprint_config" yaml:"fingerprint_config"`
-	ExperimentalFingerprintEnabled bool                     `mapstructure:"fingerprint_enabled_experimental" json:"fingerprint_enabled_experimental" yaml:"fingerprint_enabled_experimental"`
+	AutoMultiLineSamples []*AutoMultilineSample   `mapstructure:"auto_multi_line_detection_custom_samples" json:"auto_multi_line_detection_custom_samples" yaml:"auto_multi_line_detection_custom_samples"`
+	FingerprintConfig    *types.FingerprintConfig `mapstructure:"fingerprint_config" json:"fingerprint_config" yaml:"fingerprint_config"`
 
 	// IntegrationSource is the source of the integration file that contains this source.
 	IntegrationSource string `mapstructure:"integration_source" json:"integration_source" yaml:"integration_source"`
@@ -249,7 +248,11 @@ func (c *LogsConfig) Dump(multiline bool) string {
 	}
 	fmt.Fprintf(&b, ws("AutoMultiLineSampleSize: %d,"), c.AutoMultiLineSampleSize)
 	fmt.Fprintf(&b, ws("AutoMultiLineMatchThreshold: %f,"), c.AutoMultiLineMatchThreshold)
-	fmt.Fprintf(&b, ws("ExperimentalFingerprintEnabled: %t}"), c.ExperimentalFingerprintEnabled)
+	if c.FingerprintConfig != nil {
+		fmt.Fprintf(&b, ws("FingerprintConfig: %+v}"), c.FingerprintConfig)
+	} else {
+		fmt.Fprint(&b, ws("FingerprintConfig: nil}"))
+	}
 	return b.String()
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -40,9 +40,6 @@ import (
 
 const (
 
-	// DefaultExperimentalFingerprintingEnabled is a flag to determine whether we want to detect file rotation or truncation using checksum fingerprinting
-	DefaultExperimentalFingerprintingEnabled = false
-
 	// DefaultFingerprintingMaxBytes is the maximum number of bytes that will be used to generate a checksum fingerprint;
 	// used in cases where the line to hash is too large or if the fingerprinting maxLines=0
 	DefaultFingerprintingMaxBytes = 100000
@@ -58,7 +55,8 @@ const (
 	// Options are:
 	// - "line_checksum": compute the fingerprint by lines
 	// - "byte_checksum": compute the fingerprint by bytes
-	DefaultFingerprintStrategy = "line_checksum"
+	// - "disabled": disable fingerprinting
+	DefaultFingerprintStrategy = "disabled"
 
 	// DefaultSite is the default site the Agent sends data to.
 	DefaultSite = "datadoghq.com"
@@ -1630,8 +1628,6 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.socks5_proxy_address", "")
 	// disable distributed senders
 	config.BindEnvAndSetDefault("logs_config.disable_distributed_senders", false)
-	// determines fingerprinting strategy to detect rotation and truncation
-	config.BindEnvAndSetDefault("logs_config.fingerprint_enabled_experimental", DefaultExperimentalFingerprintingEnabled)
 	// default fingerprint configuration
 	config.BindEnvAndSetDefault("logs_config.fingerprint_config.count", DefaultFingerprintingMaxLines)
 	config.BindEnvAndSetDefault("logs_config.fingerprint_config.max_bytes", DefaultFingerprintingMaxBytes)

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
 	fileprovider "github.com/DataDog/datadog-agent/pkg/logs/launchers/file/provider"
@@ -94,7 +93,7 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 		flarecontroller:        flarecontroller,
 		tagger:                 tagger,
 		oldInfoMap:             make(map[string]*oldTailerInfo),
-		fingerprinter:          tailer.NewFingerprinter(pkgconfigsetup.Datadog().GetBool("logs_config.fingerprint_enabled_experimental"), fingerprintConfig),
+		fingerprinter:          tailer.NewFingerprinter(fingerprintConfig),
 	}
 }
 
@@ -547,12 +546,23 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 		Fingerprint:     fingerprint,
 	}
 
+	if fingerprint != nil {
+		log.Debugf("Creating new tailer for %s with fingerprint 0x%x", file.Path, fingerprint.Value)
+	} else {
+		log.Debugf("Creating new tailer for %s with no fingerprint", file.Path)
+	}
+
 	return tailer.NewTailer(tailerOptions)
 }
 
 func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, pattern *regexp.Regexp, fingerprint *types.Fingerprint) *tailer.Tailer {
 	tailerInfo := t.GetInfo()
 	channel, monitor := s.pipelineProvider.NextPipelineChanWithMonitor()
+	if fingerprint != nil {
+		log.Debugf("Creating new tailer for %s with fingerprint 0x%x (configuration: %v)", file.Path, fingerprint.Value, fingerprint.Config)
+	} else {
+		log.Debugf("Creating new tailer for %s with no fingerprint", file.Path)
+	}
 	return t.NewRotatedTailer(file, channel, monitor, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo, s.tagger, fingerprint, s.registry)
 }
 

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -79,7 +79,7 @@ func (suite *LauncherTestSuite) SetupTest() {
 
 	// Create default fingerprint config for tests
 	defaultFingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyDisabled,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            10000,
@@ -162,7 +162,6 @@ func (suite *LauncherTestSuite) TestLauncherScanWithLogRotation() {
 func (suite *LauncherTestSuite) TestLauncherScanWithLogRotationAndChecksum_RotationOccurs() {
 	suite.s.cleanup()
 	mockConfig := configmock.New(suite.T())
-	mockConfig.SetWithoutSource("logs_config.fingerprint_enabled_experimental", true)
 	mockConfig.SetWithoutSource("logs_config.fingerprint_config.max_bytes", 256)
 	mockConfig.SetWithoutSource("logs_config.fingerprint_config.max_lines", 1)
 	mockConfig.SetWithoutSource("logs_config.fingerprint_config.to_skip", 0)
@@ -245,7 +244,6 @@ func (suite *LauncherTestSuite) TestLauncherScanWithLogRotationAndChecksum_Rotat
 func (suite *LauncherTestSuite) TestLauncherScanWithLogRotationAndChecksum_NoRotationOccurs() {
 	suite.s.cleanup()
 	mockConfig := configmock.New(suite.T())
-	mockConfig.SetWithoutSource("logs_config.fingerprint_enabled_experimental", true)
 	mockConfig.SetWithoutSource("logs_config.fingerprint_config.max_bytes", 256)
 
 	sleepDuration := 20 * time.Millisecond
@@ -395,7 +393,7 @@ func TestLauncherScanStartNewTailer(t *testing.T) {
 
 		// Create default fingerprint config for tests
 		defaultFingerprintConfig := types.FingerprintConfig{
-			FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+			FingerprintStrategy: types.FingerprintStrategyDisabled,
 			Count:               1,
 			CountToSkip:         0,
 			MaxBytes:            10000,
@@ -437,7 +435,6 @@ func TestLauncherScanStartNewTailerForEmptyFile(t *testing.T) {
 	mockConfig := configmock.New(t)
 
 	// Temporarily set the global config for this test
-	mockConfig.SetWithoutSource("logs_config.fingerprint_enabled_experimental", true)
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
 	testDir := t.TempDir()
@@ -487,7 +484,7 @@ func TestLauncherScanStartNewTailerWithOneLine(t *testing.T) {
 
 	// Create fingerprint config for this test
 	fingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyDisabled,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            256,
@@ -496,7 +493,7 @@ func TestLauncherScanStartNewTailerWithOneLine(t *testing.T) {
 	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger, fingerprintConfig)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditorMock.NewMockRegistry()
-	source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, FingerprintConfig: &types.FingerprintConfig{Count: 1, MaxBytes: 256, CountToSkip: 0, FingerprintStrategy: types.FingerprintStrategyLineChecksum}})
+	source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, FingerprintConfig: &types.FingerprintConfig{Count: 1, MaxBytes: 256, CountToSkip: 0, FingerprintStrategy: types.FingerprintStrategyDisabled}})
 	launcher.activeSources = append(launcher.activeSources, source)
 	status.Clear()
 	status.InitStatus(mockConfig, util.CreateSources([]*sources.LogSource{source}))
@@ -519,7 +516,6 @@ func TestLauncherScanStartNewTailerWithOneLine(t *testing.T) {
 
 func TestLauncherScanStartNewTailerWithLongLine(t *testing.T) {
 	mockConfig := configmock.New(t)
-	mockConfig.SetWithoutSource("logs_config.fingerprint_enabled_experimental", true)
 	mockConfig.SetWithoutSource("logs_config.fingerprint_config.max_bytes", 256)
 	// Temporarily set the global config for this test
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
@@ -533,7 +529,7 @@ func TestLauncherScanStartNewTailerWithLongLine(t *testing.T) {
 
 	// Create fingerprint config for this test
 	fingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyByteChecksum,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            256,
@@ -542,7 +538,7 @@ func TestLauncherScanStartNewTailerWithLongLine(t *testing.T) {
 	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger, fingerprintConfig)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditorMock.NewMockRegistry()
-	source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, FingerprintConfig: &types.FingerprintConfig{Count: 1, MaxBytes: 256, CountToSkip: 0, FingerprintStrategy: types.FingerprintStrategyLineChecksum}})
+	source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, FingerprintConfig: &types.FingerprintConfig{Count: 1, MaxBytes: 256, CountToSkip: 0, FingerprintStrategy: types.FingerprintStrategyByteChecksum}})
 	launcher.activeSources = append(launcher.activeSources, source)
 	status.Clear()
 	status.InitStatus(mockConfig, util.CreateSources([]*sources.LogSource{source}))
@@ -575,7 +571,7 @@ func TestLauncherWithConcurrentContainerTailer(t *testing.T) {
 
 	// Create default fingerprint config for tests
 	defaultFingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyDisabled,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            10000,
@@ -633,7 +629,7 @@ func TestLauncherTailFromTheBeginning(t *testing.T) {
 
 	// Create default fingerprint config for tests
 	defaultFingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyDisabled,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            10000,
@@ -696,7 +692,7 @@ func TestLauncherSetTail(t *testing.T) {
 
 	// Create default fingerprint config for tests
 	defaultFingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyDisabled,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            10000,
@@ -730,7 +726,7 @@ func TestLauncherConfigIdentifier(t *testing.T) {
 
 	// Create default fingerprint config for tests
 	defaultFingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyDisabled,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            10000,
@@ -779,7 +775,7 @@ func TestLauncherScanWithTooManyFiles(t *testing.T) {
 
 	// Create default fingerprint config for tests
 	defaultFingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyDisabled,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            10000,
@@ -820,7 +816,7 @@ func TestLauncherUpdatesSourceForExistingTailer(t *testing.T) {
 
 	// Create default fingerprint config for tests
 	defaultFingerprintConfig := types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		FingerprintStrategy: types.FingerprintStrategyDisabled,
 		Count:               1,
 		CountToSkip:         0,
 		MaxBytes:            10000,
@@ -878,7 +874,7 @@ func TestLauncherScanRecentFilesWithRemoval(t *testing.T) {
 
 		// Create default fingerprint config for tests
 		defaultFingerprintConfig := types.FingerprintConfig{
-			FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+			FingerprintStrategy: types.FingerprintStrategyDisabled,
 			Count:               1,
 			CountToSkip:         0,
 			MaxBytes:            10000,
@@ -894,7 +890,7 @@ func TestLauncherScanRecentFilesWithRemoval(t *testing.T) {
 			scanPeriod:             10 * time.Second,
 			flarecontroller:        flareController.NewFlareController(),
 			tagger:                 fakeTagger,
-			fingerprinter:          filetailer.NewFingerprinter(false, defaultFingerprintConfig),
+			fingerprinter:          filetailer.NewFingerprinter(defaultFingerprintConfig),
 		}
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditorMock.NewMockRegistry()
@@ -957,7 +953,7 @@ func TestLauncherScanRecentFilesWithNewFiles(t *testing.T) {
 
 		// Create default fingerprint config for tests
 		defaultFingerprintConfig := types.FingerprintConfig{
-			FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+			FingerprintStrategy: types.FingerprintStrategyDisabled,
 			Count:               1,
 			CountToSkip:         0,
 			MaxBytes:            10000,
@@ -1030,7 +1026,7 @@ func TestLauncherFileRotation(t *testing.T) {
 
 		// Create default fingerprint config for tests
 		defaultFingerprintConfig := types.FingerprintConfig{
-			FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+			FingerprintStrategy: types.FingerprintStrategyDisabled,
 			Count:               1,
 			CountToSkip:         0,
 			MaxBytes:            10000,
@@ -1107,7 +1103,7 @@ func TestLauncherFileDetectionSingleScan(t *testing.T) {
 
 		// Create default fingerprint config for tests
 		defaultFingerprintConfig := types.FingerprintConfig{
-			FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+			FingerprintStrategy: types.FingerprintStrategyDisabled,
 			Count:               1,
 			CountToSkip:         0,
 			MaxBytes:            10000,
@@ -1146,7 +1142,6 @@ func TestLauncherFileDetectionSingleScan(t *testing.T) {
 func (suite *LauncherTestSuite) TestLauncherDoesNotCreateTailerForTruncatedUndersizedFile() {
 	suite.s.cleanup()
 	mockConfig := configmock.New(suite.T())
-	mockConfig.SetWithoutSource("logs_config.fingerprint_enabled_experimental", true)
 
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()
@@ -1206,7 +1201,6 @@ func (suite *LauncherTestSuite) TestLauncherDoesNotCreateTailerForTruncatedUnder
 func (suite *LauncherTestSuite) TestLauncherDoesNotCreateTailerForRotatedUndersizedFile() {
 	suite.s.cleanup()
 	mockConfig := configmock.New(suite.T())
-	mockConfig.SetWithoutSource("logs_config.fingerprint_enabled_experimental", true)
 
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()

--- a/pkg/logs/launchers/file/position.go
+++ b/pkg/logs/launchers/file/position.go
@@ -30,7 +30,7 @@ func Position(registry auditor.Registry, identifier string, mode config.TailingM
 
 	fingerprintsAlign := true
 
-	if fingerprinter.IsFingerprintingEnabled() && filePath != "" {
+	if filePath != "" {
 		prevFingerprint := registry.GetFingerprint(identifier)
 		if prevFingerprint != nil {
 			newFingerprint, err := fingerprinter.ComputeFingerprintFromConfig(filePath, prevFingerprint.Config)

--- a/pkg/logs/launchers/file/position_test.go
+++ b/pkg/logs/launchers/file/position_test.go
@@ -34,7 +34,7 @@ func TestPosition(t *testing.T) {
 	}
 
 	// Create a mock fingerprinter
-	mockFingerprinter := file.NewFingerprinter(true, *fingerprintConfig)
+	mockFingerprinter := file.NewFingerprinter(*fingerprintConfig)
 
 	// Set a fingerprint in the registry
 	fingerprint := &types.Fingerprint{

--- a/pkg/logs/tailers/file/fingerprint.go
+++ b/pkg/logs/tailers/file/fingerprint.go
@@ -34,16 +34,13 @@ var defaultLinesConfig = &types.FingerprintConfig{
 
 // Fingerprinter is a struct that contains the fingerprinting configuration
 type Fingerprinter struct {
-	fingerprintingEnabled bool
-	FingerprintConfig     types.FingerprintConfig
+	FingerprintConfig types.FingerprintConfig
 }
 
 // NewFingerprinter creates a new Fingerprinter with the given configuration
-func NewFingerprinter(fingerprintEnabled bool, fingerprintConfig types.FingerprintConfig) *Fingerprinter {
-	log.Debugf("Creating new fingerprinter: enabled=%t, defaultConfig=%+v", fingerprintEnabled, fingerprintConfig)
+func NewFingerprinter(fingerprintConfig types.FingerprintConfig) *Fingerprinter {
 	return &Fingerprinter{
-		fingerprintingEnabled: fingerprintEnabled,
-		FingerprintConfig:     fingerprintConfig,
+		FingerprintConfig: fingerprintConfig,
 	}
 }
 
@@ -58,26 +55,34 @@ var crc64Table = crc64.MakeTable(crc64.ISO)
 
 // ShouldFileFingerprint returns whether or not a given file should be fingerprinted to detect rotation and truncation
 func (f *Fingerprinter) ShouldFileFingerprint(file *File) bool {
-	if !f.IsFingerprintingEnabled() {
-		log.Debugf("Fingerprinting disabled globally, skipping file %s", file.Path)
+	fileFingerprintConfig := file.Source.Config().FingerprintConfig
+
+	// Check per-source config first (takes precedence over global config)
+	if fileFingerprintConfig != nil {
+		if fileFingerprintConfig.FingerprintStrategy == types.FingerprintStrategyDisabled {
+			return false
+		}
+		if fileFingerprintConfig.FingerprintStrategy != "" {
+			return true
+		}
+	}
+
+	// Now, check global config
+	globalConfig := f.GetFingerprintConfig()
+	if globalConfig == nil {
 		return false
 	}
 
-	if file.Source.Config().FingerprintConfig == nil && f.GetFingerprintConfig() == nil {
-		log.Debugf("No fingerprint config available for file %s (source config: %+v, default config: %+v)",
-			file.Path,
-			file.Source.Config().FingerprintConfig,
-			f.GetFingerprintConfig())
+	if globalConfig.FingerprintStrategy == types.FingerprintStrategyDisabled {
 		return false
 	}
 
-	log.Debugf("File %s will be fingerprinted", file.Path)
 	return true
 }
 
 // ComputeFingerprintFromConfig computes the fingerprint for the given file path using a specific config
 func (f *Fingerprinter) ComputeFingerprintFromConfig(filepath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
-	if !f.IsFingerprintingEnabled() {
+	if fingerprintConfig != nil && fingerprintConfig.FingerprintStrategy == types.FingerprintStrategyDisabled {
 		return newInvalidFingerprint(nil), nil
 	}
 	return computeFingerprint(filepath, fingerprintConfig)
@@ -85,61 +90,46 @@ func (f *Fingerprinter) ComputeFingerprintFromConfig(filepath string, fingerprin
 
 // ComputeFingerprint computes the fingerprint for the given file path
 func (f *Fingerprinter) ComputeFingerprint(file *File) (*types.Fingerprint, error) {
-	if !f.IsFingerprintingEnabled() {
-		log.Debugf("Fingerprinting disabled, returning invalid fingerprint")
-		return newInvalidFingerprint(nil), nil
-	}
 	if file == nil {
 		log.Warnf("file is nil, skipping fingerprinting")
 		return newInvalidFingerprint(nil), nil
 	}
 
-	configFingerprintConfig := file.Source.Config().FingerprintConfig
-	if configFingerprintConfig == nil {
-		fingerprintConfig := f.GetFingerprintConfig()
-		if fingerprintConfig == nil {
-			log.Debugf("No fingerprint config found in file source or defaults, returning invalid fingerprint")
+	fileFingerprintConfig := file.Source.Config().FingerprintConfig
+
+	// Check per-source config first (takes precedence over global config)
+	if fileFingerprintConfig != nil && fileFingerprintConfig.FingerprintStrategy != "" {
+		if fileFingerprintConfig.FingerprintStrategy == types.FingerprintStrategyDisabled {
 			return newInvalidFingerprint(nil), nil
 		}
-		// Use the default config directly since it's already the right type
-		log.Debugf("Using default fingerprint config: strategy=%s, count=%d, countToSkip=%d, maxBytes=%d",
-			fingerprintConfig.FingerprintStrategy,
-			fingerprintConfig.Count,
-			fingerprintConfig.CountToSkip,
-			fingerprintConfig.MaxBytes)
+
+		// Convert from config.FingerprintConfig to types.FingerprintConfig
+		fingerprintConfig := &types.FingerprintConfig{
+			FingerprintStrategy: types.FingerprintStrategy(fileFingerprintConfig.FingerprintStrategy),
+			Count:               fileFingerprintConfig.Count,
+			CountToSkip:         fileFingerprintConfig.CountToSkip,
+			MaxBytes:            fileFingerprintConfig.MaxBytes,
+		}
+
 		return computeFingerprint(file.Path, fingerprintConfig)
 	}
 
-	// Convert from config.FingerprintConfig to types.FingerprintConfig
-	fingerprintConfig := &types.FingerprintConfig{
-		FingerprintStrategy: types.FingerprintStrategy(configFingerprintConfig.FingerprintStrategy),
-		Count:               configFingerprintConfig.Count,
-		CountToSkip:         configFingerprintConfig.CountToSkip,
-		MaxBytes:            configFingerprintConfig.MaxBytes,
+	// If per-source config exists but no strategy is set, or no per-source config exists,
+	// fall back to global config
+	fingerprintConfig := f.GetFingerprintConfig()
+	if fingerprintConfig == nil {
+		return newInvalidFingerprint(nil), nil
 	}
 
-	log.Debugf("Using file source fingerprint config: strategy=%s, count=%d, countToSkip=%d, maxBytes=%d",
-		fingerprintConfig.FingerprintStrategy,
-		fingerprintConfig.Count,
-		fingerprintConfig.CountToSkip,
-		fingerprintConfig.MaxBytes)
-
+	// Use the global config directly since it's already the right type
 	return computeFingerprint(file.Path, fingerprintConfig)
 }
 
 // computeFingerprint computes the fingerprint for the given file path
 func computeFingerprint(filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
 	if fingerprintConfig == nil {
-		log.Debugf("No fingerprint config provided, returning invalid fingerprint")
 		return newInvalidFingerprint(nil), nil
 	}
-
-	log.Debugf("Computing fingerprint for %s with config: strategy=%s, count=%d, countToSkip=%d, maxBytes=%d",
-		filePath,
-		fingerprintConfig.FingerprintStrategy,
-		fingerprintConfig.Count,
-		fingerprintConfig.CountToSkip,
-		fingerprintConfig.MaxBytes)
 
 	fpFile, err := filesystem.OpenShared(filePath)
 	if err != nil {
@@ -152,15 +142,12 @@ func computeFingerprint(filePath string, fingerprintConfig *types.FingerprintCon
 	strategy := fingerprintConfig.FingerprintStrategy
 	switch strategy {
 	case types.FingerprintStrategyLineChecksum:
-		log.Debugf("Using line-based fingerprinting strategy for %s", filePath)
 		return computeFingerPrintByLines(fpFile, filePath, fingerprintConfig)
 	case types.FingerprintStrategyByteChecksum:
-		log.Debugf("Using byte-based fingerprinting strategy for %s", filePath)
 		return computeFingerPrintByBytes(fpFile, filePath, fingerprintConfig)
 	default:
-		log.Warnf("invalid fingerprint strategy %q for file %q, using default lines strategy: %v", strategy, filePath, err)
+		log.Warnf("invalid fingerprint strategy %q for file %q, using default lines strategy", strategy, filePath)
 		// Default to line_checksum if no strategy is specified
-		log.Debugf("Falling back to default line-based strategy for %s", filePath)
 		return computeFingerPrintByLines(fpFile, filePath, defaultLinesConfig)
 	}
 }
@@ -189,14 +176,12 @@ func computeFingerPrintByBytes(fpFile *os.File, filePath string, fingerprintConf
 
 	// Check if we have enough bytes to create a meaningful fingerprint
 	if bytesRead == 0 || bytesRead < maxBytes {
-		log.Debugf("No bytes available for fingerprinting file %q", filePath)
 		return newInvalidFingerprint(fingerprintConfig), nil
 	}
 
 	// Compute fingerprint
 	checksum := crc64.Checksum(buffer, crc64Table)
 
-	log.Debugf("Computed byte-based fingerprint 0x%x for file %q (bytes=%d)", checksum, filePath, bytesRead)
 	return &types.Fingerprint{Value: checksum, Config: fingerprintConfig}, nil
 }
 
@@ -241,7 +226,6 @@ func computeFingerPrintByLines(fpFile *os.File, filePath string, fingerprintConf
 			}
 			// Check if we have enough data for fingerprinting
 			// We need either enough lines OR enough bytes to create a meaningful fingerprint
-			log.Debugf("Not enough data for fingerprinting file %q", filePath)
 			return newInvalidFingerprint(fingerprintConfig), nil
 
 		}
@@ -249,13 +233,7 @@ func computeFingerPrintByLines(fpFile *os.File, filePath string, fingerprintConf
 
 	// Compute fingerprint
 	checksum := crc64.Checksum(buffer, crc64Table)
-	log.Debugf("Computed line-based fingerprint 0x%x for file %q (bytes=%d, lines=%d)", checksum, filePath, len(buffer), linesRead)
 	return &types.Fingerprint{Value: checksum, Config: fingerprintConfig}, nil
-}
-
-// IsFingerprintingEnabled returns whether or not our configuration has checksum fingerprinting enabled
-func (f *Fingerprinter) IsFingerprintingEnabled() bool {
-	return f.fingerprintingEnabled
 }
 
 // GetFingerprintConfig returns the fingerprint configuration

--- a/pkg/logs/tailers/file/fingerprint_test.go
+++ b/pkg/logs/tailers/file/fingerprint_test.go
@@ -101,7 +101,7 @@ func (suite *FingerprintTestSuite) TestLineBased_WithSkip1() {
 	expectedChecksum := crc64.Checksum([]byte(text), table)
 
 	tailer := suite.createTailer()
-	fingerprinter := NewFingerprinter(true, config)
+	fingerprinter := NewFingerprinter(config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
 }
@@ -145,7 +145,7 @@ func (suite *FingerprintTestSuite) TestLineBased_SingleLongLine() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
@@ -189,7 +189,7 @@ func (suite *FingerprintTestSuite) TestLineBased_MultipleLinesAddUpToByteLimit()
 
 	tailer := suite.createTailer()
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
@@ -227,7 +227,7 @@ func (suite *FingerprintTestSuite) TestLineBased_WithSkip2() {
 
 	tailer := suite.createTailer()
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
@@ -251,7 +251,7 @@ func (suite *FingerprintTestSuite) TestLineBased_EmptyFile() {
 	// Expected: empty file should return nil since we don't have any data to hash
 	tailer := suite.createTailer()
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(uint64(0), receivedChecksum.Value, "Empty file should return fingerprint with Value=0")
 }
@@ -283,7 +283,7 @@ func (suite *FingerprintTestSuite) TestLineBased_InsufficientData() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(uint64(0), receivedChecksum.Value, "Should return fingerprint with Value=0 when insufficient lines")
 }
@@ -318,7 +318,7 @@ func (suite *FingerprintTestSuite) TestByteBased_WithSkip1() {
 
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
 }
@@ -350,7 +350,7 @@ func (suite *FingerprintTestSuite) TestByteBased_WithSkip_InvalidNotEnoughData()
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(uint64(0), receivedChecksum.Value, "Insufficient data after skip should return fingerprint with Value=0")
 }
@@ -386,7 +386,7 @@ func (suite *FingerprintTestSuite) TestByteBased_NoSkip() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
 }
@@ -418,7 +418,7 @@ func (suite *FingerprintTestSuite) TestByteBased_InsufficientData() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(uint64(0), receivedChecksum.Value, "Insufficient data should return fingerprint with Value=0")
 }
@@ -457,7 +457,7 @@ func (suite *FingerprintTestSuite) TestLineBased_WithSkip3() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
 }
@@ -492,7 +492,7 @@ func (suite *FingerprintTestSuite) TestByteBased_WithSkip2() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
 }
@@ -530,7 +530,7 @@ func (suite *FingerprintTestSuite) TestLineBased_NoSkip() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
 }
@@ -568,7 +568,7 @@ func (suite *FingerprintTestSuite) TestLineBased_WithSkip5() {
 	tailer.osFile = osFile
 
 	// Compute fingerprint (now returns uint64 directly)
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	fingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	expectedText := "line 1: important data" + "line 2: more important data"
@@ -604,7 +604,7 @@ func (suite *FingerprintTestSuite) TestByteBased_WithSkip3() {
 
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	fingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	textToHash := "thisisexactly20chars"
@@ -633,7 +633,7 @@ func (suite *FingerprintTestSuite) TestEmptyFile_And_SkippingMoreThanFileSize() 
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	fingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	suite.Equal(uint64(0), fingerprint.Value, "Empty file should return fingerprint with Value=0")
@@ -654,7 +654,7 @@ func (suite *FingerprintTestSuite) TestEmptyFile_And_SkippingMoreThanFileSize() 
 	tailer = suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter = NewFingerprinter(true, *config)
+	fingerprinter = NewFingerprinter(*config)
 	fingerprint, _ = fingerprinter.ComputeFingerprint(tailer.file)
 
 	suite.Equal(uint64(0), fingerprint.Value, "Insufficient data should return fingerprint with Value=0")
@@ -687,7 +687,7 @@ func (suite *FingerprintTestSuite) TestLineBased_SingleLongLine2() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	fingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	expectedText := strings.Repeat("X", 80)
@@ -725,7 +725,7 @@ func (suite *FingerprintTestSuite) TestXLinesOrYBytesFirstHash() {
 
 	tailer := suite.createTailer()
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	fingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	fmt.Println(lines)
@@ -760,7 +760,7 @@ func (suite *FingerprintTestSuite) TestLineBased_WithSkip4() {
 	tailer := suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter := NewFingerprinter(true, *fpConfig)
+	fingerprinter := NewFingerprinter(*fpConfig)
 	fingerprint1, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	osFile.Close()
@@ -795,7 +795,7 @@ func (suite *FingerprintTestSuite) TestLineBased_WithSkip4() {
 	tailer = suite.createTailer()
 	tailer.osFile = osFile
 
-	fingerprinter = NewFingerprinter(true, *fpConfig)
+	fingerprinter = NewFingerprinter(*fpConfig)
 	fingerprint2, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	textToHash2 := "line1line"
@@ -838,7 +838,7 @@ func (suite *FingerprintTestSuite) TestLineBased_SkipAndMaxMidLine() {
 
 	tailer := suite.createTailer()
 
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	suite.Equal(uint64(0), receivedChecksum.Value, "Should return fingerprint with Value=0 when there's insufficient data after skipping")
@@ -859,7 +859,7 @@ func (suite *FingerprintTestSuite) TestDidRotateViaFingerprint() {
 		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
 	}
 	tailer := suite.createTailer()
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 
 	// Compute initial fingerprint
 	initialFingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
@@ -898,7 +898,7 @@ func (suite *FingerprintTestSuite) TestDidRotateViaFingerprint() {
 	// We 're-arm' the tailer, as if the launcher had picked up the new file.
 	// This tailer now considers the current content ("a completely new file") as its baseline.
 	tailer = suite.createTailer()
-	fingerprinter = NewFingerprinter(true, *config)
+	fingerprinter = NewFingerprinter(*config)
 	newFingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.NotNil(newFingerprint)
 	suite.True(newFingerprint.ValidFingerprint())
@@ -943,7 +943,7 @@ func (suite *FingerprintTestSuite) TestDidRotateViaFingerprint() {
 	suite.Nil(err)
 	suite.Nil(suite.testFile.Sync())
 	tailer = suite.createTailer()
-	fingerprinter = NewFingerprinter(true, *config)
+	fingerprinter = NewFingerprinter(*config)
 	emptyFingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(uint64(0), emptyFingerprint.Value, "Fingerprint of an empty file should have Value=0")
 
@@ -977,7 +977,7 @@ func (suite *FingerprintTestSuite) TestLineBased_FallbackToByteBased() {
 	}
 
 	tailer := suite.createTailer()
-	fingerprinter := NewFingerprinter(true, *config)
+	fingerprinter := NewFingerprinter(*config)
 	fingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 
 	// Since we're trying to skip more lines than exist, and the LimitedReader exhausts,
@@ -986,4 +986,298 @@ func (suite *FingerprintTestSuite) TestLineBased_FallbackToByteBased() {
 
 	// Expected: the new implementation returns fingerprint with Value=0 when there's insufficient data
 	suite.Equal(uint64(0), fingerprint.Value, "Should return fingerprint with Value=0 when there's insufficient data for fingerprinting")
+}
+
+func (suite *FingerprintTestSuite) TestFingerprintConfigFallback() {
+	// tests the fallback logic between file-specific and global configs
+	testData := "line1\nline2\nline3\nline4\n"
+	_, err := suite.testFile.WriteString(testData)
+	suite.Nil(err)
+	suite.testFile.Sync()
+
+	testCases := []struct {
+		name                      string
+		globalConfig              types.FingerprintConfig
+		fileConfig                *types.FingerprintConfig
+		expectedShouldFingerprint bool
+		expectedStrategy          types.FingerprintStrategy
+		expectedCount             int
+		expectedCountToSkip       int
+		expectedMaxBytes          int
+	}{
+		{
+			name: "file_config_with_strategy_overrides_global",
+			globalConfig: types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyDisabled,
+				Count:               1,
+				CountToSkip:         0,
+				MaxBytes:            1000,
+			},
+			fileConfig: &types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+				Count:               2,
+				CountToSkip:         1,
+				MaxBytes:            2000,
+			},
+			expectedShouldFingerprint: true,
+			expectedStrategy:          types.FingerprintStrategyLineChecksum,
+			expectedCount:             2,
+			expectedCountToSkip:       1,
+			expectedMaxBytes:          2000,
+		},
+		{
+			name: "file_config_disabled_overrides_global_enabled",
+			globalConfig: types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+				Count:               1,
+				CountToSkip:         0,
+				MaxBytes:            1000,
+			},
+			fileConfig: &types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyDisabled,
+				Count:               1,
+				CountToSkip:         0,
+				MaxBytes:            1000,
+			},
+			expectedShouldFingerprint: false,
+			expectedStrategy:          types.FingerprintStrategyDisabled,
+		},
+		{
+			name: "file_config_empty_strategy_falls_back_to_global",
+			globalConfig: types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyByteChecksum,
+				Count:               512,
+				CountToSkip:         0,
+				MaxBytes:            0,
+			},
+			fileConfig: &types.FingerprintConfig{
+				FingerprintStrategy: "", // Empty strategy should fall back to global
+				Count:               2,
+				CountToSkip:         1,
+				MaxBytes:            2000,
+			},
+			expectedShouldFingerprint: true,
+			expectedStrategy:          types.FingerprintStrategyByteChecksum,
+			expectedCount:             512,
+			expectedCountToSkip:       0,
+			expectedMaxBytes:          0,
+		},
+		{
+			name: "no_file_config_falls_back_to_global",
+			globalConfig: types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+				Count:               3,
+				CountToSkip:         0,
+				MaxBytes:            1500,
+			},
+			fileConfig:                nil, // No file config should fall back to global
+			expectedShouldFingerprint: true,
+			expectedStrategy:          types.FingerprintStrategyLineChecksum,
+			expectedCount:             3,
+			expectedCountToSkip:       0,
+			expectedMaxBytes:          1500,
+		},
+		{
+			name: "file_config_nil_strategy_falls_back_to_global",
+			globalConfig: types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+				Count:               1,
+				CountToSkip:         0,
+				MaxBytes:            1000,
+			},
+			fileConfig: &types.FingerprintConfig{
+				// FingerprintStrategy not set
+				Count:       5,
+				CountToSkip: 2,
+				MaxBytes:    3000,
+			},
+			expectedShouldFingerprint: true,
+			expectedStrategy:          types.FingerprintStrategyLineChecksum,
+			expectedCount:             1, // Should use global config values
+			expectedCountToSkip:       0,
+			expectedMaxBytes:          1000,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(_ *testing.T) {
+			var source *sources.ReplaceableSource
+			if tc.fileConfig != nil {
+				source = sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+					Type:              config.FileType,
+					Path:              suite.testPath,
+					FingerprintConfig: tc.fileConfig,
+				}))
+			} else {
+				source = sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+					Type: config.FileType,
+					Path: suite.testPath,
+				}))
+			}
+
+			// Create fingerprinter with global config
+			fingerprinter := NewFingerprinter(tc.globalConfig)
+
+			file := NewFile(suite.testPath, source.UnderlyingSource(), false)
+
+			shouldFingerprint := fingerprinter.ShouldFileFingerprint(file)
+			suite.Equal(tc.expectedShouldFingerprint, shouldFingerprint,
+				"ShouldFileFingerprint should return %v for test case %s", tc.expectedShouldFingerprint, tc.name)
+
+			fingerprint, err := fingerprinter.ComputeFingerprint(file)
+			suite.Nil(err, "ComputeFingerprint should not return error for test case %s", tc.name)
+
+			if tc.expectedShouldFingerprint {
+				// If fingerprinting is enabled, verify the config used
+				suite.NotNil(fingerprint.Config, "Fingerprint config should not be nil for test case %s", tc.name)
+				suite.Equal(tc.expectedStrategy, fingerprint.Config.FingerprintStrategy,
+					"Fingerprint strategy should be %s for test case %s", tc.expectedStrategy, tc.name)
+				suite.Equal(tc.expectedCount, fingerprint.Config.Count,
+					"Fingerprint count should be %d for test case %s", tc.expectedCount, tc.name)
+				suite.Equal(tc.expectedCountToSkip, fingerprint.Config.CountToSkip,
+					"Fingerprint countToSkip should be %d for test case %s", tc.expectedCountToSkip, tc.name)
+				suite.Equal(tc.expectedMaxBytes, fingerprint.Config.MaxBytes,
+					"Fingerprint maxBytes should be %d for test case %s", tc.expectedMaxBytes, tc.name)
+			} else {
+				// If fingerprinting is disabled, return invalid fingerprint
+				suite.Equal(uint64(types.InvalidFingerprintValue), fingerprint.Value,
+					"Fingerprint value should be invalid for disabled test case %s", tc.name)
+			}
+		})
+	}
+}
+
+func (suite *FingerprintTestSuite) TestFingerprintConfigPrecedence() {
+	// check file-specific configs take precedence over global configs
+	testData := "line1\nline2\nline3\nline4\n"
+	_, err := suite.testFile.WriteString(testData)
+	suite.Nil(err)
+	suite.testFile.Sync()
+
+	// global config == line_checksum
+	globalConfig := types.FingerprintConfig{
+		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		Count:               1,
+		CountToSkip:         0,
+		MaxBytes:            1000,
+	}
+
+	// File config == byte_checksum - should override global
+	fileConfig := &types.FingerprintConfig{
+		FingerprintStrategy: types.FingerprintStrategyByteChecksum,
+		Count:               512,
+		CountToSkip:         0,
+		MaxBytes:            0,
+	}
+
+	source := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type:              config.FileType,
+		Path:              suite.testPath,
+		FingerprintConfig: fileConfig,
+	}))
+
+	fingerprinter := NewFingerprinter(globalConfig)
+
+	file := NewFile(suite.testPath, source.UnderlyingSource(), false)
+
+	// Should use file config (byte_checksum), not global config (line_checksum)
+	shouldFingerprint := fingerprinter.ShouldFileFingerprint(file)
+	suite.True(shouldFingerprint, "Should fingerprint with file config")
+
+	fingerprint, err := fingerprinter.ComputeFingerprint(file)
+	suite.Nil(err, "ComputeFingerprint should not return error")
+	suite.NotNil(fingerprint.Config, "Fingerprint config should not be nil")
+	suite.Equal(types.FingerprintStrategyByteChecksum, fingerprint.Config.FingerprintStrategy,
+		"Should use file config strategy (byte_checksum), not global config (line_checksum)")
+	suite.Equal(512, fingerprint.Config.Count,
+		"Should use file config count (512), not global config count (1)")
+}
+
+func (suite *FingerprintTestSuite) TestFingerprintConfigEdgeCases() {
+	// Write test data
+	testData := "line1\nline2\nline3\nline4\n"
+	_, err := suite.testFile.WriteString(testData)
+	suite.Nil(err)
+	suite.testFile.Sync()
+
+	testCases := []struct {
+		name                      string
+		globalConfig              types.FingerprintConfig
+		fileConfig                *types.FingerprintConfig
+		expectedShouldFingerprint bool
+		description               string
+	}{
+		{
+			name: "file_config_with_zero_values",
+			globalConfig: types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+				Count:               1,
+				CountToSkip:         0,
+				MaxBytes:            1000,
+			},
+			fileConfig: &types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+				Count:               0, // Zero count
+				CountToSkip:         0,
+				MaxBytes:            0, // Zero maxBytes
+			},
+			expectedShouldFingerprint: true,
+			description:               "File config with zero values should still be used",
+		},
+		{
+			name: "file_config_with_negative_values",
+			globalConfig: types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+				Count:               1,
+				CountToSkip:         0,
+				MaxBytes:            1000,
+			},
+			fileConfig: &types.FingerprintConfig{
+				FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+				Count:               -1, // Negative count
+				CountToSkip:         -1, // Negative countToSkip
+				MaxBytes:            -1, // Negative maxBytes
+			},
+			expectedShouldFingerprint: true,
+			description:               "File config with negative values should still be used",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(_ *testing.T) {
+			// Create source with the file config
+			source := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+				Type:              config.FileType,
+				Path:              suite.testPath,
+				FingerprintConfig: tc.fileConfig,
+			}))
+
+			// Create fingerprinter with global config
+			fingerprinter := NewFingerprinter(tc.globalConfig)
+
+			// Create file object
+			file := NewFile(suite.testPath, source.UnderlyingSource(), false)
+
+			// Test ShouldFileFingerprint
+			shouldFingerprint := fingerprinter.ShouldFileFingerprint(file)
+			suite.Equal(tc.expectedShouldFingerprint, shouldFingerprint,
+				"ShouldFileFingerprint should return %v for %s: %s",
+				tc.expectedShouldFingerprint, tc.name, tc.description)
+
+			// Test ComputeFingerprint
+			fingerprint, err := fingerprinter.ComputeFingerprint(file)
+			suite.Nil(err, "ComputeFingerprint should not return error for %s: %s", tc.name, tc.description)
+
+			if tc.expectedShouldFingerprint {
+				suite.NotNil(fingerprint.Config, "Fingerprint config should not be nil for %s", tc.name)
+				// Verify that file config values are used (even if they're zero or negative)
+				suite.Equal(tc.fileConfig.Count, fingerprint.Config.Count,
+					"Should use file config count for %s", tc.name)
+				suite.Equal(tc.fileConfig.CountToSkip, fingerprint.Config.CountToSkip,
+					"Should use file config countToSkip for %s", tc.name)
+				suite.Equal(tc.fileConfig.MaxBytes, fingerprint.Config.MaxBytes,
+					"Should use file config maxBytes for %s", tc.name)
+			}
+		})
+	}
 }

--- a/pkg/logs/tailers/file/rotate_nix.go
+++ b/pkg/logs/tailers/file/rotate_nix.go
@@ -73,5 +73,10 @@ func (t *Tailer) DidRotateViaFingerprint(fingerprinter *Fingerprinter) (bool, er
 
 	// If fingerprints are different, it means the file was rotated.
 	// This is also true if the new fingerprint is invalid (Value=0), which means the file was truncated.
-	return !t.fingerprint.Equals(newFingerprint), nil
+	rotated := !t.fingerprint.Equals(newFingerprint)
+	if rotated {
+		log.Debugf("File rotation detected via fingerprint mismatch for %s (old: 0x%x, new: 0x%x)",
+			t.file.Path, t.fingerprint.Value, newFingerprint.Value)
+	}
+	return rotated, nil
 }

--- a/pkg/logs/tailers/file/rotate_windows.go
+++ b/pkg/logs/tailers/file/rotate_windows.go
@@ -66,5 +66,10 @@ func (t *Tailer) DidRotateViaFingerprint(fingerprinter *Fingerprinter) (bool, er
 
 	// If fingerprints are different, it means the file was rotated.
 	// This is also true if the new fingerprint is invalid (Value=0), which means the file was truncated.
-	return !t.fingerprint.Equals(newFingerprint), nil
+	rotated := !t.fingerprint.Equals(newFingerprint)
+	if rotated {
+		log.Debugf("File rotation detected via fingerprint mismatch for %s (old: 0x%x, new: 0x%x)",
+			t.file.Path, t.fingerprint.Value, newFingerprint.Value)
+	}
+	return rotated, nil
 }

--- a/pkg/logs/types/fingerprint.go
+++ b/pkg/logs/types/fingerprint.go
@@ -41,6 +41,7 @@ type FingerprintConfig struct {
 	// FingerprintStrategy defines the strategy used for fingerprinting. Options are:
 	// - "line_checksum": compute checksum based on line content (default)
 	// - "byte_checksum": compute checksum based on byte content
+	// - "disabled": disable fingerprinting
 	FingerprintStrategy FingerprintStrategy `json:"fingerprint_strategy" mapstructure:"fingerprint_strategy" yaml:"fingerprint_strategy"`
 
 	// Count is the number of lines or bytes to use for fingerprinting, depending on the strategy
@@ -62,6 +63,8 @@ const (
 	FingerprintStrategyLineChecksum FingerprintStrategy = "line_checksum"
 	// FingerprintStrategyByteChecksum computes a checksum based on byte content
 	FingerprintStrategyByteChecksum FingerprintStrategy = "byte_checksum"
+	// FingerprintStrategyDisabled disables fingerprinting
+	FingerprintStrategyDisabled FingerprintStrategy = "disabled"
 )
 
 func (s FingerprintStrategy) String() string {
@@ -71,7 +74,7 @@ func (s FingerprintStrategy) String() string {
 // Validate checks if the fingerprint strategy is valid (either line_checksum or byte_checksum)
 func (s FingerprintStrategy) Validate() error {
 	switch s {
-	case FingerprintStrategyLineChecksum, FingerprintStrategyByteChecksum:
+	case FingerprintStrategyLineChecksum, FingerprintStrategyByteChecksum, FingerprintStrategyDisabled:
 		return nil
 	}
 	return fmt.Errorf("invalid fingerprint strategy: %s", s)

--- a/releasenotes/notes/fingerprint-selective-enablement-config-47a98af72a91a0de.yaml
+++ b/releasenotes/notes/fingerprint-selective-enablement-config-47a98af72a91a0de.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Enhanced fingerprinting configuration with file-specific overrides and improved fallback behavior. 
+    `logs_config.fingerprint_config` can now be set on a per-source and global basis, as either [disabled, line_checksum, byte_checksum].
+
+    File-specific configurations take precedence over global settings, with automatic fallback to global config when file configs
+    are missing or incomplete.


### PR DESCRIPTION
### What does this PR do?
Updates Logs Agent fingerprinting configuration so fingerprinting can be turned on/off at a global and source-specific level. Source-specific config overrides the global config when specified, otherwise we fallback to the global default. 

<details><summary>Cleans up fingerprint logs: </summary>
<p>

Add:
- log rotation detection: "File rotation detected via fingerprint mismatch for %s (old: 0x%x, new: 0x%x)"
- log when creating tailers with/out fingerprints

Remove from `fingerprint.go`: 
- fingerprinter creation
- per-file fingerprinting decisions 
- fingerprint config usage 
- fingerprint computation 
- fingerprint strategy selection 

</p>
</details> 



### Motivation
https://datadoghq.atlassian.net/browse/AGNTLOG-281

### Describe how you validated your changes
unit tests 

<details><summary>Local Testing</summary>
<p>

With this Agent config:
```
logs_config:
  # Global fingerprint config with "disabled" strategy (new default)
  fingerprint_config:
    fingerprint_strategy: "disabled"

# Test log sources with different fingerprint configurations
logs:
  # Source 1: Use global config (disabled) - should show "Fingerprinting disabled globally"
  - type: file
    path: /var/log/test1.log
    service: test1
    source: test1

  # Source 2: Override with line_checksum strategy - should show "File will be fingerprinted"
  - type: file
    path: /var/log/test2.log
    service: test2
    source: test2
    fingerprint_config:
      fingerprint_strategy: "line_checksum"
      count: 2
      count_to_skip: 0
      max_bytes: 5000

  # Source 3: Override with byte_checksum strategy - should show "File will be fingerprinted"
  - type: file
    path: /var/log/test3.log
    service: test3
    source: test3
    fingerprint_config:
      fingerprint_strategy: "byte_checksum"
      count: 512
      count_to_skip: 0

  # Source 4: Explicitly disable fingerprinting - should show "Fingerprinting disabled for this source"
  - type: file
    path: /var/log/test4.log
    service: test4
    source: test4
    fingerprint_config:
      fingerprint_strategy: "disabled"

``` 

Verify Agent behavior:

```
2025-09-11 18:24:06 UTC | CORE | DEBUG | (pkg/logs/tailers/file/fingerprint.go:73 in ShouldFileFingerprint) | Fingerprinting disabled globally, skipping file /var/log/test1.log

2025-09-11 18:23:56 UTC | CORE | DEBUG | (pkg/logs/tailers/file/fingerprint.go:67 in ShouldFileFingerprint) | File /var/log/test2.log will be fingerprinted with per-source config (strategy: line_checksum)

2025-09-11 18:23:46 UTC | CORE | DEBUG | (pkg/logs/tailers/file/fingerprint.go:67 in ShouldFileFingerprint) | File /var/log/test3.log will be fingerprinted with per-source config (strategy: byte_checksum)

2025-09-11 18:23:36 UTC | CORE | DEBUG | (pkg/logs/tailers/file/fingerprint.go:64 in ShouldFileFingerprint) | Fingerprinting disabled for source test4, skipping file /var/log/test4.log
```

</p>
</details> 

### Additional Notes
