### PR TITLE
Avoid using pr-commenter service in golang_deps_diff job

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,7 +117,7 @@
 /.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml  @DataDog/agent-delivery
 /.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml        @DataDog/agent-delivery
 /.gitlab/package_deps_build/package_deps_build.yml   @DataDog/agent-devx @DataDog/ebpf-platform
-/.gitlab/source_test/golang_deps_diff.yml            @DataDog/agent-devx
+/.gitlab/source_test/golang_deps_diff.yml            @DataDog/agent-runtimes
 /.gitlab/source_test/*                               @DataDog/agent-devx
 /.gitlab/source_test/linux.yml                       @DataDog/agent-devx
 /.gitlab/source_test/macos.yml                       @DataDog/agent-devx

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -31,8 +31,8 @@ protobuf_test                           @DataDog/multiple
 # Send count metrics about Golang dependencies
 golang_deps_send_count_metrics       @DataDog/agent-runtimes
 # Golang dependency diff generation
-golang_deps_diff                     @DataDog/ebpf-platform
-golang_deps_commenter                @DataDog/ebpf-platform
+golang_deps_diff                     @DataDog/agent-runtimes
+golang_deps_commenter                @DataDog/agent-runtimes
 
 # Binary build
 build_system-probe*                  @DataDog/ebpf-platform

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -33,9 +33,9 @@ golang_deps_commenter:
   needs: ["golang_deps_diff"]
   script:
     - if [ ! -s deps-report.md ]; then
-        dda inv -- -e pr-commenter --title="Go Package Import Differences" --delete ;
+        dda inv -- -e github.pr-commenter --title="Go Package Import Differences" --delete ;
       else
-        dda inv -- -e pr-commenter --title="Go Package Import Differences" --body-file=deps-report.md ;
+        dda inv -- -e github.pr-commenter --title="Go Package Import Differences" --body-file=deps-report.md ;
       fi
 
 golang_deps_send_count_metrics:

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -32,8 +32,8 @@ golang_deps_commenter:
     - when: on_success
   needs: ["golang_deps_diff"]
   script:
-    - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 key_b64) || exit $?; export GITHUB_KEY_B64
-    - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 app_id) || exit $?; export GITHUB_APP_ID
+    - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP key_b64) || exit $?; export GITHUB_KEY_B64
+    - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP app_id) || exit $?; export GITHUB_APP_ID
     - if [ ! -s deps-report.md ]; then
         dda inv -- -e github.pr-commenter --title="Go Package Import Differences" --delete ;
       else

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -33,9 +33,9 @@ golang_deps_commenter:
   needs: ["golang_deps_diff"]
   script:
     - if [ ! -s deps-report.md ]; then
-        dda inv -- -e pr-commenter --title="Go Package Import Differences" --delete
+        dda inv -- -e pr-commenter --title="Go Package Import Differences" --delete ;
       else
-        dda inv -- -e pr-commenter --title="Go Package Import Differences" --body-file=deps-report.md
+        dda inv -- -e pr-commenter --title="Go Package Import Differences" --body-file=deps-report.md ;
       fi
 
 golang_deps_send_count_metrics:

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -25,33 +25,18 @@ golang_deps_diff:
 
 golang_deps_commenter:
   stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.on_dev_branches]
     - when: on_success
   needs: ["golang_deps_diff"]
-  variables:
-    # Not using the entrypoint script for the pr-commenter image
-    FF_KUBERNETES_HONOR_ENTRYPOINT: false
-  script: # ignore error message about no PR, because it happens for dev branches without PRs
-    - echo "${CI_COMMIT_REF_NAME}"
-    - |
-      set +e
-      out=$(pr-commenter --for-pr="${CI_COMMIT_REF_NAME}" --header="Go Package Import Differences" --infile deps-report.md 2>&1)
-      exitcode=$?
-      set -e
-      if [ -n "${out}" ]; then
-        if [ $exitcode -eq 0 ]; then
-          echo $out
-        else
-          echo $out >&2
-        fi
+  script:
+    - if [ ! -s deps-report.md ]; then
+        dda inv -- -e pr-commenter --title="Go Package Import Differences" --delete
+      else
+        dda inv -- -e pr-commenter --title="Go Package Import Differences" --body-file=deps-report.md
       fi
-      if [ "${out}" != "${out/invalid request: no pr found for this commit}" ]; then
-        exit 0
-      fi
-      exit $exitcode
 
 golang_deps_send_count_metrics:
   stage: source_test

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -32,6 +32,8 @@ golang_deps_commenter:
     - when: on_success
   needs: ["golang_deps_diff"]
   script:
+    - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 key_b64) || exit $?; export GITHUB_KEY_B64
+    - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 app_id) || exit $?; export GITHUB_APP_ID
     - if [ ! -s deps-report.md ]; then
         dda inv -- -e github.pr-commenter --title="Go Package Import Differences" --delete ;
       else

--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/command"
+	_ "github.com/DataDog/datadog-agent/pkg/gohai"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 

--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/command"
-	_ "github.com/DataDog/datadog-agent/pkg/gohai"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -307,6 +307,7 @@ def pr_commenter(
     _,
     title: str,
     body: str = '',
+    body_file: str = '',
     pr_id: int | None = None,
     verbose: bool = True,
     delete: bool = False,
@@ -328,6 +329,12 @@ def pr_commenter(
     """
 
     from tasks.libs.ciproviders.github_api import GithubAPI
+
+    assert not body_file or not body, "Use either body or body_file, not both"
+
+    if body_file:
+        with open(body_file) as f:
+            body = f.read()
 
     if not body and not delete:
         return

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -308,7 +308,7 @@ def pr_commenter(
     title: str,
     body: str = '',
     body_file: str = '',
-    pr_id: int | None = None,
+    pr_id: int = 0,
     verbose: bool = True,
     delete: bool = False,
     force_delete: bool = False,
@@ -343,7 +343,7 @@ def pr_commenter(
 
     github = GithubAPI()
 
-    if pr_id is None:
+    if pr_id == 0:
         branch = os.environ["CI_COMMIT_BRANCH"]
         prs = list(github.get_pr_for_branch(branch))
         if len(prs) == 0 and not fail_on_pr_missing:

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -792,9 +792,9 @@ def generate_local_github_token(ctx):
     try:
         token = ctx.run('ddtool auth github token', hide=True).stdout.strip()
 
-        assert token.startswith('gh') and ' ' not in token, (
-            "`ddtool auth github token` returned an invalid token, it might be due to ddtool outdated. Please run `brew update && brew upgrade ddtool`."
-        )
+        assert (
+            token.startswith('gh') and ' ' not in token
+        ), "`ddtool auth github token` returned an invalid token, it might be due to ddtool outdated. Please run `brew update && brew upgrade ddtool`."
 
         return token
     except AssertionError:

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -548,7 +548,7 @@ class GithubAPI:
             # retrieve it, given the other credentials (app id + key).
             integration = GithubIntegration(auth=appAuth)
             installations = integration.get_installations()
-            if len(installations) == 0:
+            if installations.totalCount == 0:
                 raise Exit(message='No usable installation found', code=1)
             installation_id = installations[0]
         return appAuth.get_installation_auth(int(installation_id))
@@ -792,9 +792,9 @@ def generate_local_github_token(ctx):
     try:
         token = ctx.run('ddtool auth github token', hide=True).stdout.strip()
 
-        assert (
-            token.startswith('gh') and ' ' not in token
-        ), "`ddtool auth github token` returned an invalid token, it might be due to ddtool outdated. Please run `brew update && brew upgrade ddtool`."
+        assert token.startswith('gh') and ' ' not in token, (
+            "`ddtool auth github token` returned an invalid token, it might be due to ddtool outdated. Please run `brew update && brew upgrade ddtool`."
+        )
 
         return token
     except AssertionError:

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -550,7 +550,7 @@ class GithubAPI:
             installations = integration.get_installations()
             if installations.totalCount == 0:
                 raise Exit(message='No usable installation found', code=1)
-            installation_id = installations[0]
+            installation_id = installations[0].id
         return appAuth.get_installation_auth(int(installation_id))
 
     @staticmethod


### PR DESCRIPTION
### What does this PR do?
Replace using `pr-commenter` service with `pr-commenter` invoke task in `golang_deps_diff` job.

### Motivation
We've seen the pr-commenter service fail a couple times recently, using the invoke task should be more reliable.

### Describe how you validated your changes
Tested on the PR that it can properly add a comment and delete it.

### Additional Notes
