### PR TITLE
disable preaggregation endpoint for otel-agent

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -208,6 +208,9 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 		pkgconfig.Set("proxy.https", ddc.ProxyURL, pkgconfigmodel.SourceLocalConfigProcess)
 	}
 
+	// Disable preaggregation feature for otel-agent since it needs encrypted API keys and that's non-trivial
+	pkgconfig.Set("preaggregation.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+
 	return pkgconfig, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Disables preaggregation pipeline feature in the otel agent.

### Motivation

The feature needs an API key of its own, but the otel agent does not decrypt secrets from the agent config file on its own. The workaround of loading the new secret from the core agent config was deemed too invasive and not worthwhile for an experimental feature.

### Describe how you validated your changes

Running the otel agent locally with a core agent config enabling preaggregation, ensuring that the otel agent did not pick up the preaggregation endpoint or attempt to send any data.

### Additional Notes
