### PR TITLE
[dynamic test] Fix status field value for failure

### DIFF
--- a/tasks/libs/dynamic_test/evaluator.py
+++ b/tasks/libs/dynamic_test/evaluator.py
@@ -388,7 +388,7 @@ This indicates an issue with the dynamic test system that may affect CI performa
         for test in current_job_tests:
             if test.name not in indexed_tests:
                 continue
-            if test.status == "failed" and not test.unreliable_status and test.name not in predicted_executed_tests:
+            if test.status == "fail" and not test.unreliable_status and test.name not in predicted_executed_tests:
                 not_executed_failing_tests.add(test.name)
 
         return EvaluationResult(job, actual_executed_tests, predicted_executed_tests, not_executed_failing_tests)


### PR DESCRIPTION
### What does this PR do?

Value for status is field on failure is `fail` instead of `failed`

### Motivation

### Describe how you validated your changes

### Additional Notes
