### PR TITLE
feat(issue): Add a pending label to prevent closing unviewed issues

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -6,6 +6,24 @@ on:
     types: [opened, reopened]
 
 jobs:
+  set_pending_label:
+    if: github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Set pending label
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["pending"]
+            });
+
   auto_assign_issue:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/check_issue_status.yml
+++ b/.github/workflows/check_issue_status.yml
@@ -1,0 +1,58 @@
+---
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if there is a comment from a datadog member
+        id: datadog-comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          result-encoding: string
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            let commented = "false";
+            for (const comment of comments.data) {
+              try {
+                const membership = await github.rest.orgs.checkMembershipForUser({
+                  org: 'datadog',
+                  username: comment.user.login
+                });
+                if (membership.status === 204) {
+                  commented = "true";
+                  break;
+                }
+              } catch (error) {
+                if (error.name === 'HttpError') {
+                  // User is not a datadog member
+                  continue;
+                }
+                throw error;
+              }
+            }
+      - name: Remove the pending label when issue is commented
+        if: steps.datadog-comment.outputs.result == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            for (const label of labels.data) {
+              if (label.name === 'pending') {
+                await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: label.name
+            });
+


### PR DESCRIPTION
### What does this PR do?
- Add a `pending` label to every created issue.
- Drop this label as soon as a Datadog member comments the issue.

### Motivation
- In #40584 we will close stale issues/PR. We want to prevent closing such issues when no one from Datadog ever looked at created issues. The `pending` labeled issues will be ignored by the stale action. 

### Describe how you validated your changes
Local execution of the js code:
- [Creation of the label](https://github.com/chouetz/psychic-guacamole/issues/282)
- Test if issue is [commented](https://github.com/DataDog/datadog-agent/issues/40506) or [not](https://github.com/DataDog/datadog-agent/issues/38461)
- [Removal of the label](https://github.com/DataDog/datadog-agent/issues/38461) issue

### Additional Notes
