### PR TITLE
add installer test with proxy

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -697,6 +697,7 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestManagedConfigActiveAfterUpgrade$"
       # install-exe
       - EXTRA_PARAMS: --run "TestInstallExe$/TestInstallAgentPackage$"
+      - EXTRA_PARAMS: --run "TestInstallExeWithProxy$/TestInstallAgentPackageWithProxy$"
       # install-script
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallAgentPackage$"
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallFromOldInstaller$"

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -257,7 +257,7 @@ func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 	s.Require().NoError(os.MkdirAll(outputDir, 0755))
 
 	s.installer = NewDatadogInstaller(s.Env(), s.CurrentAgentVersion().MSIPackage().URL, outputDir)
-	s.installScriptImpl = NewDatadogInstallScript(s.Env())
+	s.installScriptImpl = NewDatadogInstallScript(s.Env().RemoteHost)
 
 	// clear the event logs before each test
 	for _, logName := range []string{"System", "Application"} {

--- a/test/new-e2e/tests/installer/windows/install_script.go
+++ b/test/new-e2e/tests/installer/windows/install_script.go
@@ -7,6 +7,7 @@ package installer
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -74,6 +75,15 @@ func (b *baseInstaller) getInstallerURL(params Params) (string, error) {
 // Always sets DD_REMOTE_UPDATES to true to ensure remote updates are enabled.
 func (b *baseInstaller) getBaseEnvVars() map[string]string {
 	envVars := installer.InstallScriptEnv(e2eos.AMD64Arch)
+	apiKey := os.Getenv("DD_API_KEY")
+	if apiKey == "" {
+		var err error
+		apiKey, err = runner.GetProfile().SecretStore().Get(parameters.APIKey)
+		if apiKey == "" || err != nil {
+			apiKey = "deadbeefdeadbeefdeadbeefdeadbeef"
+		}
+	}
+	envVars["DD_API_KEY"] = apiKey
 	for k, v := range b.params.extraEnvVars {
 		envVars[k] = v
 	}

--- a/test/new-e2e/tests/installer/windows/install_script.go
+++ b/test/new-e2e/tests/installer/windows/install_script.go
@@ -13,7 +13,6 @@ import (
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
@@ -27,14 +26,14 @@ import (
 // It provides shared methods for handling installer URLs, environment variables,
 // and file operations that are common across different installer types.
 type baseInstaller struct {
-	env    *environments.WindowsHost
+	host   *components.RemoteHost
 	params Params
 }
 
 // newBaseInstaller creates a new base installer with common initialization.
 // It sets up the default parameters and applies any provided options.
 // Panics if any option application fails, as this is a programming error.
-func newBaseInstaller(env *environments.WindowsHost, opts ...Option) baseInstaller {
+func newBaseInstaller(host *components.RemoteHost, opts ...Option) baseInstaller {
 	params := Params{
 		extraEnvVars: make(map[string]string),
 	}
@@ -43,7 +42,7 @@ func newBaseInstaller(env *environments.WindowsHost, opts ...Option) baseInstall
 		panic(err)
 	}
 	return baseInstaller{
-		env:    env,
+		host:   host,
 		params: params,
 	}
 }
@@ -56,7 +55,12 @@ func (b *baseInstaller) getInstallerURL(params Params) (string, error) {
 		return params.installerURL, nil
 	}
 
-	artifactURL, err := pipeline.GetPipelineArtifact(b.env.Environment.PipelineID(), pipeline.AgentS3BucketTesting, pipeline.DefaultMajorVersion, func(artifact string) bool {
+	pipelineID := params.pipelineID
+	if pipelineID == "" {
+		// fallback to profile pipeline if set, else empty
+		pipelineID, _ = runner.GetProfile().ParamStore().GetWithDefault(parameters.PipelineID, "")
+	}
+	artifactURL, err := pipeline.GetPipelineArtifact(pipelineID, pipeline.AgentS3BucketTesting, pipeline.DefaultMajorVersion, func(artifact string) bool {
 		return strings.Contains(artifact, "datadog-installer") && strings.HasSuffix(artifact, ".exe")
 	})
 	if err != nil {
@@ -85,9 +89,9 @@ type DatadogInstallScript struct {
 
 // NewDatadogInstallScript instantiates a new instance of the Datadog Install Script running on
 // a remote Windows host. It initializes the base installer with the provided options.
-func NewDatadogInstallScript(env *environments.WindowsHost, opts ...Option) *DatadogInstallScript {
+func NewDatadogInstallScript(host *components.RemoteHost, opts ...Option) *DatadogInstallScript {
 	return &DatadogInstallScript{
-		baseInstaller: newBaseInstaller(env, opts...),
+		baseInstaller: newBaseInstaller(host, opts...),
 	}
 }
 
@@ -121,7 +125,7 @@ func (b *baseInstaller) prepareInstaller(params Params) (string, error) {
 	}
 
 	// Handle local installer URL
-	installerPath, err := copyFileURLsToHost(b.env.RemoteHost, installerURL)
+	installerPath, err := copyFileURLsToHost(b.host, installerURL)
 	if err != nil {
 		return "", err
 	}
@@ -145,11 +149,15 @@ func (b *baseInstaller) prepareEnvVars(params Params) map[string]string {
 // Handles local file URLs by copying the script to the remote host.
 func (d *DatadogInstallScript) prepareScript(params Params) (string, error) {
 	if params.installerScript == "" {
-		params.installerScript = fmt.Sprintf("https://s3.amazonaws.com/installtesting.datad0g.com/pipeline-%s/scripts/Install-Datadog.ps1", d.env.Environment.PipelineID())
+		pipelineID := params.pipelineID
+		if pipelineID == "" {
+			pipelineID, _ = runner.GetProfile().ParamStore().GetWithDefault(parameters.PipelineID, "")
+		}
+		params.installerScript = fmt.Sprintf("https://s3.amazonaws.com/installtesting.datad0g.com/pipeline-%s/scripts/Install-Datadog.ps1", pipelineID)
 	}
 
 	// Handle local script URL
-	scriptPath, err := copyFileURLsToHost(d.env.RemoteHost, params.installerScript)
+	scriptPath, err := copyFileURLsToHost(d.host, params.installerScript)
 	if err != nil {
 		return "", err
 	}
@@ -204,7 +212,7 @@ func (d *DatadogInstallScript) Run(opts ...Option) (string, error) {
 			iex ((New-Object System.Net.WebClient).DownloadString('%s'))`, scriptPath)
 	}
 
-	return d.env.RemoteHost.Execute(cmd, client.WithEnvVariables(envVars))
+	return d.host.Execute(cmd, client.WithEnvVariables(envVars))
 }
 
 // InstallScriptRunner represents an interface for installing Datadog on Windows.
@@ -220,9 +228,9 @@ type DatadogInstallExe struct {
 
 // NewDatadogInstallExe instantiates a new instance of the Datadog Installer exe running on
 // a remote Windows host. It initializes the base installer with the provided options.
-func NewDatadogInstallExe(env *environments.WindowsHost, opts ...Option) *DatadogInstallExe {
+func NewDatadogInstallExe(host *components.RemoteHost, opts ...Option) *DatadogInstallExe {
 	return &DatadogInstallExe{
-		baseInstaller: newBaseInstaller(env, opts...),
+		baseInstaller: newBaseInstaller(host, opts...),
 	}
 }
 
@@ -262,5 +270,5 @@ func (d *DatadogInstallExe) Run(opts ...Option) (string, error) {
 			& $tempFile`, installerPath)
 	}
 
-	return d.env.RemoteHost.Execute(cmd, client.WithEnvVariables(envVars))
+	return d.host.Execute(cmd, client.WithEnvVariables(envVars))
 }

--- a/test/new-e2e/tests/installer/windows/params.go
+++ b/test/new-e2e/tests/installer/windows/params.go
@@ -22,6 +22,7 @@ type Params struct {
 	// but they can (and should) be passed to the executable.
 	installerScript string
 	extraEnvVars    map[string]string
+	pipelineID      string
 }
 
 // Option is an optional function parameter type for the Params
@@ -55,6 +56,14 @@ func WithInstallerURL(installerURL string) Option {
 func WithInstallerScript(installerScript string) Option {
 	return func(params *Params) error {
 		params.installerScript = installerScript
+		return nil
+	}
+}
+
+// WithPipelineID sets the pipeline ID to fetch artifacts/scripts from.
+func WithPipelineID(id string) Option {
+	return func(params *Params) error {
+		params.pipelineID = id
 		return nil
 	}
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/install_test.go
@@ -61,7 +61,7 @@ func (s *testAgentInstallSuite) installAgent() {
 }
 
 func (s *testAgentInstallSuite) installAgentViaSetupScript() {
-	installExe := installerwindows.NewDatadogInstallExe(s.Env())
+	installExe := installerwindows.NewDatadogInstallExe(s.Env().RemoteHost)
 
 	// Act - This calls the same path as Fleet Automation setup script: installer.exe setup --flavor default
 	output, err := installExe.Run()

--- a/test/new-e2e/tests/installer/windows/suites/install-exe/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-exe/install_test.go
@@ -46,7 +46,7 @@ func TestInstallExe(t *testing.T) {
 // BeforeTest sets up the test
 func (s *testInstallExeSuite) BeforeTest(suiteName, testName string) {
 	s.BaseSuite.BeforeTest(suiteName, testName)
-	s.SetInstallScriptImpl(installerwindows.NewDatadogInstallExe(s.Env(),
+	s.SetInstallScriptImpl(installerwindows.NewDatadogInstallExe(s.Env().RemoteHost,
 		installerwindows.WithInstallScriptDevEnvOverrides("CURRENT_AGENT"),
 	))
 }

--- a/test/new-e2e/tests/installer/windows/suites/install-exe/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-exe/install_test.go
@@ -7,11 +7,22 @@ package agenttests
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
 	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	installerhost "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	infraos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // testInstallExeSuite is a test suite that uses the exe installer
@@ -72,4 +83,117 @@ func (s *testInstallExeSuite) TestInstallAgentPackage() {
 			s.Require().Contains(actual, s.CurrentAgentVersion().PackageVersion())
 		}).
 		WithExperimentVersionEqual("")
+}
+
+// proxyEnv provisions a Windows VM (for the installer) and a Linux VM (hosting a Squid proxy)
+type proxyEnv struct {
+	WindowsVM  *components.RemoteHost
+	LinuxProxy *components.RemoteHost
+}
+
+// proxyEnvProvisioner provisions the two VMs
+func proxyEnvProvisioner() provisioners.PulumiEnvRunFunc[proxyEnv] {
+	return func(ctx *pulumi.Context, env *proxyEnv) error {
+		awsEnv, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+
+		win, err := ec2.NewVM(awsEnv, "WindowsVM", ec2.WithOS(infraos.WindowsDefault))
+		if err != nil {
+			return err
+		}
+		win.Export(ctx, &env.WindowsVM.HostOutput)
+
+		lin, err := ec2.NewVM(awsEnv, "LinuxProxyVM", ec2.WithOS(infraos.UbuntuDefault))
+		if err != nil {
+			return err
+		}
+		lin.Export(ctx, &env.LinuxProxy.HostOutput)
+		return nil
+	}
+}
+
+// testInstallExeProxySuite installs via the installer exe while using an HTTP(S) proxy
+type testInstallExeProxySuite struct {
+	e2e.BaseSuite[proxyEnv]
+}
+
+// TestInstallExeWithProxy provisions a Windows host and a Linux proxy host, configures the proxy, then installs via the exe using that proxy
+func TestInstallExeWithProxy(t *testing.T) {
+	e2e.Run(
+		t,
+		&testInstallExeProxySuite{},
+		e2e.WithPulumiProvisioner(proxyEnvProvisioner(), nil),
+	)
+}
+
+func (s *testInstallExeProxySuite) TestInstallAgentPackageWithProxy() {
+	// Arrange: start Squid on the Linux host
+	linuxHost := installerhost.New(s.T, s.Env().LinuxProxy, infraos.UbuntuDefault, infraos.AMD64Arch)
+	linuxHost.SetupProxy()
+	// s.T().Cleanup(func() { linuxHost.RemoveProxy() })
+
+	// Build proxy env vars for Windows installer
+	proxyURL := fmt.Sprintf("http://%s:3128", s.Env().LinuxProxy.HostOutput.Address)
+	proxyIP := s.Env().LinuxProxy.HostOutput.Address
+	envVars := map[string]string{
+		"DD_PROXY_HTTP":     proxyURL,
+		"DD_PROXY_HTTPS":    proxyURL,
+		"DD_API_KEY":        "deadbeefdeadbeefdeadbeefdeadbeef",
+		"DD_SITE":           "datadoghq.com",
+		"DD_REMOTE_UPDATES": "true",
+	}
+
+	// Configure Windows Firewall to allow outbound only to the proxy (80/443), then install via proxy
+	fw := fmt.Sprintf(`
+		$proxyIp = '%s'
+		# Block all outbound by default, then allow only the proxy for 80/443
+		Set-NetFirewallProfile -Profile Domain,Public,Private -DefaultOutboundAction Block
+		New-NetFirewallRule -DisplayName 'AllowProxy80' -Direction Outbound -Action Allow -RemoteAddress $proxyIp -Protocol TCP -RemotePort 80
+		New-NetFirewallRule -DisplayName 'AllowProxy443' -Direction Outbound -Action Allow -RemoteAddress $proxyIp -Protocol TCP -RemotePort 443
+	`, proxyIP)
+	_, err := s.Env().WindowsVM.Execute(fw)
+	s.Require().NoError(err)
+
+	// Ensure firewall rules are cleaned up even if the test fails
+	s.T().Cleanup(func() {
+		_, _ = s.Env().WindowsVM.Execute(`Remove-NetFirewallRule -DisplayName 'AllowProxy80' -ErrorAction SilentlyContinue; Remove-NetFirewallRule -DisplayName 'AllowProxy443' -ErrorAction SilentlyContinue; Set-NetFirewallProfile -Profile Domain,Public,Private -DefaultOutboundAction Allow`)
+	})
+
+	ps := `
+		[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+		$temp = [System.IO.Path]::GetTempFileName() + '.exe';
+		$uri  = 'https://install.datadoghq.com/datadog-installer-x86_64.exe';
+		(New-Object System.Net.WebClient).DownloadFile($uri, $temp);
+		& $temp setup --flavor default
+	`
+	output, err := s.Env().WindowsVM.Execute(ps, client.WithEnvVariables(envVars))
+	if s.NoError(err) {
+		fmt.Printf("%s\n", output)
+	}
+
+	// Assert: installer and agent services are running
+	_, err = s.Env().WindowsVM.Execute(`if ((Get-Service -Name 'Datadog Installer').Status -ne 'Running') { throw 'Installer not running' }`)
+	s.Require().NoError(err)
+	_, err = s.Env().WindowsVM.Execute(`if ((Get-Service -Name 'datadogagent').Status -ne 'Running') { throw 'Agent not running' }`)
+	s.Require().NoError(err)
+
+	// Verify squid-proxy saw traffic to the container/installer host (configurable)
+	registryHost := os.Getenv("DD_TEST_REGISTRY_HOST")
+	if registryHost == "" {
+		registryHost = "install.datadoghq.com"
+	}
+	var logs string
+	found := false
+	for i := 0; i < 30; i++ {
+		l, _ := s.Env().LinuxProxy.Execute("sudo docker logs --since 10m squid-proxy | cat")
+		logs = l
+		if strings.Contains(logs, registryHost) {
+			found = true
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	s.Require().True(found, "expected squid-proxy logs to include traffic to %s; logs:\n%s", registryHost, logs)
 }

--- a/test/new-e2e/tests/windows/common/proxy.go
+++ b/test/new-e2e/tests/windows/common/proxy.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+)
+
+// SetSystemProxy configures the Windows system proxy for both WinINET (per-user) and WinHTTP.
+// proxyURL should be a full URL like http://host:port
+func SetSystemProxy(host *components.RemoteHost, proxyURL string) error {
+	// Configure WinINET for the current user (used by many APIs and tools)
+	ps := fmt.Sprintf(`
+		$proxy = '%s'
+		$path  = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings'
+		Set-ItemProperty -Path $path -Name ProxyEnable -Value 1 -Type DWord
+		Set-ItemProperty -Path $path -Name ProxyServer -Value $proxy -Type String
+		# Configure WinHTTP for services and system components
+		$u   = [uri]$proxy
+		$hp  = $u.Host + ':' + $u.Port
+		netsh winhttp set proxy proxy-server="http=$hp;https=$hp"
+	`, proxyURL)
+	if _, err := host.Execute(ps); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ResetSystemProxy disables the WinINET proxy for the current user and resets WinHTTP proxy.
+func ResetSystemProxy(host *components.RemoteHost) error {
+	ps := `
+		$path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings'
+		Set-ItemProperty -Path $path -Name ProxyEnable -Value 0 -Type DWord
+		Remove-ItemProperty -Path $path -Name ProxyServer -ErrorAction SilentlyContinue
+		netsh winhttp reset proxy
+	`
+	if _, err := host.Execute(ps); err != nil {
+		return err
+	}
+	return nil
+}
+
+// BlockAllOutboundExceptProxy configures Windows Firewall to block all outbound traffic
+// except to the specified proxy IP and port.
+func BlockAllOutboundExceptProxy(host *components.RemoteHost, proxyIP string, port int) error {
+	script := fmt.Sprintf(`
+        $proxyIp = '%s'
+        $proxyPort = %d
+        Set-NetFirewallProfile -Profile Domain,Public,Private -DefaultOutboundAction Block
+        $ruleName = "AllowProxy$proxyPort"
+        if (-not (Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue)) {
+            New-NetFirewallRule -DisplayName $ruleName -Direction Outbound -Action Allow -RemoteAddress $proxyIp -Protocol TCP -RemotePort $proxyPort | Out-Null
+        }
+    `, proxyIP, port)
+	_, err := host.Execute(script)
+	if err != nil {
+		return err
+	}
+
+	// Ensure outbound is blocked (a generic external call should fail)
+	_, err = host.Execute(`curl.exe https://google.com`)
+	if err == nil {
+		return fmt.Errorf("outbound is not blocked")
+	}
+
+	return nil
+}
+
+// ResetOutboundPolicyAndRemoveProxyRules restores default outbound Allow and removes proxy allow rules.
+func ResetOutboundPolicyAndRemoveProxyRules(host *components.RemoteHost) error {
+	_, err := host.Execute(`
+		$rules = Get-NetFirewallRule -DisplayName 'AllowProxy*' -ErrorAction SilentlyContinue
+		if ($rules) { $rules | Remove-NetFirewallRule -ErrorAction SilentlyContinue }
+		Set-NetFirewallProfile -Profile Domain,Public,Private -DefaultOutboundAction Allow
+	`)
+	if err != nil {
+		return err
+	}
+
+	// Ensure outbound is allowed
+	_, err = host.Execute(`curl.exe https://google.com`)
+	if err != nil {
+		return fmt.Errorf("outbound is not allowed")
+	}
+
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?
add a Windows e2e test that installs the Agent with the .exe installer through a proxy

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1185

### Describe how you validated your changes
n/a, support existed, just adding a new test