### PR TITLE
Change log level for circuit breaker endpoint blocks from ERROR to WARNING

### DIFF
--- a/comp/forwarder/defaultforwarder/worker.go
+++ b/comp/forwarder/defaultforwarder/worker.go
@@ -192,7 +192,7 @@ func (w *Worker) process(ctx context.Context, t transaction.Transaction) {
 	target := t.GetTarget()
 	if w.blockedList.isBlock(target) {
 		w.requeue(t)
-		w.log.Errorf("Too many errors for endpoint '%s': retrying later", target)
+		w.log.Warnf("Too many errors for endpoint '%s': retrying later", target)
 	} else if err := t.Process(ctx, w.config, w.log, w.Client.GetClient()); err != nil {
 		w.blockedList.close(target)
 		w.requeue(t)

--- a/releasenotes/notes/forwarder-log-level-fix-1758042138.yaml
+++ b/releasenotes/notes/forwarder-log-level-fix-1758042138.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Changed log level from ERROR to WARNING for "Too many errors for endpoint" 
+    messages when forwarder circuit breaker blocks requests. This reduces log 
+    noise as these are temporary conditions that resolve automatically.


### PR DESCRIPTION
### What does this PR do?

Changes the log level for forwarder circuit breaker "too many errors for endpoint" messages from ERROR to WARNING level.

### Motivation

The "Too many errors for endpoint" message occurs when the forwarder's circuit breaker temporarily blocks requests to problematic endpoints. This is a normal recovery mechanism, not an actual error condition.

Using WARNING level reduces log noise and better reflects the temporary nature of this condition.

Fixes #39921

### Describe how you validated your changes

- Tested locally by triggering circuit breaker conditions
- Verified log level changes from ERROR to WARNING
- Confirmed circuit breaker functionality remains unchanged

### Additional Notes

This change only affects log verbosity and does not modify the circuit breaker logic or functionality.