### PR TITLE
[Backport 7.71.x]  add permission check on for ootb CR collection (#40894)

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -11,6 +11,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory"
@@ -19,26 +24,71 @@ import (
 	mockconfig "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	orchcfg "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
+
+// createMockAPIClient creates a mock APIClient with fake Kubernetes and dynamic clients
+// configured with the necessary custom resource types for testing.
+func createMockAPIClient() *apiserver.APIClient {
+	client := k8sfake.NewClientset()
+	scheme := runtime.NewScheme()
+
+	// Register custom resource types that the tests expect
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			// Datadog resources
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogmetrics"}:        "DatadogMetricList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogmonitors"}:       "DatadogMonitorList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogslos"}:           "DatadogSloList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogdashboards"}:     "DatadogDashboardList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogagentprofiles"}:  "DatadogAgentProfileList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogpodautoscalers"}: "DatadogPodAutoscalerList",
+			{Group: "datadoghq.com", Version: "v1alpha2", Resource: "datadogpodautoscalers"}: "DatadogPodAutoscalerList",
+			{Group: "datadoghq.com", Version: "v2alpha1", Resource: "datadogagents"}:         "DatadogAgentList",
+			// Third-party resources
+			{Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"}: "RolloutList",
+		})
+
+	return &apiserver.APIClient{
+		Cl:        client,
+		DynamicCl: dynamicClient,
+	}
+}
 
 func TestImportBuiltinCollectors(t *testing.T) {
 	cfg := mockconfig.New(t)
 	cfg.SetWithoutSource("orchestrator_explorer.terminated_pods.enabled", true)
 	cfg.SetWithoutSource("orchestrator_explorer.custom_resources.datadog.enabled", true)
 
-	// add resources to discovery cache to ensure that collectors are supported
+	// Set up discovery cache with supported resources
 	collectorDiscovery := &discovery.DiscoveryCollector{}
-	collectorDiscovery.SetCache(
-		discovery.DiscoveryCache{
-			CollectorForVersion: map[discovery.CollectorVersion]struct{}{
-				{GroupVersion: "v1", Kind: "pods"}:                                      {},
-				{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:        {},
-				{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:       {},
-				{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
-				{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
-				{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
+	collectorDiscovery.SetCache(discovery.DiscoveryCache{
+		CollectorForVersion: map[discovery.CollectorVersion]struct{}{
+			{GroupVersion: "v1", Kind: "pods"}:                                      {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:        {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:       {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogslos"}:           {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogdashboards"}:     {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogagentprofiles"}:  {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
+			{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
+			{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
+		},
+		Groups: []*v1.APIGroup{
+			{
+				Name: "datadoghq.com",
+				Versions: []v1.GroupVersionForDiscovery{
+					{Version: "v1alpha1"},
+					{Version: "v1alpha2"},
+					{Version: "v2alpha1"},
+				},
+				PreferredVersion: v1.GroupVersionForDiscovery{
+					GroupVersion: "datadoghq.com/v2alpha1",
+					Version:      "v2alpha1",
+				},
 			},
-		})
+		},
+	})
 
 	cb := CollectorBundle{
 		collectorDiscovery:  collectorDiscovery,
@@ -48,6 +98,11 @@ func TestImportBuiltinCollectors(t *testing.T) {
 			k8s.NewCRDCollector(),
 		},
 		inventory: inventory.NewCollectorInventory(cfg, nil, nil),
+		runCfg: &collectors.CollectorRunConfig{
+			K8sCollectorRunConfig: collectors.K8sCollectorRunConfig{
+				APIClient: createMockAPIClient(),
+			},
+		},
 	}
 
 	cb.importBuiltinCollectors()
@@ -62,8 +117,10 @@ func TestImportBuiltinCollectors(t *testing.T) {
 		"apiextensions.k8s.io/v1/customresourcedefinitions",
 		"datadoghq.com/v1alpha1/datadogmetrics",
 		"datadoghq.com/v1alpha1/datadogmonitors",
-		"datadoghq.com/v1alpha1/datadogpodautoscalers",
-		"datadoghq.com/v1alpha2/datadogpodautoscalers",
+		"datadoghq.com/v1alpha1/datadogslos",
+		"datadoghq.com/v1alpha1/datadogdashboards",
+		"datadoghq.com/v1alpha1/datadogagentprofiles",
+		"datadoghq.com/v1alpha2/datadogpodautoscalers", // preferred version selected
 		"datadoghq.com/v2alpha1/datadogagents",
 	}
 	require.ElementsMatch(t, expected, names)
@@ -78,6 +135,11 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 		collectors:         []collectors.K8sCollector{},
 		collectorDiscovery: collectorDiscovery,
 		inventory:          inventory.NewCollectorInventory(mockconfig.New(t), nil, nil),
+		runCfg: &collectors.CollectorRunConfig{
+			K8sCollectorRunConfig: collectors.K8sCollectorRunConfig{
+				APIClient: createMockAPIClient(),
+			},
+		},
 	}
 
 	for _, testCase := range []struct {
@@ -95,16 +157,35 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 				CollectorForVersion: map[discovery.CollectorVersion]struct{}{
 					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:        {},
 					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:       {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogslos"}:           {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogdashboards"}:     {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogagentprofiles"}:  {},
 					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
 					{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
 					{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
+				},
+				Groups: []*v1.APIGroup{
+					{
+						Name: "datadoghq.com",
+						Versions: []v1.GroupVersionForDiscovery{
+							{Version: "v1alpha1"},
+							{Version: "v1alpha2"},
+							{Version: "v2alpha1"},
+						},
+						PreferredVersion: v1.GroupVersionForDiscovery{
+							GroupVersion: "datadoghq.com/v1alpha2",
+							Version:      "v1alpha2",
+						},
+					},
 				},
 			},
 			expected: []string{
 				"datadoghq.com/v1alpha1/datadogmetrics",
 				"datadoghq.com/v1alpha1/datadogmonitors",
-				"datadoghq.com/v1alpha1/datadogpodautoscalers",
-				"datadoghq.com/v1alpha2/datadogpodautoscalers",
+				"datadoghq.com/v1alpha1/datadogslos",
+				"datadoghq.com/v1alpha1/datadogdashboards",
+				"datadoghq.com/v1alpha1/datadogagentprofiles",
+				"datadoghq.com/v1alpha2/datadogpodautoscalers", // preferred version selected
 				"datadoghq.com/v2alpha1/datadogagents",
 			},
 		},
@@ -114,6 +195,7 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 			hasCrdCollectors: true,
 			supportedResources: discovery.DiscoveryCache{
 				CollectorForVersion: map[discovery.CollectorVersion]struct{}{},
+				Groups:              []*v1.APIGroup{},
 			},
 			expected: []string{},
 		},
@@ -125,6 +207,18 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 				CollectorForVersion: map[discovery.CollectorVersion]struct{}{
 					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:  {},
 					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}: {},
+				},
+				Groups: []*v1.APIGroup{
+					{
+						Name: "datadoghq.com",
+						Versions: []v1.GroupVersionForDiscovery{
+							{Version: "v1alpha1"},
+						},
+						PreferredVersion: v1.GroupVersionForDiscovery{
+							GroupVersion: "datadoghq.com/v1alpha1",
+							Version:      "v1alpha1",
+						},
+					},
 				},
 			},
 			expected: []string{
@@ -144,6 +238,20 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 					{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
 					{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
 				},
+				Groups: []*v1.APIGroup{
+					{
+						Name: "datadoghq.com",
+						Versions: []v1.GroupVersionForDiscovery{
+							{Version: "v1alpha1"},
+							{Version: "v1alpha2"},
+							{Version: "v2alpha1"},
+						},
+						PreferredVersion: v1.GroupVersionForDiscovery{
+							GroupVersion: "datadoghq.com/v1alpha2",
+							Version:      "v1alpha2",
+						},
+					},
+				},
 			},
 			expected: []string{},
 		},
@@ -158,6 +266,20 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
 					{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
 					{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
+				},
+				Groups: []*v1.APIGroup{
+					{
+						Name: "datadoghq.com",
+						Versions: []v1.GroupVersionForDiscovery{
+							{Version: "v1alpha1"},
+							{Version: "v1alpha2"},
+							{Version: "v2alpha1"},
+						},
+						PreferredVersion: v1.GroupVersionForDiscovery{
+							GroupVersion: "datadoghq.com/v1alpha2",
+							Version:      "v1alpha2",
+						},
+					},
 				},
 			},
 			expected: []string{},
@@ -244,4 +366,127 @@ func TestGetTerminatedPodCollector(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewBuiltinCRDConfigs(t *testing.T) {
+	configs := newBuiltinCRDConfigs()
+
+	// Expected configurations (group/version/kind)
+	expectedConfigs := []string{
+		// Datadog resources
+		"datadoghq.com/v1alpha2/datadogpodautoscalers",
+		"datadoghq.com/v2alpha1/datadogagents",
+		"datadoghq.com/v1alpha1/datadogslos",
+		"datadoghq.com/v1alpha1/datadogdashboards",
+		"datadoghq.com/v1alpha1/datadogagentprofiles",
+		"datadoghq.com/v1alpha1/datadogmonitors",
+		"datadoghq.com/v1alpha1/datadogmetrics",
+
+		// Argo
+		"argoproj.io/v1alpha1/rollouts",
+
+		// karpenter all resources
+		"karpenter.sh/v1/",
+		"karpenter.k8s.aws/v1/",
+		"karpenter.azure.com/v1beta1/",
+	}
+
+	// Verify all expected configs are present
+	foundConfigs := make([]string, 0, len(configs))
+	for _, config := range configs {
+		gvk := config.group + "/" + config.preferredVersion + "/" + config.kind
+		foundConfigs = append(foundConfigs, gvk)
+
+		// Verify config structure
+		require.NotEmpty(t, config.group, "Group should not be empty")
+		require.NotEmpty(t, config.preferredVersion, "Version should not be empty")
+	}
+
+	require.ElementsMatch(t, expectedConfigs, foundConfigs)
+}
+
+func TestFilterCRCollectorsByPermission(t *testing.T) {
+	// Create test collectors
+	c1, err := k8s.NewCRCollector("datadogmetrics", "datadoghq.com/v1alpha1")
+	require.NoError(t, err)
+	c2, err := k8s.NewCRCollector("datadogmonitors", "datadoghq.com/v1alpha1")
+	require.NoError(t, err)
+	c3, err := k8s.NewCRCollector("datadogagents", "datadoghq.com/v1alpha2")
+	require.NoError(t, err)
+
+	// Test case 1: All collectors have permissions
+	t.Run("All collectors have permissions", func(t *testing.T) {
+		permissionMap := map[string]bool{
+			"datadoghq.com/v1alpha1/datadogmetrics":  false, // false means NOT forbidden
+			"datadoghq.com/v1alpha1/datadogmonitors": false,
+			"datadoghq.com/v1alpha2/datadogagents":   false,
+		}
+
+		isForbidden := func(gvr schema.GroupVersionResource) bool {
+			key := gvr.Group + "/" + gvr.Version + "/" + gvr.Resource
+			return permissionMap[key]
+		}
+
+		input := []collectors.K8sCollector{c1, c2, c3}
+		result := filterCRCollectorsByPermission(input, isForbidden)
+
+		require.Len(t, result, 3)
+		names := make([]string, len(result))
+		for i, collector := range result {
+			names[i] = collector.Metadata().FullName()
+		}
+		require.ElementsMatch(t, []string{
+			"datadoghq.com/v1alpha1/datadogmetrics",
+			"datadoghq.com/v1alpha1/datadogmonitors",
+			"datadoghq.com/v1alpha2/datadogagents",
+		}, names)
+	})
+
+	// Test case 2: No collectors have permissions
+	t.Run("No collectors have permissions", func(t *testing.T) {
+		isForbidden := func(_ schema.GroupVersionResource) bool {
+			return true // All resources are forbidden
+		}
+
+		input := []collectors.K8sCollector{c1, c2, c3}
+		result := filterCRCollectorsByPermission(input, isForbidden)
+
+		require.Len(t, result, 0)
+	})
+
+	// Test case 3: Mixed permissions
+	t.Run("Mixed permissions", func(t *testing.T) {
+		permissionMap := map[string]bool{
+			"datadoghq.com/v1alpha1/datadogmetrics":  false, // false means NOT forbidden (allowed)
+			"datadoghq.com/v1alpha1/datadogmonitors": true,  // true means forbidden (not allowed)
+			"datadoghq.com/v1alpha2/datadogagents":   false,
+		}
+
+		isForbidden := func(gvr schema.GroupVersionResource) bool {
+			key := gvr.Group + "/" + gvr.Version + "/" + gvr.Resource
+			return permissionMap[key]
+		}
+
+		input := []collectors.K8sCollector{c1, c2, c3}
+		result := filterCRCollectorsByPermission(input, isForbidden)
+
+		require.Len(t, result, 2)
+		names := make([]string, len(result))
+		for i, collector := range result {
+			names[i] = collector.Metadata().FullName()
+		}
+		require.ElementsMatch(t, []string{
+			"datadoghq.com/v1alpha1/datadogmetrics",
+			"datadoghq.com/v1alpha2/datadogagents",
+		}, names)
+	})
+
+	// Test case 4: Empty input
+	t.Run("Empty input", func(t *testing.T) {
+		isForbidden := func(_ schema.GroupVersionResource) bool {
+			return true // All resources are forbidden (doesn't matter for empty input)
+		}
+		result := filterCRCollectorsByPermission([]collectors.K8sCollector{}, isForbidden)
+		require.Len(t, result, 0)
+	})
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cr.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cr.go
@@ -74,13 +74,14 @@ func (c *CRCollector) Informer() cache.SharedInformer {
 	return c.informer.Informer()
 }
 
-func (c *CRCollector) getGRV() schema.GroupVersionResource {
+// GetGRV returns group, version and resource
+func (c *CRCollector) GetGRV() schema.GroupVersionResource {
 	return c.gvr
 }
 
 // Init is used to initialize the collector.
 func (c *CRCollector) Init(rcfg *collectors.CollectorRunConfig) {
-	grv := c.getGRV()
+	grv := c.GetGRV()
 	c.informer = rcfg.OrchestratorInformerFactory.DynamicInformerFactory.ForResource(grv)
 	c.lister = c.informer.Lister()
 }


### PR DESCRIPTION
backport 164e7651f39f00dbf95c30370588f6fad1d14cd3 from https://github.com/DataDog/datadog-agent/pull/40894

-----

This PR adds a permission check to the out-of-the-box CR collection. If the Cluster Agent doesn’t have the required permissions, it will skip collecting that kind of custom resource.

The check is done by making a single List request to the api server and checking if the returned error is a `forbidden` error. It doesn’t require extra permissions and is simple to implement.

- If the cluster doesn’t support the specified custom resource kind in the out-of-the-box collection, we log info
`Skipping built-in CR collector: no supported version found` once and skip it.

- If the cluster doesn’t support the specified custom resource group in the out-of-the-box collection, we log info
`Unsupported built-in CR collector` once and skip it.

- If the Cluster Agent doesn’t have permission to access a custom resource in the out-of-the-box collection, we log info `Skipping built-in collector due to insufficient permissions:` once and skip it.

- If a user manually configures the Agent to collect a CR but it lacks permissions, we log a warning every 15s:
`check:orchestrator | Collector argoproj.io/v1alpha1/rollouts is skipped: couldn't sync informer argoproj.io/v1alpha1/rollouts in 1m10.001023574s`

Add environment var to cluster agent
```
clusterAgent:
  env:
    - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_DATADOG_ENABLED
      value: true
    - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_THIRD_PARTY_ENABLED
      value: true
```

Update cluster role to have incorrect role for argo rollouts `rolloutsss`

```
- apiGroups:
  - datadoghq.com
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - karpenter.sh
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - karpenter.k8s.aws
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - karpenter.azure.com
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - argoproj.io
  resources:
  - rolloutsss
  verbs:
  - list
  - watch

```

Check cluster agent logs `Skipping built-in collector due to insufficient permissions:`

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
