### PR TITLE
[CWS] implement SBOM resolver based on trivy-less collector

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -85,6 +85,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.workloads_cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.host.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.analyzers", []string{"os"})
+	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.use_v2_collector", false)
 
 	// CWS - Security Profiles
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.enabled", true)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -341,6 +341,8 @@ type RuntimeSecurityConfig struct {
 	SBOMResolverHostEnabled bool
 	// SBOMResolverAnalyzers defines the list of analyzers that should be used to compute the SBOM
 	SBOMResolverAnalyzers []string
+	// SBOMResolverUseV2Collector defines if the SBOM resolver should use the v2 collector
+	SBOMResolverUseV2Collector bool
 
 	// HashResolverEnabled defines if the hash resolver should be enabled
 	HashResolverEnabled bool
@@ -562,6 +564,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SBOMResolverWorkloadsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.sbom.workloads_cache_size"),
 		SBOMResolverHostEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.host.enabled"),
 		SBOMResolverAnalyzers:          pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.sbom.analyzers"),
+		SBOMResolverUseV2Collector:     pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.use_v2_collector"),
 
 		// Hash resolver
 		HashResolverEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.hash_resolver.enabled"),

--- a/pkg/security/resolvers/sbom/collector_v2.go
+++ b/pkg/security/resolvers/sbom/collector_v2.go
@@ -1,0 +1,297 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && trivy
+
+// Package sbom holds sbom related files
+package sbom
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+type HostOSScannerV2 struct {
+}
+
+func NewHostOSScannerV2() *HostOSScannerV2 {
+	return &HostOSScannerV2{}
+}
+
+func (s *HostOSScannerV2) DirectScanForTrivyReport(ctx context.Context, root string) (*types.Report, error) {
+	rootFS, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	defer rootFS.Close()
+
+	pkgs, err := s.listInstalledPkgs(rootFS)
+	if err != nil {
+		return nil, err
+	}
+
+	installedFiles, err := s.listInstalledFiles(rootFS)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgsWithFiles := make([]ftypes.Package, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		if files, ok := installedFiles[pkg.Name]; ok {
+			pkg.InstalledFiles = files
+		}
+		pkgsWithFiles = append(pkgsWithFiles, pkg)
+	}
+
+	return &types.Report{
+		Results: []types.Result{
+			{
+				Packages: pkgsWithFiles,
+			},
+		},
+	}, nil
+}
+
+const statusPath = "var/lib/dpkg/status"
+const statusDPath = "var/lib/dpkg/status.d/"
+const infoPath = "var/lib/dpkg/info/"
+const readDirBatchSize = 32
+const md5sumsSuffix = ".md5sums"
+
+func (s *HostOSScannerV2) listInstalledPkgs(root *os.Root) ([]ftypes.Package, error) {
+	pkgs, err := s.parseStatusFile(root, statusPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse dpkg status file (%s): %w", statusPath, err)
+	}
+
+	statusDDir, err := root.Open(statusDPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return pkgs, nil
+		}
+		return nil, fmt.Errorf("failed to open dpkg status.d directory (%s): %w", statusDPath, err)
+	}
+	defer statusDDir.Close()
+
+	for {
+		statusFiles, err := statusDDir.Readdir(readDirBatchSize)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to read dpkg status.d directory (%s): %w", statusDPath, err)
+		}
+
+		for _, statusFile := range statusFiles {
+			fullPath := filepath.Join(statusDPath, statusFile.Name())
+			pkg, err := s.parseStatusFile(root, fullPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse dpkg status file (%s): %w", fullPath, err)
+			}
+			pkgs = append(pkgs, pkg...)
+		}
+	}
+
+	return pkgs, nil
+}
+
+func (s *HostOSScannerV2) listInstalledFiles(root *os.Root) (map[string][]string, error) {
+	// first with the main info dir
+	installedFilesInfo, err := s.listInstalledFilesFromDir(root, infoPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	// then with the status.d dir for distroless
+	installedFilesStatus, err := s.listInstalledFilesFromDir(root, statusDPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	// merge both maps, info dir has priority
+	res := make(map[string][]string, len(installedFilesInfo)+len(installedFilesStatus))
+	for k, v := range installedFilesStatus {
+		res[k] = v
+	}
+	for k, v := range installedFilesInfo {
+		res[k] = v
+	}
+	return res, nil
+}
+
+func (s *HostOSScannerV2) listInstalledFilesFromDir(root *os.Root, baseDir string) (map[string][]string, error) {
+	infoDir, err := root.Open(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	defer infoDir.Close()
+
+	res := make(map[string][]string)
+
+	for {
+		infoFiles, err := infoDir.Readdir(readDirBatchSize)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to read dpkg info directory (%s): %w", baseDir, err)
+		}
+
+		for _, infoFile := range infoFiles {
+			fileName := infoFile.Name()
+			if !strings.HasSuffix(fileName, md5sumsSuffix) {
+				continue
+			}
+			pkgName := strings.TrimSuffix(fileName, md5sumsSuffix)
+
+			installedFiles, err := s.parseInfoFile(root, filepath.Join(baseDir, fileName))
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					seclog.Warnf("failed to parse dpkg info file (%s): %v", fileName, err)
+				}
+				continue
+			}
+
+			res[pkgName] = installedFiles
+		}
+	}
+
+	return res, nil
+}
+
+func (s *HostOSScannerV2) parseInfoFile(root *os.Root, path string) ([]string, error) {
+	f, err := root.Open(path)
+	if err != nil {
+
+		return nil, fmt.Errorf("failed to open dpkg info file (%s): %w", path, err)
+	}
+	defer f.Close() // TODO(paulcacheux): defer in a loop
+
+	var installedFiles []string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		_, installedPath, ok := strings.Cut(scanner.Text(), "  ")
+		if !ok {
+			return nil, fmt.Errorf("failed to parse installed file line, bad format")
+		}
+		installedFiles = append(installedFiles, "/"+installedPath)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan %s: %w", path, err)
+	}
+
+	return installedFiles, nil
+}
+
+func (s *HostOSScannerV2) parseStatusFile(root *os.Root, path string) ([]ftypes.Package, error) {
+	f, err := root.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var pkgs []ftypes.Package
+
+	scanner := newDPKGScanner(f)
+	for scanner.Scan() {
+		header, err := scanner.Header()
+		if !errors.Is(err, io.EOF) && err != nil {
+			seclog.Warnf("Parse error, filepath=%s: %v", path, err)
+			continue
+		}
+
+		if !isInstalledFromStatus(header.Get("Status")) {
+			continue
+		}
+
+		pkg := ftypes.Package{
+			Name:    header.Get("Package"),
+			Version: header.Get("Version"),
+		}
+		if pkg.Name == "" || pkg.Version == "" {
+			continue
+		}
+		pkg.SrcVersion = pkg.Version // TODO(paulcacheux): parse source
+
+		pkgs = append(pkgs, pkg)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan %s: %w", path, err)
+	}
+
+	return pkgs, nil
+}
+
+type dpkgScanner struct {
+	*bufio.Scanner
+}
+
+// newDPKGScanner returns a new scanner that splits on empty lines.
+func newDPKGScanner(r io.Reader) *dpkgScanner {
+	s := bufio.NewScanner(r)
+	// Package data may exceed default buffer size
+	// Increase the buffer default size by 2 times
+	buf := make([]byte, 0, 128*1024)
+	s.Buffer(buf, 128*1024)
+
+	s.Split(emptyLineSplit)
+	return &dpkgScanner{Scanner: s}
+}
+
+// Scan advances the scanner to the next token.
+func (s *dpkgScanner) Scan() bool {
+	return s.Scanner.Scan()
+}
+
+// Header returns the MIME header of the current scan.
+func (s *dpkgScanner) Header() (textproto.MIMEHeader, error) {
+	b := s.Bytes()
+	reader := textproto.NewReader(bufio.NewReader(bytes.NewReader(b)))
+	return reader.ReadMIMEHeader()
+}
+
+// emptyLineSplit is a bufio.SplitFunc that splits on empty lines.
+func emptyLineSplit(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
+		// We have a full empty line terminated block.
+		return i + 2, data[0:i], nil
+	}
+
+	if atEOF {
+		// Return the rest of the data if we're at EOF.
+		return len(data), data, nil
+	}
+
+	return
+}
+
+func isInstalledFromStatus(status string) bool {
+	for ss := range strings.FieldsSeq(status) {
+		if ss == "deinstall" || ss == "purge" {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/security/resolvers/sbom/collectorv2/collector.go
+++ b/pkg/security/resolvers/sbom/collectorv2/collector.go
@@ -9,290 +9,39 @@
 package collectorv2
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
-	"io"
-	"net/textproto"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 // OSScanner is responsible for scanning the host OS for packages
 type OSScanner struct {
+	scanners []actualScanner
 }
 
+type actualScanner interface {
+	ListPackages(ctx context.Context, root string) (types.Result, error)
+}
+
+// NewOSScanner returns a new OSScanner
 func NewOSScanner() *OSScanner {
-	return &OSScanner{}
-}
-
-func (s *OSScanner) DirectScanForTrivyReport(ctx context.Context, root string) (*types.Report, error) {
-	rootFS, err := os.OpenRoot(root)
-	if err != nil {
-		return nil, err
-	}
-	defer rootFS.Close()
-
-	pkgs, err := s.listInstalledPkgs(rootFS)
-	if err != nil {
-		return nil, err
-	}
-
-	installedFiles, err := s.listInstalledFiles(rootFS)
-	if err != nil {
-		return nil, err
-	}
-
-	pkgsWithFiles := make([]ftypes.Package, 0, len(pkgs))
-	for _, pkg := range pkgs {
-		if files, ok := installedFiles[pkg.Name]; ok {
-			pkg.InstalledFiles = files
-		}
-		pkgsWithFiles = append(pkgsWithFiles, pkg)
-	}
-
-	return &types.Report{
-		Results: []types.Result{
-			{
-				Packages: pkgsWithFiles,
-			},
+	return &OSScanner{
+		scanners: []actualScanner{
+			&dpkgScanner{},
 		},
-	}, nil
+	}
 }
 
-const statusPath = "var/lib/dpkg/status"
-const statusDPath = "var/lib/dpkg/status.d/"
-const infoPath = "var/lib/dpkg/info/"
-const readDirBatchSize = 32
-const md5sumsSuffix = ".md5sums"
-
-func (s *OSScanner) listInstalledPkgs(root *os.Root) ([]ftypes.Package, error) {
-	pkgs, err := s.parseStatusFile(root, statusPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse dpkg status file (%s): %w", statusPath, err)
-	}
-
-	statusDDir, err := root.Open(statusDPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return pkgs, nil
-		}
-		return nil, fmt.Errorf("failed to open dpkg status.d directory (%s): %w", statusDPath, err)
-	}
-	defer statusDDir.Close()
-
-	for {
-		statusFiles, err := statusDDir.Readdir(readDirBatchSize)
+// DirectScanForTrivyReport scans the given rootfs and returns a trivy report
+func (s *OSScanner) DirectScanForTrivyReport(ctx context.Context, root string) (*types.Report, error) {
+	report := &types.Report{}
+	for _, scanner := range s.scanners {
+		result, err := scanner.ListPackages(ctx, root)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return nil, fmt.Errorf("failed to read dpkg status.d directory (%s): %w", statusDPath, err)
+			seclog.Errorf("failed to list packages with dpkg scanner: %v", err)
 		}
-
-		for _, statusFile := range statusFiles {
-			fullPath := filepath.Join(statusDPath, statusFile.Name())
-			pkg, err := s.parseStatusFile(root, fullPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse dpkg status file (%s): %w", fullPath, err)
-			}
-			pkgs = append(pkgs, pkg...)
-		}
+		report.Results = append(report.Results, result)
 	}
-
-	return pkgs, nil
-}
-
-func (s *OSScanner) listInstalledFiles(root *os.Root) (map[string][]string, error) {
-	// first with the main info dir
-	installedFilesInfo, err := s.listInstalledFilesFromDir(root, infoPath)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, err
-	}
-	// then with the status.d dir for distroless
-	installedFilesStatus, err := s.listInstalledFilesFromDir(root, statusDPath)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, err
-	}
-
-	// merge both maps, info dir has priority
-	res := make(map[string][]string, len(installedFilesInfo)+len(installedFilesStatus))
-	for k, v := range installedFilesStatus {
-		res[k] = v
-	}
-	for k, v := range installedFilesInfo {
-		res[k] = v
-	}
-	return res, nil
-}
-
-func (s *OSScanner) listInstalledFilesFromDir(root *os.Root, baseDir string) (map[string][]string, error) {
-	infoDir, err := root.Open(baseDir)
-	if err != nil {
-		return nil, err
-	}
-	defer infoDir.Close()
-
-	res := make(map[string][]string)
-
-	for {
-		infoFiles, err := infoDir.Readdir(readDirBatchSize)
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return nil, fmt.Errorf("failed to read dpkg info directory (%s): %w", baseDir, err)
-		}
-
-		for _, infoFile := range infoFiles {
-			fileName := infoFile.Name()
-			if !strings.HasSuffix(fileName, md5sumsSuffix) {
-				continue
-			}
-			pkgName := strings.TrimSuffix(fileName, md5sumsSuffix)
-
-			installedFiles, err := s.parseInfoFile(root, filepath.Join(baseDir, fileName))
-			if err != nil {
-				if !errors.Is(err, os.ErrNotExist) {
-					seclog.Warnf("failed to parse dpkg info file (%s): %v", fileName, err)
-				}
-				continue
-			}
-
-			res[pkgName] = installedFiles
-		}
-	}
-
-	return res, nil
-}
-
-func (s *OSScanner) parseInfoFile(root *os.Root, path string) ([]string, error) {
-	f, err := root.Open(path)
-	if err != nil {
-
-		return nil, fmt.Errorf("failed to open dpkg info file (%s): %w", path, err)
-	}
-	defer f.Close() // TODO(paulcacheux): defer in a loop
-
-	var installedFiles []string
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		_, installedPath, ok := strings.Cut(scanner.Text(), "  ")
-		if !ok {
-			return nil, fmt.Errorf("failed to parse installed file line, bad format")
-		}
-		installedFiles = append(installedFiles, "/"+installedPath)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan %s: %w", path, err)
-	}
-
-	return installedFiles, nil
-}
-
-func (s *OSScanner) parseStatusFile(root *os.Root, path string) ([]ftypes.Package, error) {
-	f, err := root.Open(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	defer f.Close()
-
-	var pkgs []ftypes.Package
-
-	scanner := newDPKGScanner(f)
-	for scanner.Scan() {
-		header, err := scanner.Header()
-		if !errors.Is(err, io.EOF) && err != nil {
-			seclog.Warnf("Parse error, filepath=%s: %v", path, err)
-			continue
-		}
-
-		if !isInstalledFromStatus(header.Get("Status")) {
-			continue
-		}
-
-		pkg := ftypes.Package{
-			Name:    header.Get("Package"),
-			Version: header.Get("Version"),
-		}
-		if pkg.Name == "" || pkg.Version == "" {
-			continue
-		}
-		pkg.SrcVersion = pkg.Version // TODO(paulcacheux): parse source
-
-		pkgs = append(pkgs, pkg)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan %s: %w", path, err)
-	}
-
-	return pkgs, nil
-}
-
-type dpkgScanner struct {
-	*bufio.Scanner
-}
-
-// newDPKGScanner returns a new scanner that splits on empty lines.
-func newDPKGScanner(r io.Reader) *dpkgScanner {
-	s := bufio.NewScanner(r)
-	// Package data may exceed default buffer size
-	// Increase the buffer default size by 2 times
-	buf := make([]byte, 0, 128*1024)
-	s.Buffer(buf, 128*1024)
-
-	s.Split(emptyLineSplit)
-	return &dpkgScanner{Scanner: s}
-}
-
-// Scan advances the scanner to the next token.
-func (s *dpkgScanner) Scan() bool {
-	return s.Scanner.Scan()
-}
-
-// Header returns the MIME header of the current scan.
-func (s *dpkgScanner) Header() (textproto.MIMEHeader, error) {
-	b := s.Bytes()
-	reader := textproto.NewReader(bufio.NewReader(bytes.NewReader(b)))
-	return reader.ReadMIMEHeader()
-}
-
-// emptyLineSplit is a bufio.SplitFunc that splits on empty lines.
-func emptyLineSplit(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	if atEOF && len(data) == 0 {
-		return 0, nil, nil
-	}
-
-	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
-		// We have a full empty line terminated block.
-		return i + 2, data[0:i], nil
-	}
-
-	if atEOF {
-		// Return the rest of the data if we're at EOF.
-		return len(data), data, nil
-	}
-
-	return
-}
-
-func isInstalledFromStatus(status string) bool {
-	for ss := range strings.FieldsSeq(status) {
-		if ss == "deinstall" || ss == "purge" {
-			return false
-		}
-	}
-	return true
+	return report, nil
 }

--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -28,19 +28,13 @@ import (
 type dpkgScanner struct {
 }
 
-func (s *dpkgScanner) ListPackages(ctx context.Context, root string) (types.Result, error) {
-	rootFS, err := os.OpenRoot(root)
-	if err != nil {
-		return types.Result{}, err
-	}
-	defer rootFS.Close()
-
-	pkgs, err := s.listInstalledPkgs(rootFS)
+func (s *dpkgScanner) ListPackages(ctx context.Context, root *os.Root) (types.Result, error) {
+	pkgs, err := s.listInstalledPkgs(root)
 	if err != nil {
 		return types.Result{}, err
 	}
 
-	installedFiles, err := s.listInstalledFiles(rootFS)
+	installedFiles, err := s.listInstalledFiles(root)
 	if err != nil {
 		return types.Result{}, err
 	}

--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -1,0 +1,289 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && trivy
+
+// Package collectorv2 holds sbom related files
+package collectorv2
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+type dpkgScanner struct {
+}
+
+func (s *dpkgScanner) ListPackages(ctx context.Context, root string) (types.Result, error) {
+	rootFS, err := os.OpenRoot(root)
+	if err != nil {
+		return types.Result{}, err
+	}
+	defer rootFS.Close()
+
+	pkgs, err := s.listInstalledPkgs(rootFS)
+	if err != nil {
+		return types.Result{}, err
+	}
+
+	installedFiles, err := s.listInstalledFiles(rootFS)
+	if err != nil {
+		return types.Result{}, err
+	}
+
+	pkgsWithFiles := make([]ftypes.Package, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		if files, ok := installedFiles[pkg.Name]; ok {
+			pkg.InstalledFiles = files
+		}
+		pkgsWithFiles = append(pkgsWithFiles, pkg)
+	}
+
+	return types.Result{
+		Packages: pkgsWithFiles,
+	}, nil
+}
+
+const statusPath = "var/lib/dpkg/status"
+const statusDPath = "var/lib/dpkg/status.d/"
+const infoPath = "var/lib/dpkg/info/"
+const readDirBatchSize = 32
+const md5sumsSuffix = ".md5sums"
+
+func (s *dpkgScanner) listInstalledPkgs(root *os.Root) ([]ftypes.Package, error) {
+	pkgs, err := s.parseStatusFile(root, statusPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse dpkg status file (%s): %w", statusPath, err)
+	}
+
+	statusDDir, err := root.Open(statusDPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return pkgs, nil
+		}
+		return nil, fmt.Errorf("failed to open dpkg status.d directory (%s): %w", statusDPath, err)
+	}
+	defer statusDDir.Close()
+
+	for {
+		statusFiles, err := statusDDir.Readdir(readDirBatchSize)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to read dpkg status.d directory (%s): %w", statusDPath, err)
+		}
+
+		for _, statusFile := range statusFiles {
+			fullPath := filepath.Join(statusDPath, statusFile.Name())
+			pkg, err := s.parseStatusFile(root, fullPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse dpkg status file (%s): %w", fullPath, err)
+			}
+			pkgs = append(pkgs, pkg...)
+		}
+	}
+
+	return pkgs, nil
+}
+
+func (s *dpkgScanner) listInstalledFiles(root *os.Root) (map[string][]string, error) {
+	// first with the main info dir
+	installedFilesInfo, err := s.listInstalledFilesFromDir(root, infoPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	// then with the status.d dir for distroless
+	installedFilesStatus, err := s.listInstalledFilesFromDir(root, statusDPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	// merge both maps, info dir has priority
+	res := make(map[string][]string, len(installedFilesInfo)+len(installedFilesStatus))
+	for k, v := range installedFilesStatus {
+		res[k] = v
+	}
+	for k, v := range installedFilesInfo {
+		res[k] = v
+	}
+	return res, nil
+}
+
+func (s *dpkgScanner) listInstalledFilesFromDir(root *os.Root, baseDir string) (map[string][]string, error) {
+	infoDir, err := root.Open(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	defer infoDir.Close()
+
+	res := make(map[string][]string)
+
+	for {
+		infoFiles, err := infoDir.Readdir(readDirBatchSize)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to read dpkg info directory (%s): %w", baseDir, err)
+		}
+
+		for _, infoFile := range infoFiles {
+			fileName := infoFile.Name()
+			if !strings.HasSuffix(fileName, md5sumsSuffix) {
+				continue
+			}
+			pkgName := strings.TrimSuffix(fileName, md5sumsSuffix)
+
+			installedFiles, err := s.parseInfoFile(root, filepath.Join(baseDir, fileName))
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					seclog.Warnf("failed to parse dpkg info file (%s): %v", fileName, err)
+				}
+				continue
+			}
+
+			res[pkgName] = installedFiles
+		}
+	}
+
+	return res, nil
+}
+
+func (s *dpkgScanner) parseInfoFile(root *os.Root, path string) ([]string, error) {
+	f, err := root.Open(path)
+	if err != nil {
+
+		return nil, fmt.Errorf("failed to open dpkg info file (%s): %w", path, err)
+	}
+	defer f.Close() // TODO(paulcacheux): defer in a loop
+
+	var installedFiles []string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		_, installedPath, ok := strings.Cut(scanner.Text(), "  ")
+		if !ok {
+			return nil, fmt.Errorf("failed to parse installed file line, bad format")
+		}
+		installedFiles = append(installedFiles, "/"+installedPath)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan %s: %w", path, err)
+	}
+
+	return installedFiles, nil
+}
+
+func (s *dpkgScanner) parseStatusFile(root *os.Root, path string) ([]ftypes.Package, error) {
+	f, err := root.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var pkgs []ftypes.Package
+
+	scanner := newDPKGStatusScanner(f)
+	for scanner.Scan() {
+		header, err := scanner.Header()
+		if !errors.Is(err, io.EOF) && err != nil {
+			seclog.Warnf("Parse error, filepath=%s: %v", path, err)
+			continue
+		}
+
+		if !isInstalledFromStatus(header.Get("Status")) {
+			continue
+		}
+
+		pkg := ftypes.Package{
+			Name:    header.Get("Package"),
+			Version: header.Get("Version"),
+		}
+		if pkg.Name == "" || pkg.Version == "" {
+			continue
+		}
+		pkg.SrcVersion = pkg.Version // TODO(paulcacheux): parse source
+
+		pkgs = append(pkgs, pkg)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan %s: %w", path, err)
+	}
+
+	return pkgs, nil
+}
+
+type dpkgStatusScanner struct {
+	*bufio.Scanner
+}
+
+// newDPKGStatusScanner returns a new scanner that splits on empty lines.
+func newDPKGStatusScanner(r io.Reader) *dpkgStatusScanner {
+	s := bufio.NewScanner(r)
+	// Package data may exceed default buffer size
+	// Increase the buffer default size by 2 times
+	buf := make([]byte, 0, 128*1024)
+	s.Buffer(buf, 128*1024)
+
+	s.Split(emptyLineSplit)
+	return &dpkgStatusScanner{Scanner: s}
+}
+
+// Scan advances the scanner to the next token.
+func (s *dpkgStatusScanner) Scan() bool {
+	return s.Scanner.Scan()
+}
+
+// Header returns the MIME header of the current scan.
+func (s *dpkgStatusScanner) Header() (textproto.MIMEHeader, error) {
+	b := s.Bytes()
+	reader := textproto.NewReader(bufio.NewReader(bytes.NewReader(b)))
+	return reader.ReadMIMEHeader()
+}
+
+// emptyLineSplit is a bufio.SplitFunc that splits on empty lines.
+func emptyLineSplit(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
+		// We have a full empty line terminated block.
+		return i + 2, data[0:i], nil
+	}
+
+	if atEOF {
+		// Return the rest of the data if we're at EOF.
+		return len(data), data, nil
+	}
+
+	return
+}
+
+func isInstalledFromStatus(status string) bool {
+	for ss := range strings.FieldsSeq(status) {
+		if ss == "deinstall" || ss == "purge" {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -28,7 +28,11 @@ import (
 type dpkgScanner struct {
 }
 
-func (s *dpkgScanner) ListPackages(ctx context.Context, root *os.Root) (types.Result, error) {
+func (s *dpkgScanner) Name() string {
+	return "dpkg"
+}
+
+func (s *dpkgScanner) ListPackages(_ context.Context, root *os.Root) (types.Result, error) {
 	pkgs, err := s.listInstalledPkgs(root)
 	if err != nil {
 		return types.Result{}, err

--- a/pkg/security/resolvers/sbom/collectorv2/rpm.go
+++ b/pkg/security/resolvers/sbom/collectorv2/rpm.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && trivy
+
+// Package collectorv2 holds sbom related files
+package collectorv2
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+)
+
+var rpmdbPaths = []string{
+	// Berkeley DB
+	"usr/lib/sysimage/rpm/Packages",
+	"var/lib/rpm/Packages",
+
+	// NDB
+	"usr/lib/sysimage/rpm/Packages.db",
+	"var/lib/rpm/Packages.db",
+
+	// SQLite3
+	"usr/lib/sysimage/rpm/rpmdb.sqlite",
+	"var/lib/rpm/rpmdb.sqlite",
+}
+
+type rpmScanner struct {
+}
+
+func (s *rpmScanner) ListPackages(ctx context.Context, root *os.Root) (types.Result, error) {
+	for _, rpmdbPath := range rpmdbPaths {
+		if _, err := root.Stat(rpmdbPath); err == nil {
+			// found the rpmdb path
+		}
+
+		// sadly, we need to escape the root here :(
+		rpmdbFullPath := filepath.Join(root.Name(), rpmdbPath)
+		db, err := rpmdb.Open(rpmdbFullPath)
+		if err != nil {
+			return types.Result{}, fmt.Errorf("failed to open rpmdb at path %s: %w", rpmdbPath, err)
+		}
+		defer db.Close()
+
+		pkgs, err := db.ListPackages()
+		if err != nil {
+			return types.Result{}, fmt.Errorf("failed to list packages in rpmdb at path %s: %w", rpmdbPath, err)
+		}
+
+		packages := make([]ftypes.Package, 0, len(pkgs))
+		for _, pkg := range pkgs {
+			packages = append(packages, ftypes.Package{
+				Name:       pkg.Name,
+				Version:    pkg.Version,
+				SrcVersion: pkg.Version,
+			})
+		}
+		return types.Result{Packages: packages}, nil
+
+	}
+
+	return types.Result{}, fmt.Errorf("no rpmdb found in any of the known paths")
+}

--- a/pkg/security/resolvers/sbom/collectorv2/rpm.go
+++ b/pkg/security/resolvers/sbom/collectorv2/rpm.go
@@ -61,10 +61,20 @@ func (s *rpmScanner) ListPackages(_ context.Context, root *os.Root) (types.Resul
 
 		packages := make([]ftypes.Package, 0, len(pkgs))
 		for _, pkg := range pkgs {
+			files, err := pkg.InstalledFileNames()
+			if err != nil {
+				return types.Result{}, fmt.Errorf("unable to get installed files: %w", err)
+			}
+
+			for i, file := range files {
+				files[i] = filepath.ToSlash(file)
+			}
+
 			packages = append(packages, ftypes.Package{
-				Name:       pkg.Name,
-				Version:    pkg.Version,
-				SrcVersion: pkg.Version,
+				Name:           pkg.Name,
+				Version:        pkg.Version,
+				SrcVersion:     pkg.Version,
+				InstalledFiles: files,
 			})
 		}
 		return types.Result{Packages: packages}, nil

--- a/pkg/security/resolvers/sbom/collectorv2/rpm.go
+++ b/pkg/security/resolvers/sbom/collectorv2/rpm.go
@@ -36,10 +36,14 @@ var rpmdbPaths = []string{
 type rpmScanner struct {
 }
 
-func (s *rpmScanner) ListPackages(ctx context.Context, root *os.Root) (types.Result, error) {
+func (s *rpmScanner) Name() string {
+	return "rpm"
+}
+
+func (s *rpmScanner) ListPackages(_ context.Context, root *os.Root) (types.Result, error) {
 	for _, rpmdbPath := range rpmdbPaths {
-		if _, err := root.Stat(rpmdbPath); err == nil {
-			// found the rpmdb path
+		if _, err := root.Stat(rpmdbPath); err != nil {
+			continue
 		}
 
 		// sadly, we need to escape the root here :(
@@ -64,8 +68,7 @@ func (s *rpmScanner) ListPackages(ctx context.Context, root *os.Root) (types.Res
 			})
 		}
 		return types.Result{Packages: packages}, nil
-
 	}
 
-	return types.Result{}, fmt.Errorf("no rpmdb found in any of the known paths")
+	return types.Result{}, fmt.Errorf("no rpmdb found in any of the known paths: %w", os.ErrNotExist)
 }

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -24,9 +24,6 @@ import (
 	"github.com/skydive-project/go-debouncer"
 	"go.uber.org/atomic"
 
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/sbom"
-	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/host"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
@@ -129,7 +126,7 @@ type Resolver struct {
 	pendingScan     []containerutils.ContainerID
 
 	statsdClient   statsd.ClientInterface
-	sbomCollector  *host.Collector
+	sbomCollector  *HostOSScannerV2
 	hostRootDevice uint64
 	hostSBOM       *SBOM
 
@@ -141,13 +138,7 @@ type Resolver struct {
 
 // NewSBOMResolver returns a new instance of Resolver
 func NewSBOMResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface) (*Resolver, error) {
-	opts := sbom.ScanOptions{
-		Analyzers: c.SBOMResolverAnalyzers,
-	}
-	sbomCollector, err := host.NewCollectorForCWS(pkgconfigsetup.SystemProbe(), opts)
-	if err != nil {
-		return nil, err
-	}
+	sbomCollector := NewHostOSScannerV2()
 
 	dataCache, err := simplelru.NewLRU[workloadKey, *Data](c.SBOMResolverWorkloadsCacheSize, nil)
 	if err != nil {

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/collectorv2"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -149,7 +150,7 @@ const useV2Collector = true
 func NewSBOMResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface) (*Resolver, error) {
 	var sbomCollector sbomCollector
 	if useV2Collector {
-		sbomCollector = NewHostOSScannerV2()
+		sbomCollector = collectorv2.NewOSScanner()
 	} else {
 		opts := sbom.ScanOptions{
 			Analyzers: c.SBOMResolverAnalyzers,

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -144,12 +144,10 @@ type sbomCollector interface {
 	DirectScanForTrivyReport(ctx context.Context, root string) (*types.Report, error)
 }
 
-const useV2Collector = true
-
 // NewSBOMResolver returns a new instance of Resolver
 func NewSBOMResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface) (*Resolver, error) {
 	var sbomCollector sbomCollector
-	if useV2Collector {
+	if c.SBOMResolverUseV2Collector {
 		sbomCollector = collectorv2.NewOSScanner()
 	} else {
 		opts := sbom.ScanOptions{

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -813,6 +813,7 @@ func genTestConfigs(cfgDir string, opts testOpts) (*emconfig.Config, *secconfig.
 		"RuntimeSecurityEnabled":                     runtimeSecurityEnabled,
 		"SBOMEnabled":                                opts.enableSBOM,
 		"HostSBOMEnabled":                            opts.enableHostSBOM,
+		"SBOMUseV2Collector":                         opts.sbomUseV2Collector,
 		"EBPFLessEnabled":                            ebpfLessEnabled,
 		"FIMEnabled":                                 opts.enableFIM, // should only be enabled/disabled on windows
 		"NetworkIngressEnabled":                      opts.networkIngressEnabled,

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -129,6 +129,7 @@ runtime_security_config:
     enabled: {{ .SBOMEnabled }}
     host:
       enabled: {{ .HostSBOMEnabled }}
+    use_v2_collector: {{ .SBOMUseV2Collector }}
   activity_dump:
     enabled: {{ .EnableActivityDump }}
     syscall_monitor:

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -22,6 +22,16 @@ import (
 )
 
 func TestSBOM(t *testing.T) {
+	t.Run("with v1 collector", func(t *testing.T) {
+		testSBOMWithCollector(t, false)
+	})
+
+	t.Run("with v2 collector", func(t *testing.T) {
+		testSBOMWithCollector(t, true)
+	})
+}
+
+func testSBOMWithCollector(t *testing.T, useV2collector bool) {
 	SkipIfNotAvailable(t)
 
 	if _, err := whichNonFatal("docker"); err != nil {
@@ -44,7 +54,7 @@ func TestSBOM(t *testing.T) {
 				`&& process.file.path != "" && process.file.package.name == "coreutils"`,
 		},
 	}
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{enableSBOM: true, enableHostSBOM: true}))
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{enableSBOM: true, enableHostSBOM: true, sbomUseV2Collector: useV2collector}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -55,6 +55,7 @@ type testOpts struct {
 	disableRuntimeSecurity                     bool
 	enableSBOM                                 bool
 	enableHostSBOM                             bool
+	sbomUseV2Collector                         bool
 	preStartCallback                           func(test *testModule)
 	tagger                                     tags.Tagger
 	ruleMatchHandler                           func(*testModule, *model.Event, *rules.Rule)


### PR DESCRIPTION
### What does this PR do?

We currently ship trivy twice in the agent, once in the core agent driving the SBOM related features, and once in the system-probe driving some CWS features related to installed packages.

The use of trivy on the system-probe side is absolutely overkill and we use only a very small subset of its features. This PR extracts the OS package scanning to a V2 collector, that reads the files directly, and respects an interface similar to the one currently provided by trivy.

This PR adds a config flag (disabled by default) to switch to using this new collector. The SBOM usage in the system-probe is itself gated on a config that is disabled by default as well, so the risk is very low here.

This new collector already passes all the current functional tests in the CWS testsuite, some follow up PRs will expand this with additional tests.

### Motivation

### Describe how you validated your changes

### Additional Notes
