### PR TITLE
[SBOM] make sure the overlayfs scanner uses the same lease during mount collection and scanning

### DIFF
--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -75,7 +75,7 @@ type ContainerdItf interface {
 	CallWithClientContext(namespace string, f func(context.Context) error) error
 	IsSandbox(namespace string, ctn containerd.Container) (bool, error)
 	MountImage(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error)
-	Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, error)
+	Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error)
 }
 
 // ContainerdUtil is the util used to interact with the Containerd api.
@@ -390,8 +390,8 @@ func (c *ContainerdUtil) IsSandbox(namespace string, ctn containerd.Container) (
 	return labels["io.cri-containerd.kind"] == "sandbox", nil
 }
 
-// getMounts retrieves mounts and returns a function to clean the snapshot and release the lease. The lease is already released in error cases.
-func (c *ContainerdUtil) getMounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error) {
+// Mounts retrieves mounts and returns a function to clean the snapshot and release the lease. The lease is already released in error cases.
+func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error) {
 	snapshotter := "nydus"
 	ctx = namespaces.WithNamespace(ctx, namespace)
 
@@ -500,21 +500,9 @@ func (c *ContainerdUtil) getMounts(ctx context.Context, expiration time.Duration
 	}, nil
 }
 
-// Mounts returns the mounts for an image
-func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, error) {
-	mounts, clean, err := c.getMounts(ctx, expiration, namespace, img)
-	if err != nil {
-		return nil, err
-	}
-	if err := clean(ctx); err != nil {
-		return nil, fmt.Errorf("unable to clean snapshot, err: %w", err)
-	}
-	return mounts, nil
-}
-
 // MountImage mounts an image to a directory
 func (c *ContainerdUtil) MountImage(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error) {
-	mounts, clean, err := c.getMounts(ctx, expiration, namespace, img)
+	mounts, clean, err := c.Mounts(ctx, expiration, namespace, img)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -48,7 +48,7 @@ type MockedContainerdClient struct {
 	MockCallWithClientContext func(namespace string, f func(context.Context) error) error
 	MockIsSandbox             func(namespace string, ctn containerd.Container) (bool, error)
 	MockMountImage            func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error)
-	MockMounts                func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, error)
+	MockMounts                func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error)
 }
 
 // Close is a mock method
@@ -172,6 +172,6 @@ func (client *MockedContainerdClient) MountImage(ctx context.Context, expiration
 }
 
 // Mounts is a mock method
-func (client *MockedContainerdClient) Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, error) {
+func (client *MockedContainerdClient) Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error) {
 	return client.MockMounts(ctx, expiration, namespace, img)
 }


### PR DESCRIPTION
### What does this PR do?

- First commit:

Before this commit, the code was using one lease for the mount
collection, and another one for the scanning. Nothing guarantees that
the mounts collected in the first step are still valid during the second
step.

More importantly, the lease was always taken with the default snapshotter, even though we also support the nydus one. Using the lease from `Mounts` ensure we always use the correct one.

-  Second commit:

The cleanupTimeout was only used because of copy/paste from the mount
scan method. Let's also handle the case where the context doesn't have
a deadline.

### Motivation

### Describe how you validated your changes

### Additional Notes
