### PR TITLE
dyninst/module: quiet error logging when no successful probes

### DIFF
--- a/pkg/dyninst/module/reporter.go
+++ b/pkg/dyninst/module/reporter.go
@@ -68,7 +68,6 @@ func (c *controllerReporter) ReportIRGenFailed(
 	err error,
 	probes []ir.ProbeDefinition,
 ) {
-	log.Errorf("IR generation for process %v failed: %v", procID, err)
 	ctrl := (*Controller)(c)
 	runtimeID, ok := ctrl.store.getRuntimeID(procID)
 	if !ok {
@@ -92,6 +91,8 @@ func (c *controllerReporter) ReportIRGenFailed(
 		}
 		return
 	}
+
+	log.Errorf("IR generation for process %v failed: %v", procID, err)
 	for _, probe := range probes {
 		ctrl.diagnostics.reportError(runtimeID, probe, err, "IRGenFailed")
 	}


### PR DESCRIPTION
This is an expected situation, we shouldn't log at such a high verbosity.

