### PR TITLE
[CWS] Do not exclude uprobes at load time in fentry mode

### DIFF
--- a/pkg/security/probe/stateful_probe_excluder.go
+++ b/pkg/security/probe/stateful_probe_excluder.go
@@ -67,7 +67,7 @@ func (af *availableFunctionsBasedExcluder) ShouldExcludeFunction(name string, pr
 		return false
 	}
 
-	if strings.HasPrefix(prog.SectionName, "uprobe") || strings.HasPrefix(prog.SectionName, "uretprobe") {
+	if strings.HasPrefix(prog.SectionName, "uprobe/") || strings.HasPrefix(prog.SectionName, "uretprobe/") {
 		return false
 	}
 

--- a/pkg/security/probe/stateful_probe_excluder.go
+++ b/pkg/security/probe/stateful_probe_excluder.go
@@ -67,6 +67,10 @@ func (af *availableFunctionsBasedExcluder) ShouldExcludeFunction(name string, pr
 		return false
 	}
 
+	if strings.HasPrefix(prog.SectionName, "uprobe") || strings.HasPrefix(prog.SectionName, "uretprobe") {
+		return false
+	}
+
 	if strings.HasPrefix(name, "tail_call") || strings.Contains(name, "dentry_resolver") || strings.Contains(name, "callback") {
 		return false
 	}


### PR DESCRIPTION
### What does this PR do?

### Motivation
In kprobe mode, no action was taken when the probes were loaded.
However, in fentry mode, the `ShouldExcludeFunction` logic immediately excluded any uprobes at load time, since they do not appear in the kernel’s list of available fentry hooks.

This behavior makes sense, because for uprobes we first need to resolve the path of the target library. Therefore, the exclusion should not happen that early.
As a result, when fentry mode was enabled, attaching uprobes became impossible.### Describe how you validated your changes

### Additional Notes
