### PR TITLE
dyninst/uploader: do not send batcher larger than limit

### DIFF
--- a/pkg/dyninst/uploader/batcher_snapshot_test.go
+++ b/pkg/dyninst/uploader/batcher_snapshot_test.go
@@ -96,7 +96,7 @@ func runSnapshotFile(t *testing.T, file string, envRewrite bool) {
 	events, err := parseBatcherEvents(eventsNode.Content)
 	require.NoError(t, err)
 
-	state := newBatcherState(cfg)
+	state := newBatcherState("test", cfg)
 	virtualNow := time.Duration(0)
 
 	var outputs [][]byte
@@ -211,7 +211,8 @@ func (s *batcherState) handleEvent(e event, now time.Time, eff effects) error {
 	case timerFiredEvent:
 		return s.handleTimerFiredEvent(eff)
 	case batchOutcomeEvent:
-		return s.handleBatchOutcomeEvent(sendResult(ev), eff)
+		_, err := s.handleBatchOutcomeEvent(sendResult(ev), eff)
+		return err
 	case stopEvent:
 		s.handleStopEvent(eff)
 		return nil

--- a/pkg/dyninst/uploader/testdata/snapshot/threshold_size_flush_single_big_message.yaml
+++ b/pkg/dyninst/uploader/testdata/snapshot/threshold_size_flush_single_big_message.yaml
@@ -4,8 +4,10 @@ config:
   max_buffer_ms: 200
 events:
   - !enqueue {value: "a"}
+  - !enqueue {value: "over the limit"}
   - !enqueue {value: "b"}
   - !batch-outcome {id: 0, success: true}
+  - !batch-outcome {id: 1, success: true}
   - !stop {} 
 ---
 now: 0s
@@ -19,16 +21,26 @@ state:
   timer_set: true
 ---
 now: 0s
-next_flush: 200ms
-event: !enqueue {value: "b"}
+event: !enqueue {value: "over the limit"}
 effects:
   - !send-batch {id: 0, items: 1, bytes: 3}
   - !reset-timer {}
+  - !send-batch {id: 1, items: 1, bytes: 16}
+state:
+  batch_len: 0
+  current_size: 0
+  inflight: [0, 1]
+  timer_set: false
+---
+now: 0s
+next_flush: 200ms
+event: !enqueue {value: "b"}
+effects:
   - !reset-timer {ts: 200ms (+200ms)}
 state:
   batch_len: 1
   current_size: 3
-  inflight: [0]
+  inflight: [0, 1]
   timer_set: true
 ---
 now: 0s
@@ -37,11 +49,24 @@ event: !batch-outcome {id: 0, success: true}
 state:
   batch_len: 1
   current_size: 3
+  inflight: [1]
   timer_set: true
 metrics:
   batches_sent: 1 (+1)
   bytes_sent: 3 (+3)
   items_sent: 1 (+1)
+---
+now: 0s
+next_flush: 200ms
+event: !batch-outcome {id: 1, success: true}
+state:
+  batch_len: 1
+  current_size: 3
+  timer_set: true
+metrics:
+  batches_sent: 2 (+1)
+  bytes_sent: 19 (+16)
+  items_sent: 2 (+1)
 ---
 now: 0s
 event: !stop {}


### PR DESCRIPTION
### What does this PR do?

Before this change, we'd flush *after* adding a message that puts the batch over the limit. Now we'll flush the current buffer before exceeding the limit.

Fixes https://datadoghq.atlassian.net/browse/DEBUG-4480

### Motivation

We've been seeing 413 errors in staging.

### Describe how you validated your changes

Added testing.
