### PR TITLE
usm: http: Improve HTTP performance with object pooling for RequestStats and RequestStat

### DIFF
--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -254,6 +254,7 @@ func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 		}, func() {
 			for _, elem := range stats {
 				elem.Close()
+				requestStatsPool.Put(elem)
 			}
 		}
 }

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -18,6 +18,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
+)
+
+var (
+	requestStatsPool = ddsync.NewTypedPool[RequestStats](NewRequestStats)
 )
 
 // StatKeeper is responsible for aggregating HTTP stats.
@@ -193,7 +198,7 @@ func (h *StatKeeper) add(tx Transaction) {
 			return
 		}
 		h.telemetry.aggregations.Add(1)
-		stats = NewRequestStats()
+		stats = requestStatsPool.Get()
 		h.stats[key] = stats
 	}
 

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -273,6 +273,7 @@ func (r *RequestStats) Close() {
 			requestStatPool.Put(stats)
 		}
 	}
+	clear(r.Data)
 }
 
 // isValidStatusCode checks if the status code is in the range of valid HTTP responses

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -145,6 +145,7 @@ func (r *RequestStat) close() {
 	if r.Latencies != nil {
 		r.Latencies.Clear()
 		protocols.SketchesPool.Put(r.Latencies)
+		r.Latencies = nil
 	}
 
 	r.Count = 0

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/intern"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
 )
 
 // Interner is used to intern strings to save memory allocations.
@@ -68,6 +69,10 @@ func (m Method) String() string {
 		return "UNKNOWN"
 	}
 }
+
+var (
+	requestStatPool = ddsync.NewDefaultTypedPool[RequestStat]()
+)
 
 // Path represents the HTTP path
 type Path struct {
@@ -141,6 +146,11 @@ func (r *RequestStat) close() {
 		r.Latencies.Clear()
 		protocols.SketchesPool.Put(r.Latencies)
 	}
+
+	r.Count = 0
+	r.FirstLatencySample = 0
+	r.StaticTags = 0
+	clear(r.DynamicTags)
 }
 
 // RequestStats stores HTTP request statistics.
@@ -207,7 +217,7 @@ func (r *RequestStats) AddRequest(statusCode uint16, latency float64, staticTags
 
 	stats, exists := r.Data[statusCode]
 	if !exists {
-		stats = &RequestStat{}
+		stats = requestStatPool.Get()
 		r.Data[statusCode] = stats
 	}
 
@@ -260,6 +270,7 @@ func (r *RequestStats) Close() {
 	for _, stats := range r.Data {
 		if stats != nil {
 			stats.close()
+			requestStatPool.Put(stats)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduces object pooling for HTTP request statistics to improve performance and reduce memory allocation pressure in the USM HTTP protocol monitoring.

The changes implement:
- A typed object pool for `RequestStats` objects using `ddsync.NewTypedPool`
- A typed object pool for `RequestStat` objects using `ddsync.NewDefaultTypedPool`
- Proper cleanup and reuse of objects through the pools instead of creating new instances
- Memory clearing in the `Close()` methods to prevent memory leaks when objects are returned to pools

### Motivation

HTTP request statistics are frequently allocated and deallocated during network monitoring operations. This creates significant memory allocation pressure and garbage collection overhead, particularly in high-throughput environments. By reusing these objects through pools, we can:

- Reduce memory allocations and GC pressure
- Improve overall HTTP monitoring performance  
- Lower memory usage patterns in long-running agents

### Describe how you validated your changes

The changes preserve existing functionality while adding pooling:
- Object lifecycle is maintained with proper initialization and cleanup
- All existing fields are properly reset when objects are returned to pools
- Pool usage follows established patterns in the codebase using `ddsync` utilities

### Additional Notes

This builds on the existing pooling infrastructure in the codebase and follows the same patterns used elsewhere for object lifecycle management. The pools are package-level globals which is appropriate for this use case where the objects are used throughout the HTTP protocol handling.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>