### PR TITLE
Disable bazel deps build on Windows

### DIFF
--- a/.gitlab/bazel/build-deps.yaml
+++ b/.gitlab/bazel/build-deps.yaml
@@ -29,7 +29,8 @@ bazel:build-deps:macos-arm64:
   script:
     - bazel build //deps/...
 
-bazel:build-deps:windows-amd64:
+# TODO(agent-build): re-enable when we're sure they won't cause problems (#incident-42947)
+.bazel:build-deps:windows-amd64:
   extends: [ .bazel:build-deps, .bazel:ext:windows ]
   variables:
     ARCH: x64


### PR DESCRIPTION
### What does this PR do?

Disables the bazel deps build job on windows.

### Motivation

https://github.com/DataDog/datadog-agent/pull/40153 added bazel jobs that confirm that the bazel installation is working as expected and to make sure we keep being able to build what we've done so far.

We've seen a number of failures (such as [this one](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1120272416)) where jobs are timing out after failing to connect to the Bazel server (`FATAL: couldn't connect to server (12260) after 120 seconds.`). Failures can also be seen [here](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40git.repository.id%3Agitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40ci.job.name%3A%22bazel%3Abuild-deps%3Awindows-amd64%22%20%40ci.status%3Aerror%20%40error.type%3A%28job_execution_timeout%20OR%20stuck_or_timeout_failure%29&agg_m=count&agg_m_source=base&agg_t=count&colorByAttr=meta%5B%27ci.stage.name%27%5D&currentTab=trace&fromUser=true&graphType=flamegraph&sort=time&tab=overview&start=1756392795881&end=1757688795881&paused=false).

We also have #incident-42947 going on which may or may not be linked to this; we want to reduce possible sources of failure by disabling this temporarily.

### Describe how you validated your changes

Not needed.

### Additional Notes
