### PR TITLE
fix(add_reviewer): Update token permissions

### DIFF
--- a/.github/chainguard/self.add-reviewer-bot-pr.review-pr.sts.yaml
+++ b/.github/chainguard/self.add-reviewer-bot-pr.review-pr.sts.yaml
@@ -10,4 +10,6 @@ claim_pattern:
 
 permissions:
   contents: read
+  members: read
+  metadata: read
   pull_requests: write


### PR DESCRIPTION
### What does this PR do?
- Update the permissions for the `Add reviewers on dependency bot PR` workflow

### Motivation
This is currently [failing](https://github.com/DataDog/datadog-agent/actions/runs/17620619910/job/50065170671) with 422 error, but sounds like we need to have members permissions as it was done [in the Github App](https://github.com/apps/agent-platform-auto-pr/installations/45116690)

### Describe how you validated your changes

### Additional Notes
