### PR TITLE
ci(security): Move API_KEY secret to protected environment

### DIFF
--- a/.github/workflows/report-merged-pr.yml
+++ b/.github/workflows/report-merged-pr.yml
@@ -3,21 +3,17 @@
 name: Report Merged PR
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types: [closed]
 
 permissions: {}
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  DD_API_KEY: ${{ secrets.REPORT_MERGED_PR_DD_API_KEY }}
-
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true
+  report_merged_pr:
     runs-on: ubuntu-latest
+    environment:
+      name: main
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -29,8 +25,31 @@ jobs:
         with:
           features: legacy-tasks
 
+      - name: Extract PR number from commit message
+        id: extract_pr
+        run: |
+          # Get the last commit message from the push to main
+          COMMIT_MESSAGE="$(git log -1 --pretty=format:"%s")"
+          echo "Last commit message: $COMMIT_MESSAGE"
+
+          # Extract PR number from format "(#1234)" in commit message
+          PR_NUMBER=$(echo "$COMMIT_MESSAGE" | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+')
+
+          # If no PR number found in commit message, exit with error
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Error: No PR number found in commit message format (#{number})"
+            echo "Commit message was: $COMMIT_MESSAGE"
+            exit 1
+          else
+            echo "Extracted PR number from commit message: $PR_NUMBER"
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
       - name: Send merge event to Datadog
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.extract_pr.outputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DD_API_KEY: ${{ secrets.REPORT_MERGED_PR_DD_API_KEY }}
         run: |
           dda inv -- -e github.pr-merge-dd-event-sender -p "$PR_NUMBER"


### PR DESCRIPTION
### What does this PR do?
- Change the triggering event from `pull_request:closed` to `push:branch:main` to be able to use the protected environment.
- Extract the PR id from the commit message
- Use the secret from the environment

### Motivation
- Secrets restricted to protected branch are more complex to extract.

### Describe how you validated your changes
- Created a [test workflow](https://github.com/chouetz/psychic-guacamole/actions/runs/17751488674/job/50447044003) on a personal repository using the same mechanism.

### Additional Notes
