### PR TITLE
[DJM-218] Tag with workspace url if env var present

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -153,6 +153,7 @@ func setupCommonHostTags(s *common.Setup) {
 		v = strings.Trim(v, "\"'")
 		return workspaceNameRegex.ReplaceAllString(v, "_")
 	})
+	// No need to normalize workspace url:  metrics tags normalization allows the :/-, usually found in such url
 	setIfExists(s, "WORKSPACE_URL", "workspace_url", nil)
 
 	setClearIfExists(s, "DB_CLUSTER_ID", "cluster_id", nil)

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -153,6 +153,7 @@ func setupCommonHostTags(s *common.Setup) {
 		v = strings.Trim(v, "\"'")
 		return workspaceNameRegex.ReplaceAllString(v, "_")
 	})
+	setIfExists(s, "WORKSPACE_URL", "workspace_url", nil)
 
 	setClearIfExists(s, "DB_CLUSTER_ID", "cluster_id", nil)
 	setIfExists(s, "DB_CLUSTER_NAME", "cluster_name", func(v string) string {

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -35,6 +35,7 @@ func TestSetupCommonHostTags(t *testing.T) {
 				"DB_CLUSTER_NAME":      "example[,'job]name",
 				"DB_CLUSTER_ID":        "cluster123",
 				"DATABRICKS_WORKSPACE": "example_workspace",
+				"WORKSPACE_URL":        "https://dbc-12345678-a1b2.cloud.databricks.com/",
 			},
 			wantTags: []string{
 				"data_workload_monitoring_trial:true",
@@ -49,6 +50,7 @@ func TestSetupCommonHostTags(t *testing.T) {
 				"databricks_workspace:example_workspace",
 				"workspace:example_workspace",
 				"dd.internal.resource:databricks_cluster:cluster123",
+				"workspace_url:https://dbc-12345678-a1b2.cloud.databricks.com/",
 			},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

Add workspace URL as host tag so that metrics bear this tag and we can have one recommendation monitor apply to all workspaces rather than having one per workspace

### Motivation

### Describe how you validated your changes
https://ddstaging.datadoghq.com/metric/explorer?fromUser=true&start=1757929633281&end=1757933233281&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMgaWBoIcKoAdJnyeE14fsBgbgDW9hjZTnjaaMgAVDwABABGWFPdfQNDI2gUyQgYM4X9TplonQ3aTtA8IDwAulSu7niYoeE3qncYMaXx51cg9VhoOaDyDB-BANZRQHAwPb3DQQTKJNCiOBOOSKZTpBFQeGIpz0JjKERuDxoc78CD2TBYZEKHIgBEiJSXHh8b7yBEIADCUmEMBQIjuaB4QA
metrics from databricks cluster with installer setting the host tag have the url as tag, not normalized as expected and ready to be used in monitor

### Additional Notes
