### PR TITLE
Bump timeout of docker_build_windows job to 60 minutes

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -48,7 +48,7 @@
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker rmi ${TARGET_TAG}
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-  timeout: 27m
+  timeout: 60m
 
 .docker_build_agent7_windows_common:
   extends:


### PR DESCRIPTION
### What does this PR do?

Bump timeout for windows docker job

### Motivation


### Describe how you validated your changes

### Additional Notes
