### PR TITLE
process: discovery: make service collection interval configurable

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -45,10 +45,9 @@ import (
 )
 
 const (
-	collectorID               = "process-collector"
-	componentName             = "workloadmeta-process"
-	cacheValidityNoRT         = 2 * time.Second
-	serviceCollectionInterval = 60 * time.Second // TODO: this should be made configurable in the future
+	collectorID       = "process-collector"
+	componentName     = "workloadmeta-process"
+	cacheValidityNoRT = 2 * time.Second
 
 	// Service discovery constants
 	maxPortCheckTries = 10
@@ -166,6 +165,10 @@ func (c *collector) isServiceDiscoveryEnabled() bool {
 	return c.systemProbeConfig.GetBool("discovery.enabled")
 }
 
+func (c *collector) getServiceCollectionInterval() time.Duration {
+	return c.systemProbeConfig.GetDuration("discovery.service_collection_interval")
+}
+
 // isLanguageCollectionEnabled returns a boolean indicating if language collection is enabled
 func (c *collector) isLanguageCollectionEnabled() bool {
 	return c.config.GetBool("language_detection.enabled")
@@ -174,6 +177,7 @@ func (c *collector) isLanguageCollectionEnabled() bool {
 // processCollectionIntervalConfig returns the configured collection interval
 func (c *collector) processCollectionIntervalConfig() time.Duration {
 	processCollectionInterval := checks.GetInterval(c.config, checks.ProcessCheckName)
+	serviceCollectionInterval := c.getServiceCollectionInterval()
 	// service discovery data will be incorrect/empty if the process collection interval > service collection interval
 	// therefore, the service collection interval must be the max interval for process collection
 	if processCollectionInterval > serviceCollectionInterval {
@@ -213,6 +217,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 	}
 
 	if c.isServiceDiscoveryEnabled() {
+		serviceCollectionInterval := c.getServiceCollectionInterval()
 		// Initialize service discovery metric
 		c.metricDiscoveredServices = telemetry.NewGaugeWithOpts(
 			collectorID,

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -364,6 +364,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "network_stats.enabled"), true)
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "network_stats.period"), "60s")
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_command_names"), []string{"chronyd", "cilium-agent", "containerd", "dhclient", "dockerd", "kubelet", "livenessprobe", "local-volume-pr", "sshd", "systemd"})
+	cfg.BindEnvAndSetDefault(join(discoveryNS, "service_collection_interval"), "60s")
 
 	// Fleet policies
 	cfg.BindEnv("fleet_policies_dir")


### PR DESCRIPTION
### What does this PR do?

This PR makes the collection interval of Service Discovery configurable via the `discovery.service_collection_interval` configuration option.

### Motivation

DSCVR-142

### Describe how you validated your changes

Setting the new `discovery.service_collection_interval` to a very short period (e.g 10s) and, without starting system-probe (so that the collection fails), witness in logs that it does try to collect services at the configured interval.

### Additional Notes
