### PR TITLE
[USMON-1490] usm: postgres: Improve PostgreSQL performance with object pooling for RequestStat

### DIFF
--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -268,6 +268,7 @@ func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 		}, func() {
 			for _, stat := range stats {
 				stat.Close()
+				requestStatPool.Put(stat)
 			}
 		}
 }

--- a/pkg/network/protocols/postgres/stats_linux.go
+++ b/pkg/network/protocols/postgres/stats_linux.go
@@ -16,6 +16,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
+)
+
+var (
+	requestStatPool = ddsync.NewDefaultTypedPool[RequestStat]()
 )
 
 // Key is an identifier for a group of Postgres transactions
@@ -81,5 +86,10 @@ func (r *RequestStat) Close() {
 	if r.Latencies != nil {
 		r.Latencies.Clear()
 		protocols.SketchesPool.Put(r.Latencies)
+		r.Latencies = nil
 	}
+
+	r.Count = 0
+	r.FirstLatencySample = 0
+	r.StaticTags = 0
 }

--- a/pkg/network/protocols/postgres/statskeeper.go
+++ b/pkg/network/protocols/postgres/statskeeper.go
@@ -45,7 +45,7 @@ func (s *StatKeeper) Process(tx *EventWrapper) {
 		if len(s.stats) >= s.maxEntries {
 			return
 		}
-		requestStats = new(RequestStat)
+		requestStats = requestStatPool.Get()
 		s.stats[key] = requestStats
 	}
 	requestStats.StaticTags = uint64(tx.Tx.Tags)


### PR DESCRIPTION
## What does this PR do?

This PR introduces object pooling for PostgreSQL request statistics to improve performance and reduce memory allocation pressure in the USM PostgreSQL protocol monitoring.

The changes implement:
- A typed object pool for `RequestStat` objects using `ddsync.NewDefaultTypedPool`
- Proper cleanup and reuse of objects through the pool instead of creating new instances
- Memory clearing in the `Close()` method to prevent memory leaks when objects are returned to pools

## Motivation

PostgreSQL request statistics are frequently allocated and deallocated during network monitoring operations. This creates significant memory allocation pressure and garbage collection overhead, particularly in high-throughput database environments. By reusing these objects through pools, we can:

- Reduce memory allocations and GC pressure
- Improve overall PostgreSQL monitoring performance
- Lower memory usage patterns in long-running agents

## Describe how you validated your changes

The changes preserve existing functionality while adding pooling:
- Object lifecycle is maintained with proper initialization and cleanup
- All existing fields are properly reset when objects are returned to pools
- Pool usage follows established patterns in the codebase using `ddsync` utilities
- All PostgreSQL protocol tests pass
- Linter passes with correct build tags

## Additional Notes

This builds on the existing pooling infrastructure in the codebase and follows the same patterns used elsewhere for object lifecycle management. PostgreSQL has a simpler structure than other protocols, requiring only `RequestStat` object pooling (no `RequestStats` container).

This follows the exact same approach as:
- PR #40907 for HTTP monitoring
- PR #40915 for Redis monitoring  
- PR #40994 for Kafka monitoring

**JIRA:** USMON-1490

---

🤖 Generated with [Claude Code](https://claude.ai/code)