### PR TITLE
[CWS] add caching to the cgroup ID to container ID translation

### DIFF
--- a/pkg/security/secl/containerutils/helpers.go
+++ b/pkg/security/secl/containerutils/helpers.go
@@ -8,6 +8,7 @@ package containerutils
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -32,11 +33,7 @@ func init() {
 func FindContainerID(s CGroupID) ContainerID {
 	matches := containerIDPattern.FindAllIndex([]byte(s), -1)
 
-	var (
-		containerID ContainerID
-	)
-
-	for _, match := range matches {
+	for _, match := range slices.Backward(matches) {
 		// first, check what's before
 		if match[0] != 0 {
 			previousChar := string(s[match[0]-1])
@@ -52,8 +49,8 @@ func FindContainerID(s CGroupID) ContainerID {
 			}
 		}
 
-		containerID = ContainerID(s[match[0]:match[1]])
+		return ContainerID(s[match[0]:match[1]])
 	}
 
-	return containerID
+	return ""
 }


### PR DESCRIPTION
### What does this PR do?

It has been reported that the cgroup ID to container ID, that is done using regexp in the hot path, can be CPU intensive. 
This PR improves:
- the translation itself (by reducing the number of loop iteration in some cases)
- adds a caching layer in the field handlers to no compute the same translation multiple times (which is the case today) using an LRU

No functional changes

### Motivation

### Describe how you validated your changes

### Additional Notes
