### PR TITLE
[tracer] Fix race in TestUDPReusePort, other tests

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1610,13 +1610,16 @@ func testUDPReusePort(t *testing.T, udpnet string, ip string) {
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	t.Logf("port: %d", assignedPort)
 
+	var incoming, outgoing *network.ConnectionStats
 	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
-		// use t instead of ct because getConnections uses require (not assert), and we get a better error message that way
 		connections, cleanup := getConnections(ct, tr)
 		defer cleanup()
 
-		incoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
-		if assert.True(ct, ok, "unable to find incoming connection") {
+		curIncoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+		if ok {
+			incoming = curIncoming
+		}
+		if assert.NotNil(ct, incoming, "unable to find incoming connection") {
 			assert.Equal(ct, network.INCOMING, incoming.Direction)
 
 			// make sure the inverse values are seen for the other message
@@ -1625,8 +1628,11 @@ func testUDPReusePort(t *testing.T, udpnet string, ip string) {
 			assert.True(ct, incoming.IntraHost, "incoming intrahost")
 		}
 
-		outgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		if assert.True(ct, ok, "unable to find outgoing connection") {
+		curOutgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+		if ok {
+			outgoing = curOutgoing
+		}
+		if assert.NotNil(ct, outgoing, "unable to find outgoing connection") {
 			assert.Equal(ct, network.OUTGOING, outgoing.Direction)
 
 			assert.Equal(ct, clientMessageSize, int(outgoing.Monotonic.SentBytes), "outgoing sent")

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2566,9 +2566,9 @@ LOOP:
 		require.Empty(collect, conn.TCPFailures, "connection should have no failures")
 
 		// after closing the client connection, the duration should be
-		// updated to a value between 1s and 2s
-		require.Greater(collect, conn.Duration, time.Second, "connection duration should be between 1 and 2 seconds")
-		require.Less(collect, conn.Duration, 2*time.Second, "connection duration should be between 1 and 2 seconds")
+		// updated to a value between 500ms and 2s.
+		require.Greater(collect, conn.Duration, 500*time.Millisecond, "connection duration should be between 500ms and 2 seconds")
+		require.Less(collect, conn.Duration, 2*time.Second, "connection duration should be between 500ms and 2 seconds")
 	}, 4*time.Second, 100*time.Millisecond, "could not find closed connection")
 }
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -213,13 +213,13 @@ func (s *TracerSuite) TestTCPSendAndReceive() {
 		require.NotNil(collect, conn)
 
 		m := conn.Monotonic
-		assert.Equal(t, 10*clientMessageSize, int(m.SentBytes))
-		assert.Equal(t, 10*serverMessageSize, int(m.RecvBytes))
+		assert.Equal(collect, 10*clientMessageSize, int(m.SentBytes))
+		assert.Equal(collect, 10*serverMessageSize, int(m.RecvBytes))
 		if !cfg.EnableEbpfless {
-			assert.Equal(t, os.Getpid(), int(conn.Pid))
+			assert.Equal(collect, os.Getpid(), int(conn.Pid))
 		}
-		assert.Equal(t, addrPort(server.Address()), int(conn.DPort))
-		assert.Equal(t, network.OUTGOING, conn.Direction)
+		assert.Equal(collect, addrPort(server.Address()), int(conn.DPort))
+		assert.Equal(collect, network.OUTGOING, conn.Direction)
 	}, 4*time.Second, 100*time.Millisecond, "failed to find connection")
 
 }
@@ -260,20 +260,20 @@ func (s *TracerSuite) TestTCPShortLived() {
 		require.True(collect, ok)
 
 		m := conn.Monotonic
-		assert.Equal(t, clientMessageSize, int(m.SentBytes))
-		assert.Equal(t, serverMessageSize, int(m.RecvBytes))
-		assert.Equal(t, 0, int(m.Retransmits))
+		assert.Equal(collect, clientMessageSize, int(m.SentBytes))
+		assert.Equal(collect, serverMessageSize, int(m.RecvBytes))
+		assert.Equal(collect, 0, int(m.Retransmits))
 		if !tr.config.EnableEbpfless {
-			assert.Equal(t, os.Getpid(), int(conn.Pid))
+			assert.Equal(collect, os.Getpid(), int(conn.Pid))
 		}
-		assert.Equal(t, addrPort(server.Address()), int(conn.DPort))
-		assert.Equal(t, network.OUTGOING, conn.Direction)
-		assert.True(t, conn.IntraHost)
+		assert.Equal(collect, addrPort(server.Address()), int(conn.DPort))
+		assert.Equal(collect, network.OUTGOING, conn.Direction)
+		assert.True(collect, conn.IntraHost)
 
 		// Verify the short lived connection is accounting for both TCP_ESTABLISHED and TCP_CLOSED events
-		assert.Equal(t, uint16(1), m.TCPEstablished)
-		assert.Equal(t, uint16(1), m.TCPClosed)
-		assert.Empty(t, conn.TCPFailures, "connection should have no failures")
+		assert.Equal(collect, uint16(1), m.TCPEstablished)
+		assert.Equal(collect, uint16(1), m.TCPClosed)
+		assert.Empty(collect, conn.TCPFailures, "connection should have no failures")
 	}, 3*time.Second, 100*time.Millisecond, "connection not found")
 
 	connections, cleanup := getConnections(t, tr)
@@ -496,13 +496,17 @@ func testUDPSendAndReceive(t *testing.T, tr *Tracer, ntwk, addr string) {
 	_, err = c.Read(make([]byte, serverMessageSize))
 	require.NoError(t, err)
 
+	var incoming, outgoing *network.ConnectionStats
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// use t instead of ct because getConnections uses require (not assert), and we get a better error message
 		connections, cleanup := getConnections(ct, tr)
 		defer cleanup()
-		incoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
-		if assert.True(ct, ok, "unable to find incoming connection") {
+		curIncoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+		if ok {
+			incoming = curIncoming
+		}
+		if assert.NotNil(ct, incoming, "unable to find incoming connection") {
 			assert.Equal(ct, network.INCOMING, incoming.Direction)
 
 			// make sure the inverse values are seen for the other message
@@ -511,8 +515,11 @@ func testUDPSendAndReceive(t *testing.T, tr *Tracer, ntwk, addr string) {
 			assert.True(ct, incoming.IntraHost, "incoming intrahost")
 		}
 
-		outgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		if assert.True(ct, ok, "unable to find outgoing connection") {
+		curOutgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+		if ok {
+			outgoing = curOutgoing
+		}
+		if assert.NotNil(ct, outgoing, "unable to find outgoing connection") {
 			assert.Equal(ct, network.OUTGOING, outgoing.Direction)
 
 			assert.Equal(ct, clientMessageSize, int(outgoing.Monotonic.SentBytes), "outgoing sent")


### PR DESCRIPTION
### What does this PR do?
This PR fixes a race condition in TestUDPReusePort where the incoming/outgoing connections could appear in separate iterations, preventing it from ever passing.

### Motivation
This race was exposed by an update to testify

### Describe how you validated your changes
Test passes now, when it failed before:
```
PATH="$PATH" sudo -E  go test -tags=linux,linux_bpf,npm,process,test -count 10 ./pkg/network/tracer -v --run 'TestTracerSuite/eBPFless/TestUDPReusePort/.*'
```
