### PR TITLE
[EBPF-808] gpu: optimize ringbuffer usage

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -377,6 +377,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(gpuNS, "enable_fatbin_parsing"), false)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "fatbin_request_queue_size"), 100)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "ring_buffer_pages_per_device"), 32) // 32 pages = 128KB by default per device
+	cfg.BindEnvAndSetDefault(join(gpuNS, "ringbuffer_wakeup_size"), 3000)     // 3000 bytes is about ~10-20 events depending on the specific type
 	cfg.BindEnvAndSetDefault(join(gpuNS, "attacher_detailed_logs"), false)
 
 	// gpu - stream config

--- a/pkg/eventmonitor/consumers/testutil/testutil.go
+++ b/pkg/eventmonitor/consumers/testutil/testutil.go
@@ -23,15 +23,15 @@ const defaultChanSize = 100
 
 // NewTestProcessConsumer creates a new ProcessConsumer for testing, registering itself with an event monitor
 // created for testing. This function should be called in tests that require a ProcessConsumer.
-func NewTestProcessConsumer(t *testing.T) *consumers.ProcessConsumer {
+func NewTestProcessConsumer(tb testing.TB) *consumers.ProcessConsumer {
 	var pc *consumers.ProcessConsumer
 	// Set fake hostname to avoid fetching it from the core agent.
 	hostnameutils.SetCachedHostname("test-hostname")
-	eventtestutil.StartEventMonitor(t, func(t *testing.T, evm *eventmonitor.EventMonitor) {
+	eventtestutil.StartEventMonitor(tb, func(tb testing.TB, evm *eventmonitor.EventMonitor) {
 		var err error
 		eventTypes := []consumers.ProcessConsumerEventTypes{consumers.ExecEventType, consumers.ExitEventType}
 		pc, err = consumers.NewProcessConsumer("test", defaultChanSize, eventTypes, evm)
-		require.NoError(t, err, "failed to create process consumer")
+		require.NoError(tb, err, "failed to create process consumer")
 	})
 
 	return pc

--- a/pkg/eventmonitor/testutil/testutil.go
+++ b/pkg/eventmonitor/testutil/testutil.go
@@ -22,10 +22,10 @@ import (
 )
 
 // PreStartCallback is a callback to register clients to the event monitor before starting it
-type PreStartCallback func(t *testing.T, evm *eventmonitor.EventMonitor)
+type PreStartCallback func(t testing.TB, evm *eventmonitor.EventMonitor)
 
 // StartEventMonitor creates and starts an event monitor for use in tests
-func StartEventMonitor(t *testing.T, callback PreStartCallback) {
+func StartEventMonitor(t testing.TB, callback PreStartCallback) {
 	if !sysconfig.ProcessEventDataStreamSupported() {
 		t.Skip("Process event data stream not supported on this kernel")
 	}

--- a/pkg/eventmonitor/testutil/testutil.go
+++ b/pkg/eventmonitor/testutil/testutil.go
@@ -22,27 +22,27 @@ import (
 )
 
 // PreStartCallback is a callback to register clients to the event monitor before starting it
-type PreStartCallback func(t testing.TB, evm *eventmonitor.EventMonitor)
+type PreStartCallback func(tb testing.TB, evm *eventmonitor.EventMonitor)
 
 // StartEventMonitor creates and starts an event monitor for use in tests
-func StartEventMonitor(t testing.TB, callback PreStartCallback) {
+func StartEventMonitor(tb testing.TB, callback PreStartCallback) {
 	if !sysconfig.ProcessEventDataStreamSupported() {
-		t.Skip("Process event data stream not supported on this kernel")
+		tb.Skip("Process event data stream not supported on this kernel")
 	}
 	emconfig := emconfig.NewConfig()
 	secconfig, err := secconfig.NewConfig()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	// Needed for the socket creation to work
-	require.NoError(t, os.MkdirAll("/opt/datadog-agent/run/", 0755))
+	require.NoError(tb, os.MkdirAll("/opt/datadog-agent/run/", 0755))
 
-	ipcComp := ipcmock.New(t)
+	ipcComp := ipcmock.New(tb)
 
 	opts := eventmonitor.Opts{}
 	evm, err := eventmonitor.NewEventMonitor(emconfig, secconfig, ipcComp, opts)
-	require.NoError(t, err)
-	require.NoError(t, evm.Init())
-	callback(t, evm)
-	require.NoError(t, evm.Start())
-	t.Cleanup(evm.Close)
+	require.NoError(tb, err)
+	require.NoError(tb, evm.Init())
+	callback(tb, evm)
+	require.NoError(tb, evm.Start())
+	tb.Cleanup(evm.Close)
 }

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	KernelCacheQueueSize int
 	// RingBufferSizePagesPerDevice is the number of pages to use for the ring buffer per device.
 	RingBufferSizePagesPerDevice int
+	// RingBufferWakeupSize is the number of bytes that need to be available in the ring buffer before waking up userspace.
+	RingBufferWakeupSize int
 	// StreamConfig is the configuration for the streams.
 	StreamConfig StreamConfig
 	// AttacherDetailedLogs indicates whether the probe should enable detailed logs for the uprobe attacher.
@@ -70,6 +72,7 @@ func New() *Config {
 		EnableFatbinParsing:          spCfg.GetBool(sysconfig.FullKeyPath(consts.GPUNS, "enable_fatbin_parsing")),
 		KernelCacheQueueSize:         spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "fatbin_request_queue_size")),
 		RingBufferSizePagesPerDevice: spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "ring_buffer_pages_per_device")),
+		RingBufferWakeupSize:         spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "ringbuffer_wakeup_size")),
 		StreamConfig: StreamConfig{
 			MaxActiveStreams:      spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "streams", "max_active")),
 			Timeout:               time.Duration(spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "streams", "timeout_seconds"))) * time.Second,

--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -46,6 +46,17 @@ static inline void fill_header(cuda_event_header_t *header, __u64 stream_id, cud
     get_cgroup_name(header->cgroup, sizeof(header->cgroup));
 }
 
+__maybe_unused static __always_inline __u64 get_ringbuf_flags(size_t data_size) {
+    __u64 ringbuffer_wakeup_size = 0;
+    LOAD_CONSTANT("ringbuffer_wakeup_size", ringbuffer_wakeup_size);
+    if (ringbuffer_wakeup_size == 0) {
+        return 0;
+    }
+
+    __u64 sz = bpf_ringbuf_query(&cuda_events, DD_BPF_RB_AVAIL_DATA);
+    return (sz + data_size) >= ringbuffer_wakeup_size ? DD_BPF_RB_FORCE_WAKEUP : DD_BPF_RB_NO_WAKEUP;
+}
+
 SEC("uprobe/cudaLaunchKernel")
 int BPF_UPROBE(uprobe__cudaLaunchKernel, const void *func, __u64 grid_xy, __u64 grid_z, __u64 block_xy, __u64 block_z, void **args) {
     cuda_kernel_launch_t launch_data = { 0 };
@@ -74,7 +85,7 @@ int BPF_UPROBE(uprobe__cudaLaunchKernel, const void *func, __u64 grid_xy, __u64 
     log_debug("cudaLaunchKernel: EMIT[1/2] pid_tgid=%llu, ts=%llu", launch_data.header.pid_tgid, launch_data.header.ktime_ns);
     log_debug("cudaLaunchKernel: EMIT[2/2] kernel_addr=0x%llx, shared_mem=%llu, stream_id=%llu", launch_data.kernel_addr, launch_data.shared_mem_size, launch_data.header.stream_id);
 
-    bpf_ringbuf_output_with_telemetry(&cuda_events, &launch_data, sizeof(launch_data), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &launch_data, sizeof(launch_data), get_ringbuf_flags(sizeof(launch_data)));
 
     return 0;
 }
@@ -115,7 +126,7 @@ int BPF_URETPROBE(uretprobe__cudaMalloc) {
 
     log_debug("cudaMalloc[ret]: EMIT size=%llu, addr=0x%llx, ts=%llu", mem_data.size, (__u64)mem_data.addr, mem_data.header.ktime_ns);
 
-    bpf_ringbuf_output_with_telemetry(&cuda_events, &mem_data, sizeof(mem_data), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &mem_data, sizeof(mem_data), get_ringbuf_flags(sizeof(mem_data)));
 
 out:
     bpf_map_delete_elem(&cuda_alloc_cache, &pid_tgid);
@@ -131,7 +142,7 @@ int BPF_UPROBE(uprobe__cudaFree, void *mem) {
     mem_data.addr = (uint64_t)mem;
     mem_data.type = cudaFree;
 
-    bpf_ringbuf_output_with_telemetry(&cuda_events, &mem_data, sizeof(mem_data), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &mem_data, sizeof(mem_data), get_ringbuf_flags(sizeof(mem_data)));
 
     return 0;
 }
@@ -164,7 +175,7 @@ int BPF_URETPROBE(uretprobe__cudaStreamSynchronize) {
 
     log_debug("cudaStreamSynchronize[ret]: EMIT cudaSync pid_tgid=%llu, stream_id=%llu", event.header.pid_tgid, event.header.stream_id);
 
-    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), get_ringbuf_flags(sizeof(event)));
     bpf_map_delete_elem(&cuda_sync_cache, &pid_tgid);
 
     return 0;
@@ -204,7 +215,7 @@ int BPF_URETPROBE(uretprobe__cudaSetDevice) {
     event.device = *device;
 
     log_debug("cudaSetDevice: EMIT pid_tgid=%llu, device=%d", event.header.pid_tgid, *device);
-    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), get_ringbuf_flags(sizeof(event)));
 
 cleanup:
     bpf_map_delete_elem(&cuda_sync_cache, &pid_tgid);
@@ -284,7 +295,7 @@ static inline int _event_api_trigger_sync(__u32 retval, void *event_cache_map) {
 
     fill_header(&sync_event.header, event_value->stream, cuda_sync);
 
-    bpf_ringbuf_output_with_telemetry(&cuda_events, &sync_event, sizeof(sync_event), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &sync_event, sizeof(sync_event), get_ringbuf_flags(sizeof(sync_event)));
 
 cleanup:
     // We don't remove the event from the stream map here, as it can be queried multiple times
@@ -360,7 +371,7 @@ int BPF_URETPROBE(uretprobe__cudaMemcpy) {
 
     log_debug("cudaMemcpy[ret]: EMIT cudaSync pid_tgid=%llu", event.header.pid_tgid);
 
-    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), get_ringbuf_flags(sizeof(event)));
     bpf_map_delete_elem(&cuda_memcpy_cache, &pid_tgid);
 
     return 0;
@@ -401,7 +412,7 @@ int BPF_UPROBE(uprobe__setenv, const char *name, const char *value, int overwrit
 
     fill_header(&event.header, 0, cuda_visible_devices_set);
 
-    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), get_ringbuf_flags(sizeof(event)));
     return 0;
 }
 

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -91,6 +91,8 @@ const (
 	setenvProbe                  probeFuncName = "uprobe__setenv"
 )
 
+const ringbufferWakeupSizeConstantName = "ringbuffer_wakeup_size"
+
 // ProbeDependencies holds the dependencies for the probe
 type ProbeDependencies struct {
 	// Telemetry is the telemetry component
@@ -349,6 +351,11 @@ func (p *Probe) setupSharedBuffer(o *manager.Options) {
 		ValueSize:  0,
 		EditorFlag: manager.EditType | manager.EditMaxEntries | manager.EditKeyValue,
 	}
+
+	o.ConstantEditors = append(o.ConstantEditors, manager.ConstantEditor{
+		Name:  ringbufferWakeupSizeConstantName,
+		Value: uint64(p.cfg.RingBufferWakeupSize),
+	})
 
 	p.m.Manager.RingBuffers = append(p.m.Manager.RingBuffers, rb)
 	p.eventHandler = rbHandler

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -61,6 +61,9 @@ func (s *probeTestSuite) getProbe() *Probe {
 	// Enable fatbin parsing in tests so we can validate it runs
 	cfg.EnableFatbinParsing = true
 
+	// Disable ring buffer wakeup threshold so that every event is processed.
+	cfg.RingBufferWakeupSize = 0
+
 	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	deps := ProbeDependencies{
 		ProcessMonitor: consumerstestutil.NewTestProcessConsumer(t),

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -9,6 +9,10 @@ package gpu
 
 import (
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -215,7 +219,7 @@ func (s *probeTestSuite) TestMultiGPUSupport() {
 
 	probe := s.getProbe()
 
-	sampleArgs := testutil.SampleArgs{
+	sampleArgs := &testutil.CudaSampleArgs{
 		StartWaitTimeSec:      6, // default wait time for WaitForProgramsToBeTraced is 5 seconds, give margin to attach manually to avoid flakes
 		CudaVisibleDevicesEnv: "1,2",
 		SelectedDevice:        1,
@@ -266,6 +270,157 @@ func (s *probeTestSuite) TestDetectsContainer() {
 
 	require.Greater(t, pidStats.UsedCores, 0.0) // core usage depends on the time this took to run, so it's not deterministic
 	require.Equal(t, pidStats.Memory.MaxBytes, uint64(110))
+}
+
+// cpuUsage represents CPU usage metrics
+type cpuUsage struct {
+	userTime   time.Duration
+	systemTime time.Duration
+}
+
+// getCPUUsage reads CPU usage from /proc/self/stat
+func getCPUUsage() (cpuUsage, error) {
+	data, err := os.ReadFile("/proc/self/stat")
+	if err != nil {
+		return cpuUsage{}, err
+	}
+
+	fields := strings.Fields(string(data))
+	if len(fields) < 15 {
+		return cpuUsage{}, syscall.EINVAL
+	}
+
+	// Fields 13 and 14 are utime and stime in clock ticks
+	utime, err := strconv.ParseUint(fields[13], 10, 64)
+	if err != nil {
+		return cpuUsage{}, err
+	}
+
+	stime, err := strconv.ParseUint(fields[14], 10, 64)
+	if err != nil {
+		return cpuUsage{}, err
+	}
+
+	// Convert clock ticks to nanoseconds
+	// Linux typically uses 100 Hz (100 clock ticks per second)
+	clockTick := time.Second / 100
+
+	return cpuUsage{
+		userTime:   time.Duration(utime) * clockTick,
+		systemTime: time.Duration(stime) * clockTick,
+	}, nil
+}
+
+// getCPUPercent calculates CPU percentage usage between two measurements
+func getCPUPercent(start, end cpuUsage, elapsed time.Duration) float64 {
+	if elapsed <= 0 {
+		return 0
+	}
+
+	totalCPUTime := (end.userTime + end.systemTime) - (start.userTime + start.systemTime)
+	maxPossibleCPU := elapsed * time.Duration(runtime.NumCPU())
+
+	if maxPossibleCPU <= 0 {
+		return 0
+	}
+
+	return float64(totalCPUTime) / float64(maxPossibleCPU) * 100.0
+}
+
+func BenchmarkProbeEventProcessing(b *testing.B) {
+	if err := config.CheckGPUSupported(); err != nil {
+		b.Skipf("minimum kernel version not met, %v", err)
+	}
+
+	// Use CO-RE mode for the benchmark
+	for k, v := range ebpftest.CORE.Env() {
+		b.Setenv(k, v)
+	}
+
+	cfg := config.New()
+	cfg.InitialProcessSync = false
+	cfg.EnableFatbinParsing = false
+	cfg.AttacherDetailedLogs = false
+
+	ddnvml.WithMockNVML(b, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
+	deps := ProbeDependencies{
+		ProcessMonitor: consumerstestutil.NewTestProcessConsumer(b),
+		WorkloadMeta:   testutil.GetWorkloadMetaMock(b),
+		Telemetry:      testutil.GetTelemetryMock(b),
+	}
+	probe, err := NewProbe(cfg, deps)
+	require.NoError(b, err)
+	require.NotNil(b, probe)
+	b.Cleanup(probe.Close)
+
+	// Configure rate sample args for high throughput
+	rateArgs := &testutil.RateSampleArgs{
+		StartWaitTimeSec: 2,
+		SelectedDevice:   0,
+		CallsPerSecond:   50000,
+		ExecutionTimeSec: 60,
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Measure CPU usage for this iteration
+		startCPU, err := getCPUUsage()
+		require.NoError(b, err)
+		startTime := time.Now()
+
+		// Run the rate sample
+		cmd, err := testutil.RunSampleWithArgs(b, testutil.RateSample, rateArgs)
+		require.NoError(b, err)
+
+		// Ensure that we have streams for the process
+		require.Eventually(b, func() bool {
+			for _, handler := range probe.streamHandlers.allStreams() {
+				if handler.metadata.pid == uint32(cmd.Process.Pid) {
+					return true
+				}
+			}
+			return false
+		}, 10*time.Second, 100*time.Millisecond, "stream handlers not created")
+
+		// Get and flush stats to process events
+		_, err = probe.GetAndFlush()
+		require.NoError(b, err)
+
+		// Measure CPU usage after processing
+		endCPU, err := getCPUUsage()
+		require.NoError(b, err)
+		elapsed := time.Since(startTime)
+
+		// Check telemetry for event counts
+		telemetryMock, ok := probe.deps.Telemetry.(telemetry.Mock)
+		require.True(b, ok)
+
+		eventMetrics, err := telemetryMock.GetCountMetric("gpu__consumer", "events")
+		require.NoError(b, err)
+
+		totalEvents := 0
+		for _, m := range eventMetrics {
+			totalEvents += int(m.Value())
+		}
+
+		require.NotZero(b, totalEvents)
+
+		// Calculate and report metrics
+		cpuPercent := getCPUPercent(startCPU, endCPU, elapsed)
+		if totalEvents > 0 {
+			b.ReportMetric(float64(totalEvents), "events/op")
+		}
+		b.ReportMetric(cpuPercent, "cpu_percent")
+		b.ReportMetric(float64(endCPU.userTime-startCPU.userTime)/float64(time.Millisecond), "user_cpu_ms/op")
+		b.ReportMetric(float64(endCPU.systemTime-startCPU.systemTime)/float64(time.Millisecond), "system_cpu_ms/op")
+
+		// Clean up process
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}
 }
 
 func TestCudaLibraryAttacherRule(t *testing.T) {

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -358,7 +358,7 @@ func BenchmarkProbeEventProcessing(b *testing.B) {
 		StartWaitTimeSec: 2,
 		SelectedDevice:   0,
 		CallsPerSecond:   50000,
-		ExecutionTimeSec: 60,
+		ExecutionTimeSec: 50,
 	}
 
 	b.ResetTimer()

--- a/pkg/gpu/testdata/.gitignore
+++ b/pkg/gpu/testdata/.gitignore
@@ -1,1 +1,2 @@
 cudasample
+cudarate

--- a/pkg/gpu/testdata/common_functions.h
+++ b/pkg/gpu/testdata/common_functions.h
@@ -1,0 +1,77 @@
+#ifndef COMMON_FUNCTIONS_H
+#define COMMON_FUNCTIONS_H
+
+#include <stdint.h>
+#include <unistd.h>
+
+// CUDA type definitions
+typedef struct {
+    uint32_t x, y, z;
+} dim3;
+
+typedef int cudaError_t;
+typedef uint64_t cudaStream_t;
+typedef uint64_t cudaEvent_t;
+
+// CUDA function implementations
+cudaError_t cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) {
+    (void)func;
+    (void)gridDim;
+    (void)blockDim;
+    (void)args;
+    (void)sharedMem;
+    (void)stream; // Suppress unused parameter warnings
+    return 0;
+}
+
+cudaError_t cudaMalloc(void **devPtr, size_t size) {
+    (void)size; // Suppress unused parameter warning
+    *devPtr = (void *)0xdeadbeef;
+    return 0;
+}
+
+cudaError_t cudaFree(void *devPtr) {
+    (void)devPtr; // Suppress unused parameter warning
+    return 0;
+}
+
+cudaError_t cudaStreamSynchronize(cudaStream_t stream) {
+    (void)stream; // Suppress unused parameter warning
+    return 0;
+}
+
+cudaError_t cudaSetDevice(int device) {
+    (void)device; // Suppress unused parameter warning
+    return 0;
+}
+
+cudaError_t cudaEventRecord(cudaEvent_t event, cudaStream_t stream) {
+    (void)event;
+    (void)stream; // Suppress unused parameter warnings
+    return 0;
+}
+
+cudaError_t cudaEventQuery(cudaEvent_t event) {
+    (void)event; // Suppress unused parameter warning
+    return 0;
+}
+
+cudaError_t cudaEventSynchronize(cudaEvent_t event) {
+    (void)event; // Suppress unused parameter warning
+    return 0;
+}
+
+cudaError_t cudaEventDestroy(cudaEvent_t event) {
+    (void)event; // Suppress unused parameter warning
+    return 0;
+}
+
+cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, int kind) {
+    (void)dst;
+    (void)src;
+    (void)count;
+    (void)kind; // Suppress unused parameter warnings
+    return 0;
+}
+
+#endif // COMMON_FUNCTIONS_H

--- a/pkg/gpu/testdata/cudarate.c
+++ b/pkg/gpu/testdata/cudarate.c
@@ -1,0 +1,108 @@
+// This is a dummy CUDA runtime library that can be used to test the GPU monitoring code without
+// having a real CUDA runtime library installed.
+// This binary should be run using the pkg/gpu/testutil/samplebins.go:RunSample* methods, which
+// call the binary with the correct arguments and environment variables to test the agent.
+// This version calls cudaLaunchKernel at a specified rate per second.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <time.h>
+
+typedef struct {
+    uint32_t x, y, z;
+} dim3;
+
+typedef int cudaError_t;
+typedef uint64_t cudaStream_t;
+typedef uint64_t cudaEvent_t;
+
+cudaError_t cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) {
+    return 0;
+}
+
+cudaError_t cudaSetDevice(int device) {
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    cudaStream_t stream = 30;
+
+    if (argc != 4) {
+        fprintf(stderr, "Usage: %s <wait-to-start-sec> <device-index> <calls-per-second>\n", argv[0]);
+        return 1;
+    }
+
+    int waitStart = atoi(argv[1]);
+    int device = atoi(argv[2]);
+    int callsPerSecond = atoi(argv[3]);
+
+    if (callsPerSecond <= 0) {
+        fprintf(stderr, "Error: calls-per-second must be positive\n");
+        return 1;
+    }
+
+    // This string is used by PatternScanner to validate a proper start of this sample program inside the container
+    fprintf(stderr, "Starting CudaRateSample program\n");
+    fprintf(stderr, "Waiting for %d seconds before starting\n", waitStart);
+    fprintf(stderr, "Will make %d cudaLaunchKernel calls per second\n", callsPerSecond);
+
+    // Give time for the eBPF program to load
+    sleep(waitStart);
+
+    fprintf(stderr, "Starting calls, will use device index %d\n", device);
+
+    cudaSetDevice(device);
+
+    // Calculate interval between calls in nanoseconds for better precision
+    long interval_ns = 1000000000L / callsPerSecond; // 1 second = 1,000,000,000 nanoseconds
+
+    struct timespec start_time, current_time, last_log_time;
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    last_log_time = start_time;
+
+    long call_count = 0;
+    long next_call_time_ns = 0;
+
+    while (1) {
+        clock_gettime(CLOCK_MONOTONIC, &current_time);
+        long current_time_ns = (current_time.tv_sec - start_time.tv_sec) * 1000000000L +
+                               (current_time.tv_nsec - start_time.tv_nsec);
+
+        if (current_time_ns >= next_call_time_ns) {
+            cudaLaunchKernel((void *)0x1234, (dim3){ 1, 2, 3 }, (dim3){ 4, 5, 6 }, NULL, 10, stream);
+            call_count++;
+            next_call_time_ns = current_time_ns + interval_ns;
+        } else {
+            // For very high rates (>10k), use busy loop for maximum performance
+            if (callsPerSecond > 10000) {
+                // Busy loop - no sleep for maximum precision
+            } else if (callsPerSecond > 1000) {
+                struct timespec sleep_time = { 0, 1000 }; // 1 microsecond
+                nanosleep(&sleep_time, NULL);
+            } else {
+                // For lower rates, sleep longer to avoid busy waiting
+                usleep(100);
+            }
+        }
+
+        // Log every second
+        long time_since_last_log_ns = (current_time.tv_sec - last_log_time.tv_sec) * 1000000000L +
+                                      (current_time.tv_nsec - last_log_time.tv_nsec);
+        if (time_since_last_log_ns >= 1000000000L) { // 1 second in nanoseconds
+            long calls_per_second_actual = call_count * 1000000000L / time_since_last_log_ns;
+            fprintf(stderr, "Made %ld calls in %ld.%03lds (rate: %ld calls/sec)\n",
+                call_count,
+                time_since_last_log_ns / 1000000000L,
+                (time_since_last_log_ns % 1000000000L) / 1000000L,
+                calls_per_second_actual);
+            last_log_time = current_time;
+            call_count = 0; // Reset counter for next second
+        }
+    }
+
+    fprintf(stderr, "CUDA calls made.\n");
+
+    return 0;
+}

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <unistd.h>
 #include "common_functions.h"
 
 int main(int argc, char **argv) {

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -6,56 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <unistd.h>
-
-typedef struct {
-    uint32_t x, y, z;
-} dim3;
-
-typedef int cudaError_t;
-typedef uint64_t cudaStream_t;
-typedef uint64_t cudaEvent_t;
-
-cudaError_t cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) {
-    return 0;
-}
-
-cudaError_t cudaMalloc(void **devPtr, size_t size) {
-    *devPtr = (void *)0xdeadbeef;
-    return 0;
-}
-
-cudaError_t cudaFree(void *devPtr) {
-    return 0;
-}
-
-cudaError_t cudaStreamSynchronize(cudaStream_t stream) {
-    return 0;
-}
-
-cudaError_t cudaSetDevice(int device) {
-    return 0;
-}
-
-cudaError_t cudaEventRecord(cudaEvent_t event, cudaStream_t stream) {
-    return 0;
-}
-
-cudaError_t cudaEventQuery(cudaEvent_t event) {
-    return 0;
-}
-
-cudaError_t cudaEventSynchronize(cudaEvent_t event) {
-    return 0;
-}
-
-cudaError_t cudaEventDestroy(cudaEvent_t event) {
-    return 0;
-}
-
-cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, int kind) {
-    return 0;
-}
+#include "common_functions.h"
 
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -43,6 +43,7 @@ var CudaSample Sample = Sample{
 	DefaultArgs:     defaultCudaSampleArgs(),
 }
 
+// RateSample is a binary that calls the CUDA rate sample, allowing to launch CUDA calls at a given rate
 var RateSample Sample = Sample{
 	Name:            "cudarate",
 	StartPattern:    regexp.MustCompile("Starting CudaRateSample program"),
@@ -58,6 +59,7 @@ const (
 	MinimalDockerImage dockerImage = dockerutils.MinimalDockerImage
 )
 
+// SampleArgs is an interface that represents the arguments for the sample binary
 type SampleArgs interface {
 	Env() []string
 	CLIArgs() []string
@@ -75,6 +77,7 @@ type CudaSampleArgs struct {
 	SelectedDevice int
 }
 
+// Env returns the environment variables for the CUDA sample binary
 func (a *CudaSampleArgs) Env() []string {
 	if a.CudaVisibleDevicesEnv != "" {
 		return []string{fmt.Sprintf("CUDA_VISIBLE_DEVICES=%s", a.CudaVisibleDevicesEnv)}
@@ -82,6 +85,7 @@ func (a *CudaSampleArgs) Env() []string {
 	return nil
 }
 
+// CLIArgs returns the command line arguments for the CUDA sample binary
 func (a *CudaSampleArgs) CLIArgs() []string {
 	return []string{
 		strconv.Itoa(a.StartWaitTimeSec),
@@ -98,6 +102,7 @@ func defaultCudaSampleArgs() *CudaSampleArgs {
 	}
 }
 
+// RateSampleArgs is an interface that represents the arguments for the CUDA rate sample binary
 type RateSampleArgs struct {
 	// StartWaitTimeSec represents the time in seconds to wait before the binary starting the CUDA calls
 	StartWaitTimeSec int
@@ -109,10 +114,12 @@ type RateSampleArgs struct {
 	ExecutionTimeSec int
 }
 
+// Env returns the environment variables for the CUDA rate sample binary
 func (a *RateSampleArgs) Env() []string {
 	return nil
 }
 
+// CLIArgs returns the command line arguments for the CUDA rate sample binary
 func (a *RateSampleArgs) CLIArgs() []string {
 	return []string{strconv.Itoa(a.StartWaitTimeSec), strconv.Itoa(a.SelectedDevice), strconv.Itoa(a.CallsPerSecond), strconv.Itoa(a.ExecutionTimeSec)}
 }

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -36,7 +36,7 @@ type Sample struct {
 }
 
 // CudaSample is a binary that calls all the CUDA functions we probe for
-var CudaSample Sample = Sample{
+var CudaSample = Sample{
 	Name:            "cudasample",
 	StartPattern:    regexp.MustCompile("Starting CudaSample program"),
 	FinishedPattern: regexp.MustCompile("CUDA calls made."),
@@ -44,7 +44,7 @@ var CudaSample Sample = Sample{
 }
 
 // RateSample is a binary that calls the CUDA rate sample, allowing to launch CUDA calls at a given rate
-var RateSample Sample = Sample{
+var RateSample = Sample{
 	Name:            "cudarate",
 	StartPattern:    regexp.MustCompile("Starting CudaRateSample program"),
 	FinishedPattern: regexp.MustCompile("CUDA calls made."),
@@ -65,7 +65,7 @@ type SampleArgs interface {
 	CLIArgs() []string
 }
 
-// SampleArgs holds arguments for the sample binary
+// CudaSampleArgs holds arguments for the sample binary
 type CudaSampleArgs struct {
 	// StartWaitTimeSec represents the time in seconds to wait before the binary starting the CUDA calls
 	StartWaitTimeSec int

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -27,27 +27,44 @@ import (
 	dockerutils "github.com/DataDog/datadog-agent/pkg/util/testutil/docker"
 )
 
-// sampleName represents the name of the sample binary.
-type sampleName string
+// Sample represents a sample binary that can be run and tested
+type Sample struct {
+	Name            string
+	StartPattern    *regexp.Regexp
+	FinishedPattern *regexp.Regexp
+	DefaultArgs     SampleArgs
+}
 
-const (
-	// CudaSample is the sample binary that uses CUDA.
-	CudaSample sampleName = "cudasample"
-)
+// CudaSample is a binary that calls all the CUDA functions we probe for
+var CudaSample Sample = Sample{
+	Name:            "cudasample",
+	StartPattern:    regexp.MustCompile("Starting CudaSample program"),
+	FinishedPattern: regexp.MustCompile("CUDA calls made."),
+	DefaultArgs:     defaultCudaSampleArgs(),
+}
+
+var RateSample Sample = Sample{
+	Name:            "cudarate",
+	StartPattern:    regexp.MustCompile("Starting CudaRateSample program"),
+	FinishedPattern: regexp.MustCompile("CUDA calls made."),
+	DefaultArgs:     defaultRateSampleArgs(),
+}
 
 // dockerImage represents the Docker image to use for running the sample binary.
 type dockerImage string
-
-var startedPattern = regexp.MustCompile("Starting CudaSample program")
-var finishedPattern = regexp.MustCompile("CUDA calls made")
 
 const (
 	// MinimalDockerImage is the minimal docker image, just used for running a binary
 	MinimalDockerImage dockerImage = dockerutils.MinimalDockerImage
 )
 
+type SampleArgs interface {
+	Env() []string
+	CLIArgs() []string
+}
+
 // SampleArgs holds arguments for the sample binary
-type SampleArgs struct {
+type CudaSampleArgs struct {
 	// StartWaitTimeSec represents the time in seconds to wait before the binary starting the CUDA calls
 	StartWaitTimeSec int
 
@@ -58,27 +75,59 @@ type SampleArgs struct {
 	SelectedDevice int
 }
 
-func (a *SampleArgs) getEnv() []string {
+func (a *CudaSampleArgs) Env() []string {
 	if a.CudaVisibleDevicesEnv != "" {
 		return []string{fmt.Sprintf("CUDA_VISIBLE_DEVICES=%s", a.CudaVisibleDevicesEnv)}
 	}
 	return nil
 }
 
-func (a *SampleArgs) getCLIArgs() []string {
+func (a *CudaSampleArgs) CLIArgs() []string {
 	return []string{
 		strconv.Itoa(a.StartWaitTimeSec),
 		strconv.Itoa(a.SelectedDevice),
 	}
 }
 
+// defaultCudaSampleArgs returns the default arguments for the CUDA sample binary
+func defaultCudaSampleArgs() *CudaSampleArgs {
+	return &CudaSampleArgs{
+		StartWaitTimeSec:      5,
+		CudaVisibleDevicesEnv: "",
+		SelectedDevice:        0,
+	}
+}
+
+type RateSampleArgs struct {
+	StartWaitTimeSec int
+	SelectedDevice   int
+	CallsPerSecond   int
+}
+
+func (a *RateSampleArgs) Env() []string {
+	return nil
+}
+
+func (a *RateSampleArgs) CLIArgs() []string {
+	return []string{strconv.Itoa(a.StartWaitTimeSec), strconv.Itoa(a.SelectedDevice), strconv.Itoa(a.CallsPerSecond)}
+}
+
+// defaultRateSampleArgs returns the default arguments for the CUDA rate sample binary
+func defaultRateSampleArgs() *RateSampleArgs {
+	return &RateSampleArgs{
+		StartWaitTimeSec: 5,
+		SelectedDevice:   0,
+		CallsPerSecond:   1000,
+	}
+}
+
 // RunSampleWithArgs executes the sample binary and returns the command. Cleanup is configured automatically
-func getBuiltSamplePath(t *testing.T, sample sampleName) string {
+func getBuiltSamplePath(t *testing.T, sample Sample) string {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
 
-	sourceFile := filepath.Join(curDir, "..", "testdata", string(sample)+".c")
-	binaryFile := filepath.Join(curDir, "..", "testdata", string(sample))
+	sourceFile := filepath.Join(curDir, "..", "testdata", sample.Name+".c")
+	binaryFile := filepath.Join(curDir, "..", "testdata", sample.Name)
 
 	builtBin, err := buildCBinary(sourceFile, binaryFile)
 	require.NoError(t, err)
@@ -86,17 +135,8 @@ func getBuiltSamplePath(t *testing.T, sample sampleName) string {
 	return builtBin
 }
 
-// getDefaultArgs returns the default arguments for the sample binary
-func getDefaultArgs() SampleArgs {
-	return SampleArgs{
-		StartWaitTimeSec:      5,
-		CudaVisibleDevicesEnv: "",
-		SelectedDevice:        0,
-	}
-}
-
-func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (cmd *exec.Cmd, err error) {
-	command = append(command, args.getCLIArgs()...)
+func runCommandAndPipeOutput(t *testing.T, command []string, sample Sample, args SampleArgs) (cmd *exec.Cmd, err error) {
+	command = append(command, args.CLIArgs()...)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -108,7 +148,7 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 		}
 	})
 
-	scanner, err := procutil.NewScanner(startedPattern, finishedPattern)
+	scanner, err := procutil.NewScanner(sample.StartPattern, sample.FinishedPattern)
 	require.NoError(t, err, "failed to create pattern scanner")
 	defer func() {
 		//print the cudasample log in case there was an error
@@ -116,7 +156,7 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 			scanner.PrintLogs(t)
 		}
 	}()
-	env := args.getEnv()
+	env := args.Env()
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Stdout = scanner
 	cmd.Stderr = scanner
@@ -144,37 +184,37 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 }
 
 // RunSample executes the sample binary and returns the command. Cleanup is configured automatically
-func RunSample(t *testing.T, name sampleName) (*exec.Cmd, error) {
-	return RunSampleWithArgs(t, name, getDefaultArgs())
+func RunSample(t *testing.T, sample Sample) (*exec.Cmd, error) {
+	return RunSampleWithArgs(t, sample, sample.DefaultArgs)
 }
 
 // RunSampleWithArgs executes the sample binary with args and returns the command. Cleanup is configured automatically
-func RunSampleWithArgs(t *testing.T, name sampleName, args SampleArgs) (*exec.Cmd, error) {
-	builtBin := getBuiltSamplePath(t, name)
-	return runCommandAndPipeOutput(t, []string{builtBin}, args)
+func RunSampleWithArgs(t *testing.T, sample Sample, args SampleArgs) (*exec.Cmd, error) {
+	builtBin := getBuiltSamplePath(t, sample)
+	return runCommandAndPipeOutput(t, []string{builtBin}, sample, args)
 }
 
 // RunSampleInDocker executes the sample binary in a Docker container and returns the PID of the main container process, and the container ID
-func RunSampleInDocker(t *testing.T, name sampleName, image dockerImage) (int, string) {
-	return RunSampleInDockerWithArgs(t, name, image, getDefaultArgs())
+func RunSampleInDocker(t *testing.T, sample Sample, image dockerImage) (int, string) {
+	return RunSampleInDockerWithArgs(t, sample, image, sample.DefaultArgs)
 }
 
 // RunSampleInDockerWithArgs executes the sample binary in a Docker container and returns the PID of the main container process, and the container ID
-func RunSampleInDockerWithArgs(t *testing.T, name sampleName, image dockerImage, args SampleArgs) (int, string) {
-	builtBin := getBuiltSamplePath(t, name)
+func RunSampleInDockerWithArgs(t *testing.T, sample Sample, image dockerImage, args SampleArgs) (int, string) {
+	builtBin := getBuiltSamplePath(t, sample)
 	containerName := fmt.Sprintf("gpu-testutil-%s", utils.RandString(10))
-	scanner, err := procutil.NewScanner(startedPattern, finishedPattern)
+	scanner, err := procutil.NewScanner(sample.StartPattern, sample.FinishedPattern)
 	require.NoError(t, err, "failed to create pattern scanner")
 
 	dockerConfig := dockerutils.NewRunConfig(
 		dockerutils.NewBaseConfig(
 			containerName,
 			scanner,
-			dockerutils.WithEnv(args.getEnv()),
+			dockerutils.WithEnv(args.Env()),
 		),
 		string(image),
 		builtBin,
-		dockerutils.WithBinaryArgs(args.getCLIArgs()),
+		dockerutils.WithBinaryArgs(args.CLIArgs()),
 		dockerutils.WithMounts(map[string]string{builtBin: builtBin}))
 
 	require.NoError(t, dockerutils.Run(t, dockerConfig))
@@ -187,7 +227,7 @@ func RunSampleInDockerWithArgs(t *testing.T, name sampleName, image dockerImage,
 	dockerContainerID, err = dockerutils.GetContainerID(containerName)
 	assert.NoError(t, err, "failed to get docker container ID")
 
-	log.Debugf("Sample binary %s running in Docker container %s (CID=%s) with PID %d", name, containerName, dockerContainerID, dockerPID)
+	log.Debugf("Sample binary %s running in Docker container %s (CID=%s) with PID %d", sample.Name, containerName, dockerContainerID, dockerPID)
 
 	return int(dockerPID), dockerContainerID
 }

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -172,16 +172,6 @@ func runCommandAndPipeOutput(t testing.TB, command []string, sample Sample, args
 		return nil, err
 	}
 
-	// Calculate timeout based on sample arguments
-	timeout := dockerutils.DefaultTimeout
-	if rateArgs, ok := args.(*RateSampleArgs); ok {
-		// For rate sample, timeout should be start wait + execution time + buffer
-		sampleTimeout := time.Duration(rateArgs.StartWaitTimeSec+rateArgs.ExecutionTimeSec+10) * time.Second
-		if sampleTimeout > timeout {
-			timeout = sampleTimeout
-		}
-	}
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -191,9 +181,9 @@ func runCommandAndPipeOutput(t testing.TB, command []string, sample Sample, args
 		case <-scanner.DoneChan:
 			t.Logf("%s command succeeded", command)
 			return cmd, nil
-		case <-time.After(timeout):
+		case <-time.After(dockerutils.DefaultTimeout):
 			//setting the error explicitly to trigger the defer function
-			err = fmt.Errorf("%s execution attempt reached timeout %v ", sample.Name, timeout)
+			err = fmt.Errorf("%s execution attempt reached timeout %v ", sample.Name, dockerutils.DefaultTimeout)
 			return nil, err
 		}
 	}

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -105,6 +105,8 @@ agents:
       env:
         - name: HOST_PROC
           value: "/host/root/proc"
+		- name: DD_GPU_MONITORING_RINGBUFFER_WAKEUP_SIZE
+		  value: "0" 
     agent:
       env:
         - name: DD_GPU_ENABLED

--- a/test/new-e2e/tests/gpu/testdata/config/system_probe_config.yaml
+++ b/test/new-e2e/tests/gpu/testdata/config/system_probe_config.yaml
@@ -3,3 +3,4 @@ system_probe_config:
   enabled: true
 gpu_monitoring:
   enabled: true
+  ringbuffer_wakeup_size: 0  # Wake up the ringbuffer every time a new event is available, our workloads might not generate enough events to trigger the wakeup


### PR DESCRIPTION
### What does this PR do?

This PR changes how we send events to the `cuda_events` ring buffer, reducing the amount of times we wake up in order to reduce CPU usage. Instead of waking up on every event, userspace will only wake up if there is a certain amount of bytes in the buffer. This is configurable, by default it's set to 3000 bytes as that covers 10-20 events (depending on the specific event type). Higher and lower wakeup sizes were tested, values higher than 3000 bytes did not yield significant CPU usage improvements.

To test this, this PR also includes a new sample binary that calls CUDA functions at a specified rate per second. A good portion of the code of this PR is the support for this new sample.

### Motivation

In production, some monitors triggered because the CPU usage of system-probe was significantly higher compared to non-GPU nodes. This PR allows us to reduce CPU usage and make GPUm more lightweight.

### Describe how you validated your changes

Wrote a benchmark that measures CPU time being used (number of events should not change), with the following results:

```
Before:
BenchmarkProbeEventProcessing-8                1        62110724945 ns/op                8.893 cpu_percent         2846651 events/op         25940 system_cpu_ms/op          18250 user_cpu_ms/op       2323968488 B/op   718624 allocs/op

After
BenchmarkProbeEventProcessing-8                1        62114422319 ns/op                2.477 cpu_percent         2868075 events/op          5870 system_cpu_ms/op           6440 user_cpu_ms/op       2343513696 B/op   753910 allocs/op
``` 

I validated in the profiles that we had a similar percentage of CPU usage due to EpollWait initially, and then validated that with the changes it was significantly reduced. The new CPU usage seems to be around 35%/22% (user/system) of the previous usage.

### Additional Notes

Wakeup buffer size is set to 0 in e2e and integration tests that run workloads that send a very small number of events.
