### PR TITLE
[USMON-1481] usm: config: Migrate Kafka configuration to tree structure

### DIFF
--- a/cmd/system-probe/modules/usm_endpoints_linux.go
+++ b/cmd/system-probe/modules/usm_endpoints_linux.go
@@ -26,7 +26,7 @@ func registerUSMEndpoints(nt *networkTracer, httpMux *module.Router) {
 	registerUSMCommonEndpoints(nt, httpMux)
 
 	httpMux.HandleFunc("/debug/kafka_monitoring", func(w http.ResponseWriter, req *http.Request) {
-		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.enable_kafka_monitoring") {
+		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.kafka.enabled") {
 			writeDisabledProtocolMessage("kafka", w)
 			return
 		}

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -325,7 +325,7 @@ func (ia *inventoryagent) fetchSystemProbeMetadata() {
 	ia.data["feature_networks_https_enabled"] = sysProbeConf.GetBool("service_monitoring_config.tls.native.enabled")
 
 	ia.data["feature_usm_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enabled")
-	ia.data["feature_usm_kafka_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enable_kafka_monitoring")
+	ia.data["feature_usm_kafka_enabled"] = sysProbeConf.GetBool("service_monitoring_config.kafka.enabled")
 	ia.data["feature_usm_postgres_enabled"] = sysProbeConf.GetBool("service_monitoring_config.postgres.enabled")
 	ia.data["feature_usm_redis_enabled"] = sysProbeConf.GetBool("service_monitoring_config.redis.enabled")
 	ia.data["feature_usm_http2_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enable_http2_monitoring")

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -124,7 +124,7 @@ func TestInitData(t *testing.T) {
 		"service_monitoring_config.tls.native.enabled":         true,
 		"service_monitoring_config.enabled":                    true,
 		"service_monitoring_config.enable_http2_monitoring":    true,
-		"service_monitoring_config.enable_kafka_monitoring":    true,
+		"service_monitoring_config.kafka.enabled":              true,
 		"service_monitoring_config.postgres.enabled":           true,
 		"service_monitoring_config.redis.enabled":              true,
 		"service_monitoring_config.tls.istio.enabled":          true,
@@ -616,7 +616,8 @@ service_monitoring_config:
     go:
       enabled: true
   enabled: true
-  enable_kafka_monitoring: true
+  kafka:
+    enabled: true
   postgres:
     enabled: true
   redis:

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -92,11 +92,11 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// ========================================
 	cfg.BindEnvAndSetDefault(join(smNS, "kafka", "enabled"), false)
 	// For backward compatibility
-	cfg.BindEnv(join(smNS, "enable_kafka_monitoring"))
+	cfg.BindEnvAndSetDefault(join(smNS, "enable_kafka_monitoring"), false)
 
 	cfg.BindEnvAndSetDefault(join(smNS, "kafka", "max_stats_buffered"), 100000)
 	// For backward compatibility
-	cfg.BindEnv(join(smNS, "max_kafka_stats_buffered"))
+	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
 
 	// ========================================
 	// PostgreSQL Protocol Configuration

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -90,8 +90,13 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// ========================================
 	// Kafka Protocol Configuration
 	// ========================================
-	cfg.BindEnvAndSetDefault(join(smNS, "enable_kafka_monitoring"), false)
-	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
+	cfg.BindEnvAndSetDefault(join(smNS, "kafka", "enabled"), false)
+	// For backward compatibility
+	cfg.BindEnv(join(smNS, "enable_kafka_monitoring"))
+
+	cfg.BindEnvAndSetDefault(join(smNS, "kafka", "max_stats_buffered"), 100000)
+	// For backward compatibility
+	cfg.BindEnv(join(smNS, "max_kafka_stats_buffered"))
 
 	// ========================================
 	// PostgreSQL Protocol Configuration

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -192,8 +192,8 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		HTTP2DynamicTableMapCleanerInterval: time.Duration(cfg.GetInt(sysconfig.FullKeyPath(smNS, "http2_dynamic_table_map_cleaner_interval_seconds"))) * time.Second,
 
 		// Kafka Protocol Configuration
-		EnableKafkaMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "enable_kafka_monitoring")),
-		MaxKafkaStatsBuffered: cfg.GetInt(sysconfig.FullKeyPath(smNS, "max_kafka_stats_buffered")),
+		EnableKafkaMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "kafka", "enabled")),
+		MaxKafkaStatsBuffered: cfg.GetInt(sysconfig.FullKeyPath(smNS, "kafka", "max_stats_buffered")),
 
 		// Postgres Protocol Configuration
 		EnablePostgresMonitoring:   cfg.GetBool(sysconfig.FullKeyPath(smNS, "postgres", "enabled")),

--- a/pkg/system-probe/config/adjust_usm.go
+++ b/pkg/system-probe/config/adjust_usm.go
@@ -37,6 +37,8 @@ func adjustUSM(cfg model.Config) {
 	// shorten the allowed path, but not lengthen it.
 	applyDefault(cfg, smNS("http_max_request_fragment"), maxHTTPFrag)
 	applyDefault(cfg, smNS("max_concurrent_requests"), cfg.GetInt(spNS("max_tracked_connections")))
+	deprecateBool(cfg, smNS("enable_kafka_monitoring"), smNS("kafka", "enabled"))
+	deprecateInt(cfg, smNS("max_kafka_stats_buffered"), smNS("kafka", "max_stats_buffered"))
 	deprecateBool(cfg, smNS("process_service_inference", "enabled"), spNS("process_service_inference", "enabled"))
 	deprecateBool(cfg, smNS("process_service_inference", "use_windows_service_name"), spNS("process_service_inference", "use_windows_service_name"))
 

--- a/releasenotes/notes/usm-kafka-config-tree-migration-e4bf9cd96e4a2d62.yaml
+++ b/releasenotes/notes/usm-kafka-config-tree-migration-e4bf9cd96e4a2d62.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    ``service_monitoring_config.enable_kafka_monitoring`` is deprecated and replaced by ``service_monitoring_config.kafka.enabled``.
+    ``service_monitoring_config.max_kafka_stats_buffered`` is deprecated and replaced by ``service_monitoring_config.kafka.max_stats_buffered``.
+    The old configuration keys will continue to work but users are encouraged to migrate to the new tree structure for consistency with other protocol configurations.


### PR DESCRIPTION
### What does this PR do?

Migrates Kafka monitoring configuration from flat structure to tree structure while maintaining full backward compatibility.

**Configuration Migration:**
- `service_monitoring_config.enable_kafka_monitoring` → `service_monitoring_config.kafka.enabled`
- `service_monitoring_config.max_kafka_stats_buffered` → `service_monitoring_config.kafka.max_stats_buffered`

### Motivation

USMON-1481 requires migrating Kafka configuration to use a nested tree structure consistent with other protocol configurations (Postgres, Redis) rather than flat keys. This improves configuration organization and maintainability.

### Describe how you validated your changes

1. **Build Verification**: Successfully built system-probe binary with all changes
2. **Comprehensive Test Coverage**: Added extensive test cases including:
   - New tree structure configuration (YAML & ENV)
   - Backward compatibility with old flat keys (YAML & ENV) 
   - "Both enabled" scenarios verifying new config takes precedence
   - Default value testing
3. **Repository-wide Search**: Found and updated all references to old config keys:
   - `cmd/system-probe/modules/usm_endpoints_linux.go` - Debug endpoint config check
   - `comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go` - Inventory metadata
   - `comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go` - Test configurations
4. **Deprecation System**: Implemented proper deprecation warnings using existing patterns
5. **Configuration Binding**: Added backward compatibility bindings alongside new tree structure

**Files Modified (7 total):**
- `pkg/config/setup/system_probe_usm.go` - Config binding with backward compatibility
- `pkg/system-probe/config/adjust_usm.go` - Deprecation logic 
- `pkg/network/config/usm_config.go` - Config usage update
- `pkg/network/config/usm_config_test.go` - Comprehensive test coverage
- `comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go` - Inventory update
- `comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go` - Test update
- `cmd/system-probe/modules/usm_endpoints_linux.go` - Debug endpoint update

### Additional Notes

- **Full Backward Compatibility**: Existing configurations using old keys continue to work unchanged
- **Precedence Handling**: New tree structure takes precedence when both old and new keys are set
- **Consistent with Other Protocols**: Follows same pattern as Postgres (`postgres.enabled`) and Redis (`redis.enabled`)
- **Zero Breaking Changes**: Users can migrate at their own pace while receiving deprecation warnings