### PR TITLE
Carlosroman/agtmetrics 138 jmxfetch metadata update

### DIFF
--- a/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go
@@ -83,7 +83,7 @@ func (ic *inventorychecksImpl) getJMXChecksMetadata() (jmxMetadata map[string][]
 					metadataEntry["jmxfetch.version"] = jmxFetchVersion
 				}
 				if javaRuntimeVersion != "" {
-					metadataEntry["java.runtime_version"] = javaRuntimeVersion
+					metadataEntry["java.version"] = javaRuntimeVersion
 				}
 
 				jmxMetadata[jmxName] = append(jmxMetadata[jmxName], metadataEntry)

--- a/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
+	"github.com/DataDog/datadog-agent/pkg/status/jmx"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 )
@@ -24,6 +25,16 @@ func (ic *inventorychecksImpl) getJMXChecksMetadata() (jmxMetadata map[string][]
 	if err != nil {
 		ic.log.Warnf("could not get JMX metadata: %v", err)
 		return
+	}
+
+	// Get JMX status to extract Java version information
+	statusData := make(map[string]interface{})
+	jmx.PopulateStatus(statusData)
+	var jmxFetchVersion, javaRuntimeVersion string
+	if jmxStatusInfo, ok := statusData["JMXStatus"]; ok {
+		if status, ok := jmxStatusInfo.(jmx.Status); ok {
+			jmxFetchVersion, javaRuntimeVersion = status.GetInfo()
+		}
 	}
 
 	if configsRaw, ok := jmxIntegrations["configs"]; ok {
@@ -59,13 +70,23 @@ func (ic *inventorychecksImpl) getJMXChecksMetadata() (jmxMetadata map[string][]
 					provider = "file"
 				}
 
-				jmxMetadata[jmxName] = append(jmxMetadata[jmxName], metadata{
+				metadataEntry := metadata{
 					"init_config":     string(initConfigYaml),
 					"instance":        string(instanceYaml),
 					"config.provider": provider,
 					"config.hash":     configHash,
 					"config.source":   source,
-				})
+				}
+
+				// Add Java version information if available
+				if jmxFetchVersion != "" {
+					metadataEntry["jmxfetch.version"] = jmxFetchVersion
+				}
+				if javaRuntimeVersion != "" {
+					metadataEntry["java.runtime_version"] = javaRuntimeVersion
+				}
+
+				jmxMetadata[jmxName] = append(jmxMetadata[jmxName], metadataEntry)
 			}
 		}
 	}

--- a/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx_test.go
@@ -57,6 +57,6 @@ func Test_inventorychecksImpl_getJMXChecksMetadata(t *testing.T) {
 		"1.0.1", jCheck[0]["jmxfetch.version"],
 		"Could not get JMXFetch version", jCheck[0])
 	assert.Equal(t,
-		"1.2.3", jCheck[0]["java.runtime_version"],
+		"1.2.3", jCheck[0]["java.version"],
 		"Could not get Java version", jCheck[0])
 }

--- a/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build jmx
+
+package inventorychecksimpl
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
+	"github.com/DataDog/datadog-agent/pkg/status/jmx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/collector/collector"
+	logagent "github.com/DataDog/datadog-agent/comp/logs/agent"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+var jmxFetchConfigInstances = `instances:
+  - host: localhost
+    port: 9999
+    tags:
+      - env:test`
+
+func Test_inventorychecksImpl_getJMXChecksMetadata(t *testing.T) {
+	ic := getTestInventoryChecks(
+		t, option.None[collector.Component](), option.Option[logagent.Component]{}, nil,
+	)
+
+	// GIVEN a JMXFetch config scheduled
+	jmxfetch.AddScheduledConfig(integration.Config{
+		Name:      "JMXFetch_check",
+		Instances: []integration.Data{integration.Data(jmxFetchConfigInstances)},
+	})
+
+	// AND JMX Status set
+	jmx.SetStatus(jmx.Status{
+		Info: map[string]interface{}{
+			"version":         "1.0.1",
+			"runtime_version": "1.2.3",
+		},
+	})
+
+	// When I get the JMX checks metatdata
+	jmxMetadata := ic.getJMXChecksMetadata()
+
+	// Then the metadata should be populated
+	require.NotEmpty(t, jmxMetadata)
+	jCheck := jmxMetadata["JMXFetch_check"]
+	require.NotEmpty(t, jCheck)
+	assert.Equal(t,
+		"1.0.1", jCheck[0]["jmxfetch.version"],
+		"Could not get JMXFetch version", jCheck[0])
+	assert.Equal(t,
+		"1.2.3", jCheck[0]["java.runtime_version"],
+		"Could not get Java version", jCheck[0])
+}

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -10,6 +10,7 @@ package jmxfetch
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -385,7 +386,7 @@ func (j *JMXFetch) Start(manage bool) error {
 		for in.Scan() {
 			j.Output(in.Text())
 		}
-		if in.Err() == bufio.ErrTooLong {
+		if errors.Is(in.Err(), bufio.ErrTooLong) {
 			goto scan
 		}
 	}()
@@ -401,7 +402,7 @@ func (j *JMXFetch) Start(manage bool) error {
 		for in.Scan() {
 			_ = j.logger.JMXError(in.Text())
 		}
-		if in.Err() == bufio.ErrTooLong {
+		if errors.Is(in.Err(), bufio.ErrTooLong) {
 			goto scan
 		}
 	}()

--- a/pkg/jmxfetch/state.go
+++ b/pkg/jmxfetch/state.go
@@ -104,23 +104,22 @@ func InitRunner(server dogstatsdServer.Component, logger jmxlogger.Component, ip
 
 // GetIntegrations returns the JMXFetch integrations' instances as a map[string]interface{}.
 func GetIntegrations() (map[string]interface{}, error) {
-	integrations := map[string]interface{}{}
-	configs := map[string]integration.JSONMap{}
+	scheduledConfigs := GetScheduledConfigs()
+	integrations := make(map[string]interface{}, 2)
+	configs := make(map[string]integration.JSONMap, len(scheduledConfigs))
 
-	for name, config := range GetScheduledConfigs() {
+	for name, config := range scheduledConfigs {
 		var rawInitConfig integration.RawMap
-		err := yaml.Unmarshal(config.InitConfig, &rawInitConfig)
-		if err != nil {
+		if err := yaml.Unmarshal(config.InitConfig, &rawInitConfig); err != nil {
 			return nil, fmt.Errorf("unable to parse JMX configuration: %w", err)
 		}
 
-		c := map[string]interface{}{}
+		c := make(map[string]interface{}, 3)
 		c["init_config"] = GetJSONSerializableMap(rawInitConfig)
-		instances := []integration.JSONMap{}
+		instances := make([]integration.JSONMap, 0, len(config.Instances))
 		for _, instance := range config.Instances {
 			var rawInstanceConfig integration.JSONMap
-			err := yaml.Unmarshal(instance, &rawInstanceConfig)
-			if err != nil {
+			if err := yaml.Unmarshal(instance, &rawInstanceConfig); err != nil {
 				return nil, fmt.Errorf("unable to parse JMX configuration: %w", err)
 			}
 			instances = append(instances, GetJSONSerializableMap(rawInstanceConfig).(integration.JSONMap))

--- a/pkg/status/jmx/jmx.go
+++ b/pkg/status/jmx/jmx.go
@@ -6,6 +6,11 @@
 // Package jmx allows to set and collect information about JMX check
 package jmx
 
+const (
+	jmxFetchVersion    = "version"
+	javaRuntimeVersion = "runtime_version"
+)
+
 type jmxCheckStatus struct {
 	InitializedChecks map[string]interface{} `json:"initialized_checks"`
 	FailedChecks      map[string]interface{} `json:"failed_checks"`
@@ -17,6 +22,23 @@ type Status struct {
 	ChecksStatus jmxCheckStatus         `json:"checks"`
 	Timestamp    int64                  `json:"timestamp"`
 	Errors       int64                  `json:"errors"`
+}
+
+// GetInfo returns JMXFetch version and Java runtime version
+func (s *Status) GetInfo() (version, runtimeVersion string) {
+	if v, ok := s.Info[jmxFetchVersion]; ok {
+		if vStr, isString := v.(string); isString {
+			version = vStr
+		}
+	}
+
+	if rv, ok := s.Info[javaRuntimeVersion]; ok {
+		if rvStr, isString := rv.(string); isString {
+			runtimeVersion = rvStr
+		}
+	}
+
+	return version, runtimeVersion
 }
 
 // StartupError holds startup status and errors


### PR DESCRIPTION
### What does this PR do?

Add `java.version` and `jmxfetch.version` to the `metadata` entry in the integrations payload sent back for JMX based integrations.

### Motivation

It allows us track adoption of new versions of JMXFetch and the version of Java being used with the Agent.

### Describe how you validated your changes

### Additional Notes
