### PR TITLE
fix(docker): pass collectContainerSize parameter to runDockerCustom method

### DIFF
--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -276,7 +276,7 @@ func (d *DockerCheck) runDockerCustom(sender sender.Sender, du docker.Client, ra
 			log.Warnf("Unable to fetch tags for container: %s, err: %v", rawContainer.ID, err)
 		}
 
-		if collectContainerSize && (rawContainer.SizeRw > 0 || rawContainer.SizeRootFs > 0) {
+		if rawContainer.SizeRw > 0 || rawContainer.SizeRootFs > 0 {
 			sender.Gauge("docker.container.size_rw", float64(rawContainer.SizeRw), "", containerTags)
 			sender.Gauge("docker.container.size_rootfs", float64(rawContainer.SizeRootFs), "", containerTags)
 		}

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -189,7 +189,7 @@ func (d *DockerCheck) Run() error {
 		_ = d.Warnf("Error collecting metrics: %s", err)
 	}
 
-	return d.runDockerCustom(sender, du, rawContainerList)
+	return d.runDockerCustom(sender, du, rawContainerList, collectContainerSize)
 }
 
 func (d *DockerCheck) runProcessor(sender sender.Sender) error {
@@ -203,7 +203,7 @@ type containersPerTags struct {
 	stopped int64
 }
 
-func (d *DockerCheck) runDockerCustom(sender sender.Sender, du docker.Client, rawContainerList []container.Summary) error {
+func (d *DockerCheck) runDockerCustom(sender sender.Sender, du docker.Client, rawContainerList []container.Summary, collectContainerSize bool) error {
 	// Container metrics
 	var containersRunning, containersStopped uint64
 	containerGroups := map[string]*containersPerTags{}
@@ -276,7 +276,7 @@ func (d *DockerCheck) runDockerCustom(sender sender.Sender, du docker.Client, ra
 			log.Warnf("Unable to fetch tags for container: %s, err: %v", rawContainer.ID, err)
 		}
 
-		if rawContainer.SizeRw > 0 || rawContainer.SizeRootFs > 0 {
+		if collectContainerSize && (rawContainer.SizeRw > 0 || rawContainer.SizeRootFs > 0) {
 			sender.Gauge("docker.container.size_rw", float64(rawContainer.SizeRw), "", containerTags)
 			sender.Gauge("docker.container.size_rootfs", float64(rawContainer.SizeRootFs), "", containerTags)
 		}

--- a/pkg/collector/corechecks/containers/docker/check_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_test.go
@@ -201,12 +201,13 @@ func TestDockerCustomPart(t *testing.T) {
 	// Create Docker check
 	check := DockerCheck{
 		instance: &DockerConfig{
-			CollectExitCodes:   true,
-			CollectImagesStats: true,
-			CollectImageSize:   true,
-			CollectDiskStats:   true,
-			CollectVolumeCount: true,
-			CollectEvent:       true,
+			CollectExitCodes:     true,
+			CollectImagesStats:   true,
+			CollectImageSize:     true,
+			CollectDiskStats:     true,
+			CollectVolumeCount:   true,
+			CollectContainerSize: true,
+			CollectEvent:         true,
 		},
 		eventTransformer: newBundledTransformer("testhostname", []string{}, fakeTagger),
 		dockerHostname:   "testhostname",
@@ -215,7 +216,7 @@ func TestDockerCustomPart(t *testing.T) {
 		tagger:           fakeTagger,
 	}
 
-	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList)
+	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList, true)
 	assert.NoError(t, err)
 
 	mockSender.AssertNumberOfCalls(t, "Gauge", 14)
@@ -294,7 +295,7 @@ func TestContainersRunning(t *testing.T) {
 		tagger:         fakeTagger,
 	}
 
-	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList)
+	err := check.runDockerCustom(mockSender, &dockerClient, dockerClient.FakeContainerList, false)
 	assert.NoError(t, err)
 
 	// Containers that share the same set of tags should be reported together,

--- a/releasenotes/notes/fix-docker-container-size-metrics-39084-5e3ccb6d216ea716.yaml
+++ b/releasenotes/notes/fix-docker-container-size-metrics-39084-5e3ccb6d216ea716.yaml
@@ -1,0 +1,9 @@
+# Fix for Docker container size metrics not being collected when configured via autodiscovery
+---
+fixes:
+  - |
+    Fixed an issue where ``docker.container.size_rw`` and ``docker.container.size_rootfs`` 
+    metrics were not being sent to Datadog when ``collect_container_size`` was enabled 
+    via autodiscovery configuration. The ``collectContainerSize`` parameter was not being 
+    properly passed to the ``runDockerCustom`` method, causing the size metrics to be 
+    ignored regardless of the configuration setting.


### PR DESCRIPTION
## What does this PR do?

Fixes #39084 

This PR fixes an issue where  and  metrics were not being sent to Datadog when  was enabled via autodiscovery configuration.

## Motivation

The  parameter was calculated in the  method but was not being passed to the  method. This caused the size metrics to be ignored regardless of the configuration setting, leading to missing metrics in the Datadog UI.

## Describe how to test this change

1. Configure a Docker container with autodiscovery:
   

2. Run the agent and verify that  and  metrics are now collected and sent to Datadog.

## Additional Notes

- Updated test cases to include the new  parameter
- Added release note documenting the fix
- No breaking changes to existing functionality