### PR TITLE
[CWS] Use pre-allocated maps on <6.1 kernels

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -318,9 +318,10 @@ func (k *Version) IsInRangeCloseOpen(begin kernel.Version, end kernel.Version) b
 	return k.Code != 0 && begin <= k.Code && k.Code < end
 }
 
-// HasNoPreallocMapsInPerfEvent returns true if the kernel supports using non-preallocated maps in perf_event programs
+// HasSafeBPFMemoryAllocations returns true if the kernel supports using non-preallocated maps in perf_event programs
+// and considers using non-preallocated maps in tracing programs as safe
 // See https://github.com/torvalds/linux/commit/274052a2b0ab9f380ce22b19ff80a99b99ecb198
-func (k *Version) HasNoPreallocMapsInPerfEvent() bool {
+func (k *Version) HasSafeBPFMemoryAllocations() bool {
 	return k.Code >= Kernel6_1
 }
 

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -361,7 +361,7 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 		}
 	}
 
-	if !kv.HasNoPreallocMapsInPerfEvent() {
+	if !kv.HasSafeBPFMemoryAllocations() {
 		editors["active_flows"] = manager.MapSpecEditor{
 			MaxEntries: activeFlowsMaxEntries,
 			Flags:      unix.BPF_ANY,

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -263,10 +263,6 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			MaxEntries: nsFlowToNetworkStats,
 			EditorFlag: manager.EditMaxEntries,
 		},
-		"inet_bind_args": {
-			MaxEntries: superReducedProcPidCacheSize,
-			EditorFlag: manager.EditMaxEntries,
-		},
 		"activity_dumps_config": {
 			MaxEntries: model.MaxTracedCgroupsCount,
 			EditorFlag: manager.EditMaxEntries,
@@ -357,7 +353,8 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			KeySize:    1,
 			ValueSize:  1,
 			MaxEntries: 1,
-			EditorFlag: manager.EditKeyValue | manager.EditType | manager.EditMaxEntries,
+			Flags:      unix.BPF_ANY,
+			EditorFlag: manager.EditKeyValue | manager.EditType | manager.EditMaxEntries | manager.EditFlags,
 		}
 	}
 
@@ -367,9 +364,18 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			Flags:      unix.BPF_ANY,
 			EditorFlag: manager.EditMaxEntries | manager.EditFlags,
 		}
+		editors["inet_bind_args"] = manager.MapSpecEditor{
+			MaxEntries: superReducedProcPidCacheSize,
+			Flags:      unix.BPF_ANY,
+			EditorFlag: manager.EditMaxEntries | manager.EditFlags,
+		}
 	} else {
 		editors["active_flows"] = manager.MapSpecEditor{
 			MaxEntries: activeFlowsMaxEntries,
+			EditorFlag: manager.EditMaxEntries,
+		}
+		editors["inet_bind_args"] = manager.MapSpecEditor{
+			MaxEntries: superReducedProcPidCacheSize,
 			EditorFlag: manager.EditMaxEntries,
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Remove the `BPF_F_NO_PREALLOC` flag from eBPF maps used by tracing programs when the kernel considers memory allocations from eBPF unsafe. This change should have no functional impact.

### Motivation

Avoid kernel warning on <6.1 kernels when CWS is enabled.

```
[   77.807596] ------------[ cut here ]------------                                                                                                                                                           
[   77.807598] trace type BPF program uses run-time allocation                                                                                                                                                
[   77.807608] WARNING: CPU: 1 PID: 1528 at kernel/bpf/verifier.c:11728 check_map_prog_compatibility+0x231/0x2a0                                                                                              
[   77.807613] Modules linked in: xt_conntrack xt_MASQUERADE bridge stp llc xt_set ip_set nft_counter nft_chain_nat nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 xt_addrtype nft_compat nf_tables nfnetli
nk xfrm_user xfrm_algo binfmt_misc overlay kvm_intel kvm joydev input_leds serio_raw sch_fq_codel dm_multipath scsi_dh_rdac scsi_dh_emc scsi_dh_alua ipmi_devintf ipmi_msghandler msr drm ip_tables x_tables a
utofs4 btrfs blake2b_generic zstd_compress raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor raid6_pq libcrc32c raid1 raid0 multipath linear crct10dif_pclmul crc32_pclmul ghash_c
lmulni_intel sha256_ssse3 sha1_ssse3 aesni_intel crypto_simd virtio_net net_failover cryptd psmouse failover virtio_blk                                                                                       
[   77.807641] CPU: 1 PID: 1528 Comm: testsuite Not tainted 5.15.0-139-generic #149-Ubuntu                                                                                                                    
[   77.807643] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.16.0-debian-1.16.0-5~20.04.sav0 04/01/2014                                                                                       
[   77.807644] RIP: 0010:check_map_prog_compatibility+0x231/0x2a0                                                                                                                                             
[   77.807645] Code: 00 c6 ff a0 4c 89 ef 41 be ea ff ff ff e8 37 d2 ff ff e9 e3 fe ff ff 48 c7 c7 78 c4 ff a0 c6 05 71 76 f9 01 01 e8 76 8c ac 00 <0f> 0b e9 0d ff ff ff 48 c7 c6 48 c5 ff a0 4c 89 ef 41 be 
ea ff ff
[   77.807647] RSP: 0018:ffffaf88c0c43bf8 EFLAGS: 00010282                                                                                                                                                    
[   77.807648] RAX: 0000000000000000 RBX: ffffaf88c0915000 RCX: 0000000000000027                                                                                                                              
[   77.807649] RDX: ffff923db7ca0588 RSI: 0000000000000001 RDI: ffff923db7ca0580                                                                                                                              
[   77.807650] RBP: ffffaf88c0c43c20 R08: 0000000000000003 R09: fffffffffffca418                                                                                                                              
[   77.807650] R10: ffffffffa2c46b90 R11: 0000000000000001 R12: ffff923c853e4000                                                                                                                              
[   77.807651] R13: ffff923c85cf6000 R14: 0000000000000002 R15: 0000000000000000                                                                                                                              
[   77.807651] FS:  00007f5e4089d640(0000) GS:ffff923db7c80000(0000) knlGS:0000000000000000                                                                                                                   
[   77.807652] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033                                                                                                                                              
[   77.807653] CR2: 000000c005ea6b1d CR3: 000000010263a003 CR4: 0000000000770ee0                                                                                                                              
[   77.807655] PKRU: 55555554                                                                                                                                                                                 
[   77.807656] Call Trace:                                                                                                                                                                                    
[   77.807657]  <TASK>                                                                                                                                                                                        
[   77.807659]  ? show_trace_log_lvl+0x1d6/0x2ea                                                                                                                                                              
[   77.807661]  ? show_trace_log_lvl+0x1d6/0x2ea                                                                                                                                                              
[   77.807662]  ? resolve_pseudo_ldimm64+0x134/0x5f0                                                                                                                                                          
[   77.807664]  ? show_regs.part.0+0x23/0x29                                                                                                                                                                  
[   77.807665]  ? show_regs.cold+0x8/0xd                                                                                                                                                                      
[   77.807666]  ? check_map_prog_compatibility+0x231/0x2a0                                                                                                                                                    
[   77.807667]  ? __warn+0x8c/0x100                                                                                                                                                                           
[   77.807668]  ? check_map_prog_compatibility+0x231/0x2a0                                                                                                                                                    
[   77.807670]  ? report_bug+0xa4/0xd0                                                                                                                                                                        
[   77.807672]  ? handle_bug+0x39/0x90                                                                                                                                                                        
[   77.807674]  ? exc_invalid_op+0x19/0x70                                                                                                                                                                    
[   77.807675]  ? asm_exc_invalid_op+0x1b/0x20                                                                                                                                                                
[   77.807677]  ? check_map_prog_compatibility+0x231/0x2a0                                                                                                                                                    
[   77.807678]  ? check_map_prog_compatibility+0x231/0x2a0                                                                                                                                                    
[   77.807680]  resolve_pseudo_ldimm64+0x134/0x5f0                                                                                                                                                            
[   77.807681]  bpf_check+0x6a4/0xf10                                                                                                                                                                         
[   77.807683]  bpf_prog_load+0x63f/0xa20                                                                                                                                                                     
[   77.807684]  ? capable+0x33/0x60                                                                                                                                                                           
[   77.807686]  ? __sys_bpf+0x8ce/0xdc0                                                                                                                                                                       
[   77.807687]  ? security_capable+0x3a/0x60                                                                                                                                                                  
[   77.807690]  __sys_bpf+0x62c/0xdc0                                                                                                                                                                         
[   77.807691]  __x64_sys_bpf+0x1a/0x30                                                                                                                                                                       
[   77.807692]  x64_sys_call+0x1753/0x1fa0                                                                                                                                                                    
[   77.807695]  do_syscall_64+0x56/0xb0                                                                                                                                                                       
[   77.807695]  ? clear_bhb_loop+0x45/0xa0                                                                                                                                                                    
[   77.807696]  ? clear_bhb_loop+0x45/0xa0                                                                                                                                                                    
[   77.807697]  ? clear_bhb_loop+0x45/0xa0                                                                                                                                                                    
[   77.807698]  ? clear_bhb_loop+0x45/0xa0                                                                                                                                                                    
[   77.807698]  entry_SYSCALL_64_after_hwframe+0x6c/0xd6                                                                                                                                                      
[   77.807700] RIP: 0033:0x410cae                                                                                                                                                                             
[   77.807701] Code: 24 28 44 8b 44 24 2c e9 70 ff ff ff cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc 49 89 f2 48 89 fa 48 89 ce 48 89 df 0f 05 <48> 3d 01 f0 ff ff 76 15 48 f7 d8 48 89 c1 48 c7 c0 ff ff 
ff ff 48
[   77.807701] RSP: 002b:000000c004b8d960 EFLAGS: 00000212 ORIG_RAX: 0000000000000141
[   77.807702] RAX: ffffffffffffffda RBX: 0000000000000005 RCX: 0000000000410cae
[   77.807703] RDX: 0000000000000098 RSI: 000000c004b8e010 RDI: 0000000000000005
[   77.807704] RBP: 000000c004b8d9a0 R08: 0000000000000000 R09: 0000000000000000
[   77.807704] R10: 0000000000000000 R11: 0000000000000212 R12: 000000c004b8d988
[   77.807705] R13: 000000c000100008 R14: 000000c000bfc700 R15: 000000c005d1d7d0
[   77.807706]  </TASK>
[   77.807706] ---[ end trace 4d99ac0c6f38b8b8 ]---
```

### Describe how you validated your changes

### Additional Notes
