### PR TITLE
[e2e] add additional error context when unmarshalling SBOMs fails

### DIFF
--- a/test/fakeintake/aggregator/sbomAggregator.go
+++ b/test/fakeintake/aggregator/sbomAggregator.go
@@ -45,7 +45,7 @@ func ParseSbomPayload(payload api.Payload) ([]*SBOMPayload, error) {
 
 	msg := agentmodel.SBOMPayload{}
 	if err := proto.Unmarshal(inflated, &msg); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing SBOM payload: data_len=%d, inflated_len=%d, encoding=%s, first_few_data_bytes=%v: %w", len(payload.Data), len(inflated), payload.Encoding, payload.Data[:min(20, len(payload.Data))], err)
 	}
 
 	payloads := make([]*SBOMPayload, len(msg.Entities))


### PR DESCRIPTION
### What does this PR do?

We recently started to see a bit of flakyness when unmarshalling SBOMs in `TestSBOM` in new-e2e-containers. The error usually looks like
```
        	Error:      	Received unexpected error:
        	            	proto: cannot parse invalid wire-format data
        	Messages:   	Failed to query fake intake
```
the issue is that the agent sends directly the result of `proto.Marshal` so this error is pretty suspicious. To help further investigation, this PR adds additional context to the error: the encoding used, the size of the payload, and a few bytes from the payload (just in case the payload is reporting a encoding different than the one actually seen in the data).

### Motivation

### Describe how you validated your changes

### Additional Notes
