### PR TITLE
codeowners: give ownership of compliance system-probe module to CSPM

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -249,6 +249,7 @@
 /cmd/system-probe/modules/oom_kill_probe*   @DataDog/container-integrations
 /cmd/system-probe/modules/process*      @DataDog/container-experiences
 /cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
+/cmd/system-probe/modules/compliance*   @DataDog/agent-cspm
 /cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
 /cmd/system-probe/modules/traceroute*  @DataDog/cloud-network-monitoring
 /cmd/system-probe/modules/ping*         @DataDog/ndm-core


### PR DESCRIPTION
### What does this PR do?

Those files are part of the cspm product, they should be owned by agent-cspm.

### Motivation

### Describe how you validated your changes

### Additional Notes
