### PR TITLE
[USMON-1487] usm: redis: Improve Redis performance with object pooling for RequestStats and RequestStat

### DIFF
--- a/pkg/network/protocols/redis/protocol.go
+++ b/pkg/network/protocols/redis/protocol.go
@@ -234,6 +234,7 @@ func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 		}, func() {
 			for _, stats := range keysToStats {
 				stats.Close()
+				requestStatsPool.Put(stats)
 			}
 		}
 }

--- a/pkg/network/protocols/redis/statskeeper.go
+++ b/pkg/network/protocols/redis/statskeeper.go
@@ -64,7 +64,7 @@ func (s *StatsKeeper) Process(event *EventWrapper) {
 			s.telemetry.dropped.Add(1)
 			return
 		}
-		requestStats = NewRequestStats()
+		requestStats = requestStatsPool.Get()
 		s.stats[key] = requestStats
 	}
 	count := 1 // We process one event at a time
@@ -73,8 +73,8 @@ func (s *StatsKeeper) Process(event *EventWrapper) {
 
 // GetAndResetAllStats returns all the records and resets the statskeeper
 func (s *StatsKeeper) GetAndResetAllStats() map[Key]*RequestStats {
-	s.statsMutex.RLock()
-	defer s.statsMutex.RUnlock()
+	s.statsMutex.Lock()
+	defer s.statsMutex.Unlock()
 
 	ret := s.stats
 	s.resetNoLock()


### PR DESCRIPTION
### What does this PR do?

This PR introduces object pooling for Redis request statistics to improve
performance and reduce memory allocation pressure in the USM Redis
protocol monitoring.

The changes implement:
- A typed object pool for `RequestStats` objects using
`ddsync.NewTypedPool`
- A typed object pool for `RequestStat` objects using
`ddsync.NewDefaultTypedPool`
- Proper cleanup and reuse of objects through the pools instead of
creating new instances
- Memory clearing in the `close()` methods to prevent memory leaks when
objects are returned to pools

### Motivation

Redis request statistics are frequently allocated and deallocated during
network monitoring operations. This creates significant memory
allocation pressure and garbage collection overhead, particularly in
high-throughput environments. By reusing these objects through pools, we
can:

- Reduce memory allocations and GC pressure
- Improve overall Redis monitoring performance
- Lower memory usage patterns in long-running agents

### Describe how you validated your changes

The changes preserve existing functionality while adding pooling:
- Object lifecycle is maintained with proper initialization and cleanup
- All existing fields are properly reset when objects are returned to
pools
- Pool usage follows established patterns in the codebase using `ddsync`
utilities
- All Redis protocol tests pass

### Additional Notes

This builds on the existing pooling infrastructure in the codebase and
follows the same patterns used elsewhere for object lifecycle
management. The pools are package-level globals which is appropriate for
this use case where the objects are used throughout the Redis protocol
handling.

This follows the exact same approach as PR #40907 for HTTP monitoring.

**JIRA:** USMON-1487

---

🤖 Generated with [Claude Code](https://claude.ai/code)