### PR TITLE
Windows 2025 jobs must be allowed to fail

### DIFF
--- a/.gitlab/trigger_distribution/conditions.yml
+++ b/.gitlab/trigger_distribution/conditions.yml
@@ -174,6 +174,9 @@
 
 # The windows-v2 runner is currently only used in container_build jobs needed to do authenticated push. It should not replace the basic windows runner, unless agreeded first with #ci-infra team
 .windows_docker_2025:
+  # The windows 2025 runners are expeimental and cannot be in the critical path
+  # This should not be changed without approval from #ci-infra team
+  allow_failure: true
   tags: ["windows-v2:2025"]
   variables:
     # Full image name for Agent windows build image, for use in docker run command


### PR DESCRIPTION
### What does this PR do?

Configure any CI job using windows 2025 with allow_failure

### Motivation

Windows 2025 runners are experimental and cannot be in the critical path today

### Describe how you validated your changes

Tested in CI
