### PR TITLE
fix(docker): Docker container size metrics not sent when configured via autodiscovery

### DIFF
--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -189,7 +189,7 @@ func (d *DockerCheck) Run() error {
 		_ = d.Warnf("Error collecting metrics: %s", err)
 	}
 
-	return d.runDockerCustom(sender, du, rawContainerList)
+	return d.runDockerCustom(sender, du, rawContainerList, collectContainerSize)
 }
 
 func (d *DockerCheck) runProcessor(sender sender.Sender) error {
@@ -203,7 +203,7 @@ type containersPerTags struct {
 	stopped int64
 }
 
-func (d *DockerCheck) runDockerCustom(sender sender.Sender, du docker.Client, rawContainerList []container.Summary) error {
+func (d *DockerCheck) runDockerCustom(sender sender.Sender, du docker.Client, rawContainerList []container.Summary, collectContainerSize bool) error {
 	// Container metrics
 	var containersRunning, containersStopped uint64
 	containerGroups := map[string]*containersPerTags{}
@@ -270,13 +270,12 @@ func (d *DockerCheck) runDockerCustom(sender sender.Sender, du docker.Client, ra
 			continue
 		}
 
-		// Send container size metrics
-		containerTags, err := d.tagger.Tag(taggerEntityID, types.HighCardinality)
-		if err != nil {
-			log.Warnf("Unable to fetch tags for container: %s, err: %v", rawContainer.ID, err)
-		}
-
-		if rawContainer.SizeRw > 0 || rawContainer.SizeRootFs > 0 {
+		// Send container size metrics only when size collection is enabled and requested
+		if collectContainerSize && (rawContainer.SizeRw > 0 || rawContainer.SizeRootFs > 0) {
+			containerTags, err := d.tagger.Tag(taggerEntityID, types.HighCardinality)
+			if err != nil {
+				log.Warnf("Unable to fetch tags for container: %s, err: %v", rawContainer.ID, err)
+			}
 			sender.Gauge("docker.container.size_rw", float64(rawContainer.SizeRw), "", containerTags)
 			sender.Gauge("docker.container.size_rootfs", float64(rawContainer.SizeRootFs), "", containerTags)
 		}

--- a/pkg/collector/corechecks/containers/docker/check_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_test.go
@@ -215,7 +215,7 @@ func TestDockerCustomPart(t *testing.T) {
 		tagger:           fakeTagger,
 	}
 
-	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList)
+	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList, true)
 	assert.NoError(t, err)
 
 	mockSender.AssertNumberOfCalls(t, "Gauge", 14)
@@ -294,7 +294,7 @@ func TestContainersRunning(t *testing.T) {
 		tagger:         fakeTagger,
 	}
 
-	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList)
+	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList, false)
 	assert.NoError(t, err)
 
 	// Containers that share the same set of tags should be reported together,
@@ -358,4 +358,46 @@ func TestProcess_CPUSharesMetric(t *testing.T) {
 	mockSender.AssertMetric(t, "Gauge", "docker.cpu.shares", 1024, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "docker.cpu.shares", 2597, "", expectedTags)
 	mockSender.AssertNotCalled(t, "Gauge", "docker.cpu.shares", 0.0, "", mocksender.MatchTagsContains(expectedTags))
+}
+
+func TestDockerCheckSizeMetricsNotCollectedWhenDisabled(t *testing.T) {
+	dockerClient := docker.FakeDockerClient{
+		FakeContainerList: []container.Summary{
+			{
+				ID:         "container_id",
+				Names:      []string{"/container_name"},
+				Image:      "datadog/agent:latest",
+				ImageID:    "sha256:image_id",
+				State:      "running",
+				SizeRw:     100,
+				SizeRootFs: 200,
+			},
+		},
+	}
+
+	mockSender := mocksender.NewMockSender("docker")
+	mockSender.SetupAcceptAll()
+
+	fakeTagger := taggermock.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
+	fakeTagger.SetTags("container_id://container_id", "workload", []string{"image_name:datadog/agent", "short:agent", "tag:latest"}, nil, nil, nil)
+
+	check := DockerCheck{
+		CheckBase: core.NewCheckBase("docker"),
+		instance: &DockerConfig{
+			CollectContainerSize: true,
+		},
+		tagger: fakeTagger,
+	}
+
+	// Test with collectContainerSize=false - size metrics should not be sent
+	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList, false)
+	assert.NoError(t, err)
+
+	// Should not have size metrics when collectContainerSize is false
+	mockSender.AssertNotCalled(t, "Gauge", "docker.container.size_rw")
+	mockSender.AssertNotCalled(t, "Gauge", "docker.container.size_rootfs")
+
+	// But should still have other container metrics
+	mockSender.AssertMetric(t, "Gauge", "docker.containers.running", 1, "", []string{"image_name:datadog/agent", "short:agent", "tag:latest"})
 }

--- a/releasenotes/notes/docker-container-size-metrics-fix-21f8ef01bc7eaa06.yaml
+++ b/releasenotes/notes/docker-container-size-metrics-fix-21f8ef01bc7eaa06.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed Docker container size metrics (docker.container.size_rw and 
+    docker.container.size_rootfs) not being sent to Datadog when configured 
+    via autodiscovery labels. The metrics are now properly collected and sent 
+    only when collect_container_size is enabled and the collection frequency 
+    conditions are met.


### PR DESCRIPTION
### What does this PR do?

Fixes Docker container size metrics (`docker.container.size_rw` and `docker.container.size_rootfs`) not being sent to Datadog when configured via autodiscovery labels, even though they appear in `agent check docker` output.

### Motivation

Fixes #39158 - Docker container size metrics are collected locally but not sent to Datadog when using autodiscovery configuration. The Docker check was attempting to send size metrics regardless of whether size collection was actually requested from the Docker API, causing metrics to either not be sent or sent with incorrect values when collection frequency conditions weren't met.

### Describe how you validated your changes

- **Local testing:** Reproduced the issue with autodiscovery configuration from #39158
- **Unit tests:** Added test case `TestDockerCheckSizeMetricsNotCollectedWhenDisabled` to verify size metrics are not sent when `collectContainerSize=false`
- **Updated existing tests:** Modified test calls to maintain compatibility
- **Manual verification:** Confirmed `agent check docker` shows size metrics only when collection is enabled

### Additional Notes

This enables proper gating of Docker container size metrics based on collection settings. The change maintains backward compatibility - existing functionality continues to work unchanged, but now metrics are only sent when size collection is actually enabled and requested.