### PR TITLE
Add Segment and template fields to probe definition types

### DIFF
--- a/pkg/dyninst/actuator/state_property_test.go
+++ b/pkg/dyninst/actuator/state_property_test.go
@@ -229,9 +229,7 @@ func (pts *propertyTestState) generateProcessUpdate() event {
 						},
 						Template: "test log message",
 						Segments: rcjson.SegmentList{
-							rcjson.TemplateSegment{
-								StringSegment: newStringSegment("test log message"),
-							},
+							newStringSegment("test log message"),
 						},
 					},
 				}

--- a/pkg/dyninst/actuator/state_property_test.go
+++ b/pkg/dyninst/actuator/state_property_test.go
@@ -10,7 +10,6 @@ package actuator
 import (
 	"bytes"
 	"cmp"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -229,8 +228,10 @@ func (pts *propertyTestState) generateProcessUpdate() event {
 							Language: "go",
 						},
 						Template: "test log message",
-						Segments: []json.RawMessage{
-							json.RawMessage(`"test log message"`),
+						Segments: rcjson.SegmentList{
+							rcjson.TemplateSegment{
+								StringSegment: newStringSegment("test log message"),
+							},
 						},
 					},
 				}
@@ -375,4 +376,9 @@ func (pts *propertyTestState) completeRandomEffect() event {
 		panic(fmt.Sprintf("unknown effect: %T", eff))
 	}
 
+}
+
+func newStringSegment(value string) *rcjson.StringSegment {
+	s := rcjson.StringSegment(value)
+	return &s
 }

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 57 04 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6046]
 	PrepareEventRoot c2 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 69 04 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6090]
 	PrepareEventRoot c3 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 97 06 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 49 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6553]
 	PrepareEventRoot ba 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 39 05 00 00 // ProcessType[[3]string]
+	Call eb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
 	PrepareEventRoot b7 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 85 05 00 00 // ProcessType[[]int]
+	Call 37 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a620a]
 	PrepareEventRoot af 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 91 06 00 00 // ProcessType[map[string]int]
+	Call 43 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a64ea]
 	PrepareEventRoot b8 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a3 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 39 05 00 00 // ProcessType[[3]string]
+	Call eb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
 	PrepareEventRoot b5 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 9f 05 00 00 // ProcessType[[]string]
+	Call 51 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
 	PrepareEventRoot b3 00 00 00 19 00 00 00 
@@ -172,388 +172,367 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
 // 0x2d0: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a5 00 00 00 11 00 00 00 
 	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
-// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
-	ExprPrepare 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot a6 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
-	Return 
-// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
-	PrepareEventRoot a6 00 00 00 11 00 00 00 
-	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
-	Return 
-// 0x303: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
-// 0x325: ProcessEvent[Probe[main.stringArg]@4a618a]
+// 0x30b: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a7 00 00 00 11 00 00 00 
-	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
-// 0x334: ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
-	ExprPrepare 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot a8 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
-	Return 
-// 0x349: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
-	PrepareEventRoot a8 00 00 00 11 00 00 00 
-	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
-	Return 
-// 0x358: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+// 0x324: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringArg]@4a618a]
+// 0x346: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a9 00 00 00 11 00 00 00 
-	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
-// 0x389: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
 	PrepareEventRoot aa 00 00 00 00 00 00 00 
 	Return 
-// 0x393: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
-// 0x3b5: ProcessEvent[Probe[main.stringArg]@4a618a]
+// 0x381: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot ab 00 00 00 11 00 00 00 
-	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
-// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
-	ExprPrepare 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
-	Return 
-// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
-	PrepareEventRoot ac 00 00 00 11 00 00 00 
-	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
-	Return 
-// 0x3e8: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
-// 0x40a: ProcessEvent[Probe[main.stringArg]@4a618a]
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot ad 00 00 00 11 00 00 00 
-	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
-// 0x419: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
 	PrepareEventRoot ae 00 00 00 00 00 00 00 
 	Return 
-// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a3 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 55 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
 	PrepareEventRoot bf 00 00 00 09 00 00 00 
-	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	Return 
-// 0x457: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x45d: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x463: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x469: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x46f: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x475: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x47b: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x42d: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x481: ProcessType[*bucket<string,int>]
+// 0x433: ProcessType[*bucket<string,int>]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x487: ProcessType[*bucket<string,main.bigStruct>]
+// 0x439: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 72 00 00 00 
 	Return 
-// 0x48d: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x43f: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x493: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x445: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x499: ProcessType[*error]
+// 0x44b: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x49f: ProcessType[*float32]
+// 0x451: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x4a5: ProcessType[*float64]
+// 0x457: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x4ab: ProcessType[*int]
+// 0x45d: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x4b1: ProcessType[*int32]
+// 0x463: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x4b7: ProcessType[*int64]
+// 0x469: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x4bd: ProcessType[*main.bigStruct]
+// 0x46f: ProcessType[*main.bigStruct]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x4c3: ProcessType[*runtime._defer]
+// 0x475: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x4c9: ProcessType[*runtime._panic]
+// 0x47b: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x4cf: ProcessType[*runtime.cgoCallers]
+// 0x481: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x4d5: ProcessType[*runtime.coro]
+// 0x487: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x4db: ProcessType[*runtime.g]
+// 0x48d: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x4e1: ProcessType[*runtime.m]
+// 0x493: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x4e7: ProcessType[*runtime.mapextra]
+// 0x499: ProcessType[*runtime.mapextra]
 	ProcessPointer 6d 00 00 00 
 	Return 
-// 0x4ed: ProcessType[*runtime.sudog]
+// 0x49f: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x4f3: ProcessType[*runtime.timer]
+// 0x4a5: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x4f9: ProcessType[*runtime.traceBuf]
+// 0x4ab: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x4ff: ProcessType[*string]
+// 0x4b1: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x505: ProcessType[*uint]
+// 0x4b7: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x50b: ProcessType[*uint16]
+// 0x4bd: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x511: ProcessType[*uint32]
+// 0x4c3: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x517: ProcessType[*uint64]
+// 0x4c9: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x51d: ProcessType[*uint8]
+// 0x4cf: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x523: ProcessType[*uintptr]
+// 0x4d5: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x529: ProcessType[[2]*runtime.traceBuf]
+// 0x4db: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call f9 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call ab 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x539: ProcessType[[3]string]
+// 0x4eb: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x549: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x4fb: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e9 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 9b 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x555: ProcessType[[]bucket<string,int>.array]
+// 0x507: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f4 05 00 00 // ProcessType[bucket<string,int>]
+	Call a6 05 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x561: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x513: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 09 06 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call bb 05 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x56d: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x51f: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 1e 06 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d0 05 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x579: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x52b: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 33 06 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call e5 05 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x585: ProcessType[[]int]
+// 0x537: ProcessType[[]int]
 	ProcessSlice 86 00 00 00 08 00 00 00 
 	Return 
-// 0x58f: ProcessType[[]key<string>]
+// 0x541: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x59f: ProcessType[[]string]
+// 0x551: ProcessType[[]string]
 	ProcessSlice 88 00 00 00 10 00 00 00 
 	Return 
-// 0x5a9: ProcessType[[]string.array]
+// 0x55b: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x5b5: ProcessType[[]uint8]
+// 0x567: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x5bf: ProcessType[[]uintptr]
+// 0x571: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x5c9: ProcessType[[]val<main.bigStruct>]
+// 0x57b: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call bd 04 00 00 // ProcessType[*main.bigStruct]
+	Call 6f 04 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5d9: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x58b: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 8b 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3d 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5e9: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x59b: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 7b 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 2d 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x5f4: ProcessType[bucket<string,int>]
+// 0x5a6: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8f 05 00 00 // ProcessType[[]key<string>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 81 04 00 00 // ProcessType[*bucket<string,int>]
+	Call 33 04 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x609: ProcessType[bucket<string,main.bigStruct>]
+// 0x5bb: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8f 05 00 00 // ProcessType[[]key<string>]
-	Call c9 05 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 87 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
+	Call 7b 05 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 39 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x61e: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5d0: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8f 05 00 00 // ProcessType[[]key<string>]
-	Call d9 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 8d 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
+	Call 8b 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 3f 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x633: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5e5: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call d9 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 93 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8b 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 45 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x643: ProcessType[error]
+// 0x5f5: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x645: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x5f7: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9e 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x653: ProcessType[hash<string,int>]
+// 0x605: ProcessType[hash<string,int>]
 	ProcessGoHmap 8d 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x661: ProcessType[hash<string,main.bigStruct>]
+// 0x613: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 91 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x66f: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x621: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x67d: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x62f: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 99 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x68b: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x63d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x691: ProcessType[map[string]int]
+// 0x643: ProcessType[map[string]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x697: ProcessType[map[string]main.bigStruct]
+// 0x649: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x69d: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64f: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x6a3: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x655: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x6a9: ProcessType[runtime.g]
+// 0x65b: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call c9 04 00 00 // ProcessType[*runtime._panic]
+	Call 7b 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime._defer]
+	Call 75 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call e1 04 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call b5 05 00 00 // ProcessType[[]uint8]
+	Call 67 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ed 04 00 00 // ProcessType[*runtime.sudog]
+	Call 9f 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call bf 05 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f3 04 00 00 // ProcessType[*runtime.timer]
+	Call a5 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call d5 04 00 00 // ProcessType[*runtime.coro]
+	Call 87 04 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x704: ProcessType[runtime.m]
-	Call db 04 00 00 // ProcessType[*runtime.g]
+// 0x6b6: ProcessType[runtime.m]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call db 04 00 00 // ProcessType[*runtime.g]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call db 04 00 00 // ProcessType[*runtime.g]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call cf 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 81 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call e1 04 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 64 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call 16 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call bf 05 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call e1 04 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6f 07 00 00 // ProcessType[runtime.mTraceState]
+	Call 21 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x764: ProcessType[runtime.mLockProfile]
+// 0x716: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call bf 05 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x76f: ProcessType[runtime.mTraceState]
+// 0x721: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 29 05 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call e1 04 00 00 // ProcessType[*runtime.m]
+	Call db 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x77f: ProcessType[string]
+// 0x731: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -575,12 +554,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1141
-ID: 6 Len: 8 Enqueue: 1309
+ID: 5 Len: 8 Enqueue: 1063
+ID: 6 Len: 8 Enqueue: 1231
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 1315
+ID: 8 Len: 8 Enqueue: 1237
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1919
+ID: 10 Len: 16 Enqueue: 1841
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -588,18 +567,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1603
+ID: 18 Len: 16 Enqueue: 1525
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 1201
-ID: 21 Len: 8 Enqueue: 1297
-ID: 22 Len: 432 Enqueue: 1705
+ID: 20 Len: 8 Enqueue: 1123
+ID: 21 Len: 8 Enqueue: 1219
+ID: 22 Len: 432 Enqueue: 1627
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1225
+ID: 24 Len: 8 Enqueue: 1147
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1219
+ID: 26 Len: 8 Enqueue: 1141
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1249
-ID: 29 Len: 1760 Enqueue: 1796
+ID: 28 Len: 8 Enqueue: 1171
+ID: 29 Len: 1760 Enqueue: 1718
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -608,41 +587,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1461
-ID: 39 Len: 8 Enqueue: 1135
+ID: 38 Len: 24 Enqueue: 1383
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1261
+ID: 41 Len: 8 Enqueue: 1183
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1471
-ID: 44 Len: 8 Enqueue: 1267
+ID: 43 Len: 24 Enqueue: 1393
+ID: 44 Len: 8 Enqueue: 1189
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1237
+ID: 47 Len: 8 Enqueue: 1159
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 1243
+ID: 53 Len: 8 Enqueue: 1165
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 1231
+ID: 60 Len: 8 Enqueue: 1153
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1892
+ID: 64 Len: 64 Enqueue: 1814
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1903
+ID: 69 Len: 32 Enqueue: 1825
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 1321
-ID: 72 Len: 8 Enqueue: 1273
+ID: 71 Len: 16 Enqueue: 1243
+ID: 72 Len: 8 Enqueue: 1195
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -658,46 +637,46 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 1279
+ID: 88 Len: 8 Enqueue: 1201
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 1189
-ID: 92 Len: 8 Enqueue: 1207
-ID: 93 Len: 8 Enqueue: 1195
-ID: 94 Len: 8 Enqueue: 1303
-ID: 95 Len: 8 Enqueue: 1177
-ID: 96 Len: 8 Enqueue: 1183
-ID: 97 Len: 8 Enqueue: 1285
-ID: 98 Len: 8 Enqueue: 1291
-ID: 99 Len: 24 Enqueue: 1413
+ID: 91 Len: 8 Enqueue: 1111
+ID: 92 Len: 8 Enqueue: 1129
+ID: 93 Len: 8 Enqueue: 1117
+ID: 94 Len: 8 Enqueue: 1225
+ID: 95 Len: 8 Enqueue: 1099
+ID: 96 Len: 8 Enqueue: 1105
+ID: 97 Len: 8 Enqueue: 1207
+ID: 98 Len: 8 Enqueue: 1213
+ID: 99 Len: 24 Enqueue: 1335
 ID: 100 Len: 24 Enqueue: 0
-ID: 101 Len: 24 Enqueue: 1439
-ID: 102 Len: 48 Enqueue: 1337
-ID: 103 Len: 8 Enqueue: 1681
+ID: 101 Len: 24 Enqueue: 1361
+ID: 102 Len: 48 Enqueue: 1259
+ID: 103 Len: 8 Enqueue: 1603
 ID: 104 Len: 8 Enqueue: 0
-ID: 105 Len: 48 Enqueue: 1619
-ID: 106 Len: 8 Enqueue: 1153
-ID: 107 Len: 208 Enqueue: 1524
-ID: 108 Len: 8 Enqueue: 1255
+ID: 105 Len: 48 Enqueue: 1541
+ID: 106 Len: 8 Enqueue: 1075
+ID: 107 Len: 208 Enqueue: 1446
+ID: 108 Len: 8 Enqueue: 1177
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 8 Enqueue: 1687
+ID: 110 Len: 8 Enqueue: 1609
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1633
-ID: 113 Len: 8 Enqueue: 1159
-ID: 114 Len: 208 Enqueue: 1545
-ID: 115 Len: 8 Enqueue: 1699
+ID: 112 Len: 48 Enqueue: 1555
+ID: 113 Len: 8 Enqueue: 1081
+ID: 114 Len: 208 Enqueue: 1467
+ID: 115 Len: 8 Enqueue: 1621
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1661
-ID: 118 Len: 8 Enqueue: 1171
-ID: 119 Len: 88 Enqueue: 1587
-ID: 120 Len: 8 Enqueue: 1693
+ID: 117 Len: 48 Enqueue: 1583
+ID: 118 Len: 8 Enqueue: 1093
+ID: 119 Len: 88 Enqueue: 1509
+ID: 120 Len: 8 Enqueue: 1615
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1647
-ID: 123 Len: 8 Enqueue: 1165
-ID: 124 Len: 208 Enqueue: 1566
-ID: 125 Len: 8 Enqueue: 1111
-ID: 126 Len: 8 Enqueue: 1117
-ID: 127 Len: 8 Enqueue: 1129
+ID: 122 Len: 48 Enqueue: 1569
+ID: 123 Len: 8 Enqueue: 1087
+ID: 124 Len: 208 Enqueue: 1488
+ID: 125 Len: 8 Enqueue: 1033
+ID: 126 Len: 8 Enqueue: 1039
+ID: 127 Len: 8 Enqueue: 1051
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -706,43 +685,43 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 16 Enqueue: 1449
+ID: 136 Len: 16 Enqueue: 1371
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 128 Enqueue: 1423
+ID: 139 Len: 128 Enqueue: 1345
 ID: 140 Len: 64 Enqueue: 0
-ID: 141 Len: 208 Enqueue: 1365
-ID: 142 Len: 64 Enqueue: 1481
-ID: 143 Len: 8 Enqueue: 1213
+ID: 141 Len: 208 Enqueue: 1287
+ID: 142 Len: 64 Enqueue: 1403
+ID: 143 Len: 8 Enqueue: 1135
 ID: 144 Len: 184 Enqueue: 0
-ID: 145 Len: 208 Enqueue: 1377
+ID: 145 Len: 208 Enqueue: 1299
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 64 Enqueue: 1497
-ID: 148 Len: 8 Enqueue: 1675
+ID: 147 Len: 64 Enqueue: 1419
+ID: 148 Len: 8 Enqueue: 1597
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 48 Enqueue: 1605
-ID: 151 Len: 8 Enqueue: 1147
-ID: 152 Len: 144 Enqueue: 1513
-ID: 153 Len: 88 Enqueue: 1401
-ID: 154 Len: 208 Enqueue: 1389
+ID: 150 Len: 48 Enqueue: 1527
+ID: 151 Len: 8 Enqueue: 1069
+ID: 152 Len: 144 Enqueue: 1435
+ID: 153 Len: 88 Enqueue: 1323
+ID: 154 Len: 208 Enqueue: 1311
 ID: 155 Len: 64 Enqueue: 0
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 144 Enqueue: 1353
-ID: 159 Len: 8 Enqueue: 1123
+ID: 158 Len: 144 Enqueue: 1275
+ID: 159 Len: 8 Enqueue: 1045
 ID: 160 Len: 128 Enqueue: 0
 ID: 161 Len: 9 Enqueue: 0
 ID: 162 Len: 0 Enqueue: 0
 ID: 163 Len: 17 Enqueue: 0
 ID: 164 Len: 0 Enqueue: 0
 ID: 165 Len: 17 Enqueue: 0
-ID: 166 Len: 17 Enqueue: 0
+ID: 166 Len: 0 Enqueue: 0
 ID: 167 Len: 17 Enqueue: 0
-ID: 168 Len: 17 Enqueue: 0
+ID: 168 Len: 0 Enqueue: 0
 ID: 169 Len: 17 Enqueue: 0
 ID: 170 Len: 0 Enqueue: 0
 ID: 171 Len: 17 Enqueue: 0
-ID: 172 Len: 17 Enqueue: 0
+ID: 172 Len: 0 Enqueue: 0
 ID: 173 Len: 17 Enqueue: 0
 ID: 174 Len: 0 Enqueue: 0
 ID: 175 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 57 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6046]
-	PrepareEventRoot b8 00 00 00 09 00 00 00 
+	PrepareEventRoot c2 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6046.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 69 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6090]
-	PrepareEventRoot b9 00 00 00 09 00 00 00 
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 22 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 97 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6553]
-	PrepareEventRoot b0 00 00 00 09 00 00 00 
+	PrepareEventRoot ba 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4a65de]
-	PrepareEventRoot b1 00 00 00 00 00 00 00 
+	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@4a5e0e]
-	PrepareEventRoot b6 00 00 00 09 00 00 00 
+	PrepareEventRoot c0 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@4a642a]
-	PrepareEventRoot b6 00 00 00 09 00 00 00 
+	PrepareEventRoot c0 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4a646a]
-	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0x4a610a.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@4a628a]
-	PrepareEventRoot a7 00 00 00 19 00 00 00 
+	PrepareEventRoot b1 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@4a62d6]
-	PrepareEventRoot a8 00 00 00 00 00 00 00 
+	PrepareEventRoot b2 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 03 00 00 // ProcessType[[3]string]
+	Call 39 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
-	PrepareEventRoot ad 00 00 00 31 00 00 00 
+	PrepareEventRoot b7 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 10 04 00 00 // ProcessType[[]int]
+	Call 85 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a620a]
-	PrepareEventRoot a5 00 00 00 19 00 00 00 
+	PrepareEventRoot af 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@4a624f]
-	PrepareEventRoot a6 00 00 00 00 00 00 00 
+	PrepareEventRoot b0 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 1c 05 00 00 // ProcessType[map[string]int]
+	Call 91 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a64ea]
-	PrepareEventRoot ae 00 00 00 09 00 00 00 
+	PrepareEventRoot b8 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@4a651f]
-	PrepareEventRoot af 00 00 00 00 00 00 00 
+	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@4a660a]
-	PrepareEventRoot b2 00 00 00 00 00 00 00 
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@4a6646]
-	PrepareEventRoot b3 00 00 00 00 00 00 00 
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a3 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 03 00 00 // ProcessType[[3]string]
+	Call 39 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
-	PrepareEventRoot ab 00 00 00 31 00 00 00 
+	PrepareEventRoot b5 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@4a63d6]
-	PrepareEventRoot ac 00 00 00 00 00 00 00 
+	PrepareEventRoot b6 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	ExprPrepare 
@@ -158,311 +158,402 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2a 04 00 00 // ProcessType[[]string]
+	Call 9f 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
-	PrepareEventRoot a9 00 00 00 19 00 00 00 
+	PrepareEventRoot b3 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@4a634f]
-	PrepareEventRoot aa 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
 	PrepareEventRoot b4 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot a5 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot a6 00 00 00 11 00 00 00 
+	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
+	Return 
+// 0x303: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x325: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot a7 00 00 00 11 00 00 00 
+	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x334: ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x349: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot a8 00 00 00 11 00 00 00 
+	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
+	Return 
+// 0x358: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x37a: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot a9 00 00 00 11 00 00 00 
+	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x389: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot aa 00 00 00 00 00 00 00 
+	Return 
+// 0x393: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x3b5: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot ab 00 00 00 11 00 00 00 
+	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot ac 00 00 00 11 00 00 00 
+	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a61cf.expr[0]]
+	Return 
+// 0x3e8: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x40a: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot ad 00 00 00 11 00 00 00 
+	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x419: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot ae 00 00 00 00 00 00 00 
+	Return 
+// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
+	Return 
+// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a3 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
-	PrepareEventRoot b5 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
+// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
+	PrepareEventRoot bf 00 00 00 09 00 00 00 
+	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x457: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x45d: ProcessType[****int]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x463: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x469: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x46f: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x475: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x47b: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x30c: ProcessType[*bucket<string,int>]
+// 0x481: ProcessType[*bucket<string,int>]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x312: ProcessType[*bucket<string,main.bigStruct>]
+// 0x487: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 72 00 00 00 
 	Return 
-// 0x318: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x48d: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x31e: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x493: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x324: ProcessType[*error]
+// 0x499: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x32a: ProcessType[*float32]
+// 0x49f: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x330: ProcessType[*float64]
+// 0x4a5: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x336: ProcessType[*int]
+// 0x4ab: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x33c: ProcessType[*int32]
+// 0x4b1: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x342: ProcessType[*int64]
+// 0x4b7: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x348: ProcessType[*main.bigStruct]
+// 0x4bd: ProcessType[*main.bigStruct]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime._defer]
+// 0x4c3: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime._panic]
+// 0x4c9: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.cgoCallers]
+// 0x4cf: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.coro]
+// 0x4d5: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.g]
+// 0x4db: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.m]
+// 0x4e1: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x372: ProcessType[*runtime.mapextra]
+// 0x4e7: ProcessType[*runtime.mapextra]
 	ProcessPointer 6d 00 00 00 
 	Return 
-// 0x378: ProcessType[*runtime.sudog]
+// 0x4ed: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x37e: ProcessType[*runtime.timer]
+// 0x4f3: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x384: ProcessType[*runtime.traceBuf]
+// 0x4f9: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x38a: ProcessType[*string]
+// 0x4ff: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint]
+// 0x505: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint16]
+// 0x50b: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint32]
+// 0x511: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint64]
+// 0x517: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uint8]
+// 0x51d: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3ae: ProcessType[*uintptr]
+// 0x523: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3b4: ProcessType[[2]*runtime.traceBuf]
+// 0x529: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 84 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call f9 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[[3]string]
+// 0x539: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x549: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 74 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call e9 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e0: ProcessType[[]bucket<string,int>.array]
+// 0x555: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7f 04 00 00 // ProcessType[bucket<string,int>]
+	Call f4 05 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ec: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x561: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 94 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 09 06 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f8: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x56d: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a9 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1e 06 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x404: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x579: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call be 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 33 06 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x410: ProcessType[[]int]
+// 0x585: ProcessType[[]int]
 	ProcessSlice 86 00 00 00 08 00 00 00 
 	Return 
-// 0x41a: ProcessType[[]key<string>]
+// 0x58f: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]string]
+// 0x59f: ProcessType[[]string]
 	ProcessSlice 88 00 00 00 10 00 00 00 
 	Return 
-// 0x434: ProcessType[[]string.array]
+// 0x5a9: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x440: ProcessType[[]uint8]
+// 0x5b5: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x44a: ProcessType[[]uintptr]
+// 0x5bf: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x454: ProcessType[[]val<main.bigStruct>]
+// 0x5c9: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 48 03 00 00 // ProcessType[*main.bigStruct]
+	Call bd 04 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x464: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5d9: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 16 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 8b 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x474: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x5e9: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 06 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 7b 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x47f: ProcessType[bucket<string,int>]
+// 0x5f4: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
+	Call 8f 05 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0c 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 81 04 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x494: ProcessType[bucket<string,main.bigStruct>]
+// 0x609: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
-	Call 54 04 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 12 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 8f 05 00 00 // ProcessType[[]key<string>]
+	Call c9 05 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 87 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x4a9: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x61e: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
-	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 18 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8f 05 00 00 // ProcessType[[]key<string>]
+	Call d9 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8d 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4be: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x633: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 1e 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d9 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 93 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4ce: ProcessType[error]
+// 0x643: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x4d0: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x645: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9e 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x4de: ProcessType[hash<string,int>]
+// 0x653: ProcessType[hash<string,int>]
 	ProcessGoHmap 8d 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4ec: ProcessType[hash<string,main.bigStruct>]
+// 0x661: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 91 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4fa: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x66f: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x508: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x67d: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 99 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x516: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x68b: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x51c: ProcessType[map[string]int]
+// 0x691: ProcessType[map[string]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x522: ProcessType[map[string]main.bigStruct]
+// 0x697: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x528: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x69d: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x52e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6a3: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x534: ProcessType[runtime.g]
+// 0x6a9: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime._panic]
+	Call c9 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime._defer]
+	Call c3 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call e1 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 40 04 00 00 // ProcessType[[]uint8]
+	Call b5 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 78 03 00 00 // ProcessType[*runtime.sudog]
+	Call ed 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call bf 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 7e 03 00 00 // ProcessType[*runtime.timer]
+	Call f3 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.coro]
+	Call d5 04 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x58f: ProcessType[runtime.m]
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+// 0x704: ProcessType[runtime.m]
+	Call db 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+	Call db 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+	Call db 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call cf 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call e1 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ef 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call 64 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call bf 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call e1 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 05 00 00 // ProcessType[runtime.mTraceState]
+	Call 6f 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x5ef: ProcessType[runtime.mLockProfile]
+// 0x764: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call bf 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x5fa: ProcessType[runtime.mTraceState]
+// 0x76f: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call 29 05 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call e1 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x60a: ProcessType[string]
+// 0x77f: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -484,12 +575,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 768
-ID: 6 Len: 8 Enqueue: 936
+ID: 5 Len: 8 Enqueue: 1141
+ID: 6 Len: 8 Enqueue: 1309
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 942
+ID: 8 Len: 8 Enqueue: 1315
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1546
+ID: 10 Len: 16 Enqueue: 1919
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -497,18 +588,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1230
+ID: 18 Len: 16 Enqueue: 1603
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 828
-ID: 21 Len: 8 Enqueue: 924
-ID: 22 Len: 432 Enqueue: 1332
+ID: 20 Len: 8 Enqueue: 1201
+ID: 21 Len: 8 Enqueue: 1297
+ID: 22 Len: 432 Enqueue: 1705
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 852
+ID: 24 Len: 8 Enqueue: 1225
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 846
+ID: 26 Len: 8 Enqueue: 1219
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 876
-ID: 29 Len: 1760 Enqueue: 1423
+ID: 28 Len: 8 Enqueue: 1249
+ID: 29 Len: 1760 Enqueue: 1796
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -517,41 +608,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1088
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1461
+ID: 39 Len: 8 Enqueue: 1135
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 888
+ID: 41 Len: 8 Enqueue: 1261
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1098
-ID: 44 Len: 8 Enqueue: 894
+ID: 43 Len: 24 Enqueue: 1471
+ID: 44 Len: 8 Enqueue: 1267
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 864
+ID: 47 Len: 8 Enqueue: 1237
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 870
+ID: 53 Len: 8 Enqueue: 1243
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 858
+ID: 60 Len: 8 Enqueue: 1231
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1519
+ID: 64 Len: 64 Enqueue: 1892
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1530
+ID: 69 Len: 32 Enqueue: 1903
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 948
-ID: 72 Len: 8 Enqueue: 900
+ID: 71 Len: 16 Enqueue: 1321
+ID: 72 Len: 8 Enqueue: 1273
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -567,46 +658,46 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 906
+ID: 88 Len: 8 Enqueue: 1279
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 816
-ID: 92 Len: 8 Enqueue: 834
-ID: 93 Len: 8 Enqueue: 822
-ID: 94 Len: 8 Enqueue: 930
-ID: 95 Len: 8 Enqueue: 804
-ID: 96 Len: 8 Enqueue: 810
-ID: 97 Len: 8 Enqueue: 912
-ID: 98 Len: 8 Enqueue: 918
-ID: 99 Len: 24 Enqueue: 1040
+ID: 91 Len: 8 Enqueue: 1189
+ID: 92 Len: 8 Enqueue: 1207
+ID: 93 Len: 8 Enqueue: 1195
+ID: 94 Len: 8 Enqueue: 1303
+ID: 95 Len: 8 Enqueue: 1177
+ID: 96 Len: 8 Enqueue: 1183
+ID: 97 Len: 8 Enqueue: 1285
+ID: 98 Len: 8 Enqueue: 1291
+ID: 99 Len: 24 Enqueue: 1413
 ID: 100 Len: 24 Enqueue: 0
-ID: 101 Len: 24 Enqueue: 1066
-ID: 102 Len: 48 Enqueue: 964
-ID: 103 Len: 8 Enqueue: 1308
+ID: 101 Len: 24 Enqueue: 1439
+ID: 102 Len: 48 Enqueue: 1337
+ID: 103 Len: 8 Enqueue: 1681
 ID: 104 Len: 8 Enqueue: 0
-ID: 105 Len: 48 Enqueue: 1246
-ID: 106 Len: 8 Enqueue: 780
-ID: 107 Len: 208 Enqueue: 1151
-ID: 108 Len: 8 Enqueue: 882
+ID: 105 Len: 48 Enqueue: 1619
+ID: 106 Len: 8 Enqueue: 1153
+ID: 107 Len: 208 Enqueue: 1524
+ID: 108 Len: 8 Enqueue: 1255
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 8 Enqueue: 1314
+ID: 110 Len: 8 Enqueue: 1687
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1260
-ID: 113 Len: 8 Enqueue: 786
-ID: 114 Len: 208 Enqueue: 1172
-ID: 115 Len: 8 Enqueue: 1326
+ID: 112 Len: 48 Enqueue: 1633
+ID: 113 Len: 8 Enqueue: 1159
+ID: 114 Len: 208 Enqueue: 1545
+ID: 115 Len: 8 Enqueue: 1699
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1288
-ID: 118 Len: 8 Enqueue: 798
-ID: 119 Len: 88 Enqueue: 1214
-ID: 120 Len: 8 Enqueue: 1320
+ID: 117 Len: 48 Enqueue: 1661
+ID: 118 Len: 8 Enqueue: 1171
+ID: 119 Len: 88 Enqueue: 1587
+ID: 120 Len: 8 Enqueue: 1693
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1274
-ID: 123 Len: 8 Enqueue: 792
-ID: 124 Len: 208 Enqueue: 1193
-ID: 125 Len: 8 Enqueue: 738
-ID: 126 Len: 8 Enqueue: 744
-ID: 127 Len: 8 Enqueue: 756
+ID: 122 Len: 48 Enqueue: 1647
+ID: 123 Len: 8 Enqueue: 1165
+ID: 124 Len: 208 Enqueue: 1566
+ID: 125 Len: 8 Enqueue: 1111
+ID: 126 Len: 8 Enqueue: 1117
+ID: 127 Len: 8 Enqueue: 1129
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -615,53 +706,63 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 16 Enqueue: 1076
+ID: 136 Len: 16 Enqueue: 1449
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 128 Enqueue: 1050
+ID: 139 Len: 128 Enqueue: 1423
 ID: 140 Len: 64 Enqueue: 0
-ID: 141 Len: 208 Enqueue: 992
-ID: 142 Len: 64 Enqueue: 1108
-ID: 143 Len: 8 Enqueue: 840
+ID: 141 Len: 208 Enqueue: 1365
+ID: 142 Len: 64 Enqueue: 1481
+ID: 143 Len: 8 Enqueue: 1213
 ID: 144 Len: 184 Enqueue: 0
-ID: 145 Len: 208 Enqueue: 1004
+ID: 145 Len: 208 Enqueue: 1377
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 64 Enqueue: 1124
-ID: 148 Len: 8 Enqueue: 1302
+ID: 147 Len: 64 Enqueue: 1497
+ID: 148 Len: 8 Enqueue: 1675
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 48 Enqueue: 1232
-ID: 151 Len: 8 Enqueue: 774
-ID: 152 Len: 144 Enqueue: 1140
-ID: 153 Len: 88 Enqueue: 1028
-ID: 154 Len: 208 Enqueue: 1016
+ID: 150 Len: 48 Enqueue: 1605
+ID: 151 Len: 8 Enqueue: 1147
+ID: 152 Len: 144 Enqueue: 1513
+ID: 153 Len: 88 Enqueue: 1401
+ID: 154 Len: 208 Enqueue: 1389
 ID: 155 Len: 64 Enqueue: 0
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 144 Enqueue: 980
-ID: 159 Len: 8 Enqueue: 750
+ID: 158 Len: 144 Enqueue: 1353
+ID: 159 Len: 8 Enqueue: 1123
 ID: 160 Len: 128 Enqueue: 0
 ID: 161 Len: 9 Enqueue: 0
 ID: 162 Len: 0 Enqueue: 0
 ID: 163 Len: 17 Enqueue: 0
 ID: 164 Len: 0 Enqueue: 0
-ID: 165 Len: 25 Enqueue: 0
-ID: 166 Len: 0 Enqueue: 0
-ID: 167 Len: 25 Enqueue: 0
-ID: 168 Len: 0 Enqueue: 0
-ID: 169 Len: 25 Enqueue: 0
+ID: 165 Len: 17 Enqueue: 0
+ID: 166 Len: 17 Enqueue: 0
+ID: 167 Len: 17 Enqueue: 0
+ID: 168 Len: 17 Enqueue: 0
+ID: 169 Len: 17 Enqueue: 0
 ID: 170 Len: 0 Enqueue: 0
-ID: 171 Len: 49 Enqueue: 0
-ID: 172 Len: 0 Enqueue: 0
-ID: 173 Len: 49 Enqueue: 0
-ID: 174 Len: 9 Enqueue: 0
-ID: 175 Len: 0 Enqueue: 0
-ID: 176 Len: 9 Enqueue: 0
-ID: 177 Len: 0 Enqueue: 0
+ID: 171 Len: 17 Enqueue: 0
+ID: 172 Len: 17 Enqueue: 0
+ID: 173 Len: 17 Enqueue: 0
+ID: 174 Len: 0 Enqueue: 0
+ID: 175 Len: 25 Enqueue: 0
+ID: 176 Len: 0 Enqueue: 0
+ID: 177 Len: 25 Enqueue: 0
 ID: 178 Len: 0 Enqueue: 0
-ID: 179 Len: 0 Enqueue: 0
+ID: 179 Len: 25 Enqueue: 0
 ID: 180 Len: 0 Enqueue: 0
-ID: 181 Len: 9 Enqueue: 0
-ID: 182 Len: 9 Enqueue: 0
-ID: 183 Len: 0 Enqueue: 0
+ID: 181 Len: 49 Enqueue: 0
+ID: 182 Len: 0 Enqueue: 0
+ID: 183 Len: 49 Enqueue: 0
 ID: 184 Len: 9 Enqueue: 0
-ID: 185 Len: 9 Enqueue: 0
+ID: 185 Len: 0 Enqueue: 0
+ID: 186 Len: 9 Enqueue: 0
+ID: 187 Len: 0 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
+ID: 189 Len: 0 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
+ID: 191 Len: 9 Enqueue: 0
+ID: 192 Len: 9 Enqueue: 0
+ID: 193 Len: 0 Enqueue: 0
+ID: 194 Len: 9 Enqueue: 0
+ID: 195 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 57 04 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8046]
 	PrepareEventRoot d3 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 69 04 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8090]
 	PrepareEventRoot d4 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 06 00 00 // ProcessType[map[string]main.bigStruct]
+	Call fb 05 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a8553]
 	PrepareEventRoot cb 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 43 05 00 00 // ProcessType[[3]string]
+	Call f5 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8400]
 	PrepareEventRoot c8 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 83 05 00 00 // ProcessType[[]int]
+	Call 35 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a820a]
 	PrepareEventRoot c0 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 06 00 00 // ProcessType[map[string]int]
+	Call f5 05 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a84ea]
 	PrepareEventRoot c9 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b4 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 43 05 00 00 // ProcessType[[3]string]
+	Call f5 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a838a]
 	PrepareEventRoot c6 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call b1 05 00 00 // ProcessType[[]string]
+	Call 63 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a830a]
 	PrepareEventRoot c4 00 00 00 19 00 00 00 
@@ -172,422 +172,401 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
 // 0x2d0: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b6 00 00 00 11 00 00 00 
 	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	Return 
-// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
-	ExprPrepare 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
-	Return 
-// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
-	PrepareEventRoot b7 00 00 00 11 00 00 00 
-	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
-	Return 
-// 0x303: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x325: ProcessEvent[Probe[main.stringArg]@4a818a]
+// 0x30b: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b8 00 00 00 11 00 00 00 
-	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	Return 
-// 0x334: ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
-	ExprPrepare 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
-	Return 
-// 0x349: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
-	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
-	Return 
-// 0x358: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+// 0x324: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringArg]@4a818a]
+// 0x346: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot ba 00 00 00 11 00 00 00 
-	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	Return 
-// 0x389: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
 	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x393: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x3b5: ProcessEvent[Probe[main.stringArg]@4a818a]
+// 0x381: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot bc 00 00 00 11 00 00 00 
-	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	Return 
-// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
-	ExprPrepare 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
-	Return 
-// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
-	PrepareEventRoot bd 00 00 00 11 00 00 00 
-	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
-	Return 
-// 0x3e8: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x40a: ProcessEvent[Probe[main.stringArg]@4a818a]
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot be 00 00 00 11 00 00 00 
-	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	Return 
-// 0x419: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4f 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 01 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
 	PrepareEventRoot d0 00 00 00 09 00 00 00 
-	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	Return 
-// 0x457: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x45d: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x463: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x469: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x46f: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x475: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x47b: ProcessType[*error]
+// 0x42d: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x481: ProcessType[*float32]
+// 0x433: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x487: ProcessType[*float64]
+// 0x439: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x48d: ProcessType[*int]
+// 0x43f: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x493: ProcessType[*int32]
+// 0x445: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x499: ProcessType[*int64]
+// 0x44b: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x49f: ProcessType[*main.bigStruct]
+// 0x451: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x4a5: ProcessType[*runtime._defer]
+// 0x457: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x4ab: ProcessType[*runtime._panic]
+// 0x45d: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x4b1: ProcessType[*runtime.cgoCallers]
+// 0x463: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x4b7: ProcessType[*runtime.coro]
+// 0x469: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x4bd: ProcessType[*runtime.g]
+// 0x46f: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x4c3: ProcessType[*runtime.m]
+// 0x475: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x4c9: ProcessType[*runtime.sudog]
+// 0x47b: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x4cf: ProcessType[*runtime.synctestGroup]
+// 0x481: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x4d5: ProcessType[*runtime.timer]
+// 0x487: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x4db: ProcessType[*runtime.traceBuf]
+// 0x48d: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x4e1: ProcessType[*string]
+// 0x493: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x4e7: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x499: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x4ed: ProcessType[*table<string,int>]
+// 0x49f: ProcessType[*table<string,int>]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x4f3: ProcessType[*table<string,main.bigStruct>]
+// 0x4a5: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x4f9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4ab: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9a 00 00 00 
 	Return 
-// 0x4ff: ProcessType[*uint]
+// 0x4b1: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x505: ProcessType[*uint16]
+// 0x4b7: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x50b: ProcessType[*uint32]
+// 0x4bd: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x511: ProcessType[*uint64]
+// 0x4c3: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x517: ProcessType[*uint8]
+// 0x4c9: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x51d: ProcessType[*uintptr]
+// 0x4cf: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x523: ProcessType[[2]*runtime.traceBuf]
+// 0x4d5: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call db 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call 8d 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x533: ProcessType[[2][2]*runtime.traceBuf]
+// 0x4e5: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 23 05 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call d5 04 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x543: ProcessType[[3]string]
+// 0x4f5: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x553: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x505: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e7 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 99 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x55f: ProcessType[[]*table<string,int>.array]
+// 0x511: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call ed 04 00 00 // ProcessType[*table<string,int>]
+	Call 9f 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x56b: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x51d: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call f3 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call a5 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x577: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x529: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call f9 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ab 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x583: ProcessType[[]int]
+// 0x535: ProcessType[[]int]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x58d: ProcessType[[]noalg.map.group[string]int.array]
+// 0x53f: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 85 06 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 37 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x599: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x54b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 90 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 42 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5a5: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x557: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 9b 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4d 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5b1: ProcessType[[]string]
+// 0x563: ProcessType[[]string]
 	ProcessSlice 86 00 00 00 10 00 00 00 
 	Return 
-// 0x5bb: ProcessType[[]string.array]
+// 0x56d: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x5c7: ProcessType[[]uint8]
+// 0x579: ProcessType[[]uint8]
 	ProcessSlice 80 00 00 00 01 00 00 00 
 	Return 
-// 0x5d1: ProcessType[[]uintptr]
+// 0x583: ProcessType[[]uintptr]
 	ProcessSlice 82 00 00 00 08 00 00 00 
 	Return 
-// 0x5db: ProcessType[error]
+// 0x58d: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x5dd: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x58f: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x5e9: ProcessType[groupReference<string,int>]
+// 0x59b: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 8f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x5f5: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5a7: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x601: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5b3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x60d: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x5bf: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ae 00 00 00 aa 00 00 00 10 18 
 	Return 
-// 0x619: ProcessType[map<string,int>]
+// 0x5cb: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8e 00 00 00 8b 00 00 00 10 18 
 	Return 
-// 0x625: ProcessType[map<string,main.bigStruct>]
+// 0x5d7: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 98 00 00 00 93 00 00 00 10 18 
 	Return 
-// 0x631: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5e3: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a5 00 00 00 9d 00 00 00 10 18 
 	Return 
-// 0x63d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x5ef: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a2 00 00 00 
 	Return 
-// 0x643: ProcessType[map[string]int]
+// 0x5f5: ProcessType[map[string]int]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x649: ProcessType[map[string]main.bigStruct]
+// 0x5fb: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x64f: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x601: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x655: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x607: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a6 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 58 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x665: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x617: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call b6 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 68 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x675: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x627: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call bc 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 6e 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x685: ProcessType[noalg.map.group[string]int]
+// 0x637: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 65 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 17 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x690: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x642: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 55 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 07 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x69b: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64d: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 75 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 27 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x6a6: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call a7 07 00 00 // ProcessType[string]
+// 0x658: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 59 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9f 04 00 00 // ProcessType[*main.bigStruct]
+	Call 51 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x6b6: ProcessType[noalg.struct { key string; elem int }]
-	Call a7 07 00 00 // ProcessType[string]
+// 0x668: ProcessType[noalg.struct { key string; elem int }]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x6bc: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x66e: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3d 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call ef 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x6c7: ProcessType[runtime.g]
+// 0x679: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ab 04 00 00 // ProcessType[*runtime._panic]
+	Call 5d 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a5 04 00 00 // ProcessType[*runtime._defer]
+	Call 57 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call c7 05 00 00 // ProcessType[[]uint8]
+	Call 79 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call c9 04 00 00 // ProcessType[*runtime.sudog]
+	Call 7b 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call d1 05 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call d5 04 00 00 // ProcessType[*runtime.timer]
+	Call 87 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b7 04 00 00 // ProcessType[*runtime.coro]
+	Call 69 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call cf 04 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 81 04 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x72c: ProcessType[runtime.m]
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+// 0x6de: ProcessType[runtime.m]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call b1 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 63 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 8c 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call 3e 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call d1 05 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 97 07 00 00 // ProcessType[runtime.mTraceState]
+	Call 49 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x78c: ProcessType[runtime.mLockProfile]
+// 0x73e: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call d1 05 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x797: ProcessType[runtime.mTraceState]
+// 0x749: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 33 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call e5 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x7a7: ProcessType[string]
+// 0x759: ProcessType[string]
 	ProcessString 7e 00 00 00 
 	Return 
-// 0x7ad: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x75f: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call dd 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 8f 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x7b8: ProcessType[table<string,int>]
+// 0x76a: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call e9 05 00 00 // ProcessType[groupReference<string,int>]
+	Call 9b 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x7c3: ProcessType[table<string,main.bigStruct>]
+// 0x775: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f5 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call a7 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x7ce: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x780: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 01 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b3 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -608,31 +587,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1303
+ID: 5 Len: 8 Enqueue: 1225
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1959
+ID: 9 Len: 16 Enqueue: 1881
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 1141
+ID: 11 Len: 8 Enqueue: 1063
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1499
+ID: 13 Len: 16 Enqueue: 1421
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1309
-ID: 20 Len: 8 Enqueue: 1171
-ID: 21 Len: 8 Enqueue: 1291
-ID: 22 Len: 440 Enqueue: 1735
+ID: 19 Len: 8 Enqueue: 1231
+ID: 20 Len: 8 Enqueue: 1093
+ID: 21 Len: 8 Enqueue: 1213
+ID: 22 Len: 440 Enqueue: 1657
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1195
+ID: 24 Len: 8 Enqueue: 1117
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1189
+ID: 26 Len: 8 Enqueue: 1111
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1219
-ID: 29 Len: 1808 Enqueue: 1836
+ID: 28 Len: 8 Enqueue: 1141
+ID: 29 Len: 1808 Enqueue: 1758
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -641,45 +620,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1479
-ID: 39 Len: 8 Enqueue: 1135
+ID: 38 Len: 24 Enqueue: 1401
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1225
+ID: 41 Len: 8 Enqueue: 1147
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1489
-ID: 44 Len: 8 Enqueue: 1237
+ID: 43 Len: 24 Enqueue: 1411
+ID: 44 Len: 8 Enqueue: 1159
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1207
+ID: 47 Len: 8 Enqueue: 1129
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 1231
+ID: 49 Len: 8 Enqueue: 1153
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 1213
+ID: 55 Len: 8 Enqueue: 1135
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 1201
+ID: 62 Len: 8 Enqueue: 1123
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1932
+ID: 67 Len: 64 Enqueue: 1854
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1943
+ID: 72 Len: 56 Enqueue: 1865
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 1331
-ID: 75 Len: 16 Enqueue: 1315
-ID: 76 Len: 8 Enqueue: 1243
+ID: 74 Len: 32 Enqueue: 1253
+ID: 75 Len: 16 Enqueue: 1237
+ID: 76 Len: 8 Enqueue: 1165
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -696,39 +675,39 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 1249
+ID: 93 Len: 8 Enqueue: 1171
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 1159
-ID: 97 Len: 8 Enqueue: 1177
-ID: 98 Len: 8 Enqueue: 1165
-ID: 99 Len: 8 Enqueue: 1297
-ID: 100 Len: 8 Enqueue: 1147
-ID: 101 Len: 8 Enqueue: 1153
-ID: 102 Len: 8 Enqueue: 1279
-ID: 103 Len: 8 Enqueue: 1285
-ID: 104 Len: 24 Enqueue: 1411
+ID: 96 Len: 8 Enqueue: 1081
+ID: 97 Len: 8 Enqueue: 1099
+ID: 98 Len: 8 Enqueue: 1087
+ID: 99 Len: 8 Enqueue: 1219
+ID: 100 Len: 8 Enqueue: 1069
+ID: 101 Len: 8 Enqueue: 1075
+ID: 102 Len: 8 Enqueue: 1201
+ID: 103 Len: 8 Enqueue: 1207
+ID: 104 Len: 24 Enqueue: 1333
 ID: 105 Len: 24 Enqueue: 0
-ID: 106 Len: 24 Enqueue: 1457
-ID: 107 Len: 48 Enqueue: 1347
-ID: 108 Len: 8 Enqueue: 1603
+ID: 106 Len: 24 Enqueue: 1379
+ID: 107 Len: 48 Enqueue: 1269
+ID: 108 Len: 8 Enqueue: 1525
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 48 Enqueue: 1561
+ID: 110 Len: 48 Enqueue: 1483
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 8 Enqueue: 1261
-ID: 113 Len: 8 Enqueue: 1609
+ID: 112 Len: 8 Enqueue: 1183
+ID: 113 Len: 8 Enqueue: 1531
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 48 Enqueue: 1573
+ID: 115 Len: 48 Enqueue: 1495
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 8 Enqueue: 1267
-ID: 118 Len: 8 Enqueue: 1615
+ID: 117 Len: 8 Enqueue: 1189
+ID: 118 Len: 8 Enqueue: 1537
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 48 Enqueue: 1585
+ID: 120 Len: 48 Enqueue: 1507
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 8 Enqueue: 1273
-ID: 123 Len: 8 Enqueue: 1111
-ID: 124 Len: 8 Enqueue: 1117
-ID: 125 Len: 8 Enqueue: 1129
+ID: 122 Len: 8 Enqueue: 1195
+ID: 123 Len: 8 Enqueue: 1033
+ID: 124 Len: 8 Enqueue: 1039
+ID: 125 Len: 8 Enqueue: 1051
 ID: 126 Len: 1 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 1 Enqueue: 0
@@ -737,62 +716,62 @@ ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 16 Enqueue: 1467
+ID: 134 Len: 16 Enqueue: 1389
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 32 Enqueue: 1976
-ID: 137 Len: 16 Enqueue: 1513
+ID: 136 Len: 32 Enqueue: 1898
+ID: 137 Len: 16 Enqueue: 1435
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 200 Enqueue: 1669
-ID: 140 Len: 192 Enqueue: 1637
-ID: 141 Len: 24 Enqueue: 1718
-ID: 142 Len: 8 Enqueue: 1375
-ID: 143 Len: 200 Enqueue: 1421
-ID: 144 Len: 32 Enqueue: 1987
-ID: 145 Len: 16 Enqueue: 1525
+ID: 139 Len: 200 Enqueue: 1591
+ID: 140 Len: 192 Enqueue: 1559
+ID: 141 Len: 24 Enqueue: 1640
+ID: 142 Len: 8 Enqueue: 1297
+ID: 143 Len: 200 Enqueue: 1343
+ID: 144 Len: 32 Enqueue: 1909
+ID: 145 Len: 16 Enqueue: 1447
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 200 Enqueue: 1680
-ID: 148 Len: 192 Enqueue: 1621
-ID: 149 Len: 24 Enqueue: 1702
-ID: 150 Len: 8 Enqueue: 1183
+ID: 147 Len: 200 Enqueue: 1602
+ID: 148 Len: 192 Enqueue: 1543
+ID: 149 Len: 24 Enqueue: 1624
+ID: 150 Len: 8 Enqueue: 1105
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 8 Enqueue: 1387
-ID: 153 Len: 200 Enqueue: 1433
-ID: 154 Len: 32 Enqueue: 1998
-ID: 155 Len: 16 Enqueue: 1537
+ID: 152 Len: 8 Enqueue: 1309
+ID: 153 Len: 200 Enqueue: 1355
+ID: 154 Len: 32 Enqueue: 1920
+ID: 155 Len: 16 Enqueue: 1459
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 136 Enqueue: 1691
-ID: 158 Len: 128 Enqueue: 1653
-ID: 159 Len: 16 Enqueue: 1724
-ID: 160 Len: 8 Enqueue: 1597
+ID: 157 Len: 136 Enqueue: 1613
+ID: 158 Len: 128 Enqueue: 1575
+ID: 159 Len: 16 Enqueue: 1646
+ID: 160 Len: 8 Enqueue: 1519
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 48 Enqueue: 1549
+ID: 162 Len: 48 Enqueue: 1471
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 1255
-ID: 165 Len: 8 Enqueue: 1399
-ID: 166 Len: 136 Enqueue: 1445
-ID: 167 Len: 32 Enqueue: 1965
-ID: 168 Len: 16 Enqueue: 1501
+ID: 164 Len: 8 Enqueue: 1177
+ID: 165 Len: 8 Enqueue: 1321
+ID: 166 Len: 136 Enqueue: 1367
+ID: 167 Len: 32 Enqueue: 1887
+ID: 168 Len: 16 Enqueue: 1423
 ID: 169 Len: 8 Enqueue: 0
 ID: 170 Len: 136 Enqueue: 0
 ID: 171 Len: 128 Enqueue: 0
 ID: 172 Len: 16 Enqueue: 0
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 8 Enqueue: 1363
+ID: 174 Len: 8 Enqueue: 1285
 ID: 175 Len: 136 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 1123
+ID: 176 Len: 8 Enqueue: 1045
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 9 Enqueue: 0
 ID: 179 Len: 0 Enqueue: 0
 ID: 180 Len: 17 Enqueue: 0
 ID: 181 Len: 0 Enqueue: 0
 ID: 182 Len: 17 Enqueue: 0
-ID: 183 Len: 17 Enqueue: 0
+ID: 183 Len: 0 Enqueue: 0
 ID: 184 Len: 17 Enqueue: 0
-ID: 185 Len: 17 Enqueue: 0
+ID: 185 Len: 0 Enqueue: 0
 ID: 186 Len: 17 Enqueue: 0
 ID: 187 Len: 0 Enqueue: 0
 ID: 188 Len: 17 Enqueue: 0
-ID: 189 Len: 17 Enqueue: 0
+ID: 189 Len: 0 Enqueue: 0
 ID: 190 Len: 17 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0
 ID: 192 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 57 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8046]
-	PrepareEventRoot c9 00 00 00 09 00 00 00 
+	PrepareEventRoot d3 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8046.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8090.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 69 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8090]
-	PrepareEventRoot ca 00 00 00 09 00 00 00 
+	PrepareEventRoot d4 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8090.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d4 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 49 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a8553]
-	PrepareEventRoot c1 00 00 00 09 00 00 00 
+	PrepareEventRoot cb 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4a85de]
-	PrepareEventRoot c2 00 00 00 00 00 00 00 
+	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@4a7e0e]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
+	PrepareEventRoot d1 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@4a842a]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
+	PrepareEventRoot d1 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4a846a]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0x4a810a.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@4a828a]
-	PrepareEventRoot b8 00 00 00 19 00 00 00 
+	PrepareEventRoot c2 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a828a.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@4a82d6]
-	PrepareEventRoot b9 00 00 00 00 00 00 00 
+	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call 43 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8400]
-	PrepareEventRoot be 00 00 00 31 00 00 00 
+	PrepareEventRoot c8 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0e 04 00 00 // ProcessType[[]int]
+	Call 83 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a820a]
-	PrepareEventRoot b6 00 00 00 19 00 00 00 
+	PrepareEventRoot c0 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@4a824f]
-	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ce 04 00 00 // ProcessType[map[string]int]
+	Call 43 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a84ea]
-	PrepareEventRoot bf 00 00 00 09 00 00 00 
+	PrepareEventRoot c9 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@4a851f]
-	PrepareEventRoot c0 00 00 00 00 00 00 00 
+	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@4a860a]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@4a8646]
-	PrepareEventRoot c4 00 00 00 00 00 00 00 
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call a7 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b4 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call 43 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a838a]
-	PrepareEventRoot bc 00 00 00 31 00 00 00 
+	PrepareEventRoot c6 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@4a83d6]
-	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	ExprPrepare 
@@ -158,345 +158,436 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 3c 04 00 00 // ProcessType[[]string]
+	Call b1 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a830a]
-	PrepareEventRoot ba 00 00 00 19 00 00 00 
+	PrepareEventRoot c4 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@4a834f]
-	PrepareEventRoot bb 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot b6 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot b7 00 00 00 11 00 00 00 
+	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
+	Return 
+// 0x303: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x325: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot b8 00 00 00 11 00 00 00 
+	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x334: ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x349: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot b9 00 00 00 11 00 00 00 
+	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
+	Return 
+// 0x358: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x37a: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot ba 00 00 00 11 00 00 00 
+	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x389: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot bb 00 00 00 00 00 00 00 
+	Return 
+// 0x393: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x3b5: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot bc 00 00 00 11 00 00 00 
+	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot bd 00 00 00 11 00 00 00 
+	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4a81cf.expr[0]]
+	Return 
+// 0x3e8: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x40a: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot be 00 00 00 11 00 00 00 
+	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x419: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	Return 
+// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
+	PrepareEventRoot cf 00 00 00 00 00 00 00 
+	Return 
+// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call da 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4f 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
-	PrepareEventRoot c6 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
+// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
+	PrepareEventRoot d0 00 00 00 09 00 00 00 
+	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x457: ProcessType[*****int]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x45d: ProcessType[****int]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x463: ProcessType[***int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x469: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x46f: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x475: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*error]
+// 0x47b: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float32]
+// 0x481: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x312: ProcessType[*float64]
+// 0x487: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x318: ProcessType[*int]
+// 0x48d: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int32]
+// 0x493: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x324: ProcessType[*int64]
+// 0x499: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x32a: ProcessType[*main.bigStruct]
+// 0x49f: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._defer]
+// 0x4a5: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime._panic]
+// 0x4ab: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.cgoCallers]
+// 0x4b1: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.coro]
+// 0x4b7: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.g]
+// 0x4bd: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.m]
+// 0x4c3: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.sudog]
+// 0x4c9: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.synctestGroup]
+// 0x4cf: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.timer]
+// 0x4d5: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.traceBuf]
+// 0x4db: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*string]
+// 0x4e1: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x372: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4e7: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<string,int>]
+// 0x4ed: ProcessType[*table<string,int>]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,main.bigStruct>]
+// 0x4f3: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4f9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9a 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint]
+// 0x4ff: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint16]
+// 0x505: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint32]
+// 0x50b: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint64]
+// 0x511: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint8]
+// 0x517: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uintptr]
+// 0x51d: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3ae: ProcessType[[2]*runtime.traceBuf]
+// 0x523: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call db 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3be: ProcessType[[2][2]*runtime.traceBuf]
+// 0x533: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 23 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3ce: ProcessType[[3]string]
+// 0x543: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call a7 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3de: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x553: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 72 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call e7 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ea: ProcessType[[]*table<string,int>.array]
+// 0x55f: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<string,int>]
+	Call ed 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f6: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x56b: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f3 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x402: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x577: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call f9 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x40e: ProcessType[[]int]
+// 0x583: ProcessType[[]int]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x418: ProcessType[[]noalg.map.group[string]int.array]
+// 0x58d: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 10 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 85 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x424: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x599: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 1b 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 90 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x430: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5a5: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 26 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 9b 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x43c: ProcessType[[]string]
+// 0x5b1: ProcessType[[]string]
 	ProcessSlice 86 00 00 00 10 00 00 00 
 	Return 
-// 0x446: ProcessType[[]string.array]
+// 0x5bb: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 32 06 00 00 // ProcessType[string]
+	Call a7 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x452: ProcessType[[]uint8]
+// 0x5c7: ProcessType[[]uint8]
 	ProcessSlice 80 00 00 00 01 00 00 00 
 	Return 
-// 0x45c: ProcessType[[]uintptr]
+// 0x5d1: ProcessType[[]uintptr]
 	ProcessSlice 82 00 00 00 08 00 00 00 
 	Return 
-// 0x466: ProcessType[error]
+// 0x5db: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x468: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5dd: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x474: ProcessType[groupReference<string,int>]
+// 0x5e9: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 8f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x480: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5f5: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x48c: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x601: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x498: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x60d: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ae 00 00 00 aa 00 00 00 10 18 
 	Return 
-// 0x4a4: ProcessType[map<string,int>]
+// 0x619: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8e 00 00 00 8b 00 00 00 10 18 
 	Return 
-// 0x4b0: ProcessType[map<string,main.bigStruct>]
+// 0x625: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 98 00 00 00 93 00 00 00 10 18 
 	Return 
-// 0x4bc: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x631: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a5 00 00 00 9d 00 00 00 10 18 
 	Return 
-// 0x4c8: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x63d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a2 00 00 00 
 	Return 
-// 0x4ce: ProcessType[map[string]int]
+// 0x643: ProcessType[map[string]int]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x4d4: ProcessType[map[string]main.bigStruct]
+// 0x649: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x4da: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64f: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x4e0: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x655: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 31 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a6 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4f0: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x665: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 41 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call b6 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x500: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x675: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 47 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call bc 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x510: ProcessType[noalg.map.group[string]int]
+// 0x685: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 65 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x51b: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x690: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call e0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 55 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x526: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x69b: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 00 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 75 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x531: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 32 06 00 00 // ProcessType[string]
+// 0x6a6: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a7 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
+	Call 9f 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x541: ProcessType[noalg.struct { key string; elem int }]
-	Call 32 06 00 00 // ProcessType[string]
+// 0x6b6: ProcessType[noalg.struct { key string; elem int }]
+	Call a7 07 00 00 // ProcessType[string]
 	Return 
-// 0x547: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6bc: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call c8 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3d 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x552: ProcessType[runtime.g]
+// 0x6c7: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime._panic]
+	Call ab 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._defer]
+	Call a5 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 52 04 00 00 // ProcessType[[]uint8]
+	Call c7 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.sudog]
+	Call c9 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call d1 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.timer]
+	Call d5 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.coro]
+	Call b7 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.synctestGroup]
+	Call cf 04 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x5b7: ProcessType[runtime.m]
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+// 0x72c: ProcessType[runtime.m]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call a7 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b1 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 17 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 8c 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call d1 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 22 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 97 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x617: ProcessType[runtime.mLockProfile]
+// 0x78c: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call d1 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x622: ProcessType[runtime.mTraceState]
+// 0x797: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call be 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 33 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x632: ProcessType[string]
+// 0x7a7: ProcessType[string]
 	ProcessString 7e 00 00 00 
 	Return 
-// 0x638: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7ad: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 68 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call dd 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x643: ProcessType[table<string,int>]
+// 0x7b8: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 74 04 00 00 // ProcessType[groupReference<string,int>]
+	Call e9 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x64e: ProcessType[table<string,main.bigStruct>]
+// 0x7c3: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 80 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call f5 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x659: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7ce: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8c 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 01 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -517,31 +608,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 930
+ID: 5 Len: 8 Enqueue: 1303
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1586
+ID: 9 Len: 16 Enqueue: 1959
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 768
+ID: 11 Len: 8 Enqueue: 1141
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1126
+ID: 13 Len: 16 Enqueue: 1499
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 936
-ID: 20 Len: 8 Enqueue: 798
-ID: 21 Len: 8 Enqueue: 918
-ID: 22 Len: 440 Enqueue: 1362
+ID: 19 Len: 8 Enqueue: 1309
+ID: 20 Len: 8 Enqueue: 1171
+ID: 21 Len: 8 Enqueue: 1291
+ID: 22 Len: 440 Enqueue: 1735
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 822
+ID: 24 Len: 8 Enqueue: 1195
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 816
+ID: 26 Len: 8 Enqueue: 1189
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 846
-ID: 29 Len: 1808 Enqueue: 1463
+ID: 28 Len: 8 Enqueue: 1219
+ID: 29 Len: 1808 Enqueue: 1836
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -550,45 +641,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1106
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1479
+ID: 39 Len: 8 Enqueue: 1135
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 852
+ID: 41 Len: 8 Enqueue: 1225
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1116
-ID: 44 Len: 8 Enqueue: 864
+ID: 43 Len: 24 Enqueue: 1489
+ID: 44 Len: 8 Enqueue: 1237
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 834
+ID: 47 Len: 8 Enqueue: 1207
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 858
+ID: 49 Len: 8 Enqueue: 1231
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 840
+ID: 55 Len: 8 Enqueue: 1213
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 828
+ID: 62 Len: 8 Enqueue: 1201
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1559
+ID: 67 Len: 64 Enqueue: 1932
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1570
+ID: 72 Len: 56 Enqueue: 1943
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 958
-ID: 75 Len: 16 Enqueue: 942
-ID: 76 Len: 8 Enqueue: 870
+ID: 74 Len: 32 Enqueue: 1331
+ID: 75 Len: 16 Enqueue: 1315
+ID: 76 Len: 8 Enqueue: 1243
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -605,39 +696,39 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 876
+ID: 93 Len: 8 Enqueue: 1249
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 786
-ID: 97 Len: 8 Enqueue: 804
-ID: 98 Len: 8 Enqueue: 792
-ID: 99 Len: 8 Enqueue: 924
-ID: 100 Len: 8 Enqueue: 774
-ID: 101 Len: 8 Enqueue: 780
-ID: 102 Len: 8 Enqueue: 906
-ID: 103 Len: 8 Enqueue: 912
-ID: 104 Len: 24 Enqueue: 1038
+ID: 96 Len: 8 Enqueue: 1159
+ID: 97 Len: 8 Enqueue: 1177
+ID: 98 Len: 8 Enqueue: 1165
+ID: 99 Len: 8 Enqueue: 1297
+ID: 100 Len: 8 Enqueue: 1147
+ID: 101 Len: 8 Enqueue: 1153
+ID: 102 Len: 8 Enqueue: 1279
+ID: 103 Len: 8 Enqueue: 1285
+ID: 104 Len: 24 Enqueue: 1411
 ID: 105 Len: 24 Enqueue: 0
-ID: 106 Len: 24 Enqueue: 1084
-ID: 107 Len: 48 Enqueue: 974
-ID: 108 Len: 8 Enqueue: 1230
+ID: 106 Len: 24 Enqueue: 1457
+ID: 107 Len: 48 Enqueue: 1347
+ID: 108 Len: 8 Enqueue: 1603
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 48 Enqueue: 1188
+ID: 110 Len: 48 Enqueue: 1561
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 8 Enqueue: 888
-ID: 113 Len: 8 Enqueue: 1236
+ID: 112 Len: 8 Enqueue: 1261
+ID: 113 Len: 8 Enqueue: 1609
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 48 Enqueue: 1200
+ID: 115 Len: 48 Enqueue: 1573
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 8 Enqueue: 894
-ID: 118 Len: 8 Enqueue: 1242
+ID: 117 Len: 8 Enqueue: 1267
+ID: 118 Len: 8 Enqueue: 1615
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 48 Enqueue: 1212
+ID: 120 Len: 48 Enqueue: 1585
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 8 Enqueue: 900
-ID: 123 Len: 8 Enqueue: 738
-ID: 124 Len: 8 Enqueue: 744
-ID: 125 Len: 8 Enqueue: 756
+ID: 122 Len: 8 Enqueue: 1273
+ID: 123 Len: 8 Enqueue: 1111
+ID: 124 Len: 8 Enqueue: 1117
+ID: 125 Len: 8 Enqueue: 1129
 ID: 126 Len: 1 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 1 Enqueue: 0
@@ -646,72 +737,82 @@ ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 16 Enqueue: 1094
+ID: 134 Len: 16 Enqueue: 1467
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 32 Enqueue: 1603
-ID: 137 Len: 16 Enqueue: 1140
+ID: 136 Len: 32 Enqueue: 1976
+ID: 137 Len: 16 Enqueue: 1513
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 200 Enqueue: 1296
-ID: 140 Len: 192 Enqueue: 1264
-ID: 141 Len: 24 Enqueue: 1345
-ID: 142 Len: 8 Enqueue: 1002
-ID: 143 Len: 200 Enqueue: 1048
-ID: 144 Len: 32 Enqueue: 1614
-ID: 145 Len: 16 Enqueue: 1152
+ID: 139 Len: 200 Enqueue: 1669
+ID: 140 Len: 192 Enqueue: 1637
+ID: 141 Len: 24 Enqueue: 1718
+ID: 142 Len: 8 Enqueue: 1375
+ID: 143 Len: 200 Enqueue: 1421
+ID: 144 Len: 32 Enqueue: 1987
+ID: 145 Len: 16 Enqueue: 1525
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 200 Enqueue: 1307
-ID: 148 Len: 192 Enqueue: 1248
-ID: 149 Len: 24 Enqueue: 1329
-ID: 150 Len: 8 Enqueue: 810
+ID: 147 Len: 200 Enqueue: 1680
+ID: 148 Len: 192 Enqueue: 1621
+ID: 149 Len: 24 Enqueue: 1702
+ID: 150 Len: 8 Enqueue: 1183
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 8 Enqueue: 1014
-ID: 153 Len: 200 Enqueue: 1060
-ID: 154 Len: 32 Enqueue: 1625
-ID: 155 Len: 16 Enqueue: 1164
+ID: 152 Len: 8 Enqueue: 1387
+ID: 153 Len: 200 Enqueue: 1433
+ID: 154 Len: 32 Enqueue: 1998
+ID: 155 Len: 16 Enqueue: 1537
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 136 Enqueue: 1318
-ID: 158 Len: 128 Enqueue: 1280
-ID: 159 Len: 16 Enqueue: 1351
-ID: 160 Len: 8 Enqueue: 1224
+ID: 157 Len: 136 Enqueue: 1691
+ID: 158 Len: 128 Enqueue: 1653
+ID: 159 Len: 16 Enqueue: 1724
+ID: 160 Len: 8 Enqueue: 1597
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 48 Enqueue: 1176
+ID: 162 Len: 48 Enqueue: 1549
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 882
-ID: 165 Len: 8 Enqueue: 1026
-ID: 166 Len: 136 Enqueue: 1072
-ID: 167 Len: 32 Enqueue: 1592
-ID: 168 Len: 16 Enqueue: 1128
+ID: 164 Len: 8 Enqueue: 1255
+ID: 165 Len: 8 Enqueue: 1399
+ID: 166 Len: 136 Enqueue: 1445
+ID: 167 Len: 32 Enqueue: 1965
+ID: 168 Len: 16 Enqueue: 1501
 ID: 169 Len: 8 Enqueue: 0
 ID: 170 Len: 136 Enqueue: 0
 ID: 171 Len: 128 Enqueue: 0
 ID: 172 Len: 16 Enqueue: 0
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 8 Enqueue: 990
+ID: 174 Len: 8 Enqueue: 1363
 ID: 175 Len: 136 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 750
+ID: 176 Len: 8 Enqueue: 1123
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 9 Enqueue: 0
 ID: 179 Len: 0 Enqueue: 0
 ID: 180 Len: 17 Enqueue: 0
 ID: 181 Len: 0 Enqueue: 0
-ID: 182 Len: 25 Enqueue: 0
-ID: 183 Len: 0 Enqueue: 0
-ID: 184 Len: 25 Enqueue: 0
-ID: 185 Len: 0 Enqueue: 0
-ID: 186 Len: 25 Enqueue: 0
+ID: 182 Len: 17 Enqueue: 0
+ID: 183 Len: 17 Enqueue: 0
+ID: 184 Len: 17 Enqueue: 0
+ID: 185 Len: 17 Enqueue: 0
+ID: 186 Len: 17 Enqueue: 0
 ID: 187 Len: 0 Enqueue: 0
-ID: 188 Len: 49 Enqueue: 0
-ID: 189 Len: 0 Enqueue: 0
-ID: 190 Len: 49 Enqueue: 0
-ID: 191 Len: 9 Enqueue: 0
-ID: 192 Len: 0 Enqueue: 0
-ID: 193 Len: 9 Enqueue: 0
-ID: 194 Len: 0 Enqueue: 0
+ID: 188 Len: 17 Enqueue: 0
+ID: 189 Len: 17 Enqueue: 0
+ID: 190 Len: 17 Enqueue: 0
+ID: 191 Len: 0 Enqueue: 0
+ID: 192 Len: 25 Enqueue: 0
+ID: 193 Len: 0 Enqueue: 0
+ID: 194 Len: 25 Enqueue: 0
 ID: 195 Len: 0 Enqueue: 0
-ID: 196 Len: 0 Enqueue: 0
+ID: 196 Len: 25 Enqueue: 0
 ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 9 Enqueue: 0
-ID: 199 Len: 9 Enqueue: 0
-ID: 200 Len: 0 Enqueue: 0
+ID: 198 Len: 49 Enqueue: 0
+ID: 199 Len: 0 Enqueue: 0
+ID: 200 Len: 49 Enqueue: 0
 ID: 201 Len: 9 Enqueue: 0
-ID: 202 Len: 9 Enqueue: 0
+ID: 202 Len: 0 Enqueue: 0
+ID: 203 Len: 9 Enqueue: 0
+ID: 204 Len: 0 Enqueue: 0
+ID: 205 Len: 0 Enqueue: 0
+ID: 206 Len: 0 Enqueue: 0
+ID: 207 Len: 0 Enqueue: 0
+ID: 208 Len: 9 Enqueue: 0
+ID: 209 Len: 9 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
+ID: 211 Len: 9 Enqueue: 0
+ID: 212 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 57 04 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae646]
 	PrepareEventRoot d8 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 69 04 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae690]
 	PrepareEventRoot d9 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 65 06 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 17 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeb53]
 	PrepareEventRoot d0 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 49 05 00 00 // ProcessType[[3]string]
+	Call fb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4aea00]
 	PrepareEventRoot cd 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 9f 05 00 00 // ProcessType[[]int]
+	Call 51 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4ae80a]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5f 06 00 00 // ProcessType[map[string]int]
+	Call 11 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4aeaea]
 	PrepareEventRoot ce 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 49 05 00 00 // ProcessType[[3]string]
+	Call fb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4ae98a]
 	PrepareEventRoot cb 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call cd 05 00 00 // ProcessType[[]string]
+	Call 7f 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4ae90a]
 	PrepareEventRoot c9 00 00 00 19 00 00 00 
@@ -172,435 +172,414 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
 // 0x2d0: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
 	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	Return 
-// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
-	ExprPrepare 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
-	Return 
-// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
-	PrepareEventRoot bc 00 00 00 11 00 00 00 
-	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
-	Return 
-// 0x303: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x325: ProcessEvent[Probe[main.stringArg]@4ae78a]
+// 0x30b: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot bd 00 00 00 11 00 00 00 
-	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	Return 
-// 0x334: ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
-	ExprPrepare 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
-	Return 
-// 0x349: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
-	PrepareEventRoot be 00 00 00 11 00 00 00 
-	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
-	Return 
-// 0x358: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+// 0x324: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringArg]@4ae78a]
+// 0x346: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot bf 00 00 00 11 00 00 00 
-	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	Return 
-// 0x389: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x393: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x3b5: ProcessEvent[Probe[main.stringArg]@4ae78a]
+// 0x381: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot c1 00 00 00 11 00 00 00 
-	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	Return 
-// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
-	ExprPrepare 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
-	Return 
-// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
-	PrepareEventRoot c2 00 00 00 11 00 00 00 
-	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
-	Return 
-// 0x3e8: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x40a: ProcessEvent[Probe[main.stringArg]@4ae78a]
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot c3 00 00 00 11 00 00 00 
-	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	Return 
-// 0x419: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 6b 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 1d 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
 	PrepareEventRoot d5 00 00 00 09 00 00 00 
-	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	Return 
-// 0x457: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x45d: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer b5 00 00 00 
 	Return 
-// 0x463: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x469: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x46f: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x475: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x47b: ProcessType[*error]
+// 0x42d: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x481: ProcessType[*float32]
+// 0x433: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x487: ProcessType[*float64]
+// 0x439: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x48d: ProcessType[*int]
+// 0x43f: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x493: ProcessType[*int32]
+// 0x445: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x499: ProcessType[*int64]
+// 0x44b: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x49f: ProcessType[*main.bigStruct]
+// 0x451: ProcessType[*main.bigStruct]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x4a5: ProcessType[*runtime._defer]
+// 0x457: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x4ab: ProcessType[*runtime._panic]
+// 0x45d: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x4b1: ProcessType[*runtime.cgoCallers]
+// 0x463: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x4b7: ProcessType[*runtime.coro]
+// 0x469: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x4bd: ProcessType[*runtime.g]
+// 0x46f: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x4c3: ProcessType[*runtime.m]
+// 0x475: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x4c9: ProcessType[*runtime.p]
+// 0x47b: ProcessType[*runtime.p]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x4cf: ProcessType[*runtime.sudog]
+// 0x481: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x4d5: ProcessType[*runtime.synctestBubble]
+// 0x487: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x4db: ProcessType[*runtime.timer]
+// 0x48d: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x4e1: ProcessType[*runtime.traceBuf]
+// 0x493: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x4e7: ProcessType[*string]
+// 0x499: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x4ed: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x49f: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ac 00 00 00 
 	Return 
-// 0x4f3: ProcessType[*table<string,int>]
+// 0x4a5: ProcessType[*table<string,int>]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x4f9: ProcessType[*table<string,main.bigStruct>]
+// 0x4ab: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 95 00 00 00 
 	Return 
-// 0x4ff: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4b1: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x505: ProcessType[*uint]
+// 0x4b7: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x50b: ProcessType[*uint16]
+// 0x4bd: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x511: ProcessType[*uint32]
+// 0x4c3: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x517: ProcessType[*uint64]
+// 0x4c9: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x51d: ProcessType[*uint8]
+// 0x4cf: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x523: ProcessType[*uintptr]
+// 0x4d5: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x529: ProcessType[[2]*runtime.traceBuf]
+// 0x4db: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call e1 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call 93 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x539: ProcessType[[2][2]*runtime.traceBuf]
+// 0x4eb: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 29 05 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call db 04 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x549: ProcessType[[3]string]
+// 0x4fb: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x559: ProcessType[[]*runtime.p]
+// 0x50b: ProcessType[[]*runtime.p]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x563: ProcessType[[]*runtime.p.array]
+// 0x515: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call c9 04 00 00 // ProcessType[*runtime.p]
+	Call 7b 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x56f: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x521: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ed 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 9f 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x57b: ProcessType[[]*table<string,int>.array]
+// 0x52d: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f3 04 00 00 // ProcessType[*table<string,int>]
+	Call a5 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x587: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x539: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call f9 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call ab 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x593: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x545: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ff 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b1 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x59f: ProcessType[[]int]
+// 0x551: ProcessType[[]int]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x5a9: ProcessType[[]noalg.map.group[string]int.array]
+// 0x55b: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call a1 06 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 53 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5b5: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x567: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call ac 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 5e 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5c1: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x573: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call b7 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 69 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5cd: ProcessType[[]string]
+// 0x57f: ProcessType[[]string]
 	ProcessSlice 8b 00 00 00 10 00 00 00 
 	Return 
-// 0x5d7: ProcessType[[]string.array]
+// 0x589: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x5e3: ProcessType[[]uint8]
+// 0x595: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x5ed: ProcessType[[]uintptr]
+// 0x59f: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x5f7: ProcessType[error]
+// 0x5a9: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x5f9: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5ab: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x605: ProcessType[groupReference<string,int>]
+// 0x5b7: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 94 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x611: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5c3: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9e 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x61d: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5cf: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ab 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x629: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x5db: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b3 00 00 00 af 00 00 00 10 18 
 	Return 
-// 0x635: ProcessType[map<string,int>]
+// 0x5e7: ProcessType[map<string,int>]
 	ProcessGoSwissMap 93 00 00 00 90 00 00 00 10 18 
 	Return 
-// 0x641: ProcessType[map<string,main.bigStruct>]
+// 0x5f3: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9d 00 00 00 98 00 00 00 10 18 
 	Return 
-// 0x64d: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5ff: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap aa 00 00 00 a2 00 00 00 10 18 
 	Return 
-// 0x659: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x60b: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x65f: ProcessType[map[string]int]
+// 0x611: ProcessType[map[string]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x665: ProcessType[map[string]main.bigStruct]
+// 0x617: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x66b: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x61d: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x671: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x623: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call c2 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 74 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x681: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x633: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call d2 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 84 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x691: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x643: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call d8 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 8a 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x6a1: ProcessType[noalg.map.group[string]int]
+// 0x653: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 81 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 33 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x6ac: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x65e: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 71 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 23 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x6b7: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x669: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 91 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 43 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x6c2: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call cd 07 00 00 // ProcessType[string]
+// 0x674: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9f 04 00 00 // ProcessType[*main.bigStruct]
+	Call 51 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x6d2: ProcessType[noalg.struct { key string; elem int }]
-	Call cd 07 00 00 // ProcessType[string]
+// 0x684: ProcessType[noalg.struct { key string; elem int }]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x6d8: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x68a: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 59 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 0b 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x6e3: ProcessType[runtime.g]
+// 0x695: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ab 04 00 00 // ProcessType[*runtime._panic]
+	Call 5d 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a5 04 00 00 // ProcessType[*runtime._defer]
+	Call 57 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call e3 05 00 00 // ProcessType[[]uint8]
+	Call 95 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call cf 04 00 00 // ProcessType[*runtime.sudog]
+	Call 81 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call ed 05 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call db 04 00 00 // ProcessType[*runtime.timer]
+	Call 8d 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b7 04 00 00 // ProcessType[*runtime.coro]
+	Call 69 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call d5 04 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 87 04 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x748: ProcessType[runtime.m]
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+// 0x6fa: ProcessType[runtime.m]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 59 05 00 00 // ProcessType[[]*runtime.p]
+	Call 0b 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call b1 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 63 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call b2 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call 64 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call ed 05 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call bd 07 00 00 // ProcessType[runtime.mTraceState]
+	Call 6f 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x7b2: ProcessType[runtime.mLockProfile]
+// 0x764: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call ed 05 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x7bd: ProcessType[runtime.mTraceState]
+// 0x76f: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 39 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call eb 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x7cd: ProcessType[string]
+// 0x77f: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
-// 0x7d3: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x785: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f9 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call ab 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x7de: ProcessType[table<string,int>]
+// 0x790: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 05 06 00 00 // ProcessType[groupReference<string,int>]
+	Call b7 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x7e9: ProcessType[table<string,main.bigStruct>]
+// 0x79b: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 11 06 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call c3 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x7f4: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7a6: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1d 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call cf 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -621,31 +600,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1309
+ID: 5 Len: 8 Enqueue: 1231
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1997
+ID: 9 Len: 16 Enqueue: 1919
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 1141
+ID: 11 Len: 8 Enqueue: 1063
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1527
+ID: 13 Len: 16 Enqueue: 1449
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1315
-ID: 20 Len: 8 Enqueue: 1171
-ID: 21 Len: 8 Enqueue: 1297
-ID: 22 Len: 440 Enqueue: 1763
+ID: 19 Len: 8 Enqueue: 1237
+ID: 20 Len: 8 Enqueue: 1093
+ID: 21 Len: 8 Enqueue: 1219
+ID: 22 Len: 440 Enqueue: 1685
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1195
+ID: 24 Len: 8 Enqueue: 1117
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1189
+ID: 26 Len: 8 Enqueue: 1111
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1219
-ID: 29 Len: 1816 Enqueue: 1864
+ID: 28 Len: 8 Enqueue: 1141
+ID: 29 Len: 1816 Enqueue: 1786
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -654,48 +633,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1507
-ID: 39 Len: 8 Enqueue: 1135
+ID: 38 Len: 24 Enqueue: 1429
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1231
+ID: 41 Len: 8 Enqueue: 1153
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1517
-ID: 44 Len: 8 Enqueue: 1243
+ID: 43 Len: 24 Enqueue: 1439
+ID: 44 Len: 8 Enqueue: 1165
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1207
+ID: 47 Len: 8 Enqueue: 1129
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 1237
+ID: 49 Len: 8 Enqueue: 1159
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 1213
+ID: 55 Len: 8 Enqueue: 1135
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 1369
+ID: 62 Len: 24 Enqueue: 1291
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 1225
-ID: 65 Len: 8 Enqueue: 1201
+ID: 64 Len: 8 Enqueue: 1147
+ID: 65 Len: 8 Enqueue: 1123
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1970
+ID: 70 Len: 56 Enqueue: 1892
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1981
+ID: 75 Len: 56 Enqueue: 1903
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 1337
-ID: 78 Len: 16 Enqueue: 1321
-ID: 79 Len: 8 Enqueue: 1249
+ID: 77 Len: 32 Enqueue: 1259
+ID: 78 Len: 16 Enqueue: 1243
+ID: 79 Len: 8 Enqueue: 1171
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -711,39 +690,39 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 1255
+ID: 95 Len: 8 Enqueue: 1177
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 1159
-ID: 99 Len: 8 Enqueue: 1165
-ID: 100 Len: 8 Enqueue: 1177
-ID: 101 Len: 8 Enqueue: 1303
-ID: 102 Len: 8 Enqueue: 1147
-ID: 103 Len: 8 Enqueue: 1153
-ID: 104 Len: 8 Enqueue: 1285
-ID: 105 Len: 8 Enqueue: 1291
-ID: 106 Len: 24 Enqueue: 1439
+ID: 98 Len: 8 Enqueue: 1081
+ID: 99 Len: 8 Enqueue: 1087
+ID: 100 Len: 8 Enqueue: 1099
+ID: 101 Len: 8 Enqueue: 1225
+ID: 102 Len: 8 Enqueue: 1069
+ID: 103 Len: 8 Enqueue: 1075
+ID: 104 Len: 8 Enqueue: 1207
+ID: 105 Len: 8 Enqueue: 1213
+ID: 106 Len: 24 Enqueue: 1361
 ID: 107 Len: 24 Enqueue: 0
-ID: 108 Len: 24 Enqueue: 1485
-ID: 109 Len: 48 Enqueue: 1353
-ID: 110 Len: 8 Enqueue: 1631
+ID: 108 Len: 24 Enqueue: 1407
+ID: 109 Len: 48 Enqueue: 1275
+ID: 110 Len: 8 Enqueue: 1553
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1589
+ID: 112 Len: 48 Enqueue: 1511
 ID: 113 Len: 8 Enqueue: 0
-ID: 114 Len: 8 Enqueue: 1267
-ID: 115 Len: 8 Enqueue: 1637
+ID: 114 Len: 8 Enqueue: 1189
+ID: 115 Len: 8 Enqueue: 1559
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1601
+ID: 117 Len: 48 Enqueue: 1523
 ID: 118 Len: 8 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 1273
-ID: 120 Len: 8 Enqueue: 1643
+ID: 119 Len: 8 Enqueue: 1195
+ID: 120 Len: 8 Enqueue: 1565
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1613
+ID: 122 Len: 48 Enqueue: 1535
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 1279
-ID: 125 Len: 8 Enqueue: 1111
-ID: 126 Len: 8 Enqueue: 1117
-ID: 127 Len: 8 Enqueue: 1129
+ID: 124 Len: 8 Enqueue: 1201
+ID: 125 Len: 8 Enqueue: 1033
+ID: 126 Len: 8 Enqueue: 1039
+ID: 127 Len: 8 Enqueue: 1051
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -751,66 +730,66 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 1379
+ID: 135 Len: 8 Enqueue: 1301
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 16 Enqueue: 1495
+ID: 139 Len: 16 Enqueue: 1417
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 32 Enqueue: 2014
-ID: 142 Len: 16 Enqueue: 1541
+ID: 141 Len: 32 Enqueue: 1936
+ID: 142 Len: 16 Enqueue: 1463
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 200 Enqueue: 1697
-ID: 145 Len: 192 Enqueue: 1665
-ID: 146 Len: 24 Enqueue: 1746
-ID: 147 Len: 8 Enqueue: 1403
-ID: 148 Len: 200 Enqueue: 1449
-ID: 149 Len: 32 Enqueue: 2025
-ID: 150 Len: 16 Enqueue: 1553
+ID: 144 Len: 200 Enqueue: 1619
+ID: 145 Len: 192 Enqueue: 1587
+ID: 146 Len: 24 Enqueue: 1668
+ID: 147 Len: 8 Enqueue: 1325
+ID: 148 Len: 200 Enqueue: 1371
+ID: 149 Len: 32 Enqueue: 1947
+ID: 150 Len: 16 Enqueue: 1475
 ID: 151 Len: 8 Enqueue: 0
-ID: 152 Len: 200 Enqueue: 1708
-ID: 153 Len: 192 Enqueue: 1649
-ID: 154 Len: 24 Enqueue: 1730
-ID: 155 Len: 8 Enqueue: 1183
+ID: 152 Len: 200 Enqueue: 1630
+ID: 153 Len: 192 Enqueue: 1571
+ID: 154 Len: 24 Enqueue: 1652
+ID: 155 Len: 8 Enqueue: 1105
 ID: 156 Len: 184 Enqueue: 0
-ID: 157 Len: 8 Enqueue: 1415
-ID: 158 Len: 200 Enqueue: 1461
-ID: 159 Len: 32 Enqueue: 2036
-ID: 160 Len: 16 Enqueue: 1565
+ID: 157 Len: 8 Enqueue: 1337
+ID: 158 Len: 200 Enqueue: 1383
+ID: 159 Len: 32 Enqueue: 1958
+ID: 160 Len: 16 Enqueue: 1487
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 136 Enqueue: 1719
-ID: 163 Len: 128 Enqueue: 1681
-ID: 164 Len: 16 Enqueue: 1752
-ID: 165 Len: 8 Enqueue: 1625
+ID: 162 Len: 136 Enqueue: 1641
+ID: 163 Len: 128 Enqueue: 1603
+ID: 164 Len: 16 Enqueue: 1674
+ID: 165 Len: 8 Enqueue: 1547
 ID: 166 Len: 8 Enqueue: 0
-ID: 167 Len: 48 Enqueue: 1577
+ID: 167 Len: 48 Enqueue: 1499
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 1261
-ID: 170 Len: 8 Enqueue: 1427
-ID: 171 Len: 136 Enqueue: 1473
-ID: 172 Len: 32 Enqueue: 2003
-ID: 173 Len: 16 Enqueue: 1529
+ID: 169 Len: 8 Enqueue: 1183
+ID: 170 Len: 8 Enqueue: 1349
+ID: 171 Len: 136 Enqueue: 1395
+ID: 172 Len: 32 Enqueue: 1925
+ID: 173 Len: 16 Enqueue: 1451
 ID: 174 Len: 8 Enqueue: 0
 ID: 175 Len: 136 Enqueue: 0
 ID: 176 Len: 128 Enqueue: 0
 ID: 177 Len: 16 Enqueue: 0
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 8 Enqueue: 1391
+ID: 179 Len: 8 Enqueue: 1313
 ID: 180 Len: 136 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 1123
+ID: 181 Len: 8 Enqueue: 1045
 ID: 182 Len: 128 Enqueue: 0
 ID: 183 Len: 9 Enqueue: 0
 ID: 184 Len: 0 Enqueue: 0
 ID: 185 Len: 17 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
 ID: 187 Len: 17 Enqueue: 0
-ID: 188 Len: 17 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
 ID: 189 Len: 17 Enqueue: 0
-ID: 190 Len: 17 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
 ID: 191 Len: 17 Enqueue: 0
 ID: 192 Len: 0 Enqueue: 0
 ID: 193 Len: 17 Enqueue: 0
-ID: 194 Len: 17 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
 ID: 195 Len: 17 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
 ID: 197 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 57 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae646]
-	PrepareEventRoot ce 00 00 00 09 00 00 00 
+	PrepareEventRoot d8 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae646.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae690.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 69 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae690]
-	PrepareEventRoot cf 00 00 00 09 00 00 00 
+	PrepareEventRoot d9 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae690.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f0 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 65 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeb53]
-	PrepareEventRoot c6 00 00 00 09 00 00 00 
+	PrepareEventRoot d0 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4aebde]
-	PrepareEventRoot c7 00 00 00 00 00 00 00 
+	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@4ae40e]
-	PrepareEventRoot cc 00 00 00 09 00 00 00 
+	PrepareEventRoot d6 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@4aea2a]
-	PrepareEventRoot cc 00 00 00 09 00 00 00 
+	PrepareEventRoot d6 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4aea6a]
-	PrepareEventRoot cd 00 00 00 00 00 00 00 
+	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0x4ae70a.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@4ae88a]
-	PrepareEventRoot bd 00 00 00 19 00 00 00 
+	PrepareEventRoot c7 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae88a.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@4ae8d6]
-	PrepareEventRoot be 00 00 00 00 00 00 00 
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d4 03 00 00 // ProcessType[[3]string]
+	Call 49 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4aea00]
-	PrepareEventRoot c3 00 00 00 31 00 00 00 
+	PrepareEventRoot cd 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2a 04 00 00 // ProcessType[[]int]
+	Call 9f 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4ae80a]
-	PrepareEventRoot bb 00 00 00 19 00 00 00 
+	PrepareEventRoot c5 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@4ae84f]
-	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ea 04 00 00 // ProcessType[map[string]int]
+	Call 5f 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4aeaea]
-	PrepareEventRoot c4 00 00 00 09 00 00 00 
+	PrepareEventRoot ce 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@4aeb1f]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@4aec0a]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@4aec46]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call cd 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d4 03 00 00 // ProcessType[[3]string]
+	Call 49 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4ae98a]
-	PrepareEventRoot c1 00 00 00 31 00 00 00 
+	PrepareEventRoot cb 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@4ae9d6]
-	PrepareEventRoot c2 00 00 00 00 00 00 00 
+	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	ExprPrepare 
@@ -158,358 +158,449 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 58 04 00 00 // ProcessType[[]string]
+	Call cd 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4ae90a]
-	PrepareEventRoot bf 00 00 00 19 00 00 00 
+	PrepareEventRoot c9 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@4ae94f]
-	PrepareEventRoot c0 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot bb 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot bc 00 00 00 11 00 00 00 
+	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
+	Return 
+// 0x303: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x325: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot bd 00 00 00 11 00 00 00 
+	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x334: ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x349: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot be 00 00 00 11 00 00 00 
+	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
+	Return 
+// 0x358: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x37a: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot bf 00 00 00 11 00 00 00 
+	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x389: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
+	Return 
+// 0x393: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x3b5: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot c1 00 00 00 11 00 00 00 
+	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot c2 00 00 00 11 00 00 00 
+	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0x4ae7cf.expr[0]]
+	Return 
+// 0x3e8: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x40a: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot c3 00 00 00 11 00 00 00 
+	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x419: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
+	Return 
+// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
+	PrepareEventRoot d4 00 00 00 00 00 00 00 
+	Return 
+// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f6 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 6b 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
-	PrepareEventRoot cb 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
+// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
+	PrepareEventRoot d5 00 00 00 09 00 00 00 
+	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x457: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x45d: ProcessType[****int]
 	ProcessPointer b5 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x463: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x469: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x46f: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x475: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*error]
+// 0x47b: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float32]
+// 0x481: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x312: ProcessType[*float64]
+// 0x487: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x318: ProcessType[*int]
+// 0x48d: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int32]
+// 0x493: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x324: ProcessType[*int64]
+// 0x499: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x32a: ProcessType[*main.bigStruct]
+// 0x49f: ProcessType[*main.bigStruct]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._defer]
+// 0x4a5: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime._panic]
+// 0x4ab: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.cgoCallers]
+// 0x4b1: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.coro]
+// 0x4b7: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.g]
+// 0x4bd: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.m]
+// 0x4c3: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.p]
+// 0x4c9: ProcessType[*runtime.p]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.sudog]
+// 0x4cf: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.synctestBubble]
+// 0x4d5: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.timer]
+// 0x4db: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.traceBuf]
+// 0x4e1: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x372: ProcessType[*string]
+// 0x4e7: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4ed: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ac 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,int>]
+// 0x4f3: ProcessType[*table<string,int>]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<string,main.bigStruct>]
+// 0x4f9: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 95 00 00 00 
 	Return 
-// 0x38a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4ff: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint]
+// 0x505: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint16]
+// 0x50b: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint32]
+// 0x511: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint64]
+// 0x517: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uint8]
+// 0x51d: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3ae: ProcessType[*uintptr]
+// 0x523: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3b4: ProcessType[[2]*runtime.traceBuf]
+// 0x529: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call e1 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[[2][2]*runtime.traceBuf]
+// 0x539: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 29 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[3]string]
+// 0x549: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call cd 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3e4: ProcessType[[]*runtime.p]
+// 0x559: ProcessType[[]*runtime.p]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x3ee: ProcessType[[]*runtime.p.array]
+// 0x563: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 54 03 00 00 // ProcessType[*runtime.p]
+	Call c9 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3fa: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x56f: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call ed 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x406: ProcessType[[]*table<string,int>.array]
+// 0x57b: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,int>]
+	Call f3 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x412: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x587: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f9 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x41e: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x593: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 8a 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ff 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]int]
+// 0x59f: ProcessType[[]int]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x434: ProcessType[[]noalg.map.group[string]int.array]
+// 0x5a9: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 2c 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call a1 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x440: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x5b5: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 37 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call ac 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x44c: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5c1: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 42 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call b7 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x458: ProcessType[[]string]
+// 0x5cd: ProcessType[[]string]
 	ProcessSlice 8b 00 00 00 10 00 00 00 
 	Return 
-// 0x462: ProcessType[[]string.array]
+// 0x5d7: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 58 06 00 00 // ProcessType[string]
+	Call cd 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x46e: ProcessType[[]uint8]
+// 0x5e3: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x478: ProcessType[[]uintptr]
+// 0x5ed: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x482: ProcessType[error]
+// 0x5f7: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x484: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5f9: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x490: ProcessType[groupReference<string,int>]
+// 0x605: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 94 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x49c: ProcessType[groupReference<string,main.bigStruct>]
+// 0x611: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9e 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x4a8: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x61d: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ab 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x4b4: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x629: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b3 00 00 00 af 00 00 00 10 18 
 	Return 
-// 0x4c0: ProcessType[map<string,int>]
+// 0x635: ProcessType[map<string,int>]
 	ProcessGoSwissMap 93 00 00 00 90 00 00 00 10 18 
 	Return 
-// 0x4cc: ProcessType[map<string,main.bigStruct>]
+// 0x641: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9d 00 00 00 98 00 00 00 10 18 
 	Return 
-// 0x4d8: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x64d: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap aa 00 00 00 a2 00 00 00 10 18 
 	Return 
-// 0x4e4: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x659: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x4ea: ProcessType[map[string]int]
+// 0x65f: ProcessType[map[string]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x4f0: ProcessType[map[string]main.bigStruct]
+// 0x665: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x4f6: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x66b: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x4fc: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x671: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 4d 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call c2 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x50c: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x681: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 5d 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call d2 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x51c: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x691: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 63 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call d8 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x52c: ProcessType[noalg.map.group[string]int]
+// 0x6a1: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0c 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 81 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x537: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x6ac: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call fc 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 71 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x542: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6b7: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1c 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 91 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x54d: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 58 06 00 00 // ProcessType[string]
+// 0x6c2: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call cd 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
+	Call 9f 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x55d: ProcessType[noalg.struct { key string; elem int }]
-	Call 58 06 00 00 // ProcessType[string]
+// 0x6d2: ProcessType[noalg.struct { key string; elem int }]
+	Call cd 07 00 00 // ProcessType[string]
 	Return 
-// 0x563: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6d8: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call e4 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 59 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x56e: ProcessType[runtime.g]
+// 0x6e3: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime._panic]
+	Call ab 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._defer]
+	Call a5 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 6e 04 00 00 // ProcessType[[]uint8]
+	Call e3 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.sudog]
+	Call cf 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call ed 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.timer]
+	Call db 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.coro]
+	Call b7 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d5 04 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x5d3: ProcessType[runtime.m]
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+// 0x748: ProcessType[runtime.m]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call cd 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call e4 03 00 00 // ProcessType[[]*runtime.p]
+	Call 59 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b1 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 3d 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call b2 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call ed 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 06 00 00 // ProcessType[runtime.mTraceState]
+	Call bd 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x63d: ProcessType[runtime.mLockProfile]
+// 0x7b2: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call ed 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x648: ProcessType[runtime.mTraceState]
+// 0x7bd: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 39 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x658: ProcessType[string]
+// 0x7cd: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
-// 0x65e: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7d3: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 84 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call f9 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x669: ProcessType[table<string,int>]
+// 0x7de: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 90 04 00 00 // ProcessType[groupReference<string,int>]
+	Call 05 06 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x674: ProcessType[table<string,main.bigStruct>]
+// 0x7e9: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9c 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 11 06 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x67f: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7f4: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a8 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1d 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -530,31 +621,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 936
+ID: 5 Len: 8 Enqueue: 1309
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1624
+ID: 9 Len: 16 Enqueue: 1997
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 768
+ID: 11 Len: 8 Enqueue: 1141
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1154
+ID: 13 Len: 16 Enqueue: 1527
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 942
-ID: 20 Len: 8 Enqueue: 798
-ID: 21 Len: 8 Enqueue: 924
-ID: 22 Len: 440 Enqueue: 1390
+ID: 19 Len: 8 Enqueue: 1315
+ID: 20 Len: 8 Enqueue: 1171
+ID: 21 Len: 8 Enqueue: 1297
+ID: 22 Len: 440 Enqueue: 1763
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 822
+ID: 24 Len: 8 Enqueue: 1195
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 816
+ID: 26 Len: 8 Enqueue: 1189
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 846
-ID: 29 Len: 1816 Enqueue: 1491
+ID: 28 Len: 8 Enqueue: 1219
+ID: 29 Len: 1816 Enqueue: 1864
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -563,48 +654,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1134
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1507
+ID: 39 Len: 8 Enqueue: 1135
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 858
+ID: 41 Len: 8 Enqueue: 1231
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1144
-ID: 44 Len: 8 Enqueue: 870
+ID: 43 Len: 24 Enqueue: 1517
+ID: 44 Len: 8 Enqueue: 1243
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 834
+ID: 47 Len: 8 Enqueue: 1207
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 864
+ID: 49 Len: 8 Enqueue: 1237
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 840
+ID: 55 Len: 8 Enqueue: 1213
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 996
+ID: 62 Len: 24 Enqueue: 1369
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 852
-ID: 65 Len: 8 Enqueue: 828
+ID: 64 Len: 8 Enqueue: 1225
+ID: 65 Len: 8 Enqueue: 1201
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1597
+ID: 70 Len: 56 Enqueue: 1970
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1608
+ID: 75 Len: 56 Enqueue: 1981
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 964
-ID: 78 Len: 16 Enqueue: 948
-ID: 79 Len: 8 Enqueue: 876
+ID: 77 Len: 32 Enqueue: 1337
+ID: 78 Len: 16 Enqueue: 1321
+ID: 79 Len: 8 Enqueue: 1249
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -620,39 +711,39 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 882
+ID: 95 Len: 8 Enqueue: 1255
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 786
-ID: 99 Len: 8 Enqueue: 792
-ID: 100 Len: 8 Enqueue: 804
-ID: 101 Len: 8 Enqueue: 930
-ID: 102 Len: 8 Enqueue: 774
-ID: 103 Len: 8 Enqueue: 780
-ID: 104 Len: 8 Enqueue: 912
-ID: 105 Len: 8 Enqueue: 918
-ID: 106 Len: 24 Enqueue: 1066
+ID: 98 Len: 8 Enqueue: 1159
+ID: 99 Len: 8 Enqueue: 1165
+ID: 100 Len: 8 Enqueue: 1177
+ID: 101 Len: 8 Enqueue: 1303
+ID: 102 Len: 8 Enqueue: 1147
+ID: 103 Len: 8 Enqueue: 1153
+ID: 104 Len: 8 Enqueue: 1285
+ID: 105 Len: 8 Enqueue: 1291
+ID: 106 Len: 24 Enqueue: 1439
 ID: 107 Len: 24 Enqueue: 0
-ID: 108 Len: 24 Enqueue: 1112
-ID: 109 Len: 48 Enqueue: 980
-ID: 110 Len: 8 Enqueue: 1258
+ID: 108 Len: 24 Enqueue: 1485
+ID: 109 Len: 48 Enqueue: 1353
+ID: 110 Len: 8 Enqueue: 1631
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1216
+ID: 112 Len: 48 Enqueue: 1589
 ID: 113 Len: 8 Enqueue: 0
-ID: 114 Len: 8 Enqueue: 894
-ID: 115 Len: 8 Enqueue: 1264
+ID: 114 Len: 8 Enqueue: 1267
+ID: 115 Len: 8 Enqueue: 1637
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1228
+ID: 117 Len: 48 Enqueue: 1601
 ID: 118 Len: 8 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 900
-ID: 120 Len: 8 Enqueue: 1270
+ID: 119 Len: 8 Enqueue: 1273
+ID: 120 Len: 8 Enqueue: 1643
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1240
+ID: 122 Len: 48 Enqueue: 1613
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 906
-ID: 125 Len: 8 Enqueue: 738
-ID: 126 Len: 8 Enqueue: 744
-ID: 127 Len: 8 Enqueue: 756
+ID: 124 Len: 8 Enqueue: 1279
+ID: 125 Len: 8 Enqueue: 1111
+ID: 126 Len: 8 Enqueue: 1117
+ID: 127 Len: 8 Enqueue: 1129
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -660,76 +751,86 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 1006
+ID: 135 Len: 8 Enqueue: 1379
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 16 Enqueue: 1122
+ID: 139 Len: 16 Enqueue: 1495
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 32 Enqueue: 1641
-ID: 142 Len: 16 Enqueue: 1168
+ID: 141 Len: 32 Enqueue: 2014
+ID: 142 Len: 16 Enqueue: 1541
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 200 Enqueue: 1324
-ID: 145 Len: 192 Enqueue: 1292
-ID: 146 Len: 24 Enqueue: 1373
-ID: 147 Len: 8 Enqueue: 1030
-ID: 148 Len: 200 Enqueue: 1076
-ID: 149 Len: 32 Enqueue: 1652
-ID: 150 Len: 16 Enqueue: 1180
+ID: 144 Len: 200 Enqueue: 1697
+ID: 145 Len: 192 Enqueue: 1665
+ID: 146 Len: 24 Enqueue: 1746
+ID: 147 Len: 8 Enqueue: 1403
+ID: 148 Len: 200 Enqueue: 1449
+ID: 149 Len: 32 Enqueue: 2025
+ID: 150 Len: 16 Enqueue: 1553
 ID: 151 Len: 8 Enqueue: 0
-ID: 152 Len: 200 Enqueue: 1335
-ID: 153 Len: 192 Enqueue: 1276
-ID: 154 Len: 24 Enqueue: 1357
-ID: 155 Len: 8 Enqueue: 810
+ID: 152 Len: 200 Enqueue: 1708
+ID: 153 Len: 192 Enqueue: 1649
+ID: 154 Len: 24 Enqueue: 1730
+ID: 155 Len: 8 Enqueue: 1183
 ID: 156 Len: 184 Enqueue: 0
-ID: 157 Len: 8 Enqueue: 1042
-ID: 158 Len: 200 Enqueue: 1088
-ID: 159 Len: 32 Enqueue: 1663
-ID: 160 Len: 16 Enqueue: 1192
+ID: 157 Len: 8 Enqueue: 1415
+ID: 158 Len: 200 Enqueue: 1461
+ID: 159 Len: 32 Enqueue: 2036
+ID: 160 Len: 16 Enqueue: 1565
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 136 Enqueue: 1346
-ID: 163 Len: 128 Enqueue: 1308
-ID: 164 Len: 16 Enqueue: 1379
-ID: 165 Len: 8 Enqueue: 1252
+ID: 162 Len: 136 Enqueue: 1719
+ID: 163 Len: 128 Enqueue: 1681
+ID: 164 Len: 16 Enqueue: 1752
+ID: 165 Len: 8 Enqueue: 1625
 ID: 166 Len: 8 Enqueue: 0
-ID: 167 Len: 48 Enqueue: 1204
+ID: 167 Len: 48 Enqueue: 1577
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 888
-ID: 170 Len: 8 Enqueue: 1054
-ID: 171 Len: 136 Enqueue: 1100
-ID: 172 Len: 32 Enqueue: 1630
-ID: 173 Len: 16 Enqueue: 1156
+ID: 169 Len: 8 Enqueue: 1261
+ID: 170 Len: 8 Enqueue: 1427
+ID: 171 Len: 136 Enqueue: 1473
+ID: 172 Len: 32 Enqueue: 2003
+ID: 173 Len: 16 Enqueue: 1529
 ID: 174 Len: 8 Enqueue: 0
 ID: 175 Len: 136 Enqueue: 0
 ID: 176 Len: 128 Enqueue: 0
 ID: 177 Len: 16 Enqueue: 0
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 8 Enqueue: 1018
+ID: 179 Len: 8 Enqueue: 1391
 ID: 180 Len: 136 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 750
+ID: 181 Len: 8 Enqueue: 1123
 ID: 182 Len: 128 Enqueue: 0
 ID: 183 Len: 9 Enqueue: 0
 ID: 184 Len: 0 Enqueue: 0
 ID: 185 Len: 17 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
-ID: 187 Len: 25 Enqueue: 0
-ID: 188 Len: 0 Enqueue: 0
-ID: 189 Len: 25 Enqueue: 0
-ID: 190 Len: 0 Enqueue: 0
-ID: 191 Len: 25 Enqueue: 0
+ID: 187 Len: 17 Enqueue: 0
+ID: 188 Len: 17 Enqueue: 0
+ID: 189 Len: 17 Enqueue: 0
+ID: 190 Len: 17 Enqueue: 0
+ID: 191 Len: 17 Enqueue: 0
 ID: 192 Len: 0 Enqueue: 0
-ID: 193 Len: 49 Enqueue: 0
-ID: 194 Len: 0 Enqueue: 0
-ID: 195 Len: 49 Enqueue: 0
-ID: 196 Len: 9 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 9 Enqueue: 0
-ID: 199 Len: 0 Enqueue: 0
+ID: 193 Len: 17 Enqueue: 0
+ID: 194 Len: 17 Enqueue: 0
+ID: 195 Len: 17 Enqueue: 0
+ID: 196 Len: 0 Enqueue: 0
+ID: 197 Len: 25 Enqueue: 0
+ID: 198 Len: 0 Enqueue: 0
+ID: 199 Len: 25 Enqueue: 0
 ID: 200 Len: 0 Enqueue: 0
-ID: 201 Len: 0 Enqueue: 0
+ID: 201 Len: 25 Enqueue: 0
 ID: 202 Len: 0 Enqueue: 0
-ID: 203 Len: 9 Enqueue: 0
-ID: 204 Len: 9 Enqueue: 0
-ID: 205 Len: 0 Enqueue: 0
+ID: 203 Len: 49 Enqueue: 0
+ID: 204 Len: 0 Enqueue: 0
+ID: 205 Len: 49 Enqueue: 0
 ID: 206 Len: 9 Enqueue: 0
-ID: 207 Len: 9 Enqueue: 0
+ID: 207 Len: 0 Enqueue: 0
+ID: 208 Len: 9 Enqueue: 0
+ID: 209 Len: 0 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
+ID: 211 Len: 0 Enqueue: 0
+ID: 212 Len: 0 Enqueue: 0
+ID: 213 Len: 9 Enqueue: 0
+ID: 214 Len: 9 Enqueue: 0
+ID: 215 Len: 0 Enqueue: 0
+ID: 216 Len: 9 Enqueue: 0
+ID: 217 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 57 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5388]
-	PrepareEventRoot b9 00 00 00 09 00 00 00 
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5388.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 69 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b53c0]
-	PrepareEventRoot ba 00 00 00 09 00 00 00 
+	PrepareEventRoot c4 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5880.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 22 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 97 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b5880]
-	PrepareEventRoot b1 00 00 00 09 00 00 00 
+	PrepareEventRoot bb 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5880.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b58f4]
-	PrepareEventRoot b2 00 00 00 00 00 00 00 
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@b519c]
-	PrepareEventRoot b7 00 00 00 09 00 00 00 
+	PrepareEventRoot c1 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@b5748]
-	PrepareEventRoot b7 00 00 00 09 00 00 00 
+	PrepareEventRoot c1 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b5780]
-	PrepareEventRoot b8 00 00 00 00 00 00 00 
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0xb5428.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@b55a8]
-	PrepareEventRoot a8 00 00 00 19 00 00 00 
+	PrepareEventRoot b2 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb55a8.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@b55ec]
-	PrepareEventRoot a9 00 00 00 00 00 00 00 
+	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 03 00 00 // ProcessType[[3]string]
+	Call 39 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
-	PrepareEventRoot ae 00 00 00 31 00 00 00 
+	PrepareEventRoot b8 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 10 04 00 00 // ProcessType[[]int]
+	Call 85 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b5518]
-	PrepareEventRoot a6 00 00 00 19 00 00 00 
+	PrepareEventRoot b0 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@b5554]
-	PrepareEventRoot a7 00 00 00 00 00 00 00 
+	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 1c 05 00 00 // ProcessType[map[string]int]
+	Call 91 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5808]
-	PrepareEventRoot af 00 00 00 09 00 00 00 
+	PrepareEventRoot b9 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@b5838]
-	PrepareEventRoot b0 00 00 00 00 00 00 00 
+	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@b5938]
-	PrepareEventRoot b3 00 00 00 00 00 00 00 
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@b5970]
-	PrepareEventRoot b4 00 00 00 00 00 00 00 
+	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a4 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 03 00 00 // ProcessType[[3]string]
+	Call 39 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b56b8]
-	PrepareEventRoot ac 00 00 00 31 00 00 00 
+	PrepareEventRoot b6 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb56b8.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@b56fc]
-	PrepareEventRoot ad 00 00 00 00 00 00 00 
+	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
 	ExprPrepare 
@@ -158,311 +158,402 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2a 04 00 00 // ProcessType[[]string]
+	Call 9f 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b5628]
-	PrepareEventRoot aa 00 00 00 19 00 00 00 
+	PrepareEventRoot b4 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@b5664]
-	PrepareEventRoot ab 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot a6 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot a7 00 00 00 11 00 00 00 
+	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
+	Return 
+// 0x303: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x325: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot a8 00 00 00 11 00 00 00 
+	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x334: ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x349: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot a9 00 00 00 11 00 00 00 
+	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
+	Return 
+// 0x358: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x37a: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot aa 00 00 00 11 00 00 00 
+	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x389: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot ab 00 00 00 00 00 00 00 
+	Return 
+// 0x393: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x3b5: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot ac 00 00 00 11 00 00 00 
+	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot ad 00 00 00 11 00 00 00 
+	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
+	Return 
+// 0x3e8: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x40a: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot ae 00 00 00 11 00 00 00 
+	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x419: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot af 00 00 00 00 00 00 00 
+	Return 
+// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
+	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	Return 
+// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a3 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
-	PrepareEventRoot b6 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
+// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
+	PrepareEventRoot c0 00 00 00 09 00 00 00 
+	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x457: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x45d: ProcessType[****int]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x463: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x469: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x46f: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x475: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x47b: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x30c: ProcessType[*bucket<string,int>]
+// 0x481: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x312: ProcessType[*bucket<string,main.bigStruct>]
+// 0x487: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x318: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x48d: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x31e: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x493: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x324: ProcessType[*error]
+// 0x499: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x32a: ProcessType[*float32]
+// 0x49f: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x330: ProcessType[*float64]
+// 0x4a5: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x336: ProcessType[*int]
+// 0x4ab: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x33c: ProcessType[*int32]
+// 0x4b1: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x342: ProcessType[*int64]
+// 0x4b7: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x348: ProcessType[*main.bigStruct]
+// 0x4bd: ProcessType[*main.bigStruct]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime._defer]
+// 0x4c3: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime._panic]
+// 0x4c9: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.cgoCallers]
+// 0x4cf: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.coro]
+// 0x4d5: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.g]
+// 0x4db: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.m]
+// 0x4e1: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x372: ProcessType[*runtime.mapextra]
+// 0x4e7: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x378: ProcessType[*runtime.sudog]
+// 0x4ed: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x37e: ProcessType[*runtime.timer]
+// 0x4f3: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x384: ProcessType[*runtime.traceBuf]
+// 0x4f9: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x38a: ProcessType[*string]
+// 0x4ff: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint]
+// 0x505: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint16]
+// 0x50b: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint32]
+// 0x511: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint64]
+// 0x517: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uint8]
+// 0x51d: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3ae: ProcessType[*uintptr]
+// 0x523: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3b4: ProcessType[[2]*runtime.traceBuf]
+// 0x529: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 84 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call f9 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[[3]string]
+// 0x539: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x549: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 74 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call e9 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e0: ProcessType[[]bucket<string,int>.array]
+// 0x555: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7f 04 00 00 // ProcessType[bucket<string,int>]
+	Call f4 05 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ec: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x561: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 94 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 09 06 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f8: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x56d: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a9 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1e 06 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x404: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x579: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call be 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 33 06 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x410: ProcessType[[]int]
+// 0x585: ProcessType[[]int]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x41a: ProcessType[[]key<string>]
+// 0x58f: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]string]
+// 0x59f: ProcessType[[]string]
 	ProcessSlice 89 00 00 00 10 00 00 00 
 	Return 
-// 0x434: ProcessType[[]string.array]
+// 0x5a9: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x440: ProcessType[[]uint8]
+// 0x5b5: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x44a: ProcessType[[]uintptr]
+// 0x5bf: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x454: ProcessType[[]val<main.bigStruct>]
+// 0x5c9: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 48 03 00 00 // ProcessType[*main.bigStruct]
+	Call bd 04 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x464: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5d9: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 16 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 8b 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x474: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x5e9: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 06 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 7b 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x47f: ProcessType[bucket<string,int>]
+// 0x5f4: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
+	Call 8f 05 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0c 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 81 04 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x494: ProcessType[bucket<string,main.bigStruct>]
+// 0x609: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
-	Call 54 04 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 12 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 8f 05 00 00 // ProcessType[[]key<string>]
+	Call c9 05 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 87 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x4a9: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x61e: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
-	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 18 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8f 05 00 00 // ProcessType[[]key<string>]
+	Call d9 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8d 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4be: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x633: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 1e 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d9 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 93 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4ce: ProcessType[error]
+// 0x643: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x4d0: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x645: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9f 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x4de: ProcessType[hash<string,int>]
+// 0x653: ProcessType[hash<string,int>]
 	ProcessGoHmap 8e 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4ec: ProcessType[hash<string,main.bigStruct>]
+// 0x661: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 92 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4fa: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x66f: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9b 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x508: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x67d: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x516: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x68b: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x51c: ProcessType[map[string]int]
+// 0x691: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x522: ProcessType[map[string]main.bigStruct]
+// 0x697: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x528: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x69d: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x52e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6a3: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x534: ProcessType[runtime.g]
+// 0x6a9: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime._panic]
+	Call c9 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime._defer]
+	Call c3 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call e1 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 40 04 00 00 // ProcessType[[]uint8]
+	Call b5 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 78 03 00 00 // ProcessType[*runtime.sudog]
+	Call ed 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call bf 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 7e 03 00 00 // ProcessType[*runtime.timer]
+	Call f3 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.coro]
+	Call d5 04 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x58f: ProcessType[runtime.m]
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+// 0x704: ProcessType[runtime.m]
+	Call db 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+	Call db 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+	Call db 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call cf 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call e1 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ef 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call 64 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call bf 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call e1 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 05 00 00 // ProcessType[runtime.mTraceState]
+	Call 6f 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x5ef: ProcessType[runtime.mLockProfile]
+// 0x764: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call bf 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x5fa: ProcessType[runtime.mTraceState]
+// 0x76f: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call 29 05 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call e1 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x60a: ProcessType[string]
+// 0x77f: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -484,12 +575,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 768
-ID: 6 Len: 8 Enqueue: 936
+ID: 5 Len: 8 Enqueue: 1141
+ID: 6 Len: 8 Enqueue: 1309
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 942
+ID: 8 Len: 8 Enqueue: 1315
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1546
+ID: 10 Len: 16 Enqueue: 1919
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -497,18 +588,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1230
+ID: 18 Len: 16 Enqueue: 1603
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 828
-ID: 21 Len: 8 Enqueue: 924
-ID: 22 Len: 432 Enqueue: 1332
+ID: 20 Len: 8 Enqueue: 1201
+ID: 21 Len: 8 Enqueue: 1297
+ID: 22 Len: 432 Enqueue: 1705
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 852
+ID: 24 Len: 8 Enqueue: 1225
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 846
+ID: 26 Len: 8 Enqueue: 1219
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 876
-ID: 29 Len: 1760 Enqueue: 1423
+ID: 28 Len: 8 Enqueue: 1249
+ID: 29 Len: 1760 Enqueue: 1796
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -517,41 +608,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1088
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1461
+ID: 39 Len: 8 Enqueue: 1135
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 888
+ID: 41 Len: 8 Enqueue: 1261
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1098
-ID: 44 Len: 8 Enqueue: 894
+ID: 43 Len: 24 Enqueue: 1471
+ID: 44 Len: 8 Enqueue: 1267
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 864
+ID: 47 Len: 8 Enqueue: 1237
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 870
+ID: 53 Len: 8 Enqueue: 1243
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 858
+ID: 60 Len: 8 Enqueue: 1231
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1519
+ID: 64 Len: 64 Enqueue: 1892
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1530
+ID: 69 Len: 32 Enqueue: 1903
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 948
-ID: 72 Len: 8 Enqueue: 900
+ID: 71 Len: 16 Enqueue: 1321
+ID: 72 Len: 8 Enqueue: 1273
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -567,47 +658,47 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 906
+ID: 88 Len: 8 Enqueue: 1279
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 816
-ID: 93 Len: 8 Enqueue: 834
-ID: 94 Len: 8 Enqueue: 822
-ID: 95 Len: 8 Enqueue: 930
-ID: 96 Len: 8 Enqueue: 804
-ID: 97 Len: 8 Enqueue: 810
-ID: 98 Len: 8 Enqueue: 912
-ID: 99 Len: 8 Enqueue: 918
-ID: 100 Len: 24 Enqueue: 1040
+ID: 92 Len: 8 Enqueue: 1189
+ID: 93 Len: 8 Enqueue: 1207
+ID: 94 Len: 8 Enqueue: 1195
+ID: 95 Len: 8 Enqueue: 1303
+ID: 96 Len: 8 Enqueue: 1177
+ID: 97 Len: 8 Enqueue: 1183
+ID: 98 Len: 8 Enqueue: 1285
+ID: 99 Len: 8 Enqueue: 1291
+ID: 100 Len: 24 Enqueue: 1413
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 1066
-ID: 103 Len: 48 Enqueue: 964
-ID: 104 Len: 8 Enqueue: 1308
+ID: 102 Len: 24 Enqueue: 1439
+ID: 103 Len: 48 Enqueue: 1337
+ID: 104 Len: 8 Enqueue: 1681
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 1246
-ID: 107 Len: 8 Enqueue: 780
-ID: 108 Len: 208 Enqueue: 1151
-ID: 109 Len: 8 Enqueue: 882
+ID: 106 Len: 48 Enqueue: 1619
+ID: 107 Len: 8 Enqueue: 1153
+ID: 108 Len: 208 Enqueue: 1524
+ID: 109 Len: 8 Enqueue: 1255
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 1314
+ID: 111 Len: 8 Enqueue: 1687
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1260
-ID: 114 Len: 8 Enqueue: 786
-ID: 115 Len: 208 Enqueue: 1172
-ID: 116 Len: 8 Enqueue: 1326
+ID: 113 Len: 48 Enqueue: 1633
+ID: 114 Len: 8 Enqueue: 1159
+ID: 115 Len: 208 Enqueue: 1545
+ID: 116 Len: 8 Enqueue: 1699
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1288
-ID: 119 Len: 8 Enqueue: 798
-ID: 120 Len: 88 Enqueue: 1214
-ID: 121 Len: 8 Enqueue: 1320
+ID: 118 Len: 48 Enqueue: 1661
+ID: 119 Len: 8 Enqueue: 1171
+ID: 120 Len: 88 Enqueue: 1587
+ID: 121 Len: 8 Enqueue: 1693
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1274
-ID: 124 Len: 8 Enqueue: 792
-ID: 125 Len: 208 Enqueue: 1193
-ID: 126 Len: 8 Enqueue: 738
-ID: 127 Len: 8 Enqueue: 744
-ID: 128 Len: 8 Enqueue: 756
+ID: 123 Len: 48 Enqueue: 1647
+ID: 124 Len: 8 Enqueue: 1165
+ID: 125 Len: 208 Enqueue: 1566
+ID: 126 Len: 8 Enqueue: 1111
+ID: 127 Len: 8 Enqueue: 1117
+ID: 128 Len: 8 Enqueue: 1129
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -616,53 +707,63 @@ ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 16 Enqueue: 1076
+ID: 137 Len: 16 Enqueue: 1449
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 128 Enqueue: 1050
+ID: 140 Len: 128 Enqueue: 1423
 ID: 141 Len: 64 Enqueue: 0
-ID: 142 Len: 208 Enqueue: 992
-ID: 143 Len: 64 Enqueue: 1108
-ID: 144 Len: 8 Enqueue: 840
+ID: 142 Len: 208 Enqueue: 1365
+ID: 143 Len: 64 Enqueue: 1481
+ID: 144 Len: 8 Enqueue: 1213
 ID: 145 Len: 184 Enqueue: 0
-ID: 146 Len: 208 Enqueue: 1004
+ID: 146 Len: 208 Enqueue: 1377
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 64 Enqueue: 1124
-ID: 149 Len: 8 Enqueue: 1302
+ID: 148 Len: 64 Enqueue: 1497
+ID: 149 Len: 8 Enqueue: 1675
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 48 Enqueue: 1232
-ID: 152 Len: 8 Enqueue: 774
-ID: 153 Len: 144 Enqueue: 1140
-ID: 154 Len: 88 Enqueue: 1028
-ID: 155 Len: 208 Enqueue: 1016
+ID: 151 Len: 48 Enqueue: 1605
+ID: 152 Len: 8 Enqueue: 1147
+ID: 153 Len: 144 Enqueue: 1513
+ID: 154 Len: 88 Enqueue: 1401
+ID: 155 Len: 208 Enqueue: 1389
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 64 Enqueue: 0
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 144 Enqueue: 980
-ID: 160 Len: 8 Enqueue: 750
+ID: 159 Len: 144 Enqueue: 1353
+ID: 160 Len: 8 Enqueue: 1123
 ID: 161 Len: 128 Enqueue: 0
 ID: 162 Len: 9 Enqueue: 0
 ID: 163 Len: 0 Enqueue: 0
 ID: 164 Len: 17 Enqueue: 0
 ID: 165 Len: 0 Enqueue: 0
-ID: 166 Len: 25 Enqueue: 0
-ID: 167 Len: 0 Enqueue: 0
-ID: 168 Len: 25 Enqueue: 0
-ID: 169 Len: 0 Enqueue: 0
-ID: 170 Len: 25 Enqueue: 0
+ID: 166 Len: 17 Enqueue: 0
+ID: 167 Len: 17 Enqueue: 0
+ID: 168 Len: 17 Enqueue: 0
+ID: 169 Len: 17 Enqueue: 0
+ID: 170 Len: 17 Enqueue: 0
 ID: 171 Len: 0 Enqueue: 0
-ID: 172 Len: 49 Enqueue: 0
-ID: 173 Len: 0 Enqueue: 0
-ID: 174 Len: 49 Enqueue: 0
-ID: 175 Len: 9 Enqueue: 0
-ID: 176 Len: 0 Enqueue: 0
-ID: 177 Len: 9 Enqueue: 0
-ID: 178 Len: 0 Enqueue: 0
+ID: 172 Len: 17 Enqueue: 0
+ID: 173 Len: 17 Enqueue: 0
+ID: 174 Len: 17 Enqueue: 0
+ID: 175 Len: 0 Enqueue: 0
+ID: 176 Len: 25 Enqueue: 0
+ID: 177 Len: 0 Enqueue: 0
+ID: 178 Len: 25 Enqueue: 0
 ID: 179 Len: 0 Enqueue: 0
-ID: 180 Len: 0 Enqueue: 0
+ID: 180 Len: 25 Enqueue: 0
 ID: 181 Len: 0 Enqueue: 0
-ID: 182 Len: 9 Enqueue: 0
-ID: 183 Len: 9 Enqueue: 0
-ID: 184 Len: 0 Enqueue: 0
+ID: 182 Len: 49 Enqueue: 0
+ID: 183 Len: 0 Enqueue: 0
+ID: 184 Len: 49 Enqueue: 0
 ID: 185 Len: 9 Enqueue: 0
-ID: 186 Len: 9 Enqueue: 0
+ID: 186 Len: 0 Enqueue: 0
+ID: 187 Len: 9 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
+ID: 189 Len: 0 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
+ID: 191 Len: 0 Enqueue: 0
+ID: 192 Len: 9 Enqueue: 0
+ID: 193 Len: 9 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 9 Enqueue: 0
+ID: 196 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 57 04 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5388]
 	PrepareEventRoot c3 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 69 04 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b53c0]
 	PrepareEventRoot c4 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 97 06 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 49 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b5880]
 	PrepareEventRoot bb 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 39 05 00 00 // ProcessType[[3]string]
+	Call eb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
 	PrepareEventRoot b8 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 85 05 00 00 // ProcessType[[]int]
+	Call 37 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b5518]
 	PrepareEventRoot b0 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 91 06 00 00 // ProcessType[map[string]int]
+	Call 43 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5808]
 	PrepareEventRoot b9 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a4 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 39 05 00 00 // ProcessType[[3]string]
+	Call eb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b56b8]
 	PrepareEventRoot b6 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 9f 05 00 00 // ProcessType[[]string]
+	Call 51 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b5628]
 	PrepareEventRoot b4 00 00 00 19 00 00 00 
@@ -172,388 +172,367 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
 // 0x2d0: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a6 00 00 00 11 00 00 00 
 	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	Return 
-// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
-	ExprPrepare 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot a7 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
-	Return 
-// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@b54d4]
-	PrepareEventRoot a7 00 00 00 11 00 00 00 
-	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
-	Return 
-// 0x303: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
-// 0x325: ProcessEvent[Probe[main.stringArg]@b5498]
+// 0x30b: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a8 00 00 00 11 00 00 00 
-	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	Return 
-// 0x334: ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
-	ExprPrepare 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
-	Return 
-// 0x349: ProcessEvent[Probe[main.stringArg]Return@b54d4]
-	PrepareEventRoot a9 00 00 00 11 00 00 00 
-	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
-	Return 
-// 0x358: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+// 0x324: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringArg]@b5498]
+// 0x346: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot aa 00 00 00 11 00 00 00 
-	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	Return 
-// 0x389: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@b54d4]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x393: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
-// 0x3b5: ProcessEvent[Probe[main.stringArg]@b5498]
+// 0x381: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot ac 00 00 00 11 00 00 00 
-	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	Return 
-// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
-	ExprPrepare 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
-	Return 
-// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@b54d4]
-	PrepareEventRoot ad 00 00 00 11 00 00 00 
-	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb54d4.expr[0]]
-	Return 
-// 0x3e8: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
-// 0x40a: ProcessEvent[Probe[main.stringArg]@b5498]
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot ae 00 00 00 11 00 00 00 
-	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	Return 
-// 0x419: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@b54d4]
 	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
-// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a3 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 55 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
 	PrepareEventRoot c0 00 00 00 09 00 00 00 
-	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	Return 
-// 0x457: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x45d: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x463: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x469: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x46f: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x475: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x47b: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x42d: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x481: ProcessType[*bucket<string,int>]
+// 0x433: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x487: ProcessType[*bucket<string,main.bigStruct>]
+// 0x439: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x48d: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x43f: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x493: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x445: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x499: ProcessType[*error]
+// 0x44b: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x49f: ProcessType[*float32]
+// 0x451: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x4a5: ProcessType[*float64]
+// 0x457: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x4ab: ProcessType[*int]
+// 0x45d: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x4b1: ProcessType[*int32]
+// 0x463: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x4b7: ProcessType[*int64]
+// 0x469: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x4bd: ProcessType[*main.bigStruct]
+// 0x46f: ProcessType[*main.bigStruct]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x4c3: ProcessType[*runtime._defer]
+// 0x475: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x4c9: ProcessType[*runtime._panic]
+// 0x47b: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x4cf: ProcessType[*runtime.cgoCallers]
+// 0x481: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x4d5: ProcessType[*runtime.coro]
+// 0x487: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x4db: ProcessType[*runtime.g]
+// 0x48d: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x4e1: ProcessType[*runtime.m]
+// 0x493: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x4e7: ProcessType[*runtime.mapextra]
+// 0x499: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x4ed: ProcessType[*runtime.sudog]
+// 0x49f: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x4f3: ProcessType[*runtime.timer]
+// 0x4a5: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x4f9: ProcessType[*runtime.traceBuf]
+// 0x4ab: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x4ff: ProcessType[*string]
+// 0x4b1: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x505: ProcessType[*uint]
+// 0x4b7: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x50b: ProcessType[*uint16]
+// 0x4bd: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x511: ProcessType[*uint32]
+// 0x4c3: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x517: ProcessType[*uint64]
+// 0x4c9: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x51d: ProcessType[*uint8]
+// 0x4cf: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x523: ProcessType[*uintptr]
+// 0x4d5: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x529: ProcessType[[2]*runtime.traceBuf]
+// 0x4db: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call f9 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call ab 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x539: ProcessType[[3]string]
+// 0x4eb: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x549: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x4fb: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e9 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 9b 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x555: ProcessType[[]bucket<string,int>.array]
+// 0x507: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f4 05 00 00 // ProcessType[bucket<string,int>]
+	Call a6 05 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x561: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x513: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 09 06 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call bb 05 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x56d: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x51f: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 1e 06 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d0 05 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x579: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x52b: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 33 06 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call e5 05 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x585: ProcessType[[]int]
+// 0x537: ProcessType[[]int]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x58f: ProcessType[[]key<string>]
+// 0x541: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x59f: ProcessType[[]string]
+// 0x551: ProcessType[[]string]
 	ProcessSlice 89 00 00 00 10 00 00 00 
 	Return 
-// 0x5a9: ProcessType[[]string.array]
+// 0x55b: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x5b5: ProcessType[[]uint8]
+// 0x567: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x5bf: ProcessType[[]uintptr]
+// 0x571: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x5c9: ProcessType[[]val<main.bigStruct>]
+// 0x57b: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call bd 04 00 00 // ProcessType[*main.bigStruct]
+	Call 6f 04 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5d9: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x58b: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 8b 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3d 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x5e9: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x59b: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 7b 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 2d 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x5f4: ProcessType[bucket<string,int>]
+// 0x5a6: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8f 05 00 00 // ProcessType[[]key<string>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 81 04 00 00 // ProcessType[*bucket<string,int>]
+	Call 33 04 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x609: ProcessType[bucket<string,main.bigStruct>]
+// 0x5bb: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8f 05 00 00 // ProcessType[[]key<string>]
-	Call c9 05 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 87 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
+	Call 7b 05 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 39 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x61e: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5d0: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8f 05 00 00 // ProcessType[[]key<string>]
-	Call d9 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 8d 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
+	Call 8b 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 3f 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x633: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5e5: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call d9 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 93 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8b 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 45 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x643: ProcessType[error]
+// 0x5f5: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x645: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x5f7: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9f 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x653: ProcessType[hash<string,int>]
+// 0x605: ProcessType[hash<string,int>]
 	ProcessGoHmap 8e 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x661: ProcessType[hash<string,main.bigStruct>]
+// 0x613: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 92 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x66f: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x621: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9b 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x67d: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x62f: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x68b: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x63d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x691: ProcessType[map[string]int]
+// 0x643: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x697: ProcessType[map[string]main.bigStruct]
+// 0x649: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x69d: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64f: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x6a3: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x655: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x6a9: ProcessType[runtime.g]
+// 0x65b: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call c9 04 00 00 // ProcessType[*runtime._panic]
+	Call 7b 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime._defer]
+	Call 75 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call e1 04 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call b5 05 00 00 // ProcessType[[]uint8]
+	Call 67 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ed 04 00 00 // ProcessType[*runtime.sudog]
+	Call 9f 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call bf 05 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f3 04 00 00 // ProcessType[*runtime.timer]
+	Call a5 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call d5 04 00 00 // ProcessType[*runtime.coro]
+	Call 87 04 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x704: ProcessType[runtime.m]
-	Call db 04 00 00 // ProcessType[*runtime.g]
+// 0x6b6: ProcessType[runtime.m]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call db 04 00 00 // ProcessType[*runtime.g]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call db 04 00 00 // ProcessType[*runtime.g]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 7f 07 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call cf 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 81 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call e1 04 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 64 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call 16 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call bf 05 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call e1 04 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6f 07 00 00 // ProcessType[runtime.mTraceState]
+	Call 21 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x764: ProcessType[runtime.mLockProfile]
+// 0x716: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call bf 05 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x76f: ProcessType[runtime.mTraceState]
+// 0x721: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 29 05 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call e1 04 00 00 // ProcessType[*runtime.m]
+	Call db 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x77f: ProcessType[string]
+// 0x731: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -575,12 +554,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1141
-ID: 6 Len: 8 Enqueue: 1309
+ID: 5 Len: 8 Enqueue: 1063
+ID: 6 Len: 8 Enqueue: 1231
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 1315
+ID: 8 Len: 8 Enqueue: 1237
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1919
+ID: 10 Len: 16 Enqueue: 1841
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -588,18 +567,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1603
+ID: 18 Len: 16 Enqueue: 1525
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 1201
-ID: 21 Len: 8 Enqueue: 1297
-ID: 22 Len: 432 Enqueue: 1705
+ID: 20 Len: 8 Enqueue: 1123
+ID: 21 Len: 8 Enqueue: 1219
+ID: 22 Len: 432 Enqueue: 1627
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1225
+ID: 24 Len: 8 Enqueue: 1147
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1219
+ID: 26 Len: 8 Enqueue: 1141
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1249
-ID: 29 Len: 1760 Enqueue: 1796
+ID: 28 Len: 8 Enqueue: 1171
+ID: 29 Len: 1760 Enqueue: 1718
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -608,41 +587,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1461
-ID: 39 Len: 8 Enqueue: 1135
+ID: 38 Len: 24 Enqueue: 1383
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1261
+ID: 41 Len: 8 Enqueue: 1183
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1471
-ID: 44 Len: 8 Enqueue: 1267
+ID: 43 Len: 24 Enqueue: 1393
+ID: 44 Len: 8 Enqueue: 1189
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1237
+ID: 47 Len: 8 Enqueue: 1159
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 1243
+ID: 53 Len: 8 Enqueue: 1165
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 1231
+ID: 60 Len: 8 Enqueue: 1153
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1892
+ID: 64 Len: 64 Enqueue: 1814
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1903
+ID: 69 Len: 32 Enqueue: 1825
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 1321
-ID: 72 Len: 8 Enqueue: 1273
+ID: 71 Len: 16 Enqueue: 1243
+ID: 72 Len: 8 Enqueue: 1195
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -658,47 +637,47 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 1279
+ID: 88 Len: 8 Enqueue: 1201
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 1189
-ID: 93 Len: 8 Enqueue: 1207
-ID: 94 Len: 8 Enqueue: 1195
-ID: 95 Len: 8 Enqueue: 1303
-ID: 96 Len: 8 Enqueue: 1177
-ID: 97 Len: 8 Enqueue: 1183
-ID: 98 Len: 8 Enqueue: 1285
-ID: 99 Len: 8 Enqueue: 1291
-ID: 100 Len: 24 Enqueue: 1413
+ID: 92 Len: 8 Enqueue: 1111
+ID: 93 Len: 8 Enqueue: 1129
+ID: 94 Len: 8 Enqueue: 1117
+ID: 95 Len: 8 Enqueue: 1225
+ID: 96 Len: 8 Enqueue: 1099
+ID: 97 Len: 8 Enqueue: 1105
+ID: 98 Len: 8 Enqueue: 1207
+ID: 99 Len: 8 Enqueue: 1213
+ID: 100 Len: 24 Enqueue: 1335
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 1439
-ID: 103 Len: 48 Enqueue: 1337
-ID: 104 Len: 8 Enqueue: 1681
+ID: 102 Len: 24 Enqueue: 1361
+ID: 103 Len: 48 Enqueue: 1259
+ID: 104 Len: 8 Enqueue: 1603
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 1619
-ID: 107 Len: 8 Enqueue: 1153
-ID: 108 Len: 208 Enqueue: 1524
-ID: 109 Len: 8 Enqueue: 1255
+ID: 106 Len: 48 Enqueue: 1541
+ID: 107 Len: 8 Enqueue: 1075
+ID: 108 Len: 208 Enqueue: 1446
+ID: 109 Len: 8 Enqueue: 1177
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 1687
+ID: 111 Len: 8 Enqueue: 1609
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1633
-ID: 114 Len: 8 Enqueue: 1159
-ID: 115 Len: 208 Enqueue: 1545
-ID: 116 Len: 8 Enqueue: 1699
+ID: 113 Len: 48 Enqueue: 1555
+ID: 114 Len: 8 Enqueue: 1081
+ID: 115 Len: 208 Enqueue: 1467
+ID: 116 Len: 8 Enqueue: 1621
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1661
-ID: 119 Len: 8 Enqueue: 1171
-ID: 120 Len: 88 Enqueue: 1587
-ID: 121 Len: 8 Enqueue: 1693
+ID: 118 Len: 48 Enqueue: 1583
+ID: 119 Len: 8 Enqueue: 1093
+ID: 120 Len: 88 Enqueue: 1509
+ID: 121 Len: 8 Enqueue: 1615
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1647
-ID: 124 Len: 8 Enqueue: 1165
-ID: 125 Len: 208 Enqueue: 1566
-ID: 126 Len: 8 Enqueue: 1111
-ID: 127 Len: 8 Enqueue: 1117
-ID: 128 Len: 8 Enqueue: 1129
+ID: 123 Len: 48 Enqueue: 1569
+ID: 124 Len: 8 Enqueue: 1087
+ID: 125 Len: 208 Enqueue: 1488
+ID: 126 Len: 8 Enqueue: 1033
+ID: 127 Len: 8 Enqueue: 1039
+ID: 128 Len: 8 Enqueue: 1051
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -707,43 +686,43 @@ ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 16 Enqueue: 1449
+ID: 137 Len: 16 Enqueue: 1371
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 128 Enqueue: 1423
+ID: 140 Len: 128 Enqueue: 1345
 ID: 141 Len: 64 Enqueue: 0
-ID: 142 Len: 208 Enqueue: 1365
-ID: 143 Len: 64 Enqueue: 1481
-ID: 144 Len: 8 Enqueue: 1213
+ID: 142 Len: 208 Enqueue: 1287
+ID: 143 Len: 64 Enqueue: 1403
+ID: 144 Len: 8 Enqueue: 1135
 ID: 145 Len: 184 Enqueue: 0
-ID: 146 Len: 208 Enqueue: 1377
+ID: 146 Len: 208 Enqueue: 1299
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 64 Enqueue: 1497
-ID: 149 Len: 8 Enqueue: 1675
+ID: 148 Len: 64 Enqueue: 1419
+ID: 149 Len: 8 Enqueue: 1597
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 48 Enqueue: 1605
-ID: 152 Len: 8 Enqueue: 1147
-ID: 153 Len: 144 Enqueue: 1513
-ID: 154 Len: 88 Enqueue: 1401
-ID: 155 Len: 208 Enqueue: 1389
+ID: 151 Len: 48 Enqueue: 1527
+ID: 152 Len: 8 Enqueue: 1069
+ID: 153 Len: 144 Enqueue: 1435
+ID: 154 Len: 88 Enqueue: 1323
+ID: 155 Len: 208 Enqueue: 1311
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 64 Enqueue: 0
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 144 Enqueue: 1353
-ID: 160 Len: 8 Enqueue: 1123
+ID: 159 Len: 144 Enqueue: 1275
+ID: 160 Len: 8 Enqueue: 1045
 ID: 161 Len: 128 Enqueue: 0
 ID: 162 Len: 9 Enqueue: 0
 ID: 163 Len: 0 Enqueue: 0
 ID: 164 Len: 17 Enqueue: 0
 ID: 165 Len: 0 Enqueue: 0
 ID: 166 Len: 17 Enqueue: 0
-ID: 167 Len: 17 Enqueue: 0
+ID: 167 Len: 0 Enqueue: 0
 ID: 168 Len: 17 Enqueue: 0
-ID: 169 Len: 17 Enqueue: 0
+ID: 169 Len: 0 Enqueue: 0
 ID: 170 Len: 17 Enqueue: 0
 ID: 171 Len: 0 Enqueue: 0
 ID: 172 Len: 17 Enqueue: 0
-ID: 173 Len: 17 Enqueue: 0
+ID: 173 Len: 0 Enqueue: 0
 ID: 174 Len: 17 Enqueue: 0
 ID: 175 Len: 0 Enqueue: 0
 ID: 176 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 57 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b520c]
-	PrepareEventRoot ca 00 00 00 09 00 00 00 
+	PrepareEventRoot d4 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb520c.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5244.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 69 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5244]
-	PrepareEventRoot cb 00 00 00 09 00 00 00 
+	PrepareEventRoot d5 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5244.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb56f0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d4 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 49 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b56f0]
-	PrepareEventRoot c2 00 00 00 09 00 00 00 
+	PrepareEventRoot cc 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb56f0.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b5764]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@b502c]
-	PrepareEventRoot c8 00 00 00 09 00 00 00 
+	PrepareEventRoot d2 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0xb55b8.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@b55b8]
-	PrepareEventRoot c8 00 00 00 09 00 00 00 
+	PrepareEventRoot d2 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb55b8.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b55f0]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0xb52b8.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@b5428]
-	PrepareEventRoot b9 00 00 00 19 00 00 00 
+	PrepareEventRoot c3 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5428.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@b546c]
-	PrepareEventRoot ba 00 00 00 00 00 00 00 
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call 43 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5590]
-	PrepareEventRoot bf 00 00 00 31 00 00 00 
+	PrepareEventRoot c9 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0xb53a8.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0e 04 00 00 // ProcessType[[]int]
+	Call 83 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b53a8]
-	PrepareEventRoot b7 00 00 00 19 00 00 00 
+	PrepareEventRoot c1 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb53a8.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@b53e4]
-	PrepareEventRoot b8 00 00 00 00 00 00 00 
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0xb5678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ce 04 00 00 // ProcessType[map[string]int]
+	Call 43 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5678]
-	PrepareEventRoot c0 00 00 00 09 00 00 00 
+	PrepareEventRoot ca 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5678.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@b56a8]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@b57a8]
-	PrepareEventRoot c4 00 00 00 00 00 00 00 
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@b57e0]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call a7 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b5 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call 43 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b5528]
-	PrepareEventRoot bd 00 00 00 31 00 00 00 
+	PrepareEventRoot c7 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5528.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@b556c]
-	PrepareEventRoot be 00 00 00 00 00 00 00 
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0xb54a8.expr[0]]
 	ExprPrepare 
@@ -158,345 +158,436 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 3c 04 00 00 // ProcessType[[]string]
+	Call b1 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b54a8]
-	PrepareEventRoot bb 00 00 00 19 00 00 00 
+	PrepareEventRoot c5 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb54a8.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@b54e4]
-	PrepareEventRoot bc 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5820]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot b7 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot b8 00 00 00 11 00 00 00 
+	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
+	Return 
+// 0x303: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x325: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot b9 00 00 00 11 00 00 00 
+	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x334: ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x349: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot ba 00 00 00 11 00 00 00 
+	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
+	Return 
+// 0x358: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x37a: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot bb 00 00 00 11 00 00 00 
+	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x389: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	Return 
+// 0x393: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x3b5: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot bd 00 00 00 11 00 00 00 
+	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot be 00 00 00 11 00 00 00 
+	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
+	Return 
+// 0x3e8: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call a7 07 00 00 // ProcessType[string]
+	Return 
+// 0x40a: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot bf 00 00 00 11 00 00 00 
+	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x419: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
+	Return 
+// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5820]
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
+	Return 
+// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call da 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4f 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
+// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
+	PrepareEventRoot d1 00 00 00 09 00 00 00 
+	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x457: ProcessType[*****int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x45d: ProcessType[****int]
 	ProcessPointer b1 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x463: ProcessType[***int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x469: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x46f: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x475: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*error]
+// 0x47b: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float32]
+// 0x481: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x312: ProcessType[*float64]
+// 0x487: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x318: ProcessType[*int]
+// 0x48d: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int32]
+// 0x493: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x324: ProcessType[*int64]
+// 0x499: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x32a: ProcessType[*main.bigStruct]
+// 0x49f: ProcessType[*main.bigStruct]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._defer]
+// 0x4a5: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime._panic]
+// 0x4ab: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.cgoCallers]
+// 0x4b1: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.coro]
+// 0x4b7: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.g]
+// 0x4bd: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.m]
+// 0x4c3: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.sudog]
+// 0x4c9: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.synctestGroup]
+// 0x4cf: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.timer]
+// 0x4d5: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.traceBuf]
+// 0x4db: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*string]
+// 0x4e1: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x372: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4e7: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<string,int>]
+// 0x4ed: ProcessType[*table<string,int>]
 	ProcessPointer 89 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,main.bigStruct>]
+// 0x4f3: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4f9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint]
+// 0x4ff: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint16]
+// 0x505: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint32]
+// 0x50b: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint64]
+// 0x511: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint8]
+// 0x517: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uintptr]
+// 0x51d: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3ae: ProcessType[[2]*runtime.traceBuf]
+// 0x523: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call db 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3be: ProcessType[[2][2]*runtime.traceBuf]
+// 0x533: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 23 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3ce: ProcessType[[3]string]
+// 0x543: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call a7 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3de: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x553: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 72 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call e7 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ea: ProcessType[[]*table<string,int>.array]
+// 0x55f: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<string,int>]
+	Call ed 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f6: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x56b: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f3 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x402: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x577: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call f9 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x40e: ProcessType[[]int]
+// 0x583: ProcessType[[]int]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x418: ProcessType[[]noalg.map.group[string]int.array]
+// 0x58d: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 10 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 85 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x424: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x599: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 1b 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 90 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x430: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5a5: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 26 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 9b 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x43c: ProcessType[[]string]
+// 0x5b1: ProcessType[[]string]
 	ProcessSlice 87 00 00 00 10 00 00 00 
 	Return 
-// 0x446: ProcessType[[]string.array]
+// 0x5bb: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 32 06 00 00 // ProcessType[string]
+	Call a7 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x452: ProcessType[[]uint8]
+// 0x5c7: ProcessType[[]uint8]
 	ProcessSlice 81 00 00 00 01 00 00 00 
 	Return 
-// 0x45c: ProcessType[[]uintptr]
+// 0x5d1: ProcessType[[]uintptr]
 	ProcessSlice 83 00 00 00 08 00 00 00 
 	Return 
-// 0x466: ProcessType[error]
+// 0x5db: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x468: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5dd: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x474: ProcessType[groupReference<string,int>]
+// 0x5e9: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 90 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x480: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5f5: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x48c: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x601: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x498: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x60d: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap af 00 00 00 ab 00 00 00 10 18 
 	Return 
-// 0x4a4: ProcessType[map<string,int>]
+// 0x619: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8f 00 00 00 8c 00 00 00 10 18 
 	Return 
-// 0x4b0: ProcessType[map<string,main.bigStruct>]
+// 0x625: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 99 00 00 00 94 00 00 00 10 18 
 	Return 
-// 0x4bc: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x631: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a6 00 00 00 9e 00 00 00 10 18 
 	Return 
-// 0x4c8: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x63d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x4ce: ProcessType[map[string]int]
+// 0x643: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x4d4: ProcessType[map[string]main.bigStruct]
+// 0x649: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x4da: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64f: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x4e0: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x655: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 31 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a6 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4f0: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x665: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 41 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call b6 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x500: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x675: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 47 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call bc 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x510: ProcessType[noalg.map.group[string]int]
+// 0x685: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 65 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x51b: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x690: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call e0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 55 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x526: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x69b: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 00 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 75 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x531: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 32 06 00 00 // ProcessType[string]
+// 0x6a6: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a7 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
+	Call 9f 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x541: ProcessType[noalg.struct { key string; elem int }]
-	Call 32 06 00 00 // ProcessType[string]
+// 0x6b6: ProcessType[noalg.struct { key string; elem int }]
+	Call a7 07 00 00 // ProcessType[string]
 	Return 
-// 0x547: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6bc: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call c8 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3d 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x552: ProcessType[runtime.g]
+// 0x6c7: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime._panic]
+	Call ab 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._defer]
+	Call a5 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 52 04 00 00 // ProcessType[[]uint8]
+	Call c7 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.sudog]
+	Call c9 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call d1 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.timer]
+	Call d5 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.coro]
+	Call b7 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.synctestGroup]
+	Call cf 04 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x5b7: ProcessType[runtime.m]
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+// 0x72c: ProcessType[runtime.m]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call a7 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b1 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 17 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 8c 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call d1 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 22 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 97 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x617: ProcessType[runtime.mLockProfile]
+// 0x78c: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call d1 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x622: ProcessType[runtime.mTraceState]
+// 0x797: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call be 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 33 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x632: ProcessType[string]
+// 0x7a7: ProcessType[string]
 	ProcessString 7f 00 00 00 
 	Return 
-// 0x638: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7ad: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 68 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call dd 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x643: ProcessType[table<string,int>]
+// 0x7b8: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 74 04 00 00 // ProcessType[groupReference<string,int>]
+	Call e9 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x64e: ProcessType[table<string,main.bigStruct>]
+// 0x7c3: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 80 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call f5 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x659: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7ce: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8c 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 01 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -517,31 +608,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 930
+ID: 5 Len: 8 Enqueue: 1303
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1586
+ID: 9 Len: 16 Enqueue: 1959
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 768
+ID: 11 Len: 8 Enqueue: 1141
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1126
+ID: 14 Len: 16 Enqueue: 1499
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 936
-ID: 20 Len: 8 Enqueue: 798
-ID: 21 Len: 8 Enqueue: 918
-ID: 22 Len: 440 Enqueue: 1362
+ID: 19 Len: 8 Enqueue: 1309
+ID: 20 Len: 8 Enqueue: 1171
+ID: 21 Len: 8 Enqueue: 1291
+ID: 22 Len: 440 Enqueue: 1735
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 822
+ID: 24 Len: 8 Enqueue: 1195
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 816
+ID: 26 Len: 8 Enqueue: 1189
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 846
-ID: 29 Len: 1808 Enqueue: 1463
+ID: 28 Len: 8 Enqueue: 1219
+ID: 29 Len: 1808 Enqueue: 1836
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -550,45 +641,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1106
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1479
+ID: 39 Len: 8 Enqueue: 1135
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 852
+ID: 41 Len: 8 Enqueue: 1225
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1116
-ID: 44 Len: 8 Enqueue: 864
+ID: 43 Len: 24 Enqueue: 1489
+ID: 44 Len: 8 Enqueue: 1237
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 834
+ID: 47 Len: 8 Enqueue: 1207
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 858
+ID: 49 Len: 8 Enqueue: 1231
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 840
+ID: 55 Len: 8 Enqueue: 1213
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 828
+ID: 62 Len: 8 Enqueue: 1201
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1559
+ID: 67 Len: 64 Enqueue: 1932
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1570
+ID: 72 Len: 56 Enqueue: 1943
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 958
-ID: 75 Len: 16 Enqueue: 942
-ID: 76 Len: 8 Enqueue: 870
+ID: 74 Len: 32 Enqueue: 1331
+ID: 75 Len: 16 Enqueue: 1315
+ID: 76 Len: 8 Enqueue: 1243
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -605,40 +696,40 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 876
+ID: 93 Len: 8 Enqueue: 1249
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 786
-ID: 98 Len: 8 Enqueue: 804
-ID: 99 Len: 8 Enqueue: 792
-ID: 100 Len: 8 Enqueue: 924
-ID: 101 Len: 8 Enqueue: 774
-ID: 102 Len: 8 Enqueue: 780
-ID: 103 Len: 8 Enqueue: 906
-ID: 104 Len: 8 Enqueue: 912
-ID: 105 Len: 24 Enqueue: 1038
+ID: 97 Len: 8 Enqueue: 1159
+ID: 98 Len: 8 Enqueue: 1177
+ID: 99 Len: 8 Enqueue: 1165
+ID: 100 Len: 8 Enqueue: 1297
+ID: 101 Len: 8 Enqueue: 1147
+ID: 102 Len: 8 Enqueue: 1153
+ID: 103 Len: 8 Enqueue: 1279
+ID: 104 Len: 8 Enqueue: 1285
+ID: 105 Len: 24 Enqueue: 1411
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 1084
-ID: 108 Len: 48 Enqueue: 974
-ID: 109 Len: 8 Enqueue: 1230
+ID: 107 Len: 24 Enqueue: 1457
+ID: 108 Len: 48 Enqueue: 1347
+ID: 109 Len: 8 Enqueue: 1603
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 1188
+ID: 111 Len: 48 Enqueue: 1561
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 888
-ID: 114 Len: 8 Enqueue: 1236
+ID: 113 Len: 8 Enqueue: 1261
+ID: 114 Len: 8 Enqueue: 1609
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 1200
+ID: 116 Len: 48 Enqueue: 1573
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 894
-ID: 119 Len: 8 Enqueue: 1242
+ID: 118 Len: 8 Enqueue: 1267
+ID: 119 Len: 8 Enqueue: 1615
 ID: 120 Len: 8 Enqueue: 0
-ID: 121 Len: 48 Enqueue: 1212
+ID: 121 Len: 48 Enqueue: 1585
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 900
-ID: 124 Len: 8 Enqueue: 738
-ID: 125 Len: 8 Enqueue: 744
-ID: 126 Len: 8 Enqueue: 756
+ID: 123 Len: 8 Enqueue: 1273
+ID: 124 Len: 8 Enqueue: 1111
+ID: 125 Len: 8 Enqueue: 1117
+ID: 126 Len: 8 Enqueue: 1129
 ID: 127 Len: 1 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 1 Enqueue: 0
@@ -647,72 +738,82 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 16 Enqueue: 1094
+ID: 135 Len: 16 Enqueue: 1467
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 32 Enqueue: 1603
-ID: 138 Len: 16 Enqueue: 1140
+ID: 137 Len: 32 Enqueue: 1976
+ID: 138 Len: 16 Enqueue: 1513
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 200 Enqueue: 1296
-ID: 141 Len: 192 Enqueue: 1264
-ID: 142 Len: 24 Enqueue: 1345
-ID: 143 Len: 8 Enqueue: 1002
-ID: 144 Len: 200 Enqueue: 1048
-ID: 145 Len: 32 Enqueue: 1614
-ID: 146 Len: 16 Enqueue: 1152
+ID: 140 Len: 200 Enqueue: 1669
+ID: 141 Len: 192 Enqueue: 1637
+ID: 142 Len: 24 Enqueue: 1718
+ID: 143 Len: 8 Enqueue: 1375
+ID: 144 Len: 200 Enqueue: 1421
+ID: 145 Len: 32 Enqueue: 1987
+ID: 146 Len: 16 Enqueue: 1525
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 1307
-ID: 149 Len: 192 Enqueue: 1248
-ID: 150 Len: 24 Enqueue: 1329
-ID: 151 Len: 8 Enqueue: 810
+ID: 148 Len: 200 Enqueue: 1680
+ID: 149 Len: 192 Enqueue: 1621
+ID: 150 Len: 24 Enqueue: 1702
+ID: 151 Len: 8 Enqueue: 1183
 ID: 152 Len: 184 Enqueue: 0
-ID: 153 Len: 8 Enqueue: 1014
-ID: 154 Len: 200 Enqueue: 1060
-ID: 155 Len: 32 Enqueue: 1625
-ID: 156 Len: 16 Enqueue: 1164
+ID: 153 Len: 8 Enqueue: 1387
+ID: 154 Len: 200 Enqueue: 1433
+ID: 155 Len: 32 Enqueue: 1998
+ID: 156 Len: 16 Enqueue: 1537
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 136 Enqueue: 1318
-ID: 159 Len: 128 Enqueue: 1280
-ID: 160 Len: 16 Enqueue: 1351
-ID: 161 Len: 8 Enqueue: 1224
+ID: 158 Len: 136 Enqueue: 1691
+ID: 159 Len: 128 Enqueue: 1653
+ID: 160 Len: 16 Enqueue: 1724
+ID: 161 Len: 8 Enqueue: 1597
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 48 Enqueue: 1176
+ID: 163 Len: 48 Enqueue: 1549
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 8 Enqueue: 882
-ID: 166 Len: 8 Enqueue: 1026
-ID: 167 Len: 136 Enqueue: 1072
-ID: 168 Len: 32 Enqueue: 1592
-ID: 169 Len: 16 Enqueue: 1128
+ID: 165 Len: 8 Enqueue: 1255
+ID: 166 Len: 8 Enqueue: 1399
+ID: 167 Len: 136 Enqueue: 1445
+ID: 168 Len: 32 Enqueue: 1965
+ID: 169 Len: 16 Enqueue: 1501
 ID: 170 Len: 8 Enqueue: 0
 ID: 171 Len: 136 Enqueue: 0
 ID: 172 Len: 128 Enqueue: 0
 ID: 173 Len: 16 Enqueue: 0
 ID: 174 Len: 8 Enqueue: 0
-ID: 175 Len: 8 Enqueue: 990
+ID: 175 Len: 8 Enqueue: 1363
 ID: 176 Len: 136 Enqueue: 0
-ID: 177 Len: 8 Enqueue: 750
+ID: 177 Len: 8 Enqueue: 1123
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 9 Enqueue: 0
 ID: 180 Len: 0 Enqueue: 0
 ID: 181 Len: 17 Enqueue: 0
 ID: 182 Len: 0 Enqueue: 0
-ID: 183 Len: 25 Enqueue: 0
-ID: 184 Len: 0 Enqueue: 0
-ID: 185 Len: 25 Enqueue: 0
-ID: 186 Len: 0 Enqueue: 0
-ID: 187 Len: 25 Enqueue: 0
+ID: 183 Len: 17 Enqueue: 0
+ID: 184 Len: 17 Enqueue: 0
+ID: 185 Len: 17 Enqueue: 0
+ID: 186 Len: 17 Enqueue: 0
+ID: 187 Len: 17 Enqueue: 0
 ID: 188 Len: 0 Enqueue: 0
-ID: 189 Len: 49 Enqueue: 0
-ID: 190 Len: 0 Enqueue: 0
-ID: 191 Len: 49 Enqueue: 0
-ID: 192 Len: 9 Enqueue: 0
-ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 9 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
+ID: 189 Len: 17 Enqueue: 0
+ID: 190 Len: 17 Enqueue: 0
+ID: 191 Len: 17 Enqueue: 0
+ID: 192 Len: 0 Enqueue: 0
+ID: 193 Len: 25 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 25 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
+ID: 197 Len: 25 Enqueue: 0
 ID: 198 Len: 0 Enqueue: 0
-ID: 199 Len: 9 Enqueue: 0
-ID: 200 Len: 9 Enqueue: 0
-ID: 201 Len: 0 Enqueue: 0
+ID: 199 Len: 49 Enqueue: 0
+ID: 200 Len: 0 Enqueue: 0
+ID: 201 Len: 49 Enqueue: 0
 ID: 202 Len: 9 Enqueue: 0
-ID: 203 Len: 9 Enqueue: 0
+ID: 203 Len: 0 Enqueue: 0
+ID: 204 Len: 9 Enqueue: 0
+ID: 205 Len: 0 Enqueue: 0
+ID: 206 Len: 0 Enqueue: 0
+ID: 207 Len: 0 Enqueue: 0
+ID: 208 Len: 0 Enqueue: 0
+ID: 209 Len: 9 Enqueue: 0
+ID: 210 Len: 9 Enqueue: 0
+ID: 211 Len: 0 Enqueue: 0
+ID: 212 Len: 9 Enqueue: 0
+ID: 213 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 57 04 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b520c]
 	PrepareEventRoot d4 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 69 04 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5244]
 	PrepareEventRoot d5 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 06 00 00 // ProcessType[map[string]main.bigStruct]
+	Call fb 05 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b56f0]
 	PrepareEventRoot cc 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 43 05 00 00 // ProcessType[[3]string]
+	Call f5 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5590]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 83 05 00 00 // ProcessType[[]int]
+	Call 35 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b53a8]
 	PrepareEventRoot c1 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 06 00 00 // ProcessType[map[string]int]
+	Call f5 05 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5678]
 	PrepareEventRoot ca 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b5 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 43 05 00 00 // ProcessType[[3]string]
+	Call f5 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b5528]
 	PrepareEventRoot c7 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call b1 05 00 00 // ProcessType[[]string]
+	Call 63 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b54a8]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
@@ -172,422 +172,401 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
 // 0x2d0: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b7 00 00 00 11 00 00 00 
 	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	Return 
-// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
-	ExprPrepare 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot b8 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
-	Return 
-// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@b5364]
-	PrepareEventRoot b8 00 00 00 11 00 00 00 
-	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
-	Return 
-// 0x303: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x325: ProcessEvent[Probe[main.stringArg]@b5328]
+// 0x30b: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	Return 
-// 0x334: ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
-	ExprPrepare 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
-	Return 
-// 0x349: ProcessEvent[Probe[main.stringArg]Return@b5364]
-	PrepareEventRoot ba 00 00 00 11 00 00 00 
-	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
-	Return 
-// 0x358: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+// 0x324: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringArg]@b5328]
+// 0x346: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
-	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	Return 
-// 0x389: ProcessEvent[Probe[main.stringArg]Return@b5364]
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@b5364]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x393: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x3b5: ProcessEvent[Probe[main.stringArg]@b5328]
+// 0x381: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot bd 00 00 00 11 00 00 00 
-	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	Return 
-// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
-	ExprPrepare 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
-	Return 
-// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@b5364]
-	PrepareEventRoot be 00 00 00 11 00 00 00 
-	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb5364.expr[0]]
-	Return 
-// 0x3e8: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x40a: ProcessEvent[Probe[main.stringArg]@b5328]
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot bf 00 00 00 11 00 00 00 
-	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	Return 
-// 0x419: ProcessEvent[Probe[main.stringArg]Return@b5364]
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@b5364]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5820]
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5820]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4f 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 01 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
 	PrepareEventRoot d1 00 00 00 09 00 00 00 
-	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	Return 
-// 0x457: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x45d: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer b1 00 00 00 
 	Return 
-// 0x463: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x469: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x46f: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x475: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x47b: ProcessType[*error]
+// 0x42d: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x481: ProcessType[*float32]
+// 0x433: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x487: ProcessType[*float64]
+// 0x439: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x48d: ProcessType[*int]
+// 0x43f: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x493: ProcessType[*int32]
+// 0x445: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x499: ProcessType[*int64]
+// 0x44b: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x49f: ProcessType[*main.bigStruct]
+// 0x451: ProcessType[*main.bigStruct]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x4a5: ProcessType[*runtime._defer]
+// 0x457: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x4ab: ProcessType[*runtime._panic]
+// 0x45d: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x4b1: ProcessType[*runtime.cgoCallers]
+// 0x463: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x4b7: ProcessType[*runtime.coro]
+// 0x469: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x4bd: ProcessType[*runtime.g]
+// 0x46f: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x4c3: ProcessType[*runtime.m]
+// 0x475: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x4c9: ProcessType[*runtime.sudog]
+// 0x47b: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x4cf: ProcessType[*runtime.synctestGroup]
+// 0x481: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x4d5: ProcessType[*runtime.timer]
+// 0x487: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x4db: ProcessType[*runtime.traceBuf]
+// 0x48d: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x4e1: ProcessType[*string]
+// 0x493: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x4e7: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x499: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x4ed: ProcessType[*table<string,int>]
+// 0x49f: ProcessType[*table<string,int>]
 	ProcessPointer 89 00 00 00 
 	Return 
-// 0x4f3: ProcessType[*table<string,main.bigStruct>]
+// 0x4a5: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x4f9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4ab: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x4ff: ProcessType[*uint]
+// 0x4b1: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x505: ProcessType[*uint16]
+// 0x4b7: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x50b: ProcessType[*uint32]
+// 0x4bd: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x511: ProcessType[*uint64]
+// 0x4c3: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x517: ProcessType[*uint8]
+// 0x4c9: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x51d: ProcessType[*uintptr]
+// 0x4cf: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x523: ProcessType[[2]*runtime.traceBuf]
+// 0x4d5: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call db 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call 8d 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x533: ProcessType[[2][2]*runtime.traceBuf]
+// 0x4e5: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 23 05 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call d5 04 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x543: ProcessType[[3]string]
+// 0x4f5: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x553: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x505: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e7 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 99 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x55f: ProcessType[[]*table<string,int>.array]
+// 0x511: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call ed 04 00 00 // ProcessType[*table<string,int>]
+	Call 9f 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x56b: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x51d: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call f3 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call a5 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x577: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x529: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call f9 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ab 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x583: ProcessType[[]int]
+// 0x535: ProcessType[[]int]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x58d: ProcessType[[]noalg.map.group[string]int.array]
+// 0x53f: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 85 06 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 37 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x599: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x54b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 90 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 42 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5a5: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x557: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 9b 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4d 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5b1: ProcessType[[]string]
+// 0x563: ProcessType[[]string]
 	ProcessSlice 87 00 00 00 10 00 00 00 
 	Return 
-// 0x5bb: ProcessType[[]string.array]
+// 0x56d: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x5c7: ProcessType[[]uint8]
+// 0x579: ProcessType[[]uint8]
 	ProcessSlice 81 00 00 00 01 00 00 00 
 	Return 
-// 0x5d1: ProcessType[[]uintptr]
+// 0x583: ProcessType[[]uintptr]
 	ProcessSlice 83 00 00 00 08 00 00 00 
 	Return 
-// 0x5db: ProcessType[error]
+// 0x58d: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x5dd: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x58f: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x5e9: ProcessType[groupReference<string,int>]
+// 0x59b: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 90 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x5f5: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5a7: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x601: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5b3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x60d: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x5bf: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap af 00 00 00 ab 00 00 00 10 18 
 	Return 
-// 0x619: ProcessType[map<string,int>]
+// 0x5cb: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8f 00 00 00 8c 00 00 00 10 18 
 	Return 
-// 0x625: ProcessType[map<string,main.bigStruct>]
+// 0x5d7: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 99 00 00 00 94 00 00 00 10 18 
 	Return 
-// 0x631: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5e3: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a6 00 00 00 9e 00 00 00 10 18 
 	Return 
-// 0x63d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x5ef: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x643: ProcessType[map[string]int]
+// 0x5f5: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x649: ProcessType[map[string]main.bigStruct]
+// 0x5fb: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x64f: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x601: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x655: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x607: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a6 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 58 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x665: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x617: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call b6 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 68 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x675: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x627: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call bc 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 6e 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x685: ProcessType[noalg.map.group[string]int]
+// 0x637: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 65 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 17 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x690: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x642: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 55 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 07 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x69b: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64d: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 75 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 27 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x6a6: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call a7 07 00 00 // ProcessType[string]
+// 0x658: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 59 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9f 04 00 00 // ProcessType[*main.bigStruct]
+	Call 51 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x6b6: ProcessType[noalg.struct { key string; elem int }]
-	Call a7 07 00 00 // ProcessType[string]
+// 0x668: ProcessType[noalg.struct { key string; elem int }]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x6bc: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x66e: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3d 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call ef 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x6c7: ProcessType[runtime.g]
+// 0x679: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ab 04 00 00 // ProcessType[*runtime._panic]
+	Call 5d 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a5 04 00 00 // ProcessType[*runtime._defer]
+	Call 57 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call c7 05 00 00 // ProcessType[[]uint8]
+	Call 79 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call c9 04 00 00 // ProcessType[*runtime.sudog]
+	Call 7b 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call d1 05 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call d5 04 00 00 // ProcessType[*runtime.timer]
+	Call 87 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b7 04 00 00 // ProcessType[*runtime.coro]
+	Call 69 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call cf 04 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 81 04 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x72c: ProcessType[runtime.m]
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+// 0x6de: ProcessType[runtime.m]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call a7 07 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call b1 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 63 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 8c 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call 3e 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call d1 05 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 97 07 00 00 // ProcessType[runtime.mTraceState]
+	Call 49 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x78c: ProcessType[runtime.mLockProfile]
+// 0x73e: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call d1 05 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x797: ProcessType[runtime.mTraceState]
+// 0x749: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 33 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call e5 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x7a7: ProcessType[string]
+// 0x759: ProcessType[string]
 	ProcessString 7f 00 00 00 
 	Return 
-// 0x7ad: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x75f: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call dd 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 8f 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x7b8: ProcessType[table<string,int>]
+// 0x76a: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call e9 05 00 00 // ProcessType[groupReference<string,int>]
+	Call 9b 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x7c3: ProcessType[table<string,main.bigStruct>]
+// 0x775: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f5 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call a7 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x7ce: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x780: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 01 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b3 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -608,31 +587,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1303
+ID: 5 Len: 8 Enqueue: 1225
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1959
+ID: 9 Len: 16 Enqueue: 1881
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 1141
+ID: 11 Len: 8 Enqueue: 1063
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1499
+ID: 14 Len: 16 Enqueue: 1421
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1309
-ID: 20 Len: 8 Enqueue: 1171
-ID: 21 Len: 8 Enqueue: 1291
-ID: 22 Len: 440 Enqueue: 1735
+ID: 19 Len: 8 Enqueue: 1231
+ID: 20 Len: 8 Enqueue: 1093
+ID: 21 Len: 8 Enqueue: 1213
+ID: 22 Len: 440 Enqueue: 1657
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1195
+ID: 24 Len: 8 Enqueue: 1117
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1189
+ID: 26 Len: 8 Enqueue: 1111
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1219
-ID: 29 Len: 1808 Enqueue: 1836
+ID: 28 Len: 8 Enqueue: 1141
+ID: 29 Len: 1808 Enqueue: 1758
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -641,45 +620,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1479
-ID: 39 Len: 8 Enqueue: 1135
+ID: 38 Len: 24 Enqueue: 1401
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1225
+ID: 41 Len: 8 Enqueue: 1147
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1489
-ID: 44 Len: 8 Enqueue: 1237
+ID: 43 Len: 24 Enqueue: 1411
+ID: 44 Len: 8 Enqueue: 1159
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1207
+ID: 47 Len: 8 Enqueue: 1129
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 1231
+ID: 49 Len: 8 Enqueue: 1153
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 1213
+ID: 55 Len: 8 Enqueue: 1135
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 1201
+ID: 62 Len: 8 Enqueue: 1123
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1932
+ID: 67 Len: 64 Enqueue: 1854
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1943
+ID: 72 Len: 56 Enqueue: 1865
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 1331
-ID: 75 Len: 16 Enqueue: 1315
-ID: 76 Len: 8 Enqueue: 1243
+ID: 74 Len: 32 Enqueue: 1253
+ID: 75 Len: 16 Enqueue: 1237
+ID: 76 Len: 8 Enqueue: 1165
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -696,40 +675,40 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 1249
+ID: 93 Len: 8 Enqueue: 1171
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 1159
-ID: 98 Len: 8 Enqueue: 1177
-ID: 99 Len: 8 Enqueue: 1165
-ID: 100 Len: 8 Enqueue: 1297
-ID: 101 Len: 8 Enqueue: 1147
-ID: 102 Len: 8 Enqueue: 1153
-ID: 103 Len: 8 Enqueue: 1279
-ID: 104 Len: 8 Enqueue: 1285
-ID: 105 Len: 24 Enqueue: 1411
+ID: 97 Len: 8 Enqueue: 1081
+ID: 98 Len: 8 Enqueue: 1099
+ID: 99 Len: 8 Enqueue: 1087
+ID: 100 Len: 8 Enqueue: 1219
+ID: 101 Len: 8 Enqueue: 1069
+ID: 102 Len: 8 Enqueue: 1075
+ID: 103 Len: 8 Enqueue: 1201
+ID: 104 Len: 8 Enqueue: 1207
+ID: 105 Len: 24 Enqueue: 1333
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 1457
-ID: 108 Len: 48 Enqueue: 1347
-ID: 109 Len: 8 Enqueue: 1603
+ID: 107 Len: 24 Enqueue: 1379
+ID: 108 Len: 48 Enqueue: 1269
+ID: 109 Len: 8 Enqueue: 1525
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 1561
+ID: 111 Len: 48 Enqueue: 1483
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 1261
-ID: 114 Len: 8 Enqueue: 1609
+ID: 113 Len: 8 Enqueue: 1183
+ID: 114 Len: 8 Enqueue: 1531
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 1573
+ID: 116 Len: 48 Enqueue: 1495
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 1267
-ID: 119 Len: 8 Enqueue: 1615
+ID: 118 Len: 8 Enqueue: 1189
+ID: 119 Len: 8 Enqueue: 1537
 ID: 120 Len: 8 Enqueue: 0
-ID: 121 Len: 48 Enqueue: 1585
+ID: 121 Len: 48 Enqueue: 1507
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 1273
-ID: 124 Len: 8 Enqueue: 1111
-ID: 125 Len: 8 Enqueue: 1117
-ID: 126 Len: 8 Enqueue: 1129
+ID: 123 Len: 8 Enqueue: 1195
+ID: 124 Len: 8 Enqueue: 1033
+ID: 125 Len: 8 Enqueue: 1039
+ID: 126 Len: 8 Enqueue: 1051
 ID: 127 Len: 1 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 1 Enqueue: 0
@@ -738,62 +717,62 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 16 Enqueue: 1467
+ID: 135 Len: 16 Enqueue: 1389
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 32 Enqueue: 1976
-ID: 138 Len: 16 Enqueue: 1513
+ID: 137 Len: 32 Enqueue: 1898
+ID: 138 Len: 16 Enqueue: 1435
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 200 Enqueue: 1669
-ID: 141 Len: 192 Enqueue: 1637
-ID: 142 Len: 24 Enqueue: 1718
-ID: 143 Len: 8 Enqueue: 1375
-ID: 144 Len: 200 Enqueue: 1421
-ID: 145 Len: 32 Enqueue: 1987
-ID: 146 Len: 16 Enqueue: 1525
+ID: 140 Len: 200 Enqueue: 1591
+ID: 141 Len: 192 Enqueue: 1559
+ID: 142 Len: 24 Enqueue: 1640
+ID: 143 Len: 8 Enqueue: 1297
+ID: 144 Len: 200 Enqueue: 1343
+ID: 145 Len: 32 Enqueue: 1909
+ID: 146 Len: 16 Enqueue: 1447
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 1680
-ID: 149 Len: 192 Enqueue: 1621
-ID: 150 Len: 24 Enqueue: 1702
-ID: 151 Len: 8 Enqueue: 1183
+ID: 148 Len: 200 Enqueue: 1602
+ID: 149 Len: 192 Enqueue: 1543
+ID: 150 Len: 24 Enqueue: 1624
+ID: 151 Len: 8 Enqueue: 1105
 ID: 152 Len: 184 Enqueue: 0
-ID: 153 Len: 8 Enqueue: 1387
-ID: 154 Len: 200 Enqueue: 1433
-ID: 155 Len: 32 Enqueue: 1998
-ID: 156 Len: 16 Enqueue: 1537
+ID: 153 Len: 8 Enqueue: 1309
+ID: 154 Len: 200 Enqueue: 1355
+ID: 155 Len: 32 Enqueue: 1920
+ID: 156 Len: 16 Enqueue: 1459
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 136 Enqueue: 1691
-ID: 159 Len: 128 Enqueue: 1653
-ID: 160 Len: 16 Enqueue: 1724
-ID: 161 Len: 8 Enqueue: 1597
+ID: 158 Len: 136 Enqueue: 1613
+ID: 159 Len: 128 Enqueue: 1575
+ID: 160 Len: 16 Enqueue: 1646
+ID: 161 Len: 8 Enqueue: 1519
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 48 Enqueue: 1549
+ID: 163 Len: 48 Enqueue: 1471
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 8 Enqueue: 1255
-ID: 166 Len: 8 Enqueue: 1399
-ID: 167 Len: 136 Enqueue: 1445
-ID: 168 Len: 32 Enqueue: 1965
-ID: 169 Len: 16 Enqueue: 1501
+ID: 165 Len: 8 Enqueue: 1177
+ID: 166 Len: 8 Enqueue: 1321
+ID: 167 Len: 136 Enqueue: 1367
+ID: 168 Len: 32 Enqueue: 1887
+ID: 169 Len: 16 Enqueue: 1423
 ID: 170 Len: 8 Enqueue: 0
 ID: 171 Len: 136 Enqueue: 0
 ID: 172 Len: 128 Enqueue: 0
 ID: 173 Len: 16 Enqueue: 0
 ID: 174 Len: 8 Enqueue: 0
-ID: 175 Len: 8 Enqueue: 1363
+ID: 175 Len: 8 Enqueue: 1285
 ID: 176 Len: 136 Enqueue: 0
-ID: 177 Len: 8 Enqueue: 1123
+ID: 177 Len: 8 Enqueue: 1045
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 9 Enqueue: 0
 ID: 180 Len: 0 Enqueue: 0
 ID: 181 Len: 17 Enqueue: 0
 ID: 182 Len: 0 Enqueue: 0
 ID: 183 Len: 17 Enqueue: 0
-ID: 184 Len: 17 Enqueue: 0
+ID: 184 Len: 0 Enqueue: 0
 ID: 185 Len: 17 Enqueue: 0
-ID: 186 Len: 17 Enqueue: 0
+ID: 186 Len: 0 Enqueue: 0
 ID: 187 Len: 17 Enqueue: 0
 ID: 188 Len: 0 Enqueue: 0
 ID: 189 Len: 17 Enqueue: 0
-ID: 190 Len: 17 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
 ID: 191 Len: 17 Enqueue: 0
 ID: 192 Len: 0 Enqueue: 0
 ID: 193 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 57 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7da0]
-	PrepareEventRoot cf 00 00 00 09 00 00 00 
+	PrepareEventRoot d9 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7da0.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7dd4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 69 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7dd4]
-	PrepareEventRoot d0 00 00 00 09 00 00 00 
+	PrepareEventRoot da 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7dd4.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb8240.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f0 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 65 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b8240]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
+	PrepareEventRoot d1 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8240.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b82b0]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@b7bc8]
-	PrepareEventRoot cd 00 00 00 09 00 00 00 
+	PrepareEventRoot d7 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0xb8108.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@b8108]
-	PrepareEventRoot cd 00 00 00 09 00 00 00 
+	PrepareEventRoot d7 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb8108.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b813c]
-	PrepareEventRoot ce 00 00 00 00 00 00 00 
+	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0xb7e38.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@b7f98]
-	PrepareEventRoot be 00 00 00 19 00 00 00 
+	PrepareEventRoot c8 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f98.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@b7fd8]
-	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d4 03 00 00 // ProcessType[[3]string]
+	Call 49 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80e0]
-	PrepareEventRoot c4 00 00 00 31 00 00 00 
+	PrepareEventRoot ce 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0xb7f18.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2a 04 00 00 // ProcessType[[]int]
+	Call 9f 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b7f18]
-	PrepareEventRoot bc 00 00 00 19 00 00 00 
+	PrepareEventRoot c6 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7f18.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@b7f50]
-	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ea 04 00 00 // ProcessType[map[string]int]
+	Call 5f 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b81c8]
-	PrepareEventRoot c5 00 00 00 09 00 00 00 
+	PrepareEventRoot cf 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@b81f4]
-	PrepareEventRoot c6 00 00 00 00 00 00 00 
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@b82e8]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@b831c]
-	PrepareEventRoot ca 00 00 00 00 00 00 00 
+	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call cd 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot ba 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d4 03 00 00 // ProcessType[[3]string]
+	Call 49 05 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b8088]
-	PrepareEventRoot c2 00 00 00 31 00 00 00 
+	PrepareEventRoot cc 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8088.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@b80c8]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0xb8008.expr[0]]
 	ExprPrepare 
@@ -158,358 +158,449 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 58 04 00 00 // ProcessType[[]string]
+	Call cd 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b8008]
-	PrepareEventRoot c0 00 00 00 19 00 00 00 
+	PrepareEventRoot ca 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8008.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@b8040]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8360]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot bc 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot bd 00 00 00 11 00 00 00 
+	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
+	Return 
+// 0x303: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x325: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot be 00 00 00 11 00 00 00 
+	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x334: ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x349: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot bf 00 00 00 11 00 00 00 
+	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
+	Return 
+// 0x358: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x37a: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot c0 00 00 00 11 00 00 00 
+	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x389: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	Return 
+// 0x393: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x3b5: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot c2 00 00 00 11 00 00 00 
+	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot c3 00 00 00 11 00 00 00 
+	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
+	Return 
+// 0x3e8: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call cd 07 00 00 // ProcessType[string]
+	Return 
+// 0x40a: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot c4 00 00 00 11 00 00 00 
+	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x419: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	Return 
+// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8360]
+	PrepareEventRoot d5 00 00 00 00 00 00 00 
+	Return 
+// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f6 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 6b 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
-	PrepareEventRoot cc 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
+// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
+	PrepareEventRoot d6 00 00 00 09 00 00 00 
+	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x457: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x45d: ProcessType[****int]
 	ProcessPointer b6 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x463: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x469: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x46f: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x475: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*error]
+// 0x47b: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float32]
+// 0x481: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x312: ProcessType[*float64]
+// 0x487: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x318: ProcessType[*int]
+// 0x48d: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int32]
+// 0x493: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x324: ProcessType[*int64]
+// 0x499: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x32a: ProcessType[*main.bigStruct]
+// 0x49f: ProcessType[*main.bigStruct]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._defer]
+// 0x4a5: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime._panic]
+// 0x4ab: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.cgoCallers]
+// 0x4b1: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.coro]
+// 0x4b7: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.g]
+// 0x4bd: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.m]
+// 0x4c3: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.p]
+// 0x4c9: ProcessType[*runtime.p]
 	ProcessPointer 87 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.sudog]
+// 0x4cf: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.synctestBubble]
+// 0x4d5: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.timer]
+// 0x4db: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.traceBuf]
+// 0x4e1: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x372: ProcessType[*string]
+// 0x4e7: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x4ed: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ad 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,int>]
+// 0x4f3: ProcessType[*table<string,int>]
 	ProcessPointer 8e 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<string,main.bigStruct>]
+// 0x4f9: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x38a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4ff: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint]
+// 0x505: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint16]
+// 0x50b: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint32]
+// 0x511: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint64]
+// 0x517: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uint8]
+// 0x51d: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3ae: ProcessType[*uintptr]
+// 0x523: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3b4: ProcessType[[2]*runtime.traceBuf]
+// 0x529: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call e1 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[[2][2]*runtime.traceBuf]
+// 0x539: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 29 05 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[3]string]
+// 0x549: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call cd 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3e4: ProcessType[[]*runtime.p]
+// 0x559: ProcessType[[]*runtime.p]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x3ee: ProcessType[[]*runtime.p.array]
+// 0x563: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 54 03 00 00 // ProcessType[*runtime.p]
+	Call c9 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3fa: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x56f: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call ed 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x406: ProcessType[[]*table<string,int>.array]
+// 0x57b: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,int>]
+	Call f3 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x412: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x587: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f9 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x41e: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x593: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 8a 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ff 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]int]
+// 0x59f: ProcessType[[]int]
 	ProcessSlice 8a 00 00 00 08 00 00 00 
 	Return 
-// 0x434: ProcessType[[]noalg.map.group[string]int.array]
+// 0x5a9: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 2c 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call a1 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x440: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x5b5: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 37 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call ac 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x44c: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x5c1: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 42 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call b7 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x458: ProcessType[[]string]
+// 0x5cd: ProcessType[[]string]
 	ProcessSlice 8c 00 00 00 10 00 00 00 
 	Return 
-// 0x462: ProcessType[[]string.array]
+// 0x5d7: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 58 06 00 00 // ProcessType[string]
+	Call cd 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x46e: ProcessType[[]uint8]
+// 0x5e3: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x478: ProcessType[[]uintptr]
+// 0x5ed: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x482: ProcessType[error]
+// 0x5f7: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x484: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5f9: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b5 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x490: ProcessType[groupReference<string,int>]
+// 0x605: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 95 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x49c: ProcessType[groupReference<string,main.bigStruct>]
+// 0x611: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x4a8: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x61d: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ac 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x4b4: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x629: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b4 00 00 00 b0 00 00 00 10 18 
 	Return 
-// 0x4c0: ProcessType[map<string,int>]
+// 0x635: ProcessType[map<string,int>]
 	ProcessGoSwissMap 94 00 00 00 91 00 00 00 10 18 
 	Return 
-// 0x4cc: ProcessType[map<string,main.bigStruct>]
+// 0x641: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9e 00 00 00 99 00 00 00 10 18 
 	Return 
-// 0x4d8: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x64d: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ab 00 00 00 a3 00 00 00 10 18 
 	Return 
-// 0x4e4: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x659: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x4ea: ProcessType[map[string]int]
+// 0x65f: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x4f0: ProcessType[map[string]main.bigStruct]
+// 0x665: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x4f6: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x66b: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x4fc: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x671: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 4d 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call c2 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x50c: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x681: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 5d 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call d2 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x51c: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x691: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 63 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call d8 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x52c: ProcessType[noalg.map.group[string]int]
+// 0x6a1: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0c 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 81 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x537: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x6ac: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call fc 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 71 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x542: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x6b7: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1c 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 91 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x54d: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 58 06 00 00 // ProcessType[string]
+// 0x6c2: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call cd 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
+	Call 9f 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x55d: ProcessType[noalg.struct { key string; elem int }]
-	Call 58 06 00 00 // ProcessType[string]
+// 0x6d2: ProcessType[noalg.struct { key string; elem int }]
+	Call cd 07 00 00 // ProcessType[string]
 	Return 
-// 0x563: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x6d8: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call e4 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 59 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x56e: ProcessType[runtime.g]
+// 0x6e3: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime._panic]
+	Call ab 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._defer]
+	Call a5 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 6e 04 00 00 // ProcessType[[]uint8]
+	Call e3 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.sudog]
+	Call cf 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call ed 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.timer]
+	Call db 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.coro]
+	Call b7 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d5 04 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x5d3: ProcessType[runtime.m]
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+// 0x748: ProcessType[runtime.m]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call bd 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call cd 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call e4 03 00 00 // ProcessType[[]*runtime.p]
+	Call 59 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b1 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 3d 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call b2 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call ed 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 06 00 00 // ProcessType[runtime.mTraceState]
+	Call bd 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x63d: ProcessType[runtime.mLockProfile]
+// 0x7b2: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call ed 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x648: ProcessType[runtime.mTraceState]
+// 0x7bd: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 39 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c3 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x658: ProcessType[string]
+// 0x7cd: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
-// 0x65e: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x7d3: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 84 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call f9 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x669: ProcessType[table<string,int>]
+// 0x7de: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 90 04 00 00 // ProcessType[groupReference<string,int>]
+	Call 05 06 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x674: ProcessType[table<string,main.bigStruct>]
+// 0x7e9: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9c 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 11 06 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x67f: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7f4: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a8 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1d 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -530,31 +621,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 936
+ID: 5 Len: 8 Enqueue: 1309
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1624
+ID: 9 Len: 16 Enqueue: 1997
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 768
+ID: 11 Len: 8 Enqueue: 1141
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1154
+ID: 14 Len: 16 Enqueue: 1527
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 942
-ID: 20 Len: 8 Enqueue: 798
-ID: 21 Len: 8 Enqueue: 924
-ID: 22 Len: 440 Enqueue: 1390
+ID: 19 Len: 8 Enqueue: 1315
+ID: 20 Len: 8 Enqueue: 1171
+ID: 21 Len: 8 Enqueue: 1297
+ID: 22 Len: 440 Enqueue: 1763
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 822
+ID: 24 Len: 8 Enqueue: 1195
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 816
+ID: 26 Len: 8 Enqueue: 1189
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 846
-ID: 29 Len: 1816 Enqueue: 1491
+ID: 28 Len: 8 Enqueue: 1219
+ID: 29 Len: 1816 Enqueue: 1864
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -563,48 +654,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1134
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1507
+ID: 39 Len: 8 Enqueue: 1135
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 858
+ID: 41 Len: 8 Enqueue: 1231
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1144
-ID: 44 Len: 8 Enqueue: 870
+ID: 43 Len: 24 Enqueue: 1517
+ID: 44 Len: 8 Enqueue: 1243
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 834
+ID: 47 Len: 8 Enqueue: 1207
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 864
+ID: 49 Len: 8 Enqueue: 1237
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 840
+ID: 55 Len: 8 Enqueue: 1213
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 996
+ID: 62 Len: 24 Enqueue: 1369
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 852
-ID: 65 Len: 8 Enqueue: 828
+ID: 64 Len: 8 Enqueue: 1225
+ID: 65 Len: 8 Enqueue: 1201
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1597
+ID: 70 Len: 56 Enqueue: 1970
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1608
+ID: 75 Len: 56 Enqueue: 1981
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 964
-ID: 78 Len: 16 Enqueue: 948
-ID: 79 Len: 8 Enqueue: 876
+ID: 77 Len: 32 Enqueue: 1337
+ID: 78 Len: 16 Enqueue: 1321
+ID: 79 Len: 8 Enqueue: 1249
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -620,40 +711,40 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 882
+ID: 95 Len: 8 Enqueue: 1255
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 786
-ID: 100 Len: 8 Enqueue: 792
-ID: 101 Len: 8 Enqueue: 930
-ID: 102 Len: 8 Enqueue: 804
-ID: 103 Len: 8 Enqueue: 774
-ID: 104 Len: 8 Enqueue: 780
-ID: 105 Len: 8 Enqueue: 912
-ID: 106 Len: 8 Enqueue: 918
-ID: 107 Len: 24 Enqueue: 1066
+ID: 99 Len: 8 Enqueue: 1159
+ID: 100 Len: 8 Enqueue: 1165
+ID: 101 Len: 8 Enqueue: 1303
+ID: 102 Len: 8 Enqueue: 1177
+ID: 103 Len: 8 Enqueue: 1147
+ID: 104 Len: 8 Enqueue: 1153
+ID: 105 Len: 8 Enqueue: 1285
+ID: 106 Len: 8 Enqueue: 1291
+ID: 107 Len: 24 Enqueue: 1439
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 1112
-ID: 110 Len: 48 Enqueue: 980
-ID: 111 Len: 8 Enqueue: 1258
+ID: 109 Len: 24 Enqueue: 1485
+ID: 110 Len: 48 Enqueue: 1353
+ID: 111 Len: 8 Enqueue: 1631
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1216
+ID: 113 Len: 48 Enqueue: 1589
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 894
-ID: 116 Len: 8 Enqueue: 1264
+ID: 115 Len: 8 Enqueue: 1267
+ID: 116 Len: 8 Enqueue: 1637
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1228
+ID: 118 Len: 48 Enqueue: 1601
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 900
-ID: 121 Len: 8 Enqueue: 1270
+ID: 120 Len: 8 Enqueue: 1273
+ID: 121 Len: 8 Enqueue: 1643
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1240
+ID: 123 Len: 48 Enqueue: 1613
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 906
-ID: 126 Len: 8 Enqueue: 738
-ID: 127 Len: 8 Enqueue: 744
-ID: 128 Len: 8 Enqueue: 756
+ID: 125 Len: 8 Enqueue: 1279
+ID: 126 Len: 8 Enqueue: 1111
+ID: 127 Len: 8 Enqueue: 1117
+ID: 128 Len: 8 Enqueue: 1129
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -661,76 +752,86 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 1006
+ID: 136 Len: 8 Enqueue: 1379
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 16 Enqueue: 1122
+ID: 140 Len: 16 Enqueue: 1495
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 32 Enqueue: 1641
-ID: 143 Len: 16 Enqueue: 1168
+ID: 142 Len: 32 Enqueue: 2014
+ID: 143 Len: 16 Enqueue: 1541
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 200 Enqueue: 1324
-ID: 146 Len: 192 Enqueue: 1292
-ID: 147 Len: 24 Enqueue: 1373
-ID: 148 Len: 8 Enqueue: 1030
-ID: 149 Len: 200 Enqueue: 1076
-ID: 150 Len: 32 Enqueue: 1652
-ID: 151 Len: 16 Enqueue: 1180
+ID: 145 Len: 200 Enqueue: 1697
+ID: 146 Len: 192 Enqueue: 1665
+ID: 147 Len: 24 Enqueue: 1746
+ID: 148 Len: 8 Enqueue: 1403
+ID: 149 Len: 200 Enqueue: 1449
+ID: 150 Len: 32 Enqueue: 2025
+ID: 151 Len: 16 Enqueue: 1553
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 1335
-ID: 154 Len: 192 Enqueue: 1276
-ID: 155 Len: 24 Enqueue: 1357
-ID: 156 Len: 8 Enqueue: 810
+ID: 153 Len: 200 Enqueue: 1708
+ID: 154 Len: 192 Enqueue: 1649
+ID: 155 Len: 24 Enqueue: 1730
+ID: 156 Len: 8 Enqueue: 1183
 ID: 157 Len: 184 Enqueue: 0
-ID: 158 Len: 8 Enqueue: 1042
-ID: 159 Len: 200 Enqueue: 1088
-ID: 160 Len: 32 Enqueue: 1663
-ID: 161 Len: 16 Enqueue: 1192
+ID: 158 Len: 8 Enqueue: 1415
+ID: 159 Len: 200 Enqueue: 1461
+ID: 160 Len: 32 Enqueue: 2036
+ID: 161 Len: 16 Enqueue: 1565
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 136 Enqueue: 1346
-ID: 164 Len: 128 Enqueue: 1308
-ID: 165 Len: 16 Enqueue: 1379
-ID: 166 Len: 8 Enqueue: 1252
+ID: 163 Len: 136 Enqueue: 1719
+ID: 164 Len: 128 Enqueue: 1681
+ID: 165 Len: 16 Enqueue: 1752
+ID: 166 Len: 8 Enqueue: 1625
 ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 48 Enqueue: 1204
+ID: 168 Len: 48 Enqueue: 1577
 ID: 169 Len: 8 Enqueue: 0
-ID: 170 Len: 8 Enqueue: 888
-ID: 171 Len: 8 Enqueue: 1054
-ID: 172 Len: 136 Enqueue: 1100
-ID: 173 Len: 32 Enqueue: 1630
-ID: 174 Len: 16 Enqueue: 1156
+ID: 170 Len: 8 Enqueue: 1261
+ID: 171 Len: 8 Enqueue: 1427
+ID: 172 Len: 136 Enqueue: 1473
+ID: 173 Len: 32 Enqueue: 2003
+ID: 174 Len: 16 Enqueue: 1529
 ID: 175 Len: 8 Enqueue: 0
 ID: 176 Len: 136 Enqueue: 0
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 16 Enqueue: 0
 ID: 179 Len: 8 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 1018
+ID: 180 Len: 8 Enqueue: 1391
 ID: 181 Len: 136 Enqueue: 0
-ID: 182 Len: 8 Enqueue: 750
+ID: 182 Len: 8 Enqueue: 1123
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 9 Enqueue: 0
 ID: 185 Len: 0 Enqueue: 0
 ID: 186 Len: 17 Enqueue: 0
 ID: 187 Len: 0 Enqueue: 0
-ID: 188 Len: 25 Enqueue: 0
-ID: 189 Len: 0 Enqueue: 0
-ID: 190 Len: 25 Enqueue: 0
-ID: 191 Len: 0 Enqueue: 0
-ID: 192 Len: 25 Enqueue: 0
+ID: 188 Len: 17 Enqueue: 0
+ID: 189 Len: 17 Enqueue: 0
+ID: 190 Len: 17 Enqueue: 0
+ID: 191 Len: 17 Enqueue: 0
+ID: 192 Len: 17 Enqueue: 0
 ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 49 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
-ID: 196 Len: 49 Enqueue: 0
-ID: 197 Len: 9 Enqueue: 0
-ID: 198 Len: 0 Enqueue: 0
-ID: 199 Len: 9 Enqueue: 0
-ID: 200 Len: 0 Enqueue: 0
+ID: 194 Len: 17 Enqueue: 0
+ID: 195 Len: 17 Enqueue: 0
+ID: 196 Len: 17 Enqueue: 0
+ID: 197 Len: 0 Enqueue: 0
+ID: 198 Len: 25 Enqueue: 0
+ID: 199 Len: 0 Enqueue: 0
+ID: 200 Len: 25 Enqueue: 0
 ID: 201 Len: 0 Enqueue: 0
-ID: 202 Len: 0 Enqueue: 0
+ID: 202 Len: 25 Enqueue: 0
 ID: 203 Len: 0 Enqueue: 0
-ID: 204 Len: 9 Enqueue: 0
-ID: 205 Len: 9 Enqueue: 0
-ID: 206 Len: 0 Enqueue: 0
+ID: 204 Len: 49 Enqueue: 0
+ID: 205 Len: 0 Enqueue: 0
+ID: 206 Len: 49 Enqueue: 0
 ID: 207 Len: 9 Enqueue: 0
-ID: 208 Len: 9 Enqueue: 0
+ID: 208 Len: 0 Enqueue: 0
+ID: 209 Len: 9 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
+ID: 211 Len: 0 Enqueue: 0
+ID: 212 Len: 0 Enqueue: 0
+ID: 213 Len: 0 Enqueue: 0
+ID: 214 Len: 9 Enqueue: 0
+ID: 215 Len: 9 Enqueue: 0
+ID: 216 Len: 0 Enqueue: 0
+ID: 217 Len: 9 Enqueue: 0
+ID: 218 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 57 04 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7da0]
 	PrepareEventRoot d9 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 69 04 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7dd4]
 	PrepareEventRoot da 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 65 06 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 17 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b8240]
 	PrepareEventRoot d1 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 49 05 00 00 // ProcessType[[3]string]
+	Call fb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80e0]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 9f 05 00 00 // ProcessType[[]int]
+	Call 51 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b7f18]
 	PrepareEventRoot c6 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5f 06 00 00 // ProcessType[map[string]int]
+	Call 11 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b81c8]
 	PrepareEventRoot cf 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot ba 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 49 05 00 00 // ProcessType[[3]string]
+	Call fb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b8088]
 	PrepareEventRoot cc 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call cd 05 00 00 // ProcessType[[]string]
+	Call 7f 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b8008]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
@@ -172,435 +172,414 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
 // 0x2d0: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot bc 00 00 00 11 00 00 00 
 	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	Return 
-// 0x2df: ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
-	ExprPrepare 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
-	Return 
-// 0x2f4: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
-	PrepareEventRoot bd 00 00 00 11 00 00 00 
-	Call df 02 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
-	Return 
-// 0x303: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x325: ProcessEvent[Probe[main.stringArg]@b7ea8]
+// 0x30b: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot be 00 00 00 11 00 00 00 
-	Call 03 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	Return 
-// 0x334: ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
-	ExprPrepare 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
-	Return 
-// 0x349: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
-	PrepareEventRoot bf 00 00 00 11 00 00 00 
-	Call 34 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
-	Return 
-// 0x358: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+// 0x324: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x37a: ProcessEvent[Probe[main.stringArg]@b7ea8]
+// 0x346: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 58 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	Return 
-// 0x389: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x393: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x3b5: ProcessEvent[Probe[main.stringArg]@b7ea8]
+// 0x381: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot c2 00 00 00 11 00 00 00 
-	Call 93 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	Return 
-// 0x3c4: ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
-	ExprPrepare 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
-	Return 
-// 0x3d9: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
-	PrepareEventRoot c3 00 00 00 11 00 00 00 
-	Call c4 03 00 00 // ProcessExpression[Probe[main.stringArg]Return@0xb7ee0.expr[0]]
-	Return 
-// 0x3e8: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x40a: ProcessEvent[Probe[main.stringArg]@b7ea8]
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot c4 00 00 00 11 00 00 00 
-	Call e8 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	Return 
-// 0x419: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x423: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8360]
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8360]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x42d: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 6b 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 1d 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x448: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
 	PrepareEventRoot d6 00 00 00 09 00 00 00 
-	Call 2d 04 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	Return 
-// 0x457: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x45d: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer b6 00 00 00 
 	Return 
-// 0x463: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x469: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x46f: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x475: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x47b: ProcessType[*error]
+// 0x42d: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x481: ProcessType[*float32]
+// 0x433: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x487: ProcessType[*float64]
+// 0x439: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x48d: ProcessType[*int]
+// 0x43f: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x493: ProcessType[*int32]
+// 0x445: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x499: ProcessType[*int64]
+// 0x44b: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x49f: ProcessType[*main.bigStruct]
+// 0x451: ProcessType[*main.bigStruct]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x4a5: ProcessType[*runtime._defer]
+// 0x457: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x4ab: ProcessType[*runtime._panic]
+// 0x45d: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x4b1: ProcessType[*runtime.cgoCallers]
+// 0x463: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x4b7: ProcessType[*runtime.coro]
+// 0x469: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x4bd: ProcessType[*runtime.g]
+// 0x46f: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x4c3: ProcessType[*runtime.m]
+// 0x475: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x4c9: ProcessType[*runtime.p]
+// 0x47b: ProcessType[*runtime.p]
 	ProcessPointer 87 00 00 00 
 	Return 
-// 0x4cf: ProcessType[*runtime.sudog]
+// 0x481: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x4d5: ProcessType[*runtime.synctestBubble]
+// 0x487: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x4db: ProcessType[*runtime.timer]
+// 0x48d: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x4e1: ProcessType[*runtime.traceBuf]
+// 0x493: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x4e7: ProcessType[*string]
+// 0x499: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x4ed: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x49f: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ad 00 00 00 
 	Return 
-// 0x4f3: ProcessType[*table<string,int>]
+// 0x4a5: ProcessType[*table<string,int>]
 	ProcessPointer 8e 00 00 00 
 	Return 
-// 0x4f9: ProcessType[*table<string,main.bigStruct>]
+// 0x4ab: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x4ff: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4b1: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x505: ProcessType[*uint]
+// 0x4b7: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x50b: ProcessType[*uint16]
+// 0x4bd: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x511: ProcessType[*uint32]
+// 0x4c3: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x517: ProcessType[*uint64]
+// 0x4c9: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x51d: ProcessType[*uint8]
+// 0x4cf: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x523: ProcessType[*uintptr]
+// 0x4d5: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x529: ProcessType[[2]*runtime.traceBuf]
+// 0x4db: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call e1 04 00 00 // ProcessType[*runtime.traceBuf]
+	Call 93 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x539: ProcessType[[2][2]*runtime.traceBuf]
+// 0x4eb: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 29 05 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call db 04 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x549: ProcessType[[3]string]
+// 0x4fb: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x559: ProcessType[[]*runtime.p]
+// 0x50b: ProcessType[[]*runtime.p]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x563: ProcessType[[]*runtime.p.array]
+// 0x515: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call c9 04 00 00 // ProcessType[*runtime.p]
+	Call 7b 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x56f: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x521: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ed 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 9f 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x57b: ProcessType[[]*table<string,int>.array]
+// 0x52d: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f3 04 00 00 // ProcessType[*table<string,int>]
+	Call a5 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x587: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x539: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call f9 04 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call ab 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x593: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x545: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ff 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b1 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x59f: ProcessType[[]int]
+// 0x551: ProcessType[[]int]
 	ProcessSlice 8a 00 00 00 08 00 00 00 
 	Return 
-// 0x5a9: ProcessType[[]noalg.map.group[string]int.array]
+// 0x55b: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call a1 06 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 53 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5b5: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x567: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call ac 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 5e 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5c1: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x573: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call b7 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 69 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x5cd: ProcessType[[]string]
+// 0x57f: ProcessType[[]string]
 	ProcessSlice 8c 00 00 00 10 00 00 00 
 	Return 
-// 0x5d7: ProcessType[[]string.array]
+// 0x589: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x5e3: ProcessType[[]uint8]
+// 0x595: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x5ed: ProcessType[[]uintptr]
+// 0x59f: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x5f7: ProcessType[error]
+// 0x5a9: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x5f9: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5ab: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b5 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x605: ProcessType[groupReference<string,int>]
+// 0x5b7: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 95 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x611: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5c3: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x61d: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5cf: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ac 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x629: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x5db: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b4 00 00 00 b0 00 00 00 10 18 
 	Return 
-// 0x635: ProcessType[map<string,int>]
+// 0x5e7: ProcessType[map<string,int>]
 	ProcessGoSwissMap 94 00 00 00 91 00 00 00 10 18 
 	Return 
-// 0x641: ProcessType[map<string,main.bigStruct>]
+// 0x5f3: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9e 00 00 00 99 00 00 00 10 18 
 	Return 
-// 0x64d: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5ff: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ab 00 00 00 a3 00 00 00 10 18 
 	Return 
-// 0x659: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x60b: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x65f: ProcessType[map[string]int]
+// 0x611: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x665: ProcessType[map[string]main.bigStruct]
+// 0x617: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x66b: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x61d: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x671: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x623: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call c2 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 74 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x681: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x633: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call d2 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 84 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x691: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x643: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call d8 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 8a 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x6a1: ProcessType[noalg.map.group[string]int]
+// 0x653: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 81 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 33 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x6ac: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x65e: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 71 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 23 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x6b7: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x669: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 91 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 43 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x6c2: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call cd 07 00 00 // ProcessType[string]
+// 0x674: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9f 04 00 00 // ProcessType[*main.bigStruct]
+	Call 51 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x6d2: ProcessType[noalg.struct { key string; elem int }]
-	Call cd 07 00 00 // ProcessType[string]
+// 0x684: ProcessType[noalg.struct { key string; elem int }]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x6d8: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x68a: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 59 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 0b 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x6e3: ProcessType[runtime.g]
+// 0x695: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ab 04 00 00 // ProcessType[*runtime._panic]
+	Call 5d 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a5 04 00 00 // ProcessType[*runtime._defer]
+	Call 57 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call e3 05 00 00 // ProcessType[[]uint8]
+	Call 95 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 6f 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call cf 04 00 00 // ProcessType[*runtime.sudog]
+	Call 81 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call ed 05 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call db 04 00 00 // ProcessType[*runtime.timer]
+	Call 8d 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b7 04 00 00 // ProcessType[*runtime.coro]
+	Call 69 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call d5 04 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 87 04 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x748: ProcessType[runtime.m]
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+// 0x6fa: ProcessType[runtime.m]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call bd 04 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call cd 07 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 59 05 00 00 // ProcessType[[]*runtime.p]
+	Call 0b 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call b1 04 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 63 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call b2 07 00 00 // ProcessType[runtime.mLockProfile]
+	Call 64 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call ed 05 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call bd 07 00 00 // ProcessType[runtime.mTraceState]
+	Call 6f 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x7b2: ProcessType[runtime.mLockProfile]
+// 0x764: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call ed 05 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x7bd: ProcessType[runtime.mTraceState]
+// 0x76f: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 39 05 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call c3 04 00 00 // ProcessType[*runtime.m]
+	Call eb 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x7cd: ProcessType[string]
+// 0x77f: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
-// 0x7d3: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x785: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f9 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call ab 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x7de: ProcessType[table<string,int>]
+// 0x790: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 05 06 00 00 // ProcessType[groupReference<string,int>]
+	Call b7 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x7e9: ProcessType[table<string,main.bigStruct>]
+// 0x79b: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 11 06 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call c3 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x7f4: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7a6: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1d 06 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call cf 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -621,31 +600,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 1309
+ID: 5 Len: 8 Enqueue: 1231
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1997
+ID: 9 Len: 16 Enqueue: 1919
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 1141
+ID: 11 Len: 8 Enqueue: 1063
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1527
+ID: 14 Len: 16 Enqueue: 1449
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 1315
-ID: 20 Len: 8 Enqueue: 1171
-ID: 21 Len: 8 Enqueue: 1297
-ID: 22 Len: 440 Enqueue: 1763
+ID: 19 Len: 8 Enqueue: 1237
+ID: 20 Len: 8 Enqueue: 1093
+ID: 21 Len: 8 Enqueue: 1219
+ID: 22 Len: 440 Enqueue: 1685
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 1195
+ID: 24 Len: 8 Enqueue: 1117
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 1189
+ID: 26 Len: 8 Enqueue: 1111
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 1219
-ID: 29 Len: 1816 Enqueue: 1864
+ID: 28 Len: 8 Enqueue: 1141
+ID: 29 Len: 1816 Enqueue: 1786
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -654,48 +633,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1507
-ID: 39 Len: 8 Enqueue: 1135
+ID: 38 Len: 24 Enqueue: 1429
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 1231
+ID: 41 Len: 8 Enqueue: 1153
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1517
-ID: 44 Len: 8 Enqueue: 1243
+ID: 43 Len: 24 Enqueue: 1439
+ID: 44 Len: 8 Enqueue: 1165
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 1207
+ID: 47 Len: 8 Enqueue: 1129
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 1237
+ID: 49 Len: 8 Enqueue: 1159
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 1213
+ID: 55 Len: 8 Enqueue: 1135
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 1369
+ID: 62 Len: 24 Enqueue: 1291
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 1225
-ID: 65 Len: 8 Enqueue: 1201
+ID: 64 Len: 8 Enqueue: 1147
+ID: 65 Len: 8 Enqueue: 1123
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1970
+ID: 70 Len: 56 Enqueue: 1892
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1981
+ID: 75 Len: 56 Enqueue: 1903
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 1337
-ID: 78 Len: 16 Enqueue: 1321
-ID: 79 Len: 8 Enqueue: 1249
+ID: 77 Len: 32 Enqueue: 1259
+ID: 78 Len: 16 Enqueue: 1243
+ID: 79 Len: 8 Enqueue: 1171
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -711,40 +690,40 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 1255
+ID: 95 Len: 8 Enqueue: 1177
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 1159
-ID: 100 Len: 8 Enqueue: 1165
-ID: 101 Len: 8 Enqueue: 1303
-ID: 102 Len: 8 Enqueue: 1177
-ID: 103 Len: 8 Enqueue: 1147
-ID: 104 Len: 8 Enqueue: 1153
-ID: 105 Len: 8 Enqueue: 1285
-ID: 106 Len: 8 Enqueue: 1291
-ID: 107 Len: 24 Enqueue: 1439
+ID: 99 Len: 8 Enqueue: 1081
+ID: 100 Len: 8 Enqueue: 1087
+ID: 101 Len: 8 Enqueue: 1225
+ID: 102 Len: 8 Enqueue: 1099
+ID: 103 Len: 8 Enqueue: 1069
+ID: 104 Len: 8 Enqueue: 1075
+ID: 105 Len: 8 Enqueue: 1207
+ID: 106 Len: 8 Enqueue: 1213
+ID: 107 Len: 24 Enqueue: 1361
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 1485
-ID: 110 Len: 48 Enqueue: 1353
-ID: 111 Len: 8 Enqueue: 1631
+ID: 109 Len: 24 Enqueue: 1407
+ID: 110 Len: 48 Enqueue: 1275
+ID: 111 Len: 8 Enqueue: 1553
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1589
+ID: 113 Len: 48 Enqueue: 1511
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 1267
-ID: 116 Len: 8 Enqueue: 1637
+ID: 115 Len: 8 Enqueue: 1189
+ID: 116 Len: 8 Enqueue: 1559
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1601
+ID: 118 Len: 48 Enqueue: 1523
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 1273
-ID: 121 Len: 8 Enqueue: 1643
+ID: 120 Len: 8 Enqueue: 1195
+ID: 121 Len: 8 Enqueue: 1565
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1613
+ID: 123 Len: 48 Enqueue: 1535
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 1279
-ID: 126 Len: 8 Enqueue: 1111
-ID: 127 Len: 8 Enqueue: 1117
-ID: 128 Len: 8 Enqueue: 1129
+ID: 125 Len: 8 Enqueue: 1201
+ID: 126 Len: 8 Enqueue: 1033
+ID: 127 Len: 8 Enqueue: 1039
+ID: 128 Len: 8 Enqueue: 1051
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -752,66 +731,66 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 1379
+ID: 136 Len: 8 Enqueue: 1301
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 16 Enqueue: 1495
+ID: 140 Len: 16 Enqueue: 1417
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 32 Enqueue: 2014
-ID: 143 Len: 16 Enqueue: 1541
+ID: 142 Len: 32 Enqueue: 1936
+ID: 143 Len: 16 Enqueue: 1463
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 200 Enqueue: 1697
-ID: 146 Len: 192 Enqueue: 1665
-ID: 147 Len: 24 Enqueue: 1746
-ID: 148 Len: 8 Enqueue: 1403
-ID: 149 Len: 200 Enqueue: 1449
-ID: 150 Len: 32 Enqueue: 2025
-ID: 151 Len: 16 Enqueue: 1553
+ID: 145 Len: 200 Enqueue: 1619
+ID: 146 Len: 192 Enqueue: 1587
+ID: 147 Len: 24 Enqueue: 1668
+ID: 148 Len: 8 Enqueue: 1325
+ID: 149 Len: 200 Enqueue: 1371
+ID: 150 Len: 32 Enqueue: 1947
+ID: 151 Len: 16 Enqueue: 1475
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 1708
-ID: 154 Len: 192 Enqueue: 1649
-ID: 155 Len: 24 Enqueue: 1730
-ID: 156 Len: 8 Enqueue: 1183
+ID: 153 Len: 200 Enqueue: 1630
+ID: 154 Len: 192 Enqueue: 1571
+ID: 155 Len: 24 Enqueue: 1652
+ID: 156 Len: 8 Enqueue: 1105
 ID: 157 Len: 184 Enqueue: 0
-ID: 158 Len: 8 Enqueue: 1415
-ID: 159 Len: 200 Enqueue: 1461
-ID: 160 Len: 32 Enqueue: 2036
-ID: 161 Len: 16 Enqueue: 1565
+ID: 158 Len: 8 Enqueue: 1337
+ID: 159 Len: 200 Enqueue: 1383
+ID: 160 Len: 32 Enqueue: 1958
+ID: 161 Len: 16 Enqueue: 1487
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 136 Enqueue: 1719
-ID: 164 Len: 128 Enqueue: 1681
-ID: 165 Len: 16 Enqueue: 1752
-ID: 166 Len: 8 Enqueue: 1625
+ID: 163 Len: 136 Enqueue: 1641
+ID: 164 Len: 128 Enqueue: 1603
+ID: 165 Len: 16 Enqueue: 1674
+ID: 166 Len: 8 Enqueue: 1547
 ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 48 Enqueue: 1577
+ID: 168 Len: 48 Enqueue: 1499
 ID: 169 Len: 8 Enqueue: 0
-ID: 170 Len: 8 Enqueue: 1261
-ID: 171 Len: 8 Enqueue: 1427
-ID: 172 Len: 136 Enqueue: 1473
-ID: 173 Len: 32 Enqueue: 2003
-ID: 174 Len: 16 Enqueue: 1529
+ID: 170 Len: 8 Enqueue: 1183
+ID: 171 Len: 8 Enqueue: 1349
+ID: 172 Len: 136 Enqueue: 1395
+ID: 173 Len: 32 Enqueue: 1925
+ID: 174 Len: 16 Enqueue: 1451
 ID: 175 Len: 8 Enqueue: 0
 ID: 176 Len: 136 Enqueue: 0
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 16 Enqueue: 0
 ID: 179 Len: 8 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 1391
+ID: 180 Len: 8 Enqueue: 1313
 ID: 181 Len: 136 Enqueue: 0
-ID: 182 Len: 8 Enqueue: 1123
+ID: 182 Len: 8 Enqueue: 1045
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 9 Enqueue: 0
 ID: 185 Len: 0 Enqueue: 0
 ID: 186 Len: 17 Enqueue: 0
 ID: 187 Len: 0 Enqueue: 0
 ID: 188 Len: 17 Enqueue: 0
-ID: 189 Len: 17 Enqueue: 0
+ID: 189 Len: 0 Enqueue: 0
 ID: 190 Len: 17 Enqueue: 0
-ID: 191 Len: 17 Enqueue: 0
+ID: 191 Len: 0 Enqueue: 0
 ID: 192 Len: 17 Enqueue: 0
 ID: 193 Len: 0 Enqueue: 0
 ID: 194 Len: 17 Enqueue: 0
-ID: 195 Len: 17 Enqueue: 0
+ID: 195 Len: 0 Enqueue: 0
 ID: 196 Len: 17 Enqueue: 0
 ID: 197 Len: 0 Enqueue: 0
 ID: 198 Len: 25 Enqueue: 0

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -327,15 +327,17 @@ func (s *snapshotMessage) init(
 	s.Debugger.Snapshot.Probe.ID = probe.GetID()
 	s.Debugger.Snapshot.Stack.frames = stackFrames
 
-	s.Message = message{probe: probe}
-	switch probeEvent.event.Kind {
-	case ir.EventKindEntry:
-		s.Message.captureEvent = s.Debugger.Snapshot.Captures.Entry
-	case ir.EventKindLine:
-		s.Message.captureEvent = s.Debugger.Snapshot.Captures.Lines.capture
-	case ir.EventKindReturn:
-		s.Message.captureEvent = s.Debugger.Snapshot.Captures.Return
+	s.Message = message{
+		probe:            probe,
+		captureMap:       make(map[ir.TypeID]*captureEvent),
+		evaluationErrors: &s.Debugger.EvaluationErrors,
 	}
+
+	s.Message.captureMap[decoder.entry.rootType.ID] = &decoder.entry
+	if event.Return != nil {
+		s.Message.captureMap[decoder._return.rootType.ID] = &decoder._return
+	}
+
 	return probe, nil
 }
 

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -326,10 +326,15 @@ func (s *snapshotMessage) init(
 	s.Logger.ThreadID = int(header.Goid)
 	s.Debugger.Snapshot.Probe.ID = probe.GetID()
 	s.Debugger.Snapshot.Stack.frames = stackFrames
-	s.Debugger.Snapshot.Captures.Entry = &decoder.entry
-	s.Message = message{
-		probe:        probe,
-		captureEvent: s.Debugger.Snapshot.Captures.Entry,
+
+	s.Message = message{probe: probe}
+	switch probeEvent.event.Kind {
+	case ir.EventKindEntry:
+		s.Message.captureEvent = s.Debugger.Snapshot.Captures.Entry
+	case ir.EventKindLine:
+		s.Message.captureEvent = s.Debugger.Snapshot.Captures.Lines.capture
+	case ir.EventKindReturn:
+		s.Message.captureEvent = s.Debugger.Snapshot.Captures.Return
 	}
 	return probe, nil
 }

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -218,6 +218,7 @@ type snapshotMessage struct {
 	Debugger  debuggerData     `json:"debugger"`
 	Timestamp int              `json:"timestamp"`
 	Duration  uint64           `json:"duration,omitzero"`
+	Message   message          `json:"message"`
 }
 
 func (s *snapshotMessage) init(
@@ -321,11 +322,15 @@ func (s *snapshotMessage) init(
 			probe.GetID(), where,
 		)
 	}
-
 	s.Logger.Version = probe.GetVersion()
 	s.Logger.ThreadID = int(header.Goid)
 	s.Debugger.Snapshot.Probe.ID = probe.GetID()
 	s.Debugger.Snapshot.Stack.frames = stackFrames
+	s.Debugger.Snapshot.Captures.Entry = &decoder.entry
+	s.Message = message{
+		probe:        probe,
+		captureEvent: s.Debugger.Snapshot.Captures.Entry,
+	}
 	return probe, nil
 }
 

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -238,7 +238,7 @@ func (s *snapshotMessage) init(
 		return nil, fmt.Errorf("entry event is nil")
 	}
 	if err := decoder.entry.init(
-		event.EntryOrLine, decoder.program.Types, &s.Debugger.EvaluationErrors,
+		event.EntryOrLine, ir.EventKindEntry, decoder.program.Types, &s.Debugger.EvaluationErrors,
 	); err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func (s *snapshotMessage) init(
 	var returnHeader *output.EventHeader
 	if event.Return != nil {
 		if err := decoder._return.init(
-			event.Return, decoder.program.Types, &s.Debugger.EvaluationErrors,
+			event.Return, ir.EventKindReturn, decoder.program.Types, &s.Debugger.EvaluationErrors,
 		); err != nil {
 			return nil, fmt.Errorf("error initializing return event: %w", err)
 		}

--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -905,7 +905,7 @@ func TestDecoderWithTemplate(t *testing.T) {
 			require.NoError(t, err)
 			input := tc.eventGenerator(t, irProg)
 			output, _, err := decoder.Decode(Event{
-				Entry:       output.Event(input),
+				EntryOrLine: output.Event(input),
 				ServiceName: "foo"},
 				&noopSymbolicator{},
 				[]byte{},

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -64,12 +64,11 @@ func (m *message) MarshalJSONTo(enc *jsontext.Encoder) error {
 		switch segTyped := seg.(type) {
 		case ir.JSONSegment:
 			// Extract raw value from expression (no JSON encoding)
-			value, err := m.captureEvent.extractExpressionRawValue(segTyped.ExpressionIndex)
+			err := m.captureEvent.extractExpressionRawValue(&sb, segTyped.ExpressionIndex)
 			if err != nil {
 				*m.captureEvent.evaluationErrors = append(*m.captureEvent.evaluationErrors, err.Error())
 				continue
 			}
-			sb.WriteString(value)
 		case ir.StringSegment:
 			if _, err := sb.WriteString(segTyped.Value); err != nil {
 				*m.captureEvent.evaluationErrors = append(*m.captureEvent.evaluationErrors, err.Error())
@@ -249,65 +248,68 @@ func (ce *captureEvent) processExpression(
 }
 
 // extractExpressionRawValue extracts the raw string value of an expression without JSON encoding
-func (ce *captureEvent) extractExpressionRawValue(expressionIndex int) (string, error) {
+func (ce *captureEvent) extractExpressionRawValue(sb *strings.Builder, expressionIndex int) error {
 	if expressionIndex >= len(ce.rootType.Expressions) {
-		return "", fmt.Errorf("expression index %d out of bounds", expressionIndex)
+		return fmt.Errorf("expression index %d out of bounds", expressionIndex)
 	}
 	if ce.skippedIndices.get(expressionIndex) {
-		return "", fmt.Errorf("expression skipped")
+		return fmt.Errorf("expression skipped")
 	}
 	expr := ce.rootType.Expressions[expressionIndex]
 	parameterType := expr.Expression.Type
 	parameterSize := parameterType.GetByteSize()
 	ub := expr.Offset + parameterSize
 	if int(ub) > len(ce.rootData) {
-		return "", fmt.Errorf("could not read parameter data from root data, length mismatch")
+		return fmt.Errorf("could not read parameter data from root data, length mismatch")
 	}
 
 	parameterData := ce.rootData[expr.Offset:ub]
 	presenceBitSet := bitset(ce.rootData[:ce.rootType.PresenceBitsetSize])
 	if !presenceBitSet.get(expressionIndex) && parameterSize != 0 {
-		return "", fmt.Errorf("expression not captured")
+		return fmt.Errorf("expression not captured")
 	}
 
 	// Convert binary data to raw string value based on type
 	decoderType, ok := ce.encodingContext.typesByID[parameterType.GetID()]
 	if !ok {
-		return "", fmt.Errorf("no decoder type found for type %s", parameterType.GetName())
+		return fmt.Errorf("no decoder type found for type %s", parameterType.GetName())
 	}
 
-	return extractRawValue(decoderType, &ce.encodingContext, parameterData)
+	return extractRawValue(sb, decoderType, &ce.encodingContext, parameterData)
 }
 
 // extractRawValue converts binary data to raw string representation
-func extractRawValue(dt decoderType, c *encodingContext, data []byte) (string, error) {
+func extractRawValue(sb *strings.Builder, dt decoderType, c *encodingContext, data []byte) error {
 	switch t := dt.(type) {
 	case *baseType:
-		return extractBaseTypeValue(t, data)
+		return extractBaseTypeValue(sb, t, data)
 	case *goStringHeaderType:
-		return extractStringValue(t, c, data)
+		return extractStringValue(sb, t, c, data)
 	case *pointerType:
-		// For template values, we typically want the pointed-to value
-		return "0x" + strconv.FormatUint(binary.NativeEndian.Uint64(data), 16), nil
+		_, err := sb.WriteString("0x" + strconv.FormatUint(binary.NativeEndian.Uint64(data), 16))
+		return err
 	case *structureType:
 		// Format struct fields as readable string
-		return extractStructureTypeValue(t, c, data)
+		return extractStructureTypeValue(sb, t, c, data)
 	case *arrayType:
 		// Format array elements as readable string
-		return extractArrayTypeValue(t, c, data)
+		return extractArrayTypeValue(sb, t, c, data)
 	case *goSliceHeaderType:
 		// Format slice elements as readable string
-		return extractSliceTypeValue(t, c, data)
+		return extractSliceTypeValue(sb, t, c, data)
 	default:
-		// Fallback: return type name for unsupported types
-		return "<" + dt.irType().GetName() + ">", nil
+		// Fallback: write type name for unsupported types
+		_, err := sb.WriteString("<" + dt.irType().GetName() + ">")
+		return err
 	}
 }
 
-func extractStructureTypeValue(s *structureType, c *encodingContext, data []byte) (string, error) {
-	var fieldParts []string
-
+func extractStructureTypeValue(sb *strings.Builder, s *structureType, c *encodingContext, data []byte) error {
 	structType := s.irType().(*ir.StructureType)
+	_, err := sb.WriteString(fmt.Sprintf("%s{", structType.GetName()))
+	if err != nil {
+		return err
+	}
 	for field := range structType.Fields() {
 		fieldEnd := field.Offset + field.Type.GetByteSize()
 		if fieldEnd > uint32(len(data)) {
@@ -321,31 +323,39 @@ func extractStructureTypeValue(s *structureType, c *encodingContext, data []byte
 		fieldDecoderType, ok := c.typesByID[field.Type.GetID()]
 		if !ok {
 			// Unknown field type - show type name
-			fieldParts = append(fieldParts, fmt.Sprintf("%s = <%s>", field.Name, field.Type.GetName()))
+			_, err = sb.WriteString(fmt.Sprintf("%s = <%s>", field.Name, field.Type.GetName()))
+			if err != nil {
+				return err
+			}
 			continue
 		}
 
 		// Extract the raw value for this field
-		fieldValue, err := extractRawValue(fieldDecoderType, c, fieldData)
+		// Format as "fieldName = value"
+		_, err = sb.WriteString(fmt.Sprintf("%s = ", field.Name))
+		if err != nil {
+			return err
+		}
+		err = extractRawValue(sb, fieldDecoderType, c, fieldData)
 		if err != nil {
 			// Error extracting field - show error
-			fieldParts = append(fieldParts, fmt.Sprintf("%s = <error: %v>", field.Name, err))
+			_, err = sb.WriteString(fmt.Sprintf("%s = <error: %v>", field.Name, err))
+			if err != nil {
+				return err
+			}
 			continue
 		}
 
-		// Format as "fieldName = value"
-		fieldParts = append(fieldParts, fmt.Sprintf("%s = %s", field.Name, fieldValue))
 	}
-
-	if len(fieldParts) == 0 {
-		return fmt.Sprintf("<%s{}>", structType.GetName()), nil
+	_, err = sb.WriteString("}")
+	if err != nil {
+		return err
 	}
-
-	return fmt.Sprintf("%s{%s}", structType.GetName(), strings.Join(fieldParts, ", ")), nil
+	return nil
 }
 
 // extractArrayTypeValue formats array elements as a readable string: "[element1, element2, ...]"
-func extractArrayTypeValue(a *arrayType, c *encodingContext, data []byte) (string, error) {
+func extractArrayTypeValue(sb *strings.Builder, a *arrayType, c *encodingContext, data []byte) error {
 	arrayType := a.irType().(*ir.ArrayType)
 	elementSize := int(arrayType.Element.GetByteSize())
 	numElements := int(arrayType.Count)
@@ -357,10 +367,15 @@ func extractArrayTypeValue(a *arrayType, c *encodingContext, data []byte) (strin
 	}
 
 	// Get the decoder type for array elements
-	var elementParts []string
 	elementDecoderType, ok := c.typesByID[arrayType.Element.GetID()]
 	if !ok {
-		return fmt.Sprintf("[%d]<%s>", arrayType.Count, arrayType.Element.GetName()), nil
+		_, err := sb.WriteString(fmt.Sprintf("[%d]<%s>", arrayType.Count, arrayType.Element.GetName()))
+		return err
+	}
+
+	_, err := sb.WriteString(fmt.Sprintf("[%d]%s{", arrayType.Count, arrayType.Element.GetName()))
+	if err != nil {
+		return err
 	}
 
 	for i := 0; i < numElements; i++ {
@@ -371,35 +386,33 @@ func extractArrayTypeValue(a *arrayType, c *encodingContext, data []byte) (strin
 		}
 
 		elementData := data[offset:endIdx]
-		elementValue, err := extractRawValue(elementDecoderType, c, elementData)
+		err = extractRawValue(sb, elementDecoderType, c, elementData)
 		if err != nil {
-			elementParts = append(elementParts, fmt.Sprintf("<error: %v>", err))
-			continue
+			return err
 		}
-
-		elementParts = append(elementParts, elementValue)
+		if i < numElements-1 {
+			_, err = sb.WriteString(", ")
+			if err != nil {
+				return err
+			}
+		}
 	}
-
-	result := fmt.Sprintf("[%d]%s{%s}", numElements, elementDecoderType.irType().GetName(), strings.Join(elementParts, ", "))
-	if int(arrayType.Count) > maxElementsToShow {
-		result += fmt.Sprintf(" ...(%d more)", arrayType.Count-uint32(maxElementsToShow))
-	}
-
-	return result, nil
+	_, err = sb.WriteString("}")
+	return err
 }
 
 // extractSliceTypeValue formats slice elements as a readable string: "[element1, element2, ...]"
-func extractSliceTypeValue(s *goSliceHeaderType, c *encodingContext, data []byte) (string, error) {
+func extractSliceTypeValue(sb *strings.Builder, s *goSliceHeaderType, c *encodingContext, data []byte) error {
 	sliceType := s.irType().(*ir.GoSliceHeaderType)
 	if len(data) < 16 {
-		return "[]", nil
+		return errors.New("data too short for slice")
 	}
 	// Extract slice header: pointer (8 bytes) + length (8 bytes) + capacity (8 bytes)
 	address := binary.NativeEndian.Uint64(data[0:8])
 	length := binary.NativeEndian.Uint64(data[8:16])
 
 	if address == 0 || length == 0 {
-		return "[]", nil
+		return errors.New("slice address or length is 0")
 	}
 
 	// Get the slice data
@@ -408,12 +421,12 @@ func extractSliceTypeValue(s *goSliceHeaderType, c *encodingContext, data []byte
 		addr:   address,
 	}]
 	if !ok {
-		return fmt.Sprintf("slice[%d]", length), nil
+		return fmt.Errorf("slice data item not found at address %#x with len %d", address, length)
 	}
 
 	sliceData, ok := sliceDataItem.Data()
 	if !ok {
-		return fmt.Sprintf("slice[%d]", length), nil
+		return fmt.Errorf("slice data item marked as failed read")
 	}
 
 	elementSize := int(sliceType.Data.Element.GetByteSize())
@@ -425,158 +438,176 @@ func extractSliceTypeValue(s *goSliceHeaderType, c *encodingContext, data []byte
 		sliceLength = maxElementsToShow
 	}
 
-	var elementParts []string
-
 	// Get the decoder type for slice elements
 	elementDecoderType, ok := c.typesByID[sliceType.Data.Element.GetID()]
 	if !ok {
-		return fmt.Sprintf("slice[%d]<%s>", length, sliceType.Data.Element.GetName()), nil
+		return fmt.Errorf("no decoder type found for slice element type %s", sliceType.Data.Element.GetName())
 	}
 
+	_, err := sb.WriteString(fmt.Sprintf("[]%s{", sliceType.Data.Element.GetName()))
+	if err != nil {
+		return err
+	}
 	elementByteSize := int(sliceType.Data.Element.GetByteSize())
 	for i := 0; i < sliceLength; i++ {
 		elementData := sliceData[i*elementByteSize : (i+1)*elementByteSize]
-		elementValue, err := extractRawValue(elementDecoderType, c, elementData)
+		err := extractRawValue(sb, elementDecoderType, c, elementData)
 		if err != nil {
-			elementParts = append(elementParts, fmt.Sprintf("<error: %v>", err))
-			continue
+			return fmt.Errorf("error extracting raw value for slice element %d: %w", i, err)
 		}
 
-		elementParts = append(elementParts, elementValue)
+		if i < sliceLength-1 {
+			_, err = sb.WriteString(", ")
+			if err != nil {
+				return err
+			}
+		}
 	}
 
-	result := fmt.Sprintf("[]%s{%s}", sliceType.Data.Element.GetName(), strings.Join(elementParts, ", "))
-	if int(length) > maxElementsToShow {
-		result += fmt.Sprintf(" ...(%d more)", length-uint64(maxElementsToShow))
+	_, err = sb.WriteString("}")
+	if err != nil {
+		return err
 	}
 
-	return result, nil
+	return nil
 }
 
 // extractBaseTypeValue converts base type binary data to string
-func extractBaseTypeValue(b *baseType, data []byte) (string, error) {
+func extractBaseTypeValue(sb *strings.Builder, b *baseType, data []byte) error {
 	kind, ok := (*ir.BaseType)(b).GetGoKind()
 	if !ok {
-		return "", fmt.Errorf("no go kind for type %s", (*ir.BaseType)(b).GetName())
+		return fmt.Errorf("no go kind for type %s", (*ir.BaseType)(b).GetName())
 	}
-
+	var err error
 	switch kind {
 	case reflect.Bool:
 		if len(data) < 1 {
-			return "", errors.New("data too short for bool")
+			return errors.New("data too short for bool")
 		}
 		if data[0] == 1 {
-			return "true", nil
+			_, err = sb.WriteString("true")
+			return err
 		}
-		return "false", nil
-
+		_, err = sb.WriteString("false")
+		return err
 	case reflect.Int, reflect.Int64:
 		if len(data) < 8 {
-			return "", errors.New("data too short for int64")
+			return errors.New("data too short for int64")
 		}
 		val := int64(binary.NativeEndian.Uint64(data))
-		return strconv.FormatInt(val, 10), nil
-
+		_, err = sb.WriteString(strconv.FormatInt(val, 10))
+		return err
 	case reflect.Int32:
 		if len(data) < 4 {
-			return "", errors.New("data too short for int32")
+			return errors.New("data too short for int32")
 		}
 		val := int32(binary.NativeEndian.Uint32(data))
-		return strconv.FormatInt(int64(val), 10), nil
+		_, err = sb.WriteString(strconv.FormatInt(int64(val), 10))
+		return err
 
 	case reflect.Int16:
 		if len(data) < 2 {
-			return "", errors.New("data too short for int16")
+			return errors.New("data too short for int16")
 		}
 		val := int16(binary.NativeEndian.Uint16(data))
-		return strconv.FormatInt(int64(val), 10), nil
+		_, err = sb.WriteString(strconv.FormatInt(int64(val), 10))
+		return err
 
 	case reflect.Int8:
 		if len(data) < 1 {
-			return "", errors.New("data too short for int8")
+			return errors.New("data too short for int8")
 		}
 		val := int8(data[0])
-		return strconv.FormatInt(int64(val), 10), nil
+		_, err = sb.WriteString(strconv.FormatInt(int64(val), 10))
+		return err
 
 	case reflect.Uint, reflect.Uint64:
 		if len(data) < 8 {
-			return "", errors.New("data too short for uint64")
+			return errors.New("data too short for uint64")
 		}
 		val := binary.NativeEndian.Uint64(data)
-		return strconv.FormatUint(val, 10), nil
+		_, err = sb.WriteString(strconv.FormatUint(val, 10))
+		return err
 
 	case reflect.Uint32:
 		if len(data) < 4 {
-			return "", errors.New("data too short for uint32")
+			return errors.New("data too short for uint32")
 		}
 		val := binary.NativeEndian.Uint32(data)
-		return strconv.FormatUint(uint64(val), 10), nil
+		_, err = sb.WriteString(strconv.FormatUint(uint64(val), 10))
+		return err
 
 	case reflect.Uint16:
 		if len(data) < 2 {
-			return "", errors.New("data too short for uint16")
+			return errors.New("data too short for uint16")
 		}
 		val := binary.NativeEndian.Uint16(data)
-		return strconv.FormatUint(uint64(val), 10), nil
+		_, err = sb.WriteString(strconv.FormatUint(uint64(val), 10))
+		return err
 
 	case reflect.Uint8:
 		if len(data) < 1 {
-			return "", errors.New("data too short for uint8")
+			return errors.New("data too short for uint8")
 		}
-		return strconv.FormatUint(uint64(data[0]), 10), nil
+		_, err = sb.WriteString(strconv.FormatUint(uint64(data[0]), 10))
+		return err
 
 	case reflect.Float32:
 		if len(data) < 4 {
-			return "", errors.New("data too short for float32")
+			return errors.New("data too short for float32")
 		}
 		bits := binary.NativeEndian.Uint32(data)
 		val := math.Float32frombits(bits)
-		return strconv.FormatFloat(float64(val), 'g', -1, 32), nil
+		_, err = sb.WriteString(strconv.FormatFloat(float64(val), 'g', -1, 32))
+		return err
 
 	case reflect.Float64:
 		if len(data) < 8 {
-			return "", errors.New("data too short for float64")
+			return errors.New("data too short for float64")
 		}
 		bits := binary.NativeEndian.Uint64(data)
 		val := math.Float64frombits(bits)
-		return strconv.FormatFloat(val, 'g', -1, 64), nil
+		_, err = sb.WriteString(strconv.FormatFloat(val, 'g', -1, 64))
+		return err
 
 	case reflect.String:
 		// Go strings are not stored as baseType, this shouldn't happen
-		return string(data), nil
+		_, err = sb.WriteString(string(data))
+		return err
 
 	default:
-		return "", fmt.Errorf("unsupported base type kind: %v", kind)
+		return fmt.Errorf("unsupported base type kind: %v", kind)
 	}
 }
 
 // extractStringValue extracts string value from Go string header
-func extractStringValue(s *goStringHeaderType, c *encodingContext, data []byte) (string, error) {
+func extractStringValue(sb *strings.Builder, s *goStringHeaderType, c *encodingContext, data []byte) error {
 	fieldEnd := s.strFieldOffset + uint32(s.strFieldSize)
 	if fieldEnd >= uint32(len(data)) {
-		return "", nil
+		return nil
 	}
 	strLen := binary.NativeEndian.Uint64(data[s.lenFieldOffset : s.lenFieldOffset+uint32(s.lenFieldSize)])
 	address := binary.NativeEndian.Uint64(data[s.strFieldOffset : s.strFieldOffset+uint32(s.strFieldSize)])
 	if address == 0 || strLen == 0 {
-		return "", nil
+		return nil
 	}
 	stringValue, ok := c.dataItems[typeAndAddr{
 		irType: uint32(s.GoStringHeaderType.Data.GetID()),
 		addr:   address,
 	}]
 	if !ok {
-		return "", nil
+		return nil
 	}
 	stringData, ok := stringValue.Data()
 	if !ok {
-		return "", nil
+		return nil
 	}
 	if len(stringData) < int(strLen) {
-		return "", nil
+		return nil
 	}
 
-	return string(stringData[:strLen]), nil
+	_, err := sb.WriteString(string(stringData[:strLen]))
+	return err
 }
 
 func (ce *captureEvent) MarshalJSONTo(enc *jsontext.Encoder) error {

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -40,7 +40,6 @@ type debuggerData struct {
 
 type message struct {
 	probe            *ir.Probe
-	captureData      *captureData
 	captureMap       map[ir.TypeID]*captureEvent
 	evaluationErrors *[]string
 }
@@ -168,7 +167,7 @@ func (ce *captureEvent) clear() {
 }
 
 func (ce *captureEvent) init(
-	ev output.Event, types map[ir.TypeID]ir.Type, evalErrors *[]string,
+	ev output.Event, kind ir.EventKind, types map[ir.TypeID]ir.Type, evalErrors *[]string,
 ) error {
 	var rootType *ir.EventRootType
 	var rootData []byte
@@ -199,6 +198,7 @@ func (ce *captureEvent) init(
 	ce.rootType = rootType
 	ce.rootData = rootData
 	ce.skippedIndices.reset(len(rootType.Expressions))
+	ce.rootType.EventKind = kind
 	ce.evaluationErrors = evalErrors
 	return nil
 }
@@ -639,7 +639,7 @@ func (ce *captureEvent) MarshalJSONTo(enc *jsontext.Encoder) error {
 		{kind: ir.RootExpressionKindLocal, token: jsontext.String("locals")},
 	} {
 		// We iterate over the 'Expressions' of the EventRoot which contains
-		// metadata and raw bytes of the parameters of this function.
+		// metadata and raw bytes of the variables of this function.
 		var haveKind bool
 		for i, expr := range ce.rootType.Expressions {
 			if expr.Kind != kind.kind {
@@ -669,7 +669,6 @@ func (ce *captureEvent) MarshalJSONTo(enc *jsontext.Encoder) error {
 				return err
 			}
 		}
-
 	}
 	if err := writeTokens(enc, jsontext.EndObject); err != nil {
 		return err

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -278,7 +278,7 @@ func (ce *captureEvent) extractExpressionRawValue(sb *strings.Builder, expressio
 	return extractRawValue(sb, decoderType, &ce.encodingContext, parameterData)
 }
 
-// extractRawValue converts binary data to raw string representation
+// extractRawValue converts binary data to raw string representation and writes it to the builder
 func extractRawValue(sb *strings.Builder, dt decoderType, c *encodingContext, data []byte) error {
 	switch t := dt.(type) {
 	case *baseType:
@@ -332,7 +332,7 @@ func extractStructureTypeValue(sb *strings.Builder, s *structureType, c *encodin
 
 		// Extract the raw value for this field
 		// Format as "fieldName = value"
-		_, err = sb.WriteString(fmt.Sprintf("%s = ", field.Name))
+		_, err = sb.WriteString(fmt.Sprintf(" %s = ", field.Name))
 		if err != nil {
 			return err
 		}
@@ -347,7 +347,7 @@ func extractStructureTypeValue(sb *strings.Builder, s *structureType, c *encodin
 		}
 
 	}
-	_, err = sb.WriteString("}")
+	_, err = sb.WriteString(" }")
 	if err != nil {
 		return err
 	}

--- a/pkg/dyninst/decode/marshal_test.go
+++ b/pkg/dyninst/decode/marshal_test.go
@@ -1,0 +1,489 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package decode
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+)
+
+// mockUnsupportedSegment embeds a JSONSegment but we'll cast it to a different type
+// to test the unsupported segment error path
+type mockUnsupportedSegment struct {
+	ir.JSONSegment
+}
+
+// createMockUnsupportedSegment creates a segment that will trigger the unsupported type error
+func createMockUnsupportedSegment() ir.TemplateSegment {
+	return &mockUnsupportedSegment{
+		JSONSegment: ir.JSONSegment{
+			ExpressionIndex: 0,
+		},
+	}
+}
+
+func TestMessageMarshalJSONToErrorPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupMessage    func() *message
+		expectedErrors  []string
+		shouldWriteJSON bool
+	}{
+		{
+			name: "extractExpressionRawValue_index_out_of_bounds",
+			setupMessage: func() *message {
+				evaluationErrors := make([]string, 0)
+				captureEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						Expressions: make([]*ir.RootExpression, 0), // empty expressions
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{ExpressionIndex: 0}, // index 0 but no expressions
+						},
+					},
+				}
+
+				return &message{
+					probe:        probe,
+					captureEvent: captureEvent,
+				}
+			},
+			expectedErrors:  []string{"expression index 0 out of bounds"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "extractExpressionRawValue_expression_skipped",
+			setupMessage: func() *message {
+				evaluationErrors := make([]string, 0)
+				captureEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:   1,
+											Name: "int",
+										},
+									},
+								},
+								Offset: 0,
+							},
+						},
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+				// Mark expression as skipped
+				captureEvent.skippedIndices.reset(1)
+				captureEvent.skippedIndices.set(0)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{ExpressionIndex: 0},
+						},
+					},
+				}
+
+				return &message{
+					probe:        probe,
+					captureEvent: captureEvent,
+				}
+			},
+			expectedErrors:  []string{"expression skipped"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "extractExpressionRawValue_length_mismatch",
+			setupMessage: func() *message {
+				evaluationErrors := make([]string, 0)
+				captureEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:       1,
+											Name:     "int64",
+											ByteSize: 8,
+										},
+									},
+								},
+								Offset: 10, // offset 10 + size 8 = 18, but rootData is only 5 bytes
+							},
+						},
+					},
+					rootData:         make([]byte, 5), // Not enough data
+					evaluationErrors: &evaluationErrors,
+				}
+				captureEvent.skippedIndices.reset(1)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{ExpressionIndex: 0},
+						},
+					},
+				}
+
+				return &message{
+					probe:        probe,
+					captureEvent: captureEvent,
+				}
+			},
+			expectedErrors:  []string{"could not read parameter data from root data, length mismatch"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "extractExpressionRawValue_expression_not_captured",
+			setupMessage: func() *message {
+				evaluationErrors := make([]string, 0)
+				captureEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:       1,
+											Name:     "int64",
+											ByteSize: 8,
+										},
+									},
+								},
+								Offset: 8,
+							},
+						},
+						PresenceBitsetSize: 1,
+					},
+					rootData:         make([]byte, 16),
+					evaluationErrors: &evaluationErrors,
+				}
+				// Set presence bitset to indicate expression not captured (bit 0 = false)
+				captureEvent.rootData[0] = 0x00
+				captureEvent.skippedIndices.reset(1)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{ExpressionIndex: 0},
+						},
+					},
+				}
+
+				return &message{
+					probe:        probe,
+					captureEvent: captureEvent,
+				}
+			},
+			expectedErrors:  []string{"expression not captured"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "extractExpressionRawValue_no_decoder_type",
+			setupMessage: func() *message {
+				evaluationErrors := make([]string, 0)
+				captureEvent := &captureEvent{
+					encodingContext: encodingContext{
+						typesByID: make(map[ir.TypeID]decoderType), // empty, so type won't be found
+					},
+					rootType: &ir.EventRootType{
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:       999,
+											Name:     "unknown_type",
+											ByteSize: 8,
+										},
+									},
+								},
+								Offset: 8,
+							},
+						},
+						PresenceBitsetSize: 1,
+					},
+					rootData:         make([]byte, 16),
+					evaluationErrors: &evaluationErrors,
+				}
+				// Set presence bitset to indicate expression captured (bit 0 = true)
+				captureEvent.rootData[0] = 0x01
+				captureEvent.skippedIndices.reset(1)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{ExpressionIndex: 0},
+						},
+					},
+				}
+
+				return &message{
+					probe:        probe,
+					captureEvent: captureEvent,
+				}
+			},
+			expectedErrors:  []string{"no decoder type found for type unknown_type"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "string_segment_writestring_error",
+			setupMessage: func() *message {
+				evaluationErrors := make([]string, 0)
+				captureEvent := &captureEvent{
+					evaluationErrors: &evaluationErrors,
+				}
+				// Create a string segment with a normal value since strings.Builder.WriteString rarely fails
+				// We're mainly testing that the error handling path works correctly
+				normalString := "test string value"
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.StringSegment{Value: normalString},
+						},
+					},
+				}
+
+				return &message{
+					probe:        probe,
+					captureEvent: captureEvent,
+				}
+			},
+			expectedErrors:  []string{}, // WriteString unlikely to fail, but test the path
+			shouldWriteJSON: true,
+		},
+		{
+			name: "unsupported_segment_type",
+			setupMessage: func() *message {
+				evaluationErrors := make([]string, 0)
+				captureEvent := &captureEvent{
+					evaluationErrors: &evaluationErrors,
+				}
+
+				// We'll simulate the unsupported segment type error by creating a segment
+				// that satisfies the interface but gets handled as an unexpected type
+				// We'll create this in a helper that returns an interface{} cast to our mock type
+				mockSegment := createMockUnsupportedSegment()
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							mockSegment,
+						},
+					},
+				}
+
+				return &message{
+					probe:        probe,
+					captureEvent: captureEvent,
+				}
+			},
+			expectedErrors:  []string{"unsupported segment type: *decode.mockUnsupportedSegment"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "multiple_errors_mixed",
+			setupMessage: func() *message {
+				evaluationErrors := make([]string, 0)
+				captureEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:       1,
+											Name:     "int64",
+											ByteSize: 8,
+										},
+									},
+								},
+								Offset: 10, // Will cause length mismatch
+							},
+						},
+					},
+					rootData:         make([]byte, 5), // Not enough data
+					evaluationErrors: &evaluationErrors,
+				}
+				captureEvent.skippedIndices.reset(1)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{ExpressionIndex: 0}, // Will fail with length mismatch
+							ir.StringSegment{Value: "test"},    // Should succeed
+							createMockUnsupportedSegment(),     // Will fail with unsupported type
+							ir.JSONSegment{ExpressionIndex: 1}, // Will fail with out of bounds
+						},
+					},
+				}
+
+				return &message{
+					probe:        probe,
+					captureEvent: captureEvent,
+				}
+			},
+			expectedErrors: []string{
+				"could not read parameter data from root data, length mismatch",
+				"unsupported segment type: *decode.mockUnsupportedSegment",
+				"expression index 1 out of bounds",
+			},
+			shouldWriteJSON: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			message := tt.setupMessage()
+
+			var buf strings.Builder
+			enc := jsontext.NewEncoder(&buf)
+
+			err := message.MarshalJSONTo(enc)
+
+			if tt.shouldWriteJSON {
+				// Should not return error - errors are added to evaluationErrors instead
+				assert.NoError(t, err, "MarshalJSONTo should not return error")
+			} else {
+				assert.Error(t, err, "Expected MarshalJSONTo to return error")
+			}
+
+			// Check that expected errors were added to evaluationErrors
+			require.NotNil(t, message.captureEvent.evaluationErrors)
+			actualErrors := *message.captureEvent.evaluationErrors
+
+			assert.Len(t, actualErrors, len(tt.expectedErrors), "Number of evaluation errors should match")
+
+			for i, expectedError := range tt.expectedErrors {
+				if i < len(actualErrors) {
+					assert.Contains(t, actualErrors[i], expectedError, "Error message should contain expected text")
+				}
+			}
+
+			// Verify JSON was written (even with errors)
+			if tt.shouldWriteJSON {
+				jsonOutput := buf.String()
+				assert.NotEmpty(t, jsonOutput, "JSON should be written even with evaluation errors")
+
+				// The MarshalJSONTo method produces a JSON string token
+				// Expected format examples:
+				// - Empty string: "\"\"\n"
+				// - With content: "\"test string value\"\n"
+				assert.True(t, strings.HasPrefix(jsonOutput, `"`), "Should start with quote (JSON string)")
+				assert.True(t, strings.HasSuffix(jsonOutput, "\n"), "Should end with newline")
+
+				// The tests are working correctly - the main goal is to verify that
+				// evaluation errors are properly captured, not the exact JSON format
+			}
+		})
+	}
+}
+
+func TestMessageMarshalJSONToSuccessPath(t *testing.T) {
+	// Test successful marshaling to ensure our error tests don't break valid functionality
+	evaluationErrors := make([]string, 0)
+
+	// Create a working base type decoder
+	irBaseType := ir.BaseType{
+		TypeCommon: ir.TypeCommon{
+			ID:       1,
+			Name:     "int64",
+			ByteSize: 8,
+		},
+		GoTypeAttributes: ir.GoTypeAttributes{
+			GoKind: reflect.Int64,
+		},
+	}
+	baseTypeDecoder := (*baseType)(&irBaseType)
+
+	captureEvent := &captureEvent{
+		encodingContext: encodingContext{
+			typesByID: map[ir.TypeID]decoderType{
+				1: baseTypeDecoder,
+			},
+		},
+		rootType: &ir.EventRootType{
+			Expressions: []*ir.RootExpression{
+				{
+					Name: "arg1",
+					Expression: ir.Expression{
+						Type: &ir.BaseType{
+							TypeCommon: ir.TypeCommon{
+								ID:       1,
+								Name:     "int64",
+								ByteSize: 8,
+							},
+							GoTypeAttributes: ir.GoTypeAttributes{
+								GoKind: reflect.Int64,
+							},
+						},
+					},
+					Offset: 8,
+				},
+			},
+			PresenceBitsetSize: 1,
+		},
+		rootData:         make([]byte, 16),
+		evaluationErrors: &evaluationErrors,
+	}
+	// Set presence bitset to indicate expression captured (bit 0 = true)
+	captureEvent.rootData[0] = 0x01
+	// Set the int64 value at offset 8 (little endian)
+	captureEvent.rootData[8] = 42
+	captureEvent.skippedIndices.reset(1)
+
+	probe := &ir.Probe{
+		Template: &ir.Template{
+			Segments: []ir.TemplateSegment{
+				ir.StringSegment{Value: "Value: "},
+				ir.JSONSegment{ExpressionIndex: 0},
+				ir.StringSegment{Value: " (end)"},
+			},
+		},
+	}
+
+	message := &message{
+		probe:        probe,
+		captureEvent: captureEvent,
+	}
+
+	var buf strings.Builder
+	enc := jsontext.NewEncoder(&buf)
+
+	err := message.MarshalJSONTo(enc)
+	assert.NoError(t, err)
+
+	// Should have no evaluation errors for successful case
+	assert.Empty(t, evaluationErrors)
+
+	jsonOutput := buf.String()
+	assert.NotEmpty(t, jsonOutput)
+
+	// Should contain the template segments
+	// Note: The actual output format depends on extractRawValue implementation
+	assert.Contains(t, jsonOutput, "Value: ")
+	assert.Contains(t, jsonOutput, " (end)")
+}

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -1040,11 +1040,11 @@ func (s *goSliceHeaderType) encodeValueFields(
 		return err
 	}
 
-	elementSize := int(s.Data.Element.GetByteSize())
+	elementSize := int((*ir.GoSliceHeaderType)(s).Data.Element.GetByteSize())
 	var sliceData []byte
 	var sliceLength int
 	if elementSize > 0 {
-		sliceDataItem, ok := c.getPtr(address, s.Data.GetID())
+		sliceDataItem, ok := c.getPtr(address, (*ir.GoSliceHeaderType)(s).Data.GetID())
 		if !ok {
 			return writeTokens(enc,
 				tokenNotCapturedReason,
@@ -1067,9 +1067,9 @@ func (s *goSliceHeaderType) encodeValueFields(
 		jsontext.BeginArray); err != nil {
 		return err
 	}
-	elementByteSize := int(s.Data.Element.GetByteSize())
-	elementName := s.Data.Element.GetName()
-	elementID := s.Data.Element.GetID()
+	elementByteSize := int((*ir.GoSliceHeaderType)(s).Data.Element.GetByteSize())
+	elementName := (*ir.GoSliceHeaderType)(s).Data.Element.GetName()
+	elementID := (*ir.GoSliceHeaderType)(s).Data.Element.GetID()
 	for i := range int(sliceLength) {
 		var elementData []byte
 		if elementSize > 0 {

--- a/pkg/dyninst/ebpf/stack_machine.h
+++ b/pkg/dyninst/ebpf/stack_machine.h
@@ -716,7 +716,7 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
     } else {
       switch (regnum) {
       // We need to switch over the regnum, as DWARF_REGISTER macro for amd64 requires
-      // paramter to be a literal number.
+      // parameter to be a literal number.
       case 0:
         *(volatile uint64_t*)(&sm->value_0) = regs->DWARF_REGISTER(0);
         break;

--- a/pkg/dyninst/exprlang/exprlang.go
+++ b/pkg/dyninst/exprlang/exprlang.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package exprlang provides utilities for parsing and working with expressions
+// in the expression language of the dynamic instrumentation and live debugger products.
+//
+// This package focuses solely on DSL parsing and validation, without any dependencies
+// on IR program structure. The parsed expressions can then be validated against specific
+// IR programs in higher-level packages.
+package exprlang
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// Expr represents an expression in the DSL.
+type Expr interface {
+	expr() // marker method
+}
+
+// RefExpr represents a reference to a variable.
+type RefExpr struct {
+	Ref string
+}
+
+func (re *RefExpr) expr() {}
+
+// UnsupportedExpr represents an expression type that is not yet supported.
+type UnsupportedExpr struct {
+	Instruction string
+	Argument    any
+}
+
+func (ue *UnsupportedExpr) expr() {}
+
+// ParseError represents an error that occurred during DSL parsing.
+type ParseError struct {
+	Message string
+	Cause   error
+}
+
+func (e *ParseError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("parse error: %s: %v", e.Message, e.Cause)
+	}
+	return fmt.Sprintf("parse error: %s", e.Message)
+}
+
+func (e *ParseError) Unwrap() error {
+	return e.Cause
+}
+
+// decoderPool is a sync.Pool for jsontext.Decoder instances to optimize allocations.
+var decoderPool = sync.Pool{
+	New: func() any {
+		return &jsontext.Decoder{}
+	},
+}
+
+// Parse parses a DSL JSON expression into a strongly-typed AST node.
+func Parse(dslJSON []byte) (Expr, error) {
+	if len(dslJSON) == 0 {
+		return nil, &ParseError{Message: "empty DSL expression"}
+	}
+
+	// Get a decoder from the pool and reset it
+	dec := decoderPool.Get().(*jsontext.Decoder)
+	defer decoderPool.Put(dec)
+	dec.Reset(bytes.NewReader(dslJSON))
+
+	// Ensure we have a JSON object
+	objStart, err := dec.ReadToken()
+	if err != nil {
+		return nil, &ParseError{Message: "failed to read token", Cause: err}
+	}
+	if kind := objStart.Kind(); kind != '{' {
+		return nil, &ParseError{Message: fmt.Sprintf("malformed DSL: got token %v (%v), expected {", objStart, kind)}
+	}
+
+	// Read the instruction key
+	key, err := dec.ReadToken()
+	if err != nil {
+		return nil, &ParseError{Message: "failed to read instruction key", Cause: err}
+	}
+	if kind := key.Kind(); kind != '"' {
+		return nil, &ParseError{Message: fmt.Sprintf("malformed DSL: got key token %v (%v), expected string", key, kind)}
+	}
+
+	instruction := key.String()
+	switch instruction {
+	case "ref":
+		return parseRefExpr(dec)
+	default:
+		// Read the argument for unsupported instructions
+		arg, err := dec.ReadToken()
+		if err != nil {
+			return nil, &ParseError{Message: "failed to read argument", Cause: err}
+		}
+
+		// Extract the argument value before reading more tokens
+		var argument any
+		switch arg.Kind() {
+		case '"':
+			argument = arg.String()
+		case 'n':
+			argument = nil
+		case 't', 'f':
+			argument = arg.Bool()
+		case '0':
+			// For numbers in unsupported expressions, store as string
+			argument = arg.String()
+		default:
+			argument = arg.String()
+		}
+
+		// Read the closing brace
+		endObj, err := dec.ReadToken()
+		if err != nil {
+			return nil, &ParseError{Message: "failed to read closing brace", Cause: err}
+		}
+		if kind := endObj.Kind(); kind != '}' {
+			return nil, &ParseError{Message: fmt.Sprintf("malformed DSL: got token %v (%v), expected }", endObj, kind)}
+		}
+
+		return &UnsupportedExpr{
+			Instruction: instruction,
+			Argument:    argument,
+		}, nil
+	}
+}
+
+func parseRefExpr(dec *jsontext.Decoder) (*RefExpr, error) {
+	// Read the value token
+	val, err := dec.ReadToken()
+	if err != nil {
+		return nil, &ParseError{Message: "failed to read ref value", Cause: err}
+	}
+	if kind := val.Kind(); kind != '"' {
+		return nil, &ParseError{Message: fmt.Sprintf("malformed ref: got value token %v (%v), expected string", val, kind)}
+	}
+
+	refValue := val.String()
+	if refValue == "" {
+		return nil, &ParseError{Message: "ref value cannot be empty"}
+	}
+
+	// Read the closing brace
+	endObj, err := dec.ReadToken()
+	if err != nil {
+		return nil, &ParseError{Message: "failed to read closing brace", Cause: err}
+	}
+	if kind := endObj.Kind(); kind != '}' {
+		return nil, &ParseError{Message: fmt.Sprintf("malformed DSL: got token %v (%v), expected }", endObj, kind)}
+	}
+
+	return &RefExpr{Ref: refValue}, nil
+}
+
+// IsSupported returns true if the expression uses only supported DSL features.
+func IsSupported(expr Expr) bool {
+	switch expr.(type) {
+	case *RefExpr:
+		return true
+	case *UnsupportedExpr:
+		return false
+	default:
+		return false
+	}
+}
+
+// CollectVariableReferences extracts all variable names referenced in an expression.
+func CollectVariableReferences(expr Expr) []string {
+	switch e := expr.(type) {
+	case *RefExpr:
+		return []string{e.Ref}
+	case *UnsupportedExpr:
+		// For unsupported expressions, try to extract variable names if possible
+		if e.Instruction == "ref" {
+			if refStr, ok := e.Argument.(string); ok && refStr != "" {
+				return []string{refStr}
+			}
+		}
+		return nil
+	default:
+		return nil
+	}
+}

--- a/pkg/dyninst/exprlang/exprlang_test.go
+++ b/pkg/dyninst/exprlang/exprlang_test.go
@@ -1,0 +1,191 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package exprlang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		wantExpr  Expr
+		wantError bool
+	}{
+		{
+			name:  "valid ref expression",
+			input: `{"ref": "s"}`,
+			wantExpr: &RefExpr{
+				Ref: "s",
+			},
+		},
+		{
+			name:  "valid ref with complex variable name",
+			input: `{"ref": "myVariable123"}`,
+			wantExpr: &RefExpr{
+				Ref: "myVariable123",
+			},
+		},
+		{
+			name:      "empty ref value",
+			input:     `{"ref": ""}`,
+			wantError: true,
+		},
+		{
+			name:  "unsupported instruction with string arg",
+			input: `{"foo": "bar"}`,
+			wantExpr: &UnsupportedExpr{
+				Instruction: "foo",
+				Argument:    "bar",
+			},
+		},
+		{
+			name:  "unsupported instruction with number arg",
+			input: `{"add": 42}`,
+			wantExpr: &UnsupportedExpr{
+				Instruction: "add",
+				Argument:    "42",
+			},
+		},
+		{
+			name:  "unsupported instruction with bool arg",
+			input: `{"enabled": true}`,
+			wantExpr: &UnsupportedExpr{
+				Instruction: "enabled",
+				Argument:    true,
+			},
+		},
+		{
+			name:  "unsupported instruction with null arg",
+			input: `{"value": null}`,
+			wantExpr: &UnsupportedExpr{
+				Instruction: "value",
+				Argument:    nil,
+			},
+		},
+		{
+			name:      "empty expression",
+			input:     `{}`,
+			wantError: true,
+		},
+		{
+			name:      "malformed JSON",
+			input:     `{"ref": "}`,
+			wantError: true,
+		},
+		{
+			name:      "not an object",
+			input:     `"ref"`,
+			wantError: true,
+		},
+		{
+			name:      "empty input",
+			input:     "",
+			wantError: true,
+		},
+		{
+			name:      "ref with non-string value",
+			input:     `{"ref": 123}`,
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := Parse([]byte(tc.input))
+
+			if tc.wantError {
+				require.Error(t, err)
+				require.Nil(t, expr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantExpr, expr)
+			}
+		})
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	testCases := []struct {
+		name          string
+		expr          Expr
+		wantSupported bool
+	}{
+		{
+			name:          "ref expression is supported",
+			expr:          &RefExpr{Ref: "s"},
+			wantSupported: true,
+		},
+		{
+			name:          "unsupported expression",
+			expr:          &UnsupportedExpr{Instruction: "foo", Argument: "bar"},
+			wantSupported: false,
+		},
+		{
+			name:          "nil expression",
+			expr:          nil,
+			wantSupported: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			supported := IsSupported(tc.expr)
+			require.Equal(t, tc.wantSupported, supported)
+		})
+	}
+}
+
+func TestCollectVariableReferences(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expr     Expr
+		wantVars []string
+	}{
+		{
+			name:     "ref expression",
+			expr:     &RefExpr{Ref: "myVar"},
+			wantVars: []string{"myVar"},
+		},
+		{
+			name:     "unsupported ref expression",
+			expr:     &UnsupportedExpr{Instruction: "ref", Argument: "someVar"},
+			wantVars: []string{"someVar"},
+		},
+		{
+			name:     "unsupported ref with empty string",
+			expr:     &UnsupportedExpr{Instruction: "ref", Argument: ""},
+			wantVars: nil,
+		},
+		{
+			name:     "unsupported ref with non-string argument",
+			expr:     &UnsupportedExpr{Instruction: "ref", Argument: 123},
+			wantVars: nil,
+		},
+		{
+			name:     "non-ref unsupported expression",
+			expr:     &UnsupportedExpr{Instruction: "foo", Argument: "bar"},
+			wantVars: nil,
+		},
+		{
+			name:     "nil expression",
+			expr:     nil,
+			wantVars: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vars := CollectVariableReferences(tc.expr)
+			require.Equal(t, tc.wantVars, vars)
+		})
+	}
+}

--- a/pkg/dyninst/ir/probe_definition.go
+++ b/pkg/dyninst/ir/probe_definition.go
@@ -5,7 +5,11 @@
 
 package ir
 
-import "cmp"
+import (
+	"cmp"
+	"encoding/json"
+	"iter"
+)
 
 // ProbeIDer is an interface that allows for comparison of probe definitions.
 type ProbeIDer interface {
@@ -28,6 +32,8 @@ type ProbeDefinition interface {
 	GetCaptureConfig() CaptureConfig
 	// ThrottleConfig returns the throttle configuration of the probe.
 	GetThrottleConfig() ThrottleConfig
+	// GetTemplate returns the template definition of the probe.
+	GetTemplate() TemplateDefinition
 }
 
 // CompareProbeIDs compares two probe definitions by their ID and version.
@@ -41,6 +47,30 @@ func CompareProbeIDs[A, B ProbeIDer](a A, b B) int {
 // Where is a where clause of a probe.
 type Where interface {
 	Where() // marker method
+}
+
+// TemplateDefinition represents the configuration-time template definition
+type TemplateDefinition interface {
+	GetTemplateString() string
+	GetSegments() iter.Seq[TemplateSegmentDefinition]
+}
+
+// TemplateSegmentDefinition represents a configuration-time template segment
+type TemplateSegmentDefinition interface {
+	TemplateSegment() // marker method
+}
+
+// TemplateSegmentString represents a string literal segment in configuration
+type TemplateSegmentString interface {
+	TemplateSegmentDefinition
+	GetString() string
+}
+
+// TemplateSegmentExpression represents an expression segment in configuration
+type TemplateSegmentExpression interface {
+	TemplateSegmentDefinition
+	GetDSL() string
+	GetJSON() json.RawMessage
 }
 
 // FunctionWhere is a where clause of a probe that is a function.

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -161,7 +161,9 @@ type JSONSegment struct {
 	// DSL is the raw expression language segment.
 	DSL string
 	// ExpressionIndex is the index of the root expression that corresponds to this segment.
-	ExpressionIndex int
+	RootTypeExpressionIndicies map[TypeID]int
+	// ExpressionKind is the kind of expression that corresponds to this segment.
+	ExpressionKind EventKind
 }
 
 func (s JSONSegment) templateSegment() {}

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -7,6 +7,8 @@
 
 package ir
 
+import "encoding/json"
+
 // ProgramID is a ID corresponding to an instance of a Program.  It is used to
 // identify messages from this program as they are communicated over the ring
 // buffer.
@@ -127,9 +129,42 @@ type Probe struct {
 	Subprogram *Subprogram
 	// The events that trigger the probe.
 	Events []*Event
-	// TODO: Add template support:
-	//	TemplateSegments []TemplateSegment
+	// Template contains the concrete template structure for this probe
+	Template *Template
 }
+
+// Template represents the concrete template structure for a probe (IR side)
+type Template struct {
+	// TemplateString is the complete template string
+	TemplateString string
+	// Segments are the ordered parts of the template
+	Segments []TemplateSegment
+}
+
+// TemplateSegment represents a concrete part of the template (IR side)
+type TemplateSegment interface {
+	templateSegment() // marker method
+}
+
+// StringSegment is a string literal in the template (IR side)
+type StringSegment struct {
+	Value string
+	Index int
+}
+
+func (s StringSegment) templateSegment() {}
+
+// JSONSegment is an expression segment in the template (IR side)
+type JSONSegment struct {
+	// JSON is the AST of the DSL segment.
+	JSON json.RawMessage
+	// DSL is the raw expression language segment.
+	DSL string
+	// ExpressionIndex is the index of the root expression that corresponds to this segment.
+	ExpressionIndex int
+}
+
+func (s JSONSegment) templateSegment() {}
 
 // Event corresponds to an action that will occur when a PC is hit.
 type Event struct {

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -2424,7 +2424,7 @@ func newProbe(
 	if returnEvent != nil {
 		events = append(events, returnEvent)
 	}
-	segments := make([]ir.TemplateSegment, 0)
+	segments := []ir.TemplateSegment{}
 	probeTemplate := probeCfg.GetTemplate()
 	for seg := range probeTemplate.GetSegments() {
 		if s, ok := seg.(rcjson.TemplateSegment); ok && (s.JSONSegment != nil || s.StringSegment != nil) {
@@ -2435,6 +2435,11 @@ func newProbe(
 				})
 			} else if s.StringSegment != nil {
 				segments = append(segments, ir.StringSegment{Value: string(*s.StringSegment)})
+			} else {
+				return nil, ir.Issue{
+					Kind:    ir.IssueKindInvalidProbeDefinition,
+					Message: fmt.Sprintf("invalid template segment: %T", seg),
+				}, nil
 			}
 		}
 	}
@@ -3185,12 +3190,12 @@ func collectSegmentVariables(msg json.RawMessage, subprogram *ir.Subprogram) ([]
 	if len(varNames) == 0 {
 		return nil, nil
 	}
-	variables := make([]*ir.Variable, 0, len(varNames))
+	variables := []*ir.Variable{}
 	for _, varName := range varNames {
 		// Validate that the referenced variable exists as a parameter in the subprogram
 		varIndex := validateVariableReference(varName, subprogram)
 		if varIndex == -1 {
-			return nil, fmt.Errorf("referenced variable '%s' is not a parameter in the subprogram", varName)
+			return nil, fmt.Errorf("referenced variable '%s' is not in the subprogram", varName)
 		}
 		variables = append(variables, subprogram.Variables[varIndex])
 	}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [{str: test log message}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -6,7 +6,7 @@ Probes:
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -30,7 +30,7 @@ Probes:
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
       template: test log message
-      segments: [{str: test log message}]
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,14 +10,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.stackC]
+          Type: 1314 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd0a46a", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1313 EventRootType Probe[main.stackC]Return
+          Type: 1315 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd0a4a5", Frameless: false}]
           Condition: null
     - id: testAny
@@ -69,14 +69,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1286 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xd08f2e", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1287 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08fe2", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -193,8 +193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -363,9 +364,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1301 EventRootType Probe[main.testEmptySlice]
+          Type: 1303 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd0a000", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -378,9 +379,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1306 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -394,9 +395,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptyString]
+          Type: 1325 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,14 +405,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testEmptyStruct]
+          Type: 1331 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd0a9e0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -423,9 +425,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1332 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd0aa00", Frameless: true}]
           Condition: null
     - id: testError
@@ -611,9 +613,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testInlinedBBB]
+          Type: 1336 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -646,9 +648,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testInlinedBCA]
+          Type: 1337 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -664,9 +666,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1338 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -679,9 +681,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testInlinedBCB]
+          Type: 1339 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -697,9 +699,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1340 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -713,9 +715,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInlinedPrint]
+          Type: 1333 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0460a"
               Frameless: false
@@ -728,9 +730,9 @@ Probes:
             - PC: "0xd0492f"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1334 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -746,9 +748,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1335 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -771,9 +773,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testInlinedSq]
+          Type: 1341 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -789,9 +791,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1340 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1342 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -805,9 +807,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1343 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04b05"
               Frameless: false
@@ -913,14 +915,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1284 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xd08dae", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1285 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08ef3", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -982,8 +984,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -1001,14 +1009,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1290 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xd09253", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1291 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xd09462", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1321,9 +1329,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testMassiveString]
+          Type: 1322 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1337,9 +1345,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testMassiveString]
+          Type: 1323 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
@@ -1351,14 +1359,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1292 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xd094f3", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1293 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xd0972b", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
@@ -1370,14 +1378,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1296 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xd0986e", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1297 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xd09936", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
@@ -1389,14 +1397,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1288 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xd0900e", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1289 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xd0922a", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
@@ -1408,14 +1416,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1250 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1251 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1452,6 +1460,32 @@ Probes:
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd08395", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1248 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd0832a", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1249 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd08395", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1477,9 +1511,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1308 EventRootType Probe[main.testNilSlice]
+          Type: 1310 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1492,9 +1526,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1307 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1507,9 +1541,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1309 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1522,9 +1556,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1321 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd0a540", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1637,14 +1671,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1260 EventRootType Probe[main.testReturnsArray]
+          Type: 1262 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xd0884a", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1261 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1263 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xd088ad", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
@@ -1656,14 +1690,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1264 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xd088ca", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1265 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xd0890b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
@@ -1675,14 +1709,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1266 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xd0892a", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1267 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xd08966", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
@@ -1694,14 +1728,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1270 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xd08a0e", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1271 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xd08a8a", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
@@ -1713,14 +1747,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1282 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xd08d4a", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1283 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xd08d90", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
@@ -1732,14 +1766,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1256 EventRootType Probe[main.testReturnsComplex]
+          Type: 1258 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xd0870a", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1259 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xd08766", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1856,14 +1890,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1260 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xd0878e", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1261 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xd08813", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
@@ -1875,14 +1909,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1256 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xd0860e", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1257 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xd086e5", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
@@ -1894,14 +1928,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1272 EventRootType Probe[main.testReturnsMixed]
+          Type: 1274 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xd08b6a", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1275 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xd08bcc", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
@@ -1913,14 +1947,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1268 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xd0898a", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1269 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xd089d8", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
@@ -1932,14 +1966,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1280 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xd08cca", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1281 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xd08d16", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
@@ -1951,14 +1985,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1278 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xd08c6a", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1279 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xd08cae", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
@@ -1970,14 +2004,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1254 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xd0858a", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1255 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xd085f1", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
@@ -1989,14 +2023,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1276 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xd08bea", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1277 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xd08c4d", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
@@ -2008,14 +2042,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1272 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xd08aae", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1273 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xd08b34", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2113,8 +2147,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2158,8 +2193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2188,14 +2224,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testSingleString]
+          Type: 1316 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd0a4c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2283,9 +2320,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1313 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2298,9 +2335,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1302 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1304 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2327,14 +2364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1252 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd084ae", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1253 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0854e", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
@@ -2346,14 +2383,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1294 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xd097ca", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1295 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xd0983c", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2396,9 +2433,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1306 EventRootType Probe[main.testStringSlice]
+          Type: 1308 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2436,19 +2473,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testStruct]
+          Type: 1329 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd0a860", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1328 EventRootType Probe[main.testStruct]Return
+          Type: 1330 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd0a882", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2461,9 +2499,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1303 EventRootType Probe[main.testStructSlice]
+          Type: 1305 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2490,14 +2528,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1298 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xd0996e", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1299 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xd09a1a", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
@@ -2509,14 +2547,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1327 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd0a720", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1328 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd0a73e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
@@ -2528,9 +2566,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1326 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd0a700", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2558,9 +2596,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testThreeStrings]
+          Type: 1317 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd0a4e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2573,14 +2611,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1318 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd0a500", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1319 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a51e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2593,9 +2631,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1320 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a520", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2693,8 +2731,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +2747,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1300 EventRootType Probe[main.testUintSlice]
+          Type: 1302 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd09fe0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2728,9 +2768,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testUnitializedString]
+          Type: 1324 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2773,9 +2813,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1311 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2788,9 +2828,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1312 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
@@ -2802,14 +2842,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1300 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xd09a4e", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1301 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09acc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3601,7 +3641,7 @@ Subprograms:
               Pieces: []
             - Range: 0xd04ac5..0xd04ac6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 54
       Name: main.testFramelessArray
@@ -3624,7 +3664,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd04b1e..0xd04b23
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 55
       Name: main.testInterface
@@ -3677,7 +3717,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd04e26..0xd04e46
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 57
       Name: main.testError
@@ -3720,7 +3760,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd04ebe..0xd04ed4
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 59
       Name: main.testStructWithAny
@@ -4224,7 +4264,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07c3c..0xd07c52
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result
           Type: 9 BaseType int
@@ -4258,7 +4298,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07cdc..0xd07cf5
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: '&result'
           Type: 93 PointerType *int
@@ -4290,12 +4330,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07dc5..0xd07dde
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0xd07d00..0xd07dde, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: resultInt
           Type: 9 BaseType int
@@ -4348,7 +4388,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd07e26..0xd07e3b
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
@@ -4434,7 +4474,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd07f5a..0xd07f86
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 GoInterfaceType error
@@ -4473,7 +4513,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xd07f5a..0xd07f86
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 9 BaseType int
@@ -4547,7 +4587,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd0816d..0xd08194
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 9 BaseType int
@@ -4618,7 +4658,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd0829c..0xd08305
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: b
           Type: 157 GoInterfaceType main.behavior
@@ -4680,7 +4720,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08396..0xd083af
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
@@ -4703,7 +4743,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08470..0xd08489
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
@@ -4714,7 +4754,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd08470..0xd08489
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
@@ -4739,7 +4779,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd0854f..0xd08568
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
@@ -4750,7 +4790,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd0854f..0xd08568
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
@@ -4761,7 +4801,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd0854f..0xd08568
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 104
       Name: main.testReturnsPrimitives
@@ -4777,7 +4817,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 97 BaseType int16
@@ -4788,7 +4828,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 12 BaseType int32
@@ -4799,7 +4839,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 13 BaseType int64
@@ -4810,7 +4850,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 3 BaseType uint8
@@ -4821,7 +4861,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 7 BaseType uint16
@@ -4832,7 +4872,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 2 BaseType uint32
@@ -4843,7 +4883,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 10 BaseType uint64
@@ -4854,7 +4894,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 105
       Name: main.testReturnsManyFloats
@@ -4864,77 +4904,77 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r9
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r10
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r11
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r12
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r13
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r14
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
@@ -4945,7 +4985,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
             - Range: 0xd086e6..0xd086f5
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
@@ -4956,7 +4996,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xd086e6..0xd086f5
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 106
       Name: main.testReturnsComplex
@@ -4966,12 +5006,12 @@ Subprograms:
         - Name: ~r0
           Type: 89 BaseType complex64
           Locations: [{Range: 0xd08700..0xd08773, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 90 BaseType complex128
           Locations: [{Range: 0xd08700..0xd08773, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 107
       Name: main.testReturnsLargeStruct
@@ -4987,7 +5027,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
             - Range: 0xd08814..0xd08825
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 108
       Name: main.testReturnsArray
@@ -5003,7 +5043,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xd088ae..0xd088ba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 109
       Name: main.testReturnsArrayOne
@@ -5019,7 +5059,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd0890c..0xd08918
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 110
       Name: main.testReturnsArrayZero
@@ -5035,7 +5075,7 @@ Subprograms:
               Pieces: []
             - Range: 0xd08967..0xd08973
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 111
       Name: main.testReturnsMixedStruct
@@ -5045,7 +5085,7 @@ Subprograms:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
           Locations: [{Range: 0xd08980..0xd089e7, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 112
       Name: main.testReturnsBacktrackInt
@@ -5061,7 +5101,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 9 BaseType int
@@ -5072,7 +5112,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
@@ -5083,7 +5123,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 9 BaseType int
@@ -5094,7 +5134,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 9 BaseType int
@@ -5105,7 +5145,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 9 BaseType int
@@ -5116,7 +5156,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 9 BaseType int
@@ -5127,7 +5167,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 9 BaseType int
@@ -5138,7 +5178,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 11 GoStringHeaderType string
@@ -5149,7 +5189,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 113
       Name: main.testReturnsWideStruct
@@ -5165,7 +5205,7 @@ Subprograms:
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
             - Range: 0xd08b35..0xd08b45
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 114
       Name: main.testReturnsMixed
@@ -5181,12 +5221,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08bcd..0xd08bd9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08b60..0xd08bd9, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
@@ -5197,12 +5237,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd08bcd..0xd08bd9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08b60..0xd08bd9, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 11 GoStringHeaderType string
@@ -5217,7 +5257,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xd08bcd..0xd08bd9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 115
       Name: main.testReturnsStructWithArray
@@ -5233,7 +5273,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xd08c4e..0xd08c5a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 116
       Name: main.testReturnsOnlyFloat
@@ -5243,7 +5283,7 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08c60..0xd08cbb, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 117
       Name: main.testReturnsMultipleFloats
@@ -5253,12 +5293,12 @@ Subprograms:
         - Name: ~r0
           Type: 16 BaseType float32
           Locations: [{Range: 0xd08cc0..0xd08d27, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08cc0..0xd08d27, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
@@ -5274,7 +5314,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08d91..0xd08d9d
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 1 BaseType uintptr
@@ -5285,7 +5325,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd08d91..0xd08d9d
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 119
       Name: main.testLargeArgAndReturn
@@ -5308,7 +5348,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
             - Range: 0xd08ef4..0xd08f05
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 120
       Name: main.testArrayArgAndReturn
@@ -5331,7 +5371,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xd08fe3..0xd08ff2
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 121
       Name: main.testMultipleLargeArgs
@@ -5361,7 +5401,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
             - Range: 0xd0922b..0xd0923a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 122
       Name: main.testManyArgsArrayReturn
@@ -5458,7 +5498,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xd09463..0xd094cf
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 123
       Name: main.testMixedArgsStackReturn
@@ -5557,7 +5597,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
             - Range: 0xd0972c..0xd097ac
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 124
       Name: main.testStackArgRegReturns
@@ -5580,7 +5620,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd0983d..0xd0984c
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 9 BaseType int
@@ -5591,7 +5631,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd0983d..0xd0984c
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
@@ -5602,7 +5642,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd0983d..0xd0984c
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 125
       Name: main.testMultipleArrayArgs
@@ -5632,7 +5672,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd09937..0xd0994a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 106 ArrayType [2]int
@@ -5643,7 +5683,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
             - Range: 0xd09937..0xd0994a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 126
       Name: main.testStructWithArrayArg
@@ -5666,7 +5706,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd09a1b..0xd09a2b
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
@@ -5677,7 +5717,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xd09a1b..0xd09a2b
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: x
           Type: 9 BaseType int
@@ -5718,7 +5758,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd09acd..0xd09ae6
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 248 ArrayType [0]int
@@ -5729,7 +5769,7 @@ Subprograms:
               Pieces: []
             - Range: 0xd09acd..0xd09ae6
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 128
       Name: main.testUintSlice
@@ -5982,7 +6022,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd0a4a6..0xd0a4b2
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 140
       Name: main.testSingleString
@@ -9236,10 +9276,10 @@ Types:
       GoKind: 22
       Pointee: 671 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1312
+      ID: 1314
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1313
+      ID: 1315
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9319,7 +9359,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1284
+      ID: 1286
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9335,7 +9375,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1285
+      ID: 1287
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9662,7 +9702,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1304
+      ID: 1306
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9688,7 +9728,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1301
+      ID: 1303
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9704,7 +9744,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1323
+      ID: 1325
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9720,7 +9760,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1332
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9736,7 +9776,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
+      ID: 1331
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9934,7 +9974,7 @@ Types:
       ID: 1182
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1334
+      ID: 1336
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1179
@@ -9966,16 +10006,16 @@ Types:
       ID: 1180
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1337
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1336
+      ID: 1338
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1337
+      ID: 1339
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1338
+      ID: 1340
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1183
@@ -9984,7 +10024,7 @@ Types:
       ID: 1184
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1333
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10000,7 +10040,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1335
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10016,10 +10056,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1334
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1341
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10035,7 +10075,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1342
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10051,7 +10091,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1343
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10163,7 +10203,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1282
+      ID: 1284
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10179,7 +10219,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1283
+      ID: 1285
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10266,7 +10306,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1288
+      ID: 1290
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10362,7 +10402,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1289
+      ID: 1291
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10698,7 +10738,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1322
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10714,7 +10754,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1321
+      ID: 1323
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10730,7 +10770,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1290
+      ID: 1292
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10826,7 +10866,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1291
+      ID: 1293
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10842,7 +10882,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1294
+      ID: 1296
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10868,7 +10908,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1295
+      ID: 1297
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10894,7 +10934,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1286
+      ID: 1288
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10920,7 +10960,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1287
+      ID: 1289
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10936,7 +10976,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1248
+      ID: 1250
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10952,7 +10992,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1251
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11050,7 +11090,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1247
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1249
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11092,7 +11164,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1307
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11118,7 +11190,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1309
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11154,7 +11226,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1310
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11170,7 +11242,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1321
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11318,10 +11390,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1262
+      ID: 1264
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1263
+      ID: 1265
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11337,10 +11409,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1266
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1265
+      ID: 1267
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11356,10 +11428,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1260
+      ID: 1262
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1261
+      ID: 1263
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11375,10 +11447,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1268
+      ID: 1270
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1269
+      ID: 1271
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11474,10 +11546,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1280
+      ID: 1282
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1281
+      ID: 1283
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11503,10 +11575,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1258
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1257
+      ID: 1259
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11702,10 +11774,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1258
+      ID: 1260
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1259
+      ID: 1261
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11721,10 +11793,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1254
+      ID: 1256
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1255
+      ID: 1257
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11900,10 +11972,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1268
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1267
+      ID: 1269
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11919,10 +11991,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1272
+      ID: 1274
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1273
+      ID: 1275
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11978,10 +12050,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1278
+      ID: 1280
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1279
+      ID: 1281
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12007,10 +12079,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1276
+      ID: 1278
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1277
+      ID: 1279
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12026,10 +12098,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1254
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1253
+      ID: 1255
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12115,10 +12187,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1274
+      ID: 1276
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1275
+      ID: 1277
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12134,10 +12206,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1270
+      ID: 1272
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1271
+      ID: 1273
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12329,7 +12401,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1314
+      ID: 1316
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12425,7 +12497,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1313
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12441,7 +12513,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1302
+      ID: 1304
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12473,7 +12545,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1250
+      ID: 1252
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12489,7 +12561,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1251
+      ID: 1253
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12525,7 +12597,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1292
+      ID: 1294
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12541,7 +12613,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1293
+      ID: 1295
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12609,7 +12681,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1308
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12657,7 +12729,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
+      ID: 1305
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12699,7 +12771,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1296
+      ID: 1298
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12715,7 +12787,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1297
+      ID: 1299
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12741,7 +12813,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1325
+      ID: 1327
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12757,10 +12829,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1326
+      ID: 1328
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1324
+      ID: 1326
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12792,7 +12864,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1329
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12808,10 +12880,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1328
+      ID: 1330
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1318
+      ID: 1320
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12827,7 +12899,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1318
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12843,10 +12915,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1317
+      ID: 1319
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1315
+      ID: 1317
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12994,7 +13066,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1300
+      ID: 1302
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13010,7 +13082,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1322
+      ID: 1324
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13058,7 +13130,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1309
+      ID: 1311
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13074,7 +13146,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1310
+      ID: 1312
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13090,7 +13162,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1298
+      ID: 1300
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13116,7 +13188,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1299
+      ID: 1301
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -20168,7 +20240,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1341
+MaxTypeID: 1343
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x175c760", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,14 +10,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1487 EventRootType Probe[main.stackC]
+          Type: 1489 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcdb8aa", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1488 EventRootType Probe[main.stackC]Return
+          Type: 1490 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcdb8e5", Frameless: false}]
           Condition: null
     - id: testAny
@@ -69,14 +69,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1461 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcda36e", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1462 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda422", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -193,8 +193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -363,9 +364,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testEmptySlice]
+          Type: 1478 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdb440", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -378,9 +379,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1481 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -394,9 +395,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptyString]
+          Type: 1500 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,14 +405,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1504 EventRootType Probe[main.testEmptyStruct]
+          Type: 1506 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcdbe20", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -423,9 +425,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1507 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcdbe40", Frameless: true}]
           Condition: null
     - id: testError
@@ -611,9 +613,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1509 EventRootType Probe[main.testInlinedBBB]
+          Type: 1511 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -646,9 +648,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1510 EventRootType Probe[main.testInlinedBCA]
+          Type: 1512 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -664,9 +666,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1513 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -679,9 +681,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1512 EventRootType Probe[main.testInlinedBCB]
+          Type: 1514 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -697,9 +699,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1515 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -713,9 +715,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1506 EventRootType Probe[main.testInlinedPrint]
+          Type: 1508 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd592a"
               Frameless: false
@@ -728,9 +730,9 @@ Probes:
             - PC: "0xcd5c4f"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1509 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -746,9 +748,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1510 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -771,9 +773,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1514 EventRootType Probe[main.testInlinedSq]
+          Type: 1516 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -789,9 +791,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1515 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1517 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -805,9 +807,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1516 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1518 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5e25"
               Frameless: false
@@ -913,14 +915,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1459 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcda1ce", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1460 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda333", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -982,8 +984,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -1001,14 +1009,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1465 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcda693", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1466 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcda8a2", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1321,9 +1329,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMassiveString]
+          Type: 1497 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1337,9 +1345,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1496 EventRootType Probe[main.testMassiveString]
+          Type: 1498 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
@@ -1351,14 +1359,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1467 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcda933", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1468 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdab6b", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
@@ -1370,14 +1378,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1471 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdacae", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1472 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdad7e", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
@@ -1389,14 +1397,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1463 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1464 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcda66a", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
@@ -1408,14 +1416,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1452,6 +1460,32 @@ Probes:
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1423 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd974a", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1424 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1477,9 +1511,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1483 EventRootType Probe[main.testNilSlice]
+          Type: 1485 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1492,9 +1526,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1482 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1507,9 +1541,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1484 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1522,9 +1556,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1496 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdb980", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1637,14 +1671,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsArray]
+          Type: 1437 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcd9c6a", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1438 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcd9ccd", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
@@ -1656,14 +1690,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1439 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcd9cea", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1440 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcd9d2b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
@@ -1675,14 +1709,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1441 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcd9d4a", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1442 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcd9d86", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
@@ -1694,14 +1728,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1445 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcd9e2e", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1446 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcd9eaa", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
@@ -1713,14 +1747,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1457 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcda16a", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1458 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcda1b0", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
@@ -1732,14 +1766,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsComplex]
+          Type: 1433 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcd9b2a", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1434 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1856,14 +1890,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1435 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1436 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcd9c33", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
@@ -1875,14 +1909,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1431 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcd9a2e", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1432 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcd9b07", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
@@ -1894,14 +1928,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsMixed]
+          Type: 1449 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcd9f8a", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1450 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcd9fec", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
@@ -1913,14 +1947,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1443 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcd9daa", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1444 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcd9df8", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
@@ -1932,14 +1966,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1455 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcda0ea", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1456 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcda136", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
@@ -1951,14 +1985,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1453 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcda08a", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1454 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcda0ce", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
@@ -1970,14 +2004,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1429 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcd99aa", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1430 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcd9a11", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
@@ -1989,14 +2023,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1451 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcda00a", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1452 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcda06d", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
@@ -2008,14 +2042,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1447 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcd9ece", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1448 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcd9f54", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2113,8 +2147,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2158,8 +2193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2188,14 +2224,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1489 EventRootType Probe[main.testSingleString]
+          Type: 1491 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdb900", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2283,9 +2320,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1488 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2298,9 +2335,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1477 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1479 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2327,14 +2364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1427 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd98ce", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1428 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd996b", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
@@ -2346,14 +2383,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1469 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdac0a", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1470 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdac7c", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2396,9 +2433,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1481 EventRootType Probe[main.testStringSlice]
+          Type: 1483 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2436,19 +2473,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1502 EventRootType Probe[main.testStruct]
+          Type: 1504 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcdbca0", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1503 EventRootType Probe[main.testStruct]Return
+          Type: 1505 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcdbcc2", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2461,9 +2499,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testStructSlice]
+          Type: 1480 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2490,14 +2528,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1473 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdadae", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1474 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdae5a", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
@@ -2509,14 +2547,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1502 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcdbb60", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1503 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcdbb7e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
@@ -2528,9 +2566,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1501 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcdbb40", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2558,9 +2596,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1490 EventRootType Probe[main.testThreeStrings]
+          Type: 1492 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdb920", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2573,14 +2611,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1493 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdb940", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1494 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdb95e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2593,9 +2631,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1495 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdb960", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2693,8 +2731,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +2747,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1475 EventRootType Probe[main.testUintSlice]
+          Type: 1477 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdb420", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2728,9 +2768,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1497 EventRootType Probe[main.testUnitializedString]
+          Type: 1499 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2773,9 +2813,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1486 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2788,9 +2828,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1487 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
@@ -2802,14 +2842,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1475 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdae8e", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1476 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdaf0c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3601,7 +3641,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcd5de5..0xcd5de6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 54
       Name: main.testFramelessArray
@@ -3624,7 +3664,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd5e3e..0xcd5e43
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 55
       Name: main.testInterface
@@ -3677,7 +3717,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd6146..0xcd6166
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 57
       Name: main.testError
@@ -3720,7 +3760,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd61de..0xcd61f4
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 59
       Name: main.testStructWithAny
@@ -4224,7 +4264,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd907c..0xcd9092
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result
           Type: 7 BaseType int
@@ -4258,7 +4298,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9115..0xcd912f
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: '&result'
           Type: 98 PointerType *int
@@ -4290,12 +4330,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9205..0xcd921e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9140..0xcd921e, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: resultInt
           Type: 7 BaseType int
@@ -4348,7 +4388,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd9266..0xcd927b
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
@@ -4434,7 +4474,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd939a..0xcd93c6
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 13 GoInterfaceType error
@@ -4473,7 +4513,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xcd939a..0xcd93c6
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 7 BaseType int
@@ -4547,7 +4587,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd95ad..0xcd95d4
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 7 BaseType int
@@ -4618,7 +4658,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd96da..0xcd973d
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: b
           Type: 160 GoInterfaceType main.behavior
@@ -4680,7 +4720,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd97b6..0xcd97cf
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
@@ -4703,7 +4743,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9890..0xcd98a9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
@@ -4714,7 +4754,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd9890..0xcd98a9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
@@ -4739,7 +4779,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd996c..0xcd9985
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
@@ -4750,7 +4790,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd996c..0xcd9985
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -4761,7 +4801,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcd996c..0xcd9985
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 104
       Name: main.testReturnsPrimitives
@@ -4777,7 +4817,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 102 BaseType int16
@@ -4788,7 +4828,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 10 BaseType int32
@@ -4799,7 +4839,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 12 BaseType int64
@@ -4810,7 +4850,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 3 BaseType uint8
@@ -4821,7 +4861,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 6 BaseType uint16
@@ -4832,7 +4872,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 2 BaseType uint32
@@ -4843,7 +4883,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 8 BaseType uint64
@@ -4854,7 +4894,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 105
       Name: main.testReturnsManyFloats
@@ -4864,77 +4904,77 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r9
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r10
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r11
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r12
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r13
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r14
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
@@ -4945,7 +4985,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
             - Range: 0xcd9b08..0xcd9b17
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
@@ -4956,7 +4996,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xcd9b08..0xcd9b17
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 106
       Name: main.testReturnsComplex
@@ -4966,12 +5006,12 @@ Subprograms:
         - Name: ~r0
           Type: 94 BaseType complex64
           Locations: [{Range: 0xcd9b20..0xcd9b93, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 95 BaseType complex128
           Locations: [{Range: 0xcd9b20..0xcd9b93, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 107
       Name: main.testReturnsLargeStruct
@@ -4987,7 +5027,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
             - Range: 0xcd9c34..0xcd9c45
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 108
       Name: main.testReturnsArray
@@ -5003,7 +5043,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xcd9cce..0xcd9cda
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 109
       Name: main.testReturnsArrayOne
@@ -5019,7 +5059,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9d2c..0xcd9d38
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 110
       Name: main.testReturnsArrayZero
@@ -5035,7 +5075,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcd9d87..0xcd9d93
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 111
       Name: main.testReturnsMixedStruct
@@ -5045,7 +5085,7 @@ Subprograms:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
           Locations: [{Range: 0xcd9da0..0xcd9e07, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 112
       Name: main.testReturnsBacktrackInt
@@ -5061,7 +5101,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 7 BaseType int
@@ -5072,7 +5112,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5083,7 +5123,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 7 BaseType int
@@ -5094,7 +5134,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 7 BaseType int
@@ -5105,7 +5145,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 7 BaseType int
@@ -5116,7 +5156,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 7 BaseType int
@@ -5127,7 +5167,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 7 BaseType int
@@ -5138,7 +5178,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 9 GoStringHeaderType string
@@ -5149,7 +5189,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 113
       Name: main.testReturnsWideStruct
@@ -5165,7 +5205,7 @@ Subprograms:
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
             - Range: 0xcd9f55..0xcd9f65
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 114
       Name: main.testReturnsMixed
@@ -5181,12 +5221,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9fed..0xcd9ff9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9f80..0xcd9ff9, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5197,12 +5237,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd9fed..0xcd9ff9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9f80..0xcd9ff9, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 9 GoStringHeaderType string
@@ -5217,7 +5257,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xcd9fed..0xcd9ff9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 115
       Name: main.testReturnsStructWithArray
@@ -5233,7 +5273,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xcda06e..0xcda07a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 116
       Name: main.testReturnsOnlyFloat
@@ -5243,7 +5283,7 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float64
           Locations: [{Range: 0xcda080..0xcda0db, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 117
       Name: main.testReturnsMultipleFloats
@@ -5253,12 +5293,12 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float32
           Locations: [{Range: 0xcda0e0..0xcda147, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0xcda0e0..0xcda147, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
@@ -5274,7 +5314,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcda1b1..0xcda1bd
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 1 BaseType uintptr
@@ -5285,7 +5325,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcda1b1..0xcda1bd
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 119
       Name: main.testLargeArgAndReturn
@@ -5308,7 +5348,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
             - Range: 0xcda334..0xcda345
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 120
       Name: main.testArrayArgAndReturn
@@ -5331,7 +5371,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xcda423..0xcda432
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 121
       Name: main.testMultipleLargeArgs
@@ -5361,7 +5401,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
             - Range: 0xcda66b..0xcda67a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 122
       Name: main.testManyArgsArrayReturn
@@ -5458,7 +5498,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xcda8a3..0xcda90f
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 123
       Name: main.testMixedArgsStackReturn
@@ -5557,7 +5597,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
             - Range: 0xcdab6c..0xcdabec
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 124
       Name: main.testStackArgRegReturns
@@ -5580,7 +5620,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdac7d..0xcdac8c
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 7 BaseType int
@@ -5591,7 +5631,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcdac7d..0xcdac8c
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5602,7 +5642,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcdac7d..0xcdac8c
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 125
       Name: main.testMultipleArrayArgs
@@ -5632,7 +5672,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdad7f..0xcdad8e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 111 ArrayType [2]int
@@ -5643,7 +5683,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
             - Range: 0xcdad7f..0xcdad8e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 126
       Name: main.testStructWithArrayArg
@@ -5666,7 +5706,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdae5b..0xcdae6b
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
@@ -5677,7 +5717,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xcdae5b..0xcdae6b
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: x
           Type: 7 BaseType int
@@ -5718,7 +5758,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdaf0d..0xcdaf26
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 251 ArrayType [0]int
@@ -5729,7 +5769,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcdaf0d..0xcdaf26
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 128
       Name: main.testUintSlice
@@ -5982,7 +6022,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcdb8e6..0xcdb8f2
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 140
       Name: main.testSingleString
@@ -9541,10 +9581,10 @@ Types:
       GoKind: 22
       Pointee: 808 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9624,7 +9664,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9640,7 +9680,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9967,7 +10007,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9993,7 +10033,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10009,7 +10049,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10025,7 +10065,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10041,7 +10081,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10239,7 +10279,7 @@ Types:
       ID: 1357
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1354
@@ -10271,16 +10311,16 @@ Types:
       ID: 1355
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1358
@@ -10289,7 +10329,7 @@ Types:
       ID: 1359
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10305,7 +10345,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10321,10 +10361,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10340,7 +10380,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10356,7 +10396,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10468,7 +10508,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10484,7 +10524,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10571,7 +10611,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10667,7 +10707,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11003,7 +11043,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11019,7 +11059,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11035,7 +11075,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11131,7 +11171,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11147,7 +11187,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -11173,7 +11213,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11199,7 +11239,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11225,7 +11265,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11241,7 +11281,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11257,7 +11297,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11355,7 +11395,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1422
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1424
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11397,7 +11469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11423,7 +11495,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11459,7 +11531,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11475,7 +11547,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11623,10 +11695,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1437
+      ID: 1439
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1438
+      ID: 1440
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11642,10 +11714,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1441
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11661,10 +11733,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1435
+      ID: 1437
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1436
+      ID: 1438
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11680,10 +11752,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11779,10 +11851,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1455
+      ID: 1457
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11808,10 +11880,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1432
+      ID: 1434
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12007,10 +12079,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1433
+      ID: 1435
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1434
+      ID: 1436
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12026,10 +12098,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -12205,10 +12277,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12224,10 +12296,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12283,10 +12355,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12312,10 +12384,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12331,10 +12403,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12420,10 +12492,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12439,10 +12511,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12634,7 +12706,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12730,7 +12802,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12746,7 +12818,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12778,7 +12850,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12794,7 +12866,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12830,7 +12902,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12846,7 +12918,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12914,7 +12986,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12962,7 +13034,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13004,7 +13076,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13020,7 +13092,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13046,7 +13118,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13062,10 +13134,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -13097,7 +13169,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -13113,10 +13185,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13132,7 +13204,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13148,10 +13220,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13299,7 +13371,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13315,7 +13387,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13363,7 +13435,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13379,7 +13451,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13395,7 +13467,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13421,7 +13493,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -21928,7 +22000,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1516
+MaxTypeID: 1518
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18003a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,14 +10,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1506 EventRootType Probe[main.stackC]
+          Type: 1508 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xce00ca", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1507 EventRootType Probe[main.stackC]Return
+          Type: 1509 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xce0105", Frameless: false}]
           Condition: null
     - id: testAny
@@ -69,14 +69,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcdebae", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1481 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdec62", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -193,8 +193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -363,9 +364,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          Type: 1497 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -378,9 +379,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1500 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -394,9 +395,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptyString]
+          Type: 1519 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,14 +405,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1523 EventRootType Probe[main.testEmptyStruct]
+          Type: 1525 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xce0640", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -423,9 +425,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1526 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xce0660", Frameless: true}]
           Condition: null
     - id: testError
@@ -611,9 +613,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1528 EventRootType Probe[main.testInlinedBBB]
+          Type: 1530 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -646,9 +648,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1529 EventRootType Probe[main.testInlinedBCA]
+          Type: 1531 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -664,9 +666,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1532 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -679,9 +681,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1531 EventRootType Probe[main.testInlinedBCB]
+          Type: 1533 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -697,9 +699,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1534 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -713,9 +715,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1525 EventRootType Probe[main.testInlinedPrint]
+          Type: 1527 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda20a"
               Frameless: false
@@ -728,9 +730,9 @@ Probes:
             - PC: "0xcda52f"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1528 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -746,9 +748,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1529 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -771,9 +773,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1533 EventRootType Probe[main.testInlinedSq]
+          Type: 1535 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -789,9 +791,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1534 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1536 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -805,9 +807,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1535 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1537 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda705"
               Frameless: false
@@ -913,14 +915,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcdea0e", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1479 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdeb73", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -982,8 +984,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -1001,14 +1009,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcdeed3", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1485 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcdf0e2", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1321,9 +1329,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1514 EventRootType Probe[main.testMassiveString]
+          Type: 1516 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1337,9 +1345,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1515 EventRootType Probe[main.testMassiveString]
+          Type: 1517 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
@@ -1351,14 +1359,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcdf173", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1487 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdf3ab", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
@@ -1370,14 +1378,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdf4ee", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1491 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdf5bf", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
@@ -1389,14 +1397,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcdec8e", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1483 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcdeeaa", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
@@ -1408,14 +1416,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1444 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1445 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1452,6 +1460,32 @@ Probes:
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1442 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcddf8a", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1443 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1477,9 +1511,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
+          Type: 1504 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1492,9 +1526,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1501 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1507,9 +1541,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1503 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1522,9 +1556,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1515 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xce01a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1637,14 +1671,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          Type: 1456 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcde4aa", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1457 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcde50d", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
@@ -1656,14 +1690,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1458 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcde52a", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1459 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcde56b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
@@ -1675,14 +1709,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1460 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcde58a", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1461 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcde5c6", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
@@ -1694,14 +1728,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcde66e", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1465 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcde6ea", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
@@ -1713,14 +1747,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcde9aa", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1477 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcde9f0", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
@@ -1732,14 +1766,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          Type: 1452 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcde36a", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1453 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcde3c6", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1856,14 +1890,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcde3ee", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1455 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcde473", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
@@ -1875,14 +1909,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1450 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcde26e", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1451 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcde347", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
@@ -1894,14 +1928,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          Type: 1468 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcde7ca", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1469 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcde82c", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
@@ -1913,14 +1947,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcde5ea", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1463 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcde638", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
@@ -1932,14 +1966,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcde92a", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1475 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcde976", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
@@ -1951,14 +1985,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcde8ca", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1473 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcde90e", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
@@ -1970,14 +2004,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1448 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcde1ea", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1449 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcde251", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
@@ -1989,14 +2023,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcde84a", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1471 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcde8ad", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
@@ -2008,14 +2042,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1466 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcde70e", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1467 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcde794", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2113,8 +2147,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2158,8 +2193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2188,14 +2224,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1508 EventRootType Probe[main.testSingleString]
+          Type: 1510 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xce0120", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2283,9 +2320,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1507 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2298,9 +2335,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1498 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2327,14 +2364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1446 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcde10e", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1447 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcde1ad", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
@@ -2346,14 +2383,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1488 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdf44a", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1489 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdf4bc", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2396,9 +2433,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
+          Type: 1502 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2436,19 +2473,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1521 EventRootType Probe[main.testStruct]
+          Type: 1523 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xce04c0", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1522 EventRootType Probe[main.testStruct]Return
+          Type: 1524 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xce04e2", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2461,9 +2499,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
+          Type: 1499 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2490,14 +2528,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1492 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdf5ee", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1493 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdf69c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
@@ -2509,14 +2547,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1521 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xce0380", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1522 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xce039e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
@@ -2528,9 +2566,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1520 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xce0360", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2558,9 +2596,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStrings]
+          Type: 1511 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xce0140", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2573,14 +2611,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xce0160", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce017e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2593,9 +2631,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0180", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2693,8 +2731,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +2747,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
+          Type: 1496 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2728,9 +2768,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1516 EventRootType Probe[main.testUnitializedString]
+          Type: 1518 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2773,9 +2813,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2788,9 +2828,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1506 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
@@ -2802,14 +2842,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdf6ce", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1495 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdf74c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3601,7 +3641,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcda6c5..0xcda6c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 54
       Name: main.testFramelessArray
@@ -3624,7 +3664,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcda71e..0xcda723
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 55
       Name: main.testInterface
@@ -3677,7 +3717,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcdaa26..0xcdaa46
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 57
       Name: main.testError
@@ -3720,7 +3760,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcdaabe..0xcdaad4
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 59
       Name: main.testStructWithAny
@@ -4224,7 +4264,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdd8bc..0xcdd8d2
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result
           Type: 7 BaseType int
@@ -4258,7 +4298,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdd955..0xcdd96f
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: '&result'
           Type: 99 PointerType *int
@@ -4290,12 +4330,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdda45..0xcdda5e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 15 BaseType float64
           Locations: [{Range: 0xcdd980..0xcdda5e, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: resultInt
           Type: 7 BaseType int
@@ -4348,7 +4388,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcddaa6..0xcddabb
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
@@ -4434,7 +4474,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcddbda..0xcddc06
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 13 GoInterfaceType error
@@ -4473,7 +4513,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xcddbda..0xcddc06
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 7 BaseType int
@@ -4547,7 +4587,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcdddeb..0xcdde0e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 7 BaseType int
@@ -4618,7 +4658,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcddf0a..0xcddf74
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: b
           Type: 162 GoInterfaceType main.behavior
@@ -4680,7 +4720,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcddff6..0xcde00f
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
@@ -4703,7 +4743,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde0d0..0xcde0e9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
@@ -4714,7 +4754,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde0d0..0xcde0e9
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
@@ -4739,7 +4779,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde1ae..0xcde1c7
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
@@ -4750,7 +4790,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde1ae..0xcde1c7
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -4761,7 +4801,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcde1ae..0xcde1c7
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 104
       Name: main.testReturnsPrimitives
@@ -4777,7 +4817,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 104 BaseType int16
@@ -4788,7 +4828,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 10 BaseType int32
@@ -4799,7 +4839,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 12 BaseType int64
@@ -4810,7 +4850,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 3 BaseType uint8
@@ -4821,7 +4861,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 6 BaseType uint16
@@ -4832,7 +4872,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 2 BaseType uint32
@@ -4843,7 +4883,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 8 BaseType uint64
@@ -4854,7 +4894,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 105
       Name: main.testReturnsManyFloats
@@ -4864,77 +4904,77 @@ Subprograms:
         - Name: ~r0
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r9
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r10
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r11
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r12
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r13
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r14
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
@@ -4945,7 +4985,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
             - Range: 0xcde348..0xcde357
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
@@ -4956,7 +4996,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xcde348..0xcde357
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 106
       Name: main.testReturnsComplex
@@ -4966,12 +5006,12 @@ Subprograms:
         - Name: ~r0
           Type: 96 BaseType complex64
           Locations: [{Range: 0xcde360..0xcde3d3, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 97 BaseType complex128
           Locations: [{Range: 0xcde360..0xcde3d3, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 107
       Name: main.testReturnsLargeStruct
@@ -4987,7 +5027,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
             - Range: 0xcde474..0xcde485
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 108
       Name: main.testReturnsArray
@@ -5003,7 +5043,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xcde50e..0xcde51a
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 109
       Name: main.testReturnsArrayOne
@@ -5019,7 +5059,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde56c..0xcde578
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 110
       Name: main.testReturnsArrayZero
@@ -5035,7 +5075,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcde5c7..0xcde5d3
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 111
       Name: main.testReturnsMixedStruct
@@ -5045,7 +5085,7 @@ Subprograms:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
           Locations: [{Range: 0xcde5e0..0xcde647, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 112
       Name: main.testReturnsBacktrackInt
@@ -5061,7 +5101,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 7 BaseType int
@@ -5072,7 +5112,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5083,7 +5123,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 7 BaseType int
@@ -5094,7 +5134,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 7 BaseType int
@@ -5105,7 +5145,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 7 BaseType int
@@ -5116,7 +5156,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 7 BaseType int
@@ -5127,7 +5167,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 7 BaseType int
@@ -5138,7 +5178,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 9 GoStringHeaderType string
@@ -5149,7 +5189,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 113
       Name: main.testReturnsWideStruct
@@ -5165,7 +5205,7 @@ Subprograms:
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
             - Range: 0xcde795..0xcde7a5
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 114
       Name: main.testReturnsMixed
@@ -5181,12 +5221,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde82d..0xcde839
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde7c0..0xcde839, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5197,12 +5237,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde82d..0xcde839
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde7c0..0xcde839, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 9 GoStringHeaderType string
@@ -5217,7 +5257,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xcde82d..0xcde839
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 115
       Name: main.testReturnsStructWithArray
@@ -5233,7 +5273,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xcde8ae..0xcde8ba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 116
       Name: main.testReturnsOnlyFloat
@@ -5243,7 +5283,7 @@ Subprograms:
         - Name: ~r0
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde8c0..0xcde91b, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 117
       Name: main.testReturnsMultipleFloats
@@ -5253,12 +5293,12 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float32
           Locations: [{Range: 0xcde920..0xcde987, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde920..0xcde987, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
@@ -5274,7 +5314,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde9f1..0xcde9fd
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 1 BaseType uintptr
@@ -5285,7 +5325,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde9f1..0xcde9fd
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 119
       Name: main.testLargeArgAndReturn
@@ -5308,7 +5348,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
             - Range: 0xcdeb74..0xcdeb85
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 120
       Name: main.testArrayArgAndReturn
@@ -5331,7 +5371,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xcdec63..0xcdec72
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 121
       Name: main.testMultipleLargeArgs
@@ -5361,7 +5401,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
             - Range: 0xcdeeab..0xcdeeba
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 122
       Name: main.testManyArgsArrayReturn
@@ -5458,7 +5498,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xcdf0e3..0xcdf14f
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 123
       Name: main.testMixedArgsStackReturn
@@ -5557,7 +5597,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
             - Range: 0xcdf3ac..0xcdf42c
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 124
       Name: main.testStackArgRegReturns
@@ -5580,7 +5620,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf4bd..0xcdf4cc
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 7 BaseType int
@@ -5591,7 +5631,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcdf4bd..0xcdf4cc
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5602,7 +5642,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcdf4bd..0xcdf4cc
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 125
       Name: main.testMultipleArrayArgs
@@ -5632,7 +5672,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf5c0..0xcdf5cf
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 113 ArrayType [2]int
@@ -5643,7 +5683,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
             - Range: 0xcdf5c0..0xcdf5cf
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 126
       Name: main.testStructWithArrayArg
@@ -5666,7 +5706,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf69d..0xcdf6ac
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
@@ -5677,7 +5717,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xcdf69d..0xcdf6ac
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: x
           Type: 7 BaseType int
@@ -5718,7 +5758,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf74d..0xcdf766
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 253 ArrayType [0]int
@@ -5729,7 +5769,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcdf74d..0xcdf766
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 128
       Name: main.testUintSlice
@@ -5982,7 +6022,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xce0106..0xce0112
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 140
       Name: main.testSingleString
@@ -9608,10 +9648,10 @@ Types:
       GoKind: 22
       Pointee: 821 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9691,7 +9731,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9707,7 +9747,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10034,7 +10074,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10060,7 +10100,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10076,7 +10116,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10092,7 +10132,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10108,7 +10148,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10306,7 +10346,7 @@ Types:
       ID: 1376
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1373
@@ -10338,16 +10378,16 @@ Types:
       ID: 1374
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1377
@@ -10356,7 +10396,7 @@ Types:
       ID: 1378
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10372,7 +10412,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10388,10 +10428,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10407,7 +10447,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10423,7 +10463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10535,7 +10575,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10551,7 +10591,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10638,7 +10678,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10734,7 +10774,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11070,7 +11110,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11086,7 +11126,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11102,7 +11142,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11198,7 +11238,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11214,7 +11254,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -11240,7 +11280,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11266,7 +11306,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11292,7 +11332,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11308,7 +11348,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11324,7 +11364,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11422,7 +11462,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1441
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1443
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11464,7 +11536,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11490,7 +11562,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11526,7 +11598,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11542,7 +11614,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11690,10 +11762,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11709,10 +11781,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11728,10 +11800,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1457
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11747,10 +11819,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11846,10 +11918,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11875,10 +11947,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12074,10 +12146,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12093,10 +12165,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -12272,10 +12344,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12291,10 +12363,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12350,10 +12422,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12379,10 +12451,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12398,10 +12470,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12487,10 +12559,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12506,10 +12578,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12701,7 +12773,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12797,7 +12869,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12813,7 +12885,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12845,7 +12917,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12861,7 +12933,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12897,7 +12969,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12913,7 +12985,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12981,7 +13053,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13029,7 +13101,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13071,7 +13143,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13087,7 +13159,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13113,7 +13185,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13129,10 +13201,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -13164,7 +13236,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -13180,10 +13252,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13199,7 +13271,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13215,10 +13287,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13366,7 +13438,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13382,7 +13454,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13430,7 +13502,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13446,7 +13518,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13462,7 +13534,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13488,7 +13560,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -22155,7 +22227,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1535
+MaxTypeID: 1537
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,14 +10,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.stackC]
+          Type: 1314 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x892858", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1313 EventRootType Probe[main.stackC]Return
+          Type: 1315 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x89288c", Frameless: false}]
           Condition: null
     - id: testAny
@@ -69,14 +69,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1286 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x89160c", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1287 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x8916a4", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -193,8 +193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -363,9 +364,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1301 EventRootType Probe[main.testEmptySlice]
+          Type: 1303 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x8924d0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -378,9 +379,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1306 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x892500", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -394,9 +395,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptyString]
+          Type: 1325 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x892930", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,14 +405,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testEmptyStruct]
+          Type: 1331 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x892c80", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -423,9 +425,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1332 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x892c90", Frameless: true}]
           Condition: null
     - id: testError
@@ -611,9 +613,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testInlinedBBB]
+          Type: 1336 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d878", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -646,9 +648,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testInlinedBCA]
+          Type: 1337 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -664,9 +666,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1338 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -679,9 +681,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testInlinedBCB]
+          Type: 1339 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -697,9 +699,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1340 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -713,9 +715,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInlinedPrint]
+          Type: 1333 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -728,9 +730,9 @@ Probes:
             - PC: "0x88d8fc"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1334 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d630", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -746,9 +748,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1335 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -771,9 +773,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testInlinedSq]
+          Type: 1341 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -789,9 +791,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1340 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1342 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -805,9 +807,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1343 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88dab4"
               Frameless: false
@@ -913,14 +915,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1284 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x891430", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1285 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x891588", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -982,8 +984,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -1001,14 +1009,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1290 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x89193c", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1291 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x891aac", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1321,9 +1329,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testMassiveString]
+          Type: 1322 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1337,9 +1345,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testMassiveString]
+          Type: 1323 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
@@ -1351,14 +1359,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1292 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x891b30", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1293 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x891ce0", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
@@ -1370,14 +1378,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1296 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x891e0c", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1297 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x891eb0", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
@@ -1389,14 +1397,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1288 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x8916e0", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1289 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x8918b0", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
@@ -1408,14 +1416,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1250 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1251 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1452,6 +1460,32 @@ Probes:
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1248 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x890958", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1249 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1477,9 +1511,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1308 EventRootType Probe[main.testNilSlice]
+          Type: 1310 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1492,9 +1526,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1307 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x892510", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1507,9 +1541,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1309 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1522,9 +1556,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1321 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x892900", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1637,14 +1671,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1260 EventRootType Probe[main.testReturnsArray]
+          Type: 1262 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x890e3c", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1261 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1263 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x890e90", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
@@ -1656,14 +1690,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1264 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x890ec8", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1265 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x890f04", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
@@ -1675,14 +1709,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1266 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x890f38", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1267 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x890f70", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
@@ -1694,14 +1728,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1270 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x891028", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1271 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x89108c", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
@@ -1713,14 +1747,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1282 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x8913b8", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1283 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x8913f8", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
@@ -1732,14 +1766,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1256 EventRootType Probe[main.testReturnsComplex]
+          Type: 1258 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x890ce8", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1259 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x890d34", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1856,14 +1890,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1260 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x890d70", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1261 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x890e04", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
@@ -1875,14 +1909,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1256 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x890c28", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1257 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x890cac", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
@@ -1894,14 +1928,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1272 EventRootType Probe[main.testReturnsMixed]
+          Type: 1274 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x8911a8", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1275 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x891200", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
@@ -1913,14 +1947,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1268 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x890fa8", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1269 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x890ff0", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
@@ -1932,14 +1966,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1280 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x891338", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1281 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x89137c", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
@@ -1951,14 +1985,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1278 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x8912c8", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1279 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x891308", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
@@ -1970,14 +2004,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1254 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x890b98", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1255 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x890bf0", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
@@ -1989,14 +2023,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1276 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x89123c", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1277 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x891290", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
@@ -2008,14 +2042,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1272 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x8910d0", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1273 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x891174", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2113,8 +2147,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2158,8 +2193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2188,14 +2224,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testSingleString]
+          Type: 1316 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x8928b0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2283,9 +2320,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1313 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2298,9 +2335,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1302 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1304 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x8924e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2327,14 +2364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1252 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x890ac8", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1253 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890b54", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
@@ -2346,14 +2383,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1294 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x891d68", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1295 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2396,9 +2433,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1306 EventRootType Probe[main.testStringSlice]
+          Type: 1308 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2436,19 +2473,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testStruct]
+          Type: 1329 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x892b80", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1328 EventRootType Probe[main.testStruct]Return
+          Type: 1330 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x892b9c", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2461,9 +2499,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1303 EventRootType Probe[main.testStructSlice]
+          Type: 1305 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x8924f0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2490,14 +2528,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1298 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x891eec", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1299 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x891f7c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
@@ -2509,14 +2547,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1327 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x892a90", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1328 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x892aa8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
@@ -2528,9 +2566,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1326 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x892a80", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2558,9 +2596,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testThreeStrings]
+          Type: 1317 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x8928c0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2573,14 +2611,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1318 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x8928d0", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1319 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x8928e8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2593,9 +2631,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1320 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8928f0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2693,8 +2731,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +2747,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1300 EventRootType Probe[main.testUintSlice]
+          Type: 1302 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x8924c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2728,9 +2768,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testUnitializedString]
+          Type: 1324 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x892920", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2773,9 +2813,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1311 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2788,9 +2828,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1312 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
@@ -2802,14 +2842,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1300 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x891fb8", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1301 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x892024", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3603,7 +3643,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x88da89..0x88da90
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 54
       Name: main.testFramelessArray
@@ -3626,7 +3666,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x88dad9..0x88daf0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 55
       Name: main.testInterface
@@ -3679,7 +3719,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x88dd85..0x88ddb0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 57
       Name: main.testError
@@ -3722,7 +3762,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x88de05..0x88de30
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 59
       Name: main.testStructWithAny
@@ -4226,7 +4266,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x89023d..0x890260
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result
           Type: 9 BaseType int
@@ -4260,7 +4300,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8902dd..0x890300
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: '&result'
           Type: 94 PointerType *int
@@ -4292,12 +4332,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8903b1..0x8903d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0x890300..0x8903d0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: resultInt
           Type: 9 BaseType int
@@ -4350,7 +4390,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x89042d..0x890450
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
@@ -4436,7 +4476,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x8905a1..0x8905d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 GoInterfaceType error
@@ -4475,7 +4515,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x8905a1..0x8905d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 9 BaseType int
@@ -4549,7 +4589,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x8907a9..0x8907d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 9 BaseType int
@@ -4620,7 +4660,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x8908cd..0x890940
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: b
           Type: 157 GoInterfaceType main.behavior
@@ -4682,7 +4722,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8909b9..0x8909e0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
@@ -4705,7 +4745,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890a85..0x890ab0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
@@ -4716,7 +4756,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x890a85..0x890ab0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
@@ -4741,7 +4781,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890b55..0x890b80
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
@@ -4752,7 +4792,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x890b55..0x890b80
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
@@ -4763,7 +4803,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x890b55..0x890b80
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 104
       Name: main.testReturnsPrimitives
@@ -4779,7 +4819,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 89 BaseType int16
@@ -4790,7 +4830,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 13 BaseType int32
@@ -4801,7 +4841,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 14 BaseType int64
@@ -4812,7 +4852,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 3 BaseType uint8
@@ -4823,7 +4863,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 7 BaseType uint16
@@ -4834,7 +4874,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 2 BaseType uint32
@@ -4845,7 +4885,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 10 BaseType uint64
@@ -4856,7 +4896,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 105
       Name: main.testReturnsManyFloats
@@ -4866,82 +4906,82 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r9
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r10
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r11
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r12
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r13
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r14
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
@@ -4952,7 +4992,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0x890cad..0x890cd0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 106
       Name: main.testReturnsComplex
@@ -4962,12 +5002,12 @@ Subprograms:
         - Name: ~r0
           Type: 90 BaseType complex64
           Locations: [{Range: 0x890cd0..0x890d50, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 91 BaseType complex128
           Locations: [{Range: 0x890cd0..0x890d50, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 107
       Name: main.testReturnsLargeStruct
@@ -5003,7 +5043,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x890e05..0x890e20
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 108
       Name: main.testReturnsArray
@@ -5019,7 +5059,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x890e91..0x890eb0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 109
       Name: main.testReturnsArrayOne
@@ -5035,7 +5075,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890f05..0x890f20
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 110
       Name: main.testReturnsArrayZero
@@ -5051,7 +5091,7 @@ Subprograms:
               Pieces: []
             - Range: 0x890f71..0x890f90
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 111
       Name: main.testReturnsMixedStruct
@@ -5061,7 +5101,7 @@ Subprograms:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
           Locations: [{Range: 0x890f90..0x891010, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 112
       Name: main.testReturnsBacktrackInt
@@ -5077,7 +5117,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 9 BaseType int
@@ -5088,7 +5128,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
@@ -5099,7 +5139,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 9 BaseType int
@@ -5110,7 +5150,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 9 BaseType int
@@ -5121,7 +5161,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 9 BaseType int
@@ -5132,7 +5172,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 9 BaseType int
@@ -5143,7 +5183,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 9 BaseType int
@@ -5154,7 +5194,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 11 GoStringHeaderType string
@@ -5169,7 +5209,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 113
       Name: main.testReturnsWideStruct
@@ -5207,7 +5247,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
             - Range: 0x891175..0x891190
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 114
       Name: main.testReturnsMixed
@@ -5223,12 +5263,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891201..0x891220
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0x891190..0x891220, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
@@ -5239,12 +5279,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x891201..0x891220
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 17 BaseType float64
           Locations: [{Range: 0x891190..0x891220, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 11 GoStringHeaderType string
@@ -5259,7 +5299,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x891201..0x891220
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 115
       Name: main.testReturnsStructWithArray
@@ -5275,7 +5315,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x891291..0x8912b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 116
       Name: main.testReturnsOnlyFloat
@@ -5285,7 +5325,7 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float64
           Locations: [{Range: 0x8912b0..0x891320, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 117
       Name: main.testReturnsMultipleFloats
@@ -5295,12 +5335,12 @@ Subprograms:
         - Name: ~r0
           Type: 16 BaseType float32
           Locations: [{Range: 0x891320..0x8913a0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0x891320..0x8913a0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
@@ -5316,7 +5356,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8913f9..0x891410
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 1 BaseType uintptr
@@ -5327,7 +5367,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x8913f9..0x891410
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 119
       Name: main.testLargeArgAndReturn
@@ -5434,7 +5474,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x891589..0x8915f0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 120
       Name: main.testArrayArgAndReturn
@@ -5457,7 +5497,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x8916a5..0x8916c0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 121
       Name: main.testMultipleLargeArgs
@@ -5571,7 +5611,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x8918b1..0x891920
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 122
       Name: main.testManyArgsArrayReturn
@@ -5668,7 +5708,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
             - Range: 0x891aad..0x891b10
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 123
       Name: main.testMixedArgsStackReturn
@@ -5793,7 +5833,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x891ce1..0x891d50
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 124
       Name: main.testStackArgRegReturns
@@ -5816,7 +5856,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891dcd..0x891df0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 9 BaseType int
@@ -5827,7 +5867,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x891dcd..0x891df0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
@@ -5838,7 +5878,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x891dcd..0x891df0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 125
       Name: main.testMultipleArrayArgs
@@ -5868,7 +5908,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891eb1..0x891ed0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 106 ArrayType [2]int
@@ -5879,7 +5919,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
             - Range: 0x891eb1..0x891ed0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 126
       Name: main.testStructWithArrayArg
@@ -5902,7 +5942,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891f7d..0x891fa0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
@@ -5913,7 +5953,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x891f7d..0x891fa0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: x
           Type: 9 BaseType int
@@ -5954,7 +5994,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x892025..0x892050
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 248 ArrayType [0]int
@@ -5965,7 +6005,7 @@ Subprograms:
               Pieces: []
             - Range: 0x892025..0x892050
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 128
       Name: main.testUintSlice
@@ -6218,7 +6258,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x89288d..0x8928b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 140
       Name: main.testSingleString
@@ -9472,10 +9512,10 @@ Types:
       GoKind: 22
       Pointee: 671 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1312
+      ID: 1314
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1313
+      ID: 1315
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9555,7 +9595,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1284
+      ID: 1286
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9571,7 +9611,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1285
+      ID: 1287
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9898,7 +9938,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1304
+      ID: 1306
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9924,7 +9964,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1301
+      ID: 1303
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9940,7 +9980,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1323
+      ID: 1325
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9956,7 +9996,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1332
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9972,7 +10012,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
+      ID: 1331
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10170,7 +10210,7 @@ Types:
       ID: 1182
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1334
+      ID: 1336
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1179
@@ -10202,16 +10242,16 @@ Types:
       ID: 1180
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1337
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1336
+      ID: 1338
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1337
+      ID: 1339
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1338
+      ID: 1340
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1183
@@ -10220,7 +10260,7 @@ Types:
       ID: 1184
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1333
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10236,7 +10276,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1335
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10252,10 +10292,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1334
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1341
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10271,7 +10311,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1342
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10287,7 +10327,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1343
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10399,7 +10439,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1282
+      ID: 1284
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10415,7 +10455,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1283
+      ID: 1285
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10502,7 +10542,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1288
+      ID: 1290
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10598,7 +10638,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1289
+      ID: 1291
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10934,7 +10974,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1322
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10950,7 +10990,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1321
+      ID: 1323
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10966,7 +11006,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1290
+      ID: 1292
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11062,7 +11102,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1291
+      ID: 1293
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11078,7 +11118,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1294
+      ID: 1296
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -11104,7 +11144,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1295
+      ID: 1297
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11130,7 +11170,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1286
+      ID: 1288
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11156,7 +11196,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1287
+      ID: 1289
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11172,7 +11212,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1248
+      ID: 1250
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11188,7 +11228,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1251
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11286,7 +11326,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1247
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1249
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11328,7 +11400,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1307
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11354,7 +11426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1309
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11390,7 +11462,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1310
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11406,7 +11478,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1321
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11554,10 +11626,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1262
+      ID: 1264
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1263
+      ID: 1265
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11573,10 +11645,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1266
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1265
+      ID: 1267
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11592,10 +11664,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1260
+      ID: 1262
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1261
+      ID: 1263
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11611,10 +11683,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1268
+      ID: 1270
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1269
+      ID: 1271
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11710,10 +11782,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1280
+      ID: 1282
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1281
+      ID: 1283
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11739,10 +11811,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1258
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1257
+      ID: 1259
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11938,10 +12010,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1258
+      ID: 1260
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1259
+      ID: 1261
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11957,10 +12029,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1254
+      ID: 1256
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1255
+      ID: 1257
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -12136,10 +12208,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1268
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1267
+      ID: 1269
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12155,10 +12227,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1272
+      ID: 1274
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1273
+      ID: 1275
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12214,10 +12286,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1278
+      ID: 1280
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1279
+      ID: 1281
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12243,10 +12315,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1276
+      ID: 1278
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1277
+      ID: 1279
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12262,10 +12334,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1254
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1253
+      ID: 1255
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12351,10 +12423,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1274
+      ID: 1276
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1275
+      ID: 1277
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12370,10 +12442,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1270
+      ID: 1272
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1271
+      ID: 1273
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12565,7 +12637,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1314
+      ID: 1316
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12661,7 +12733,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1313
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12677,7 +12749,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1302
+      ID: 1304
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12709,7 +12781,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1250
+      ID: 1252
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12725,7 +12797,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1251
+      ID: 1253
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12761,7 +12833,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1292
+      ID: 1294
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12777,7 +12849,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1293
+      ID: 1295
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12845,7 +12917,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1308
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12893,7 +12965,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
+      ID: 1305
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12935,7 +13007,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1296
+      ID: 1298
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12951,7 +13023,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1297
+      ID: 1299
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12977,7 +13049,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1325
+      ID: 1327
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12993,10 +13065,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1326
+      ID: 1328
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1324
+      ID: 1326
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -13028,7 +13100,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1329
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -13044,10 +13116,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1328
+      ID: 1330
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1318
+      ID: 1320
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13063,7 +13135,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1318
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13079,10 +13151,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1317
+      ID: 1319
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1315
+      ID: 1317
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13230,7 +13302,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1300
+      ID: 1302
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13246,7 +13318,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1322
+      ID: 1324
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13294,7 +13366,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1309
+      ID: 1311
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13310,7 +13382,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1310
+      ID: 1312
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13326,7 +13398,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1298
+      ID: 1300
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13352,7 +13424,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1299
+      ID: 1301
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -20404,7 +20476,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1341
+MaxTypeID: 1343
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,14 +10,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1487 EventRootType Probe[main.stackC]
+          Type: 1489 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84fe58", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1488 EventRootType Probe[main.stackC]Return
+          Type: 1490 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84fe8c", Frameless: false}]
           Condition: null
     - id: testAny
@@ -69,14 +69,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1461 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x84ecac", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1462 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ed44", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -193,8 +193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -363,9 +364,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testEmptySlice]
+          Type: 1478 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84fad0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -378,9 +379,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1481 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84fb00", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -394,9 +395,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptyString]
+          Type: 1500 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ff30", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,14 +405,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1504 EventRootType Probe[main.testEmptyStruct]
+          Type: 1506 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x850280", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -423,9 +425,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1507 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x850290", Frameless: true}]
           Condition: null
     - id: testError
@@ -611,9 +613,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1509 EventRootType Probe[main.testInlinedBBB]
+          Type: 1511 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -646,9 +648,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1510 EventRootType Probe[main.testInlinedBCA]
+          Type: 1512 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -664,9 +666,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1513 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -679,9 +681,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1512 EventRootType Probe[main.testInlinedBCB]
+          Type: 1514 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -697,9 +699,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1515 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -713,9 +715,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1506 EventRootType Probe[main.testInlinedPrint]
+          Type: 1508 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -728,9 +730,9 @@ Probes:
             - PC: "0x84b00c"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1509 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -746,9 +748,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1510 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -771,9 +773,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1514 EventRootType Probe[main.testInlinedSq]
+          Type: 1516 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -789,9 +791,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1515 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1517 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -805,9 +807,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1516 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1518 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1c4"
               Frameless: false
@@ -913,14 +915,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1459 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x84eaf0", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1460 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ec48", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -982,8 +984,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -1001,14 +1009,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1465 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x84efac", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1466 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x84f118", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1321,9 +1329,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMassiveString]
+          Type: 1497 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1337,9 +1345,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1496 EventRootType Probe[main.testMassiveString]
+          Type: 1498 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
@@ -1351,14 +1359,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1467 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x84f180", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1468 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x84f32c", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
@@ -1370,14 +1378,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1471 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1472 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x84f4d4", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
@@ -1389,14 +1397,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1463 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x84ed80", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1464 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x84ef50", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
@@ -1408,14 +1416,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1452,6 +1460,32 @@ Probes:
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e088", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1423 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84e028", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1424 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e088", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1477,9 +1511,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1483 EventRootType Probe[main.testNilSlice]
+          Type: 1485 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1492,9 +1526,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1482 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1507,9 +1541,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1484 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1522,9 +1556,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1496 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ff00", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1637,14 +1671,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsArray]
+          Type: 1437 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x84e4fc", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1438 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x84e550", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
@@ -1656,14 +1690,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1439 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x84e588", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1440 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x84e5c4", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
@@ -1675,14 +1709,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1441 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x84e5f8", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1442 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x84e630", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
@@ -1694,14 +1728,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1445 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x84e6e8", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1446 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x84e74c", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
@@ -1713,14 +1747,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1457 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x84ea78", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1458 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x84eab8", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
@@ -1732,14 +1766,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsComplex]
+          Type: 1433 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x84e3a8", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1434 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x84e3f4", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1856,14 +1890,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1435 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x84e430", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1436 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x84e4c4", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
@@ -1875,14 +1909,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1431 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x84e2e8", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1432 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x84e36c", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
@@ -1894,14 +1928,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsMixed]
+          Type: 1449 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x84e868", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1450 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x84e8c0", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
@@ -1913,14 +1947,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1443 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x84e668", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1444 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x84e6b0", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
@@ -1932,14 +1966,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1455 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x84e9f8", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1456 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x84ea3c", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
@@ -1951,14 +1985,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1453 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x84e988", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1454 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x84e9c8", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
@@ -1970,14 +2004,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1429 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x84e258", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1430 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x84e2b0", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
@@ -1989,14 +2023,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1451 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x84e8fc", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1452 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x84e950", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
@@ -2008,14 +2042,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1447 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x84e790", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1448 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x84e834", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2113,8 +2147,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2158,8 +2193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2188,14 +2224,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1489 EventRootType Probe[main.testSingleString]
+          Type: 1491 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84feb0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2283,9 +2320,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1488 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2298,9 +2335,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1477 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1479 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84fae0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2327,14 +2364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1427 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84e198", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1428 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84e220", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
@@ -2346,14 +2383,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1469 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x84f388", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1470 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x84f3ec", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2396,9 +2433,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1481 EventRootType Probe[main.testStringSlice]
+          Type: 1483 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2436,19 +2473,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1502 EventRootType Probe[main.testStruct]
+          Type: 1504 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x850180", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1503 EventRootType Probe[main.testStruct]Return
+          Type: 1505 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x85019c", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2461,9 +2499,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testStructSlice]
+          Type: 1480 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84faf0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2490,14 +2528,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1473 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x84f50c", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1474 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x84f59c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
@@ -2509,14 +2547,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1502 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x850090", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1503 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x8500a8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
@@ -2528,9 +2566,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1501 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x850080", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2558,9 +2596,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1490 EventRootType Probe[main.testThreeStrings]
+          Type: 1492 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84fec0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2573,14 +2611,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1493 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84fed0", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1494 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84fee8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2593,9 +2631,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1495 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84fef0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2693,8 +2731,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +2747,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1475 EventRootType Probe[main.testUintSlice]
+          Type: 1477 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84fac0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2728,9 +2768,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1497 EventRootType Probe[main.testUnitializedString]
+          Type: 1499 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ff20", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2773,9 +2813,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1486 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2788,9 +2828,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1487 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
@@ -2802,14 +2842,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1475 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1476 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84f640", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3603,7 +3643,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84b199..0x84b1a0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 54
       Name: main.testFramelessArray
@@ -3626,7 +3666,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84b1e9..0x84b200
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 55
       Name: main.testInterface
@@ -3679,7 +3719,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84b485..0x84b4b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 57
       Name: main.testError
@@ -3722,7 +3762,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84b505..0x84b530
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 59
       Name: main.testStructWithAny
@@ -4226,7 +4266,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84d91d..0x84d940
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result
           Type: 7 BaseType int
@@ -4260,7 +4300,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84d9b9..0x84d9e0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: '&result'
           Type: 99 PointerType *int
@@ -4292,12 +4332,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84da91..0x84dab0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0x84d9e0..0x84dab0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: resultInt
           Type: 7 BaseType int
@@ -4350,7 +4390,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84db0d..0x84db30
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
@@ -4436,7 +4476,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84dc81..0x84dcb0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 14 GoInterfaceType error
@@ -4475,7 +4515,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x84dc81..0x84dcb0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 7 BaseType int
@@ -4549,7 +4589,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84de85..0x84deb0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 7 BaseType int
@@ -4620,7 +4660,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84dfa9..0x84e010
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: b
           Type: 160 GoInterfaceType main.behavior
@@ -4682,7 +4722,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e089..0x84e0b0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
@@ -4705,7 +4745,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e155..0x84e180
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
@@ -4716,7 +4756,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e155..0x84e180
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
@@ -4741,7 +4781,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e221..0x84e240
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
@@ -4752,7 +4792,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e221..0x84e240
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -4763,7 +4803,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84e221..0x84e240
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 104
       Name: main.testReturnsPrimitives
@@ -4779,7 +4819,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 94 BaseType int16
@@ -4790,7 +4830,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 12 BaseType int32
@@ -4801,7 +4841,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 13 BaseType int64
@@ -4812,7 +4852,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 3 BaseType uint8
@@ -4823,7 +4863,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 6 BaseType uint16
@@ -4834,7 +4874,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 2 BaseType uint32
@@ -4845,7 +4885,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 8 BaseType uint64
@@ -4856,7 +4896,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 105
       Name: main.testReturnsManyFloats
@@ -4866,82 +4906,82 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r9
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r10
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r11
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r12
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r13
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r14
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
@@ -4952,7 +4992,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0x84e36d..0x84e390
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 106
       Name: main.testReturnsComplex
@@ -4962,12 +5002,12 @@ Subprograms:
         - Name: ~r0
           Type: 95 BaseType complex64
           Locations: [{Range: 0x84e390..0x84e410, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 96 BaseType complex128
           Locations: [{Range: 0x84e390..0x84e410, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 107
       Name: main.testReturnsLargeStruct
@@ -5003,7 +5043,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84e4c5..0x84e4e0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 108
       Name: main.testReturnsArray
@@ -5019,7 +5059,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x84e551..0x84e570
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 109
       Name: main.testReturnsArrayOne
@@ -5035,7 +5075,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e5c5..0x84e5e0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 110
       Name: main.testReturnsArrayZero
@@ -5051,7 +5091,7 @@ Subprograms:
               Pieces: []
             - Range: 0x84e631..0x84e650
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 111
       Name: main.testReturnsMixedStruct
@@ -5061,7 +5101,7 @@ Subprograms:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
           Locations: [{Range: 0x84e650..0x84e6d0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 112
       Name: main.testReturnsBacktrackInt
@@ -5077,7 +5117,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 7 BaseType int
@@ -5088,7 +5128,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5099,7 +5139,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 7 BaseType int
@@ -5110,7 +5150,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 7 BaseType int
@@ -5121,7 +5161,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 7 BaseType int
@@ -5132,7 +5172,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 7 BaseType int
@@ -5143,7 +5183,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 7 BaseType int
@@ -5154,7 +5194,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 9 GoStringHeaderType string
@@ -5169,7 +5209,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 113
       Name: main.testReturnsWideStruct
@@ -5207,7 +5247,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
             - Range: 0x84e835..0x84e850
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 114
       Name: main.testReturnsMixed
@@ -5223,12 +5263,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e8c1..0x84e8e0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e850..0x84e8e0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5239,12 +5279,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e8c1..0x84e8e0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e850..0x84e8e0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 9 GoStringHeaderType string
@@ -5259,7 +5299,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x84e8c1..0x84e8e0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 115
       Name: main.testReturnsStructWithArray
@@ -5275,7 +5315,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x84e951..0x84e970
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 116
       Name: main.testReturnsOnlyFloat
@@ -5285,7 +5325,7 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e970..0x84e9e0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 117
       Name: main.testReturnsMultipleFloats
@@ -5295,12 +5335,12 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float32
           Locations: [{Range: 0x84e9e0..0x84ea60, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e9e0..0x84ea60, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
@@ -5316,7 +5356,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84eab9..0x84ead0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 1 BaseType uintptr
@@ -5327,7 +5367,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84eab9..0x84ead0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 119
       Name: main.testLargeArgAndReturn
@@ -5434,7 +5474,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84ec49..0x84ec90
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 120
       Name: main.testArrayArgAndReturn
@@ -5457,7 +5497,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x84ed45..0x84ed60
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 121
       Name: main.testMultipleLargeArgs
@@ -5571,7 +5611,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84ef51..0x84ef90
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 122
       Name: main.testManyArgsArrayReturn
@@ -5668,7 +5708,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
             - Range: 0x84f119..0x84f160
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 123
       Name: main.testMixedArgsStackReturn
@@ -5793,7 +5833,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84f32d..0x84f370
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 124
       Name: main.testStackArgRegReturns
@@ -5816,7 +5856,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f3ed..0x84f410
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 7 BaseType int
@@ -5827,7 +5867,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84f3ed..0x84f410
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5838,7 +5878,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84f3ed..0x84f410
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 125
       Name: main.testMultipleArrayArgs
@@ -5868,7 +5908,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f4d5..0x84f4f0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 111 ArrayType [2]int
@@ -5879,7 +5919,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
             - Range: 0x84f4d5..0x84f4f0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 126
       Name: main.testStructWithArrayArg
@@ -5902,7 +5942,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f59d..0x84f5c0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
@@ -5913,7 +5953,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x84f59d..0x84f5c0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: x
           Type: 7 BaseType int
@@ -5954,7 +5994,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f641..0x84f660
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 251 ArrayType [0]int
@@ -5965,7 +6005,7 @@ Subprograms:
               Pieces: []
             - Range: 0x84f641..0x84f660
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 128
       Name: main.testUintSlice
@@ -6218,7 +6258,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84fe8d..0x84feb0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 140
       Name: main.testSingleString
@@ -9777,10 +9817,10 @@ Types:
       GoKind: 22
       Pointee: 808 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9860,7 +9900,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9876,7 +9916,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10203,7 +10243,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10229,7 +10269,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10245,7 +10285,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10261,7 +10301,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10277,7 +10317,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10475,7 +10515,7 @@ Types:
       ID: 1357
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1354
@@ -10507,16 +10547,16 @@ Types:
       ID: 1355
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1358
@@ -10525,7 +10565,7 @@ Types:
       ID: 1359
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10541,7 +10581,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10557,10 +10597,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10576,7 +10616,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10592,7 +10632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10704,7 +10744,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10720,7 +10760,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10807,7 +10847,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10903,7 +10943,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11239,7 +11279,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11255,7 +11295,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11271,7 +11311,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11367,7 +11407,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11383,7 +11423,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -11409,7 +11449,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11435,7 +11475,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11461,7 +11501,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11477,7 +11517,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11493,7 +11533,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11591,7 +11631,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1422
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1424
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11633,7 +11705,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11659,7 +11731,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11695,7 +11767,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11711,7 +11783,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11859,10 +11931,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1437
+      ID: 1439
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1438
+      ID: 1440
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11878,10 +11950,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1441
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11897,10 +11969,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1435
+      ID: 1437
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1436
+      ID: 1438
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11916,10 +11988,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -12015,10 +12087,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1455
+      ID: 1457
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -12044,10 +12116,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1432
+      ID: 1434
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12243,10 +12315,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1433
+      ID: 1435
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1434
+      ID: 1436
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12262,10 +12334,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -12441,10 +12513,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12460,10 +12532,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12519,10 +12591,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12548,10 +12620,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12567,10 +12639,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12656,10 +12728,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12675,10 +12747,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12870,7 +12942,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12966,7 +13038,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12982,7 +13054,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13014,7 +13086,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13030,7 +13102,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13066,7 +13138,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -13082,7 +13154,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13150,7 +13222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13198,7 +13270,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13240,7 +13312,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13256,7 +13328,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13282,7 +13354,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13298,10 +13370,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -13333,7 +13405,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -13349,10 +13421,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13368,7 +13440,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13384,10 +13456,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13535,7 +13607,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13551,7 +13623,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13599,7 +13671,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13615,7 +13687,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13631,7 +13703,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13657,7 +13729,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -22164,7 +22236,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1516
+MaxTypeID: 1518
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,14 +10,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1506 EventRootType Probe[main.stackC]
+          Type: 1508 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80c2e8", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1507 EventRootType Probe[main.stackC]Return
+          Type: 1509 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80c318", Frameless: false}]
           Condition: null
     - id: testAny
@@ -69,14 +69,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x80b24c", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1481 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b2d8", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -193,8 +193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -363,9 +364,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          Type: 1497 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80bf90", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -378,9 +379,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1500 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80bfc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -394,9 +395,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptyString]
+          Type: 1519 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,14 +405,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1523 EventRootType Probe[main.testEmptyStruct]
+          Type: 1525 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
@@ -423,9 +425,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1526 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
     - id: testError
@@ -611,9 +613,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1528 EventRootType Probe[main.testInlinedBBB]
+          Type: 1530 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -646,9 +648,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1529 EventRootType Probe[main.testInlinedBCA]
+          Type: 1531 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -664,9 +666,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1532 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -679,9 +681,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1531 EventRootType Probe[main.testInlinedBCB]
+          Type: 1533 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -697,9 +699,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1534 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -713,9 +715,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1525 EventRootType Probe[main.testInlinedPrint]
+          Type: 1527 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -728,9 +730,9 @@ Probes:
             - PC: "0x80781c"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1528 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -746,9 +748,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1529 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -771,9 +773,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1533 EventRootType Probe[main.testInlinedSq]
+          Type: 1535 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -789,9 +791,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1534 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1536 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -805,9 +807,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1535 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1537 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8079b4"
               Frameless: false
@@ -913,14 +915,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x80b0c0", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1479 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b1e8", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -982,8 +984,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -1001,14 +1009,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x80b51c", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1485 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x80b65c", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1321,9 +1329,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1514 EventRootType Probe[main.testMassiveString]
+          Type: 1516 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1337,9 +1345,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1515 EventRootType Probe[main.testMassiveString]
+          Type: 1517 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
@@ -1351,14 +1359,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x80b6c0", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1487 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x80b848", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
@@ -1370,14 +1378,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x80b93c", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1491 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x80b9d4", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
@@ -1389,14 +1397,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x80b310", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1483 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x80b4b4", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
@@ -1408,14 +1416,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1444 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a718", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1445 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1452,6 +1460,32 @@ Probes:
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1442 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a688", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1443 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1477,9 +1511,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
+          Type: 1504 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1492,9 +1526,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1501 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1507,9 +1541,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1503 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1522,9 +1556,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1515 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80c370", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1637,14 +1671,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          Type: 1456 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x80ab1c", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1457 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x80ab68", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
@@ -1656,14 +1690,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1458 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x80ab98", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1459 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x80abd0", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
@@ -1675,14 +1709,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1460 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x80ac08", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1461 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x80ac3c", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
@@ -1694,14 +1728,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x80acf8", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1465 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
@@ -1713,14 +1747,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x80b048", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1477 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x80b084", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
@@ -1732,14 +1766,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          Type: 1452 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x80a9d8", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1453 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x80aa20", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1856,14 +1890,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x80aa60", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1455 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x80aadc", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
@@ -1875,14 +1909,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1450 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x80a928", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1451 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x80a9a8", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
@@ -1894,14 +1928,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          Type: 1468 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1469 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80aeac", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
@@ -1913,14 +1947,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x80ac78", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1463 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80acbc", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
@@ -1932,14 +1966,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x80afd8", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1475 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x80b018", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
@@ -1951,14 +1985,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x80af68", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1473 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x80afa4", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
@@ -1970,14 +2004,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1448 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x80a898", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1449 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80a8ec", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
@@ -1989,14 +2023,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x80aeec", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1471 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x80af38", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
@@ -2008,14 +2042,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1466 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x80ad90", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1467 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x80ae1c", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2113,8 +2147,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2158,8 +2193,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2188,14 +2224,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1508 EventRootType Probe[main.testSingleString]
+          Type: 1510 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80c330", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2283,9 +2320,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1507 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2298,9 +2335,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1498 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80bfa0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2327,14 +2364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1446 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a7d8", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1447 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a85c", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
@@ -2346,14 +2383,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1488 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x80b8a8", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1489 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x80b900", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2396,9 +2433,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
+          Type: 1502 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2436,19 +2473,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1521 EventRootType Probe[main.testStruct]
+          Type: 1523 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1522 EventRootType Probe[main.testStruct]Return
+          Type: 1524 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2461,9 +2499,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
+          Type: 1499 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80bfb0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2490,14 +2528,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1492 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x80ba0c", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1493 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x80ba90", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
@@ -2509,14 +2547,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1521 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80c4f0", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1522 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80c4fc", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
@@ -2528,9 +2566,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1520 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80c4e0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2558,9 +2596,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStrings]
+          Type: 1511 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80c340", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2573,14 +2611,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80c350", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c35c", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2593,9 +2631,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c360", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2693,8 +2731,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +2747,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
+          Type: 1496 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80bf80", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2728,9 +2768,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1516 EventRootType Probe[main.testUnitializedString]
+          Type: 1518 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80c390", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2773,9 +2813,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2788,9 +2828,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1506 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
@@ -2802,14 +2842,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1495 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80bb28", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3599,7 +3639,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x807989..0x807990
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 54
       Name: main.testFramelessArray
@@ -3622,7 +3662,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8079d1..0x8079e0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 55
       Name: main.testInterface
@@ -3675,7 +3715,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x807c41..0x807c60
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 57
       Name: main.testError
@@ -3718,7 +3758,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x807cb1..0x807cd0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 59
       Name: main.testStructWithAny
@@ -4222,7 +4262,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x809fb9..0x809fe0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result
           Type: 7 BaseType int
@@ -4256,7 +4296,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a055..0x80a080
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: '&result'
           Type: 100 PointerType *int
@@ -4288,12 +4328,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a125..0x80a150
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a080..0x80a150, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: resultInt
           Type: 7 BaseType int
@@ -4346,7 +4386,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80a1a9..0x80a1d0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
@@ -4426,7 +4466,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80a315..0x80a340
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 14 GoInterfaceType error
@@ -4465,7 +4505,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x80a315..0x80a340
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 7 BaseType int
@@ -4539,7 +4579,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80a4f9..0x80a520
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: val
           Type: 7 BaseType int
@@ -4610,7 +4650,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80a605..0x80a670
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: b
           Type: 162 GoInterfaceType main.behavior
@@ -4672,7 +4712,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a6e1..0x80a700
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
@@ -4695,7 +4735,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a799..0x80a7c0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
@@ -4706,7 +4746,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80a799..0x80a7c0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
@@ -4731,7 +4771,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a85d..0x80a880
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
@@ -4742,7 +4782,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80a85d..0x80a880
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -4753,7 +4793,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80a85d..0x80a880
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 104
       Name: main.testReturnsPrimitives
@@ -4769,7 +4809,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 96 BaseType int16
@@ -4780,7 +4820,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 12 BaseType int32
@@ -4791,7 +4831,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 13 BaseType int64
@@ -4802,7 +4842,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 3 BaseType uint8
@@ -4813,7 +4853,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 6 BaseType uint16
@@ -4824,7 +4864,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 2 BaseType uint32
@@ -4835,7 +4875,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 8 BaseType uint64
@@ -4846,7 +4886,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 105
       Name: main.testReturnsManyFloats
@@ -4856,82 +4896,82 @@ Subprograms:
         - Name: ~r0
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r9
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r10
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r11
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r12
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r13
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r14
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
@@ -4942,7 +4982,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0x80a9a9..0x80a9c0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 106
       Name: main.testReturnsComplex
@@ -4952,12 +4992,12 @@ Subprograms:
         - Name: ~r0
           Type: 97 BaseType complex64
           Locations: [{Range: 0x80a9c0..0x80aa40, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 98 BaseType complex128
           Locations: [{Range: 0x80a9c0..0x80aa40, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 107
       Name: main.testReturnsLargeStruct
@@ -4993,7 +5033,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80aadd..0x80ab00
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 108
       Name: main.testReturnsArray
@@ -5009,7 +5049,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x80ab69..0x80ab80
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 109
       Name: main.testReturnsArrayOne
@@ -5025,7 +5065,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80abd1..0x80abf0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 110
       Name: main.testReturnsArrayZero
@@ -5041,7 +5081,7 @@ Subprograms:
               Pieces: []
             - Range: 0x80ac3d..0x80ac60
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 111
       Name: main.testReturnsMixedStruct
@@ -5051,7 +5091,7 @@ Subprograms:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
           Locations: [{Range: 0x80ac60..0x80ace0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 112
       Name: main.testReturnsBacktrackInt
@@ -5067,7 +5107,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 7 BaseType int
@@ -5078,7 +5118,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5089,7 +5129,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 7 BaseType int
@@ -5100,7 +5140,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 7 BaseType int
@@ -5111,7 +5151,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r5
           Type: 7 BaseType int
@@ -5122,7 +5162,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r6
           Type: 7 BaseType int
@@ -5133,7 +5173,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r7
           Type: 7 BaseType int
@@ -5144,7 +5184,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r8
           Type: 9 GoStringHeaderType string
@@ -5159,7 +5199,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 113
       Name: main.testReturnsWideStruct
@@ -5197,7 +5237,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
             - Range: 0x80ae1d..0x80ae40
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 114
       Name: main.testReturnsMixed
@@ -5213,12 +5253,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80aead..0x80aed0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 16 BaseType float64
           Locations: [{Range: 0x80ae40..0x80aed0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5229,12 +5269,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80aead..0x80aed0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r3
           Type: 16 BaseType float64
           Locations: [{Range: 0x80ae40..0x80aed0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r4
           Type: 9 GoStringHeaderType string
@@ -5249,7 +5289,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x80aead..0x80aed0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 115
       Name: main.testReturnsStructWithArray
@@ -5265,7 +5305,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x80af39..0x80af50
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 116
       Name: main.testReturnsOnlyFloat
@@ -5275,7 +5315,7 @@ Subprograms:
         - Name: ~r0
           Type: 16 BaseType float64
           Locations: [{Range: 0x80af50..0x80afc0, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 117
       Name: main.testReturnsMultipleFloats
@@ -5285,12 +5325,12 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float32
           Locations: [{Range: 0x80afc0..0x80b030, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 16 BaseType float64
           Locations: [{Range: 0x80afc0..0x80b030, Pieces: []}]
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
@@ -5306,7 +5346,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80b085..0x80b0a0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 1 BaseType uintptr
@@ -5317,7 +5357,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80b085..0x80b0a0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 119
       Name: main.testLargeArgAndReturn
@@ -5446,7 +5486,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80b1e9..0x80b230
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 120
       Name: main.testArrayArgAndReturn
@@ -5469,7 +5509,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x80b2d9..0x80b2f0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 121
       Name: main.testMultipleLargeArgs
@@ -5605,7 +5645,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80b4b5..0x80b500
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 122
       Name: main.testManyArgsArrayReturn
@@ -5702,7 +5742,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
             - Range: 0x80b65d..0x80b6a0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 123
       Name: main.testMixedArgsStackReturn
@@ -5827,7 +5867,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80b849..0x80b890
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 124
       Name: main.testStackArgRegReturns
@@ -5850,7 +5890,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80b901..0x80b920
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 7 BaseType int
@@ -5861,7 +5901,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80b901..0x80b920
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
@@ -5872,7 +5912,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80b901..0x80b920
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 125
       Name: main.testMultipleArrayArgs
@@ -5902,7 +5942,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80b9d5..0x80b9f0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 113 ArrayType [2]int
@@ -5913,7 +5953,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
             - Range: 0x80b9d5..0x80b9f0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 126
       Name: main.testStructWithArrayArg
@@ -5936,7 +5976,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80ba91..0x80bab0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
@@ -5947,7 +5987,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x80ba91..0x80bab0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: x
           Type: 7 BaseType int
@@ -5988,7 +6028,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80bb29..0x80bb50
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: ~r1
           Type: 253 ArrayType [0]int
@@ -5999,7 +6039,7 @@ Subprograms:
               Pieces: []
             - Range: 0x80bb29..0x80bb50
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 128
       Name: main.testUintSlice
@@ -6252,7 +6292,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80c319..0x80c330
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 140
       Name: main.testSingleString
@@ -9878,10 +9918,10 @@ Types:
       GoKind: 22
       Pointee: 821 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9961,7 +10001,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9977,7 +10017,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10304,7 +10344,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10330,7 +10370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10346,7 +10386,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10362,7 +10402,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10378,7 +10418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10576,7 +10616,7 @@ Types:
       ID: 1376
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1373
@@ -10608,16 +10648,16 @@ Types:
       ID: 1374
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1377
@@ -10626,7 +10666,7 @@ Types:
       ID: 1378
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10642,7 +10682,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10658,10 +10698,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10677,7 +10717,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10693,7 +10733,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10805,7 +10845,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10821,7 +10861,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10908,7 +10948,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -11004,7 +11044,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11340,7 +11380,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11356,7 +11396,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11372,7 +11412,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11468,7 +11508,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11484,7 +11524,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -11510,7 +11550,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11536,7 +11576,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11562,7 +11602,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11578,7 +11618,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11594,7 +11634,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11692,7 +11732,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1441
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1443
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11734,7 +11806,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11760,7 +11832,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11796,7 +11868,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11812,7 +11884,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11960,10 +12032,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11979,10 +12051,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11998,10 +12070,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1457
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12017,10 +12089,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -12116,10 +12188,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -12145,10 +12217,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12344,10 +12416,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12363,10 +12435,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -12542,10 +12614,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12561,10 +12633,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12620,10 +12692,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12649,10 +12721,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12668,10 +12740,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12757,10 +12829,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12776,10 +12848,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12971,7 +13043,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13067,7 +13139,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13083,7 +13155,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13115,7 +13187,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13131,7 +13203,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13167,7 +13239,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -13183,7 +13255,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13251,7 +13323,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13299,7 +13371,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13341,7 +13413,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13357,7 +13429,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13383,7 +13455,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13399,10 +13471,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -13434,7 +13506,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -13450,10 +13522,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13469,7 +13541,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13485,10 +13557,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13636,7 +13708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13652,7 +13724,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13700,7 +13772,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13716,7 +13788,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13732,7 +13804,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13758,7 +13830,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -22425,7 +22497,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1535
+MaxTypeID: 1537
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -247,10 +247,12 @@ Probes:
       message: hello {s}, and hello to {s}
       template: ""
       segments:
-        - str: 'hello '
-        - dsl: {json: {ref: s}, dsl: s}
-        - str: ', and hello to '
-        - dsl: {json: {ref: s}, dsl: s}
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -272,8 +274,10 @@ Probes:
       message: '{s}{s}'
       template: ""
       segments:
-        - dsl: {json: {ref: s}, dsl: s}
-        - dsl: {json: {ref: s}, dsl: s}
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -294,7 +298,7 @@ Probes:
       tags: ['foo:bar']
       message: hello world!
       template: ""
-      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      segments: ['hello ', world, '!']
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -315,7 +319,7 @@ Probes:
       tags: ['foo:bar']
       message: hello {s}
       template: ""
-      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -336,7 +340,7 @@ Probes:
       tags: ['foo:bar']
       message: hello
       template: ""
-      segments: [{str: hello}]
+      segments: [hello]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -516,7 +520,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4a682f..0x4a6845
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: m
           Type: 120 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
@@ -1107,54 +1111,15 @@ Types:
     - __kind: EventRootType
       ID: 166
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 168
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 170
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
       ID: 172
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 174
       Name: Probe[main.stringArg]Return

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 184 EventRootType Probe[main.PointerChainArg]
+          Type: 194 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 185 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 195 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6090", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 176 EventRootType Probe[main.bigMapArg]
+          Type: 186 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 177 EventRootType Probe[main.bigMapArg]Return
+          Type: 187 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a65de", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 182 EventRootType Probe[main.inlined]
+          Type: 192 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5e0e"
               Frameless: false
             - PC: "0x4a642a"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 183 EventRootType Probe[main.inlined]Return
+          Type: 193 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a646a", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 167 EventRootType Probe[main.intArrayArg]
+          Type: 177 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 168 EventRootType Probe[main.intArrayArg]Return
+          Type: 178 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a62d6", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 173 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 183 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a6400", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 165 EventRootType Probe[main.intSliceArg]
+          Type: 175 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 166 EventRootType Probe[main.intSliceArg]Return
+          Type: 176 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a624f", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 174 EventRootType Probe[main.mapArg]
+          Type: 184 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 175 EventRootType Probe[main.mapArg]Return
+          Type: 185 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a651f", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 178 EventRootType Probe[main.noArgs]
+          Type: 188 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a660a", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 179 EventRootType Probe[main.noArgs]Return
+          Type: 189 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a6646", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 171 EventRootType Probe[main.stringArrayArg]
+          Type: 181 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 172 EventRootType Probe[main.stringArrayArg]Return
+          Type: 182 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a63d6", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,126 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 179 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 180 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - str: 'hello '
+        - dsl: {json: {ref: s}, dsl: s}
+        - str: ', and hello to '
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 165 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 166 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - dsl: {json: {ref: s}, dsl: s}
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 167 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 168 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 169 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
+          Type: 169 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 170 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
+          Type: 170 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 171 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 172 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [{str: hello}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 173 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 174 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +360,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 180 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 190 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a6676", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 191 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a682e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -743,7 +854,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 184
+      ID: 194
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -759,7 +870,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 185
+      ID: 195
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -775,7 +886,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 176
+      ID: 186
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -791,10 +902,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 177
+      ID: 187
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 182
+      ID: 192
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -810,7 +921,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 183
+      ID: 193
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 161
@@ -832,7 +943,7 @@ Types:
       ID: 162
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 167
+      ID: 177
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -848,10 +959,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 168
+      ID: 178
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 165
+      ID: 175
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -867,10 +978,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 166
+      ID: 176
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 174
+      ID: 184
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -886,13 +997,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 175
+      ID: 185
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 178
+      ID: 188
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 179
+      ID: 189
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 163
@@ -911,10 +1022,144 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 165
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 167
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 169
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 171
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 173
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 164
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 173
+      ID: 166
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 168
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 170
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 172
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 174
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 183
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -930,7 +1175,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 171
+      ID: 181
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -946,10 +1191,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 172
+      ID: 182
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 169
+      ID: 179
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -965,13 +1210,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 170
+      ID: 180
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 180
+      ID: 190
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 181
+      ID: 191
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2584,7 +2829,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39264
       GoKind: 26
-MaxTypeID: 185
+MaxTypeID: 195
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x573240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 201 EventRootType Probe[main.PointerChainArg]
+          Type: 211 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 202 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 212 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8090", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 193 EventRootType Probe[main.bigMapArg]
+          Type: 203 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a8553", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 194 EventRootType Probe[main.bigMapArg]Return
+          Type: 204 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a85de", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 199 EventRootType Probe[main.inlined]
+          Type: 209 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a7e0e"
               Frameless: false
             - PC: "0x4a842a"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 200 EventRootType Probe[main.inlined]Return
+          Type: 210 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a846a", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 184 EventRootType Probe[main.intArrayArg]
+          Type: 194 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a828a", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 185 EventRootType Probe[main.intArrayArg]Return
+          Type: 195 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a82d6", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 190 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 200 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a8400", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 182 EventRootType Probe[main.intSliceArg]
+          Type: 192 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a820a", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 183 EventRootType Probe[main.intSliceArg]Return
+          Type: 193 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a824f", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 191 EventRootType Probe[main.mapArg]
+          Type: 201 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a84ea", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 192 EventRootType Probe[main.mapArg]Return
+          Type: 202 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a851f", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 195 EventRootType Probe[main.noArgs]
+          Type: 205 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a860a", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 196 EventRootType Probe[main.noArgs]Return
+          Type: 206 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a8646", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 188 EventRootType Probe[main.stringArrayArg]
+          Type: 198 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a838a", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 189 EventRootType Probe[main.stringArrayArg]Return
+          Type: 199 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a83d6", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,126 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 196 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 197 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0x4a834f", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - str: 'hello '
+        - dsl: {json: {ref: s}, dsl: s}
+        - str: ', and hello to '
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 182 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 183 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - dsl: {json: {ref: s}, dsl: s}
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 184 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 185 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 186 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
+          Type: 186 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 187 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4a834f", Frameless: false}]
+          Type: 187 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 188 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 189 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [{str: hello}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 190 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 191 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +360,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 197 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 207 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 208 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a883c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -768,7 +879,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -784,7 +895,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -800,7 +911,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 193
+      ID: 203
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -816,10 +927,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 194
+      ID: 204
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 199
+      ID: 209
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -835,7 +946,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 200
+      ID: 210
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 178
@@ -857,7 +968,7 @@ Types:
       ID: 179
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 184
+      ID: 194
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -873,10 +984,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 185
+      ID: 195
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 182
+      ID: 192
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -892,10 +1003,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 183
+      ID: 193
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 191
+      ID: 201
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -911,13 +1022,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 192
+      ID: 202
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 195
+      ID: 205
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 196
+      ID: 206
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 180
@@ -936,10 +1047,144 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 182
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 184
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 186
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 188
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 190
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 181
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 183
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 185
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 187
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 189
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 191
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 200
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -955,7 +1200,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -971,10 +1216,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 186
+      ID: 196
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -990,13 +1235,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 187
+      ID: 197
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 197
+      ID: 207
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 198
+      ID: 208
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2767,7 +3012,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43264
       GoKind: 26
-MaxTypeID: 202
+MaxTypeID: 212
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x57e340", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -247,10 +247,12 @@ Probes:
       message: hello {s}, and hello to {s}
       template: ""
       segments:
-        - str: 'hello '
-        - dsl: {json: {ref: s}, dsl: s}
-        - str: ', and hello to '
-        - dsl: {json: {ref: s}, dsl: s}
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -272,8 +274,10 @@ Probes:
       message: '{s}{s}'
       template: ""
       segments:
-        - dsl: {json: {ref: s}, dsl: s}
-        - dsl: {json: {ref: s}, dsl: s}
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -294,7 +298,7 @@ Probes:
       tags: ['foo:bar']
       message: hello world!
       template: ""
-      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      segments: ['hello ', world, '!']
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -315,7 +319,7 @@ Probes:
       tags: ['foo:bar']
       message: hello {s}
       template: ""
-      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -336,7 +340,7 @@ Probes:
       tags: ['foo:bar']
       message: hello
       template: ""
-      segments: [{str: hello}]
+      segments: [hello]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -516,7 +520,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4a883d..0x4a884f
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 12
       Name: main.inlined
@@ -1132,54 +1136,15 @@ Types:
     - __kind: EventRootType
       ID: 183
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 185
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 187
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
       ID: 189
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 191
       Name: Probe[main.stringArg]Return

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 206 EventRootType Probe[main.PointerChainArg]
+          Type: 216 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae646", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 207 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 217 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae690", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 198 EventRootType Probe[main.bigMapArg]
+          Type: 208 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4aeb53", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 199 EventRootType Probe[main.bigMapArg]Return
+          Type: 209 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4aebde", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 204 EventRootType Probe[main.inlined]
+          Type: 214 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae40e"
               Frameless: false
             - PC: "0x4aea2a"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 205 EventRootType Probe[main.inlined]Return
+          Type: 215 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4aea6a", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 189 EventRootType Probe[main.intArrayArg]
+          Type: 199 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4ae88a", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 190 EventRootType Probe[main.intArrayArg]Return
+          Type: 200 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4ae8d6", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 195 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 205 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4aea00", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 187 EventRootType Probe[main.intSliceArg]
+          Type: 197 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4ae80a", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 188 EventRootType Probe[main.intSliceArg]Return
+          Type: 198 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4ae84f", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 196 EventRootType Probe[main.mapArg]
+          Type: 206 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4aeaea", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 197 EventRootType Probe[main.mapArg]Return
+          Type: 207 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4aeb1f", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 200 EventRootType Probe[main.noArgs]
+          Type: 210 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4aec0a", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 201 EventRootType Probe[main.noArgs]Return
+          Type: 211 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4aec46", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 193 EventRootType Probe[main.stringArrayArg]
+          Type: 203 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4ae98a", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 194 EventRootType Probe[main.stringArrayArg]Return
+          Type: 204 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4ae9d6", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,126 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 201 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 202 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0x4ae94f", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - str: 'hello '
+        - dsl: {json: {ref: s}, dsl: s}
+        - str: ', and hello to '
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 187 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 188 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - dsl: {json: {ref: s}, dsl: s}
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 189 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 190 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 191 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
+          Type: 191 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 192 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4ae94f", Frameless: false}]
+          Type: 192 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 193 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 194 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [{str: hello}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 195 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 196 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +360,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 202 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 212 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aec76", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 213 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4aee44", Frameless: false}]
           Condition: null
 Subprograms:
@@ -786,7 +897,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 206
+      ID: 216
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -802,7 +913,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 217
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -818,7 +929,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 198
+      ID: 208
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -834,10 +945,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 199
+      ID: 209
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 204
+      ID: 214
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -853,7 +964,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 205
+      ID: 215
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 183
@@ -875,7 +986,7 @@ Types:
       ID: 184
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -891,10 +1002,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 190
+      ID: 200
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 187
+      ID: 197
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -910,10 +1021,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 196
+      ID: 206
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -929,13 +1040,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 197
+      ID: 207
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 200
+      ID: 210
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 185
@@ -954,10 +1065,144 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 187
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 189
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 191
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 193
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 195
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 186
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 195
+      ID: 188
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 190
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 192
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 194
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 196
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 205
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -973,7 +1218,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 193
+      ID: 203
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -989,10 +1234,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 194
+      ID: 204
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 191
+      ID: 201
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -1008,13 +1253,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 192
+      ID: 202
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 203
+      ID: 213
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2820,7 +3065,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 44672
       GoKind: 26
-MaxTypeID: 207
+MaxTypeID: 217
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x58d3a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -247,10 +247,12 @@ Probes:
       message: hello {s}, and hello to {s}
       template: ""
       segments:
-        - str: 'hello '
-        - dsl: {json: {ref: s}, dsl: s}
-        - str: ', and hello to '
-        - dsl: {json: {ref: s}, dsl: s}
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -272,8 +274,10 @@ Probes:
       message: '{s}{s}'
       template: ""
       segments:
-        - dsl: {json: {ref: s}, dsl: s}
-        - dsl: {json: {ref: s}, dsl: s}
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -294,7 +298,7 @@ Probes:
       tags: ['foo:bar']
       message: hello world!
       template: ""
-      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      segments: ['hello ', world, '!']
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -315,7 +319,7 @@ Probes:
       tags: ['foo:bar']
       message: hello {s}
       template: ""
-      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -336,7 +340,7 @@ Probes:
       tags: ['foo:bar']
       message: hello
       template: ""
-      segments: [{str: hello}]
+      segments: [hello]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -516,7 +520,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4aee45..0x4aee57
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 12
       Name: main.inlined
@@ -1150,54 +1154,15 @@ Types:
     - __kind: EventRootType
       ID: 188
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 190
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 192
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
       ID: 194
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 196
       Name: Probe[main.stringArg]Return

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 185 EventRootType Probe[main.PointerChainArg]
+          Type: 195 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5388", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 186 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 196 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb53c0", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 177 EventRootType Probe[main.bigMapArg]
+          Type: 187 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb5880", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 178 EventRootType Probe[main.bigMapArg]Return
+          Type: 188 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb58f4", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 183 EventRootType Probe[main.inlined]
+          Type: 193 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb519c"
               Frameless: false
             - PC: "0xb5748"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 184 EventRootType Probe[main.inlined]Return
+          Type: 194 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb5780", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 168 EventRootType Probe[main.intArrayArg]
+          Type: 178 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb55a8", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 169 EventRootType Probe[main.intArrayArg]Return
+          Type: 179 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb55ec", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 174 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 184 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5720", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 166 EventRootType Probe[main.intSliceArg]
+          Type: 176 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5518", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 167 EventRootType Probe[main.intSliceArg]Return
+          Type: 177 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5554", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 175 EventRootType Probe[main.mapArg]
+          Type: 185 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5808", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 176 EventRootType Probe[main.mapArg]Return
+          Type: 186 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb5838", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 179 EventRootType Probe[main.noArgs]
+          Type: 189 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb5938", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 180 EventRootType Probe[main.noArgs]Return
+          Type: 190 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb5970", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 172 EventRootType Probe[main.stringArrayArg]
+          Type: 182 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb56b8", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 173 EventRootType Probe[main.stringArrayArg]Return
+          Type: 183 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb56fc", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,126 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 180 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb5628", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 181 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0xb5664", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - str: 'hello '
+        - dsl: {json: {ref: s}, dsl: s}
+        - str: ', and hello to '
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 166 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 167 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - dsl: {json: {ref: s}, dsl: s}
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 168 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 169 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 170 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb5628", Frameless: false}]
+          Type: 170 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 171 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb5664", Frameless: false}]
+          Type: 171 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 172 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 173 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [{str: hello}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 174 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 175 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +360,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 191 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb59b0", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 182 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 192 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb5b24", Frameless: false}]
           Condition: null
 Subprograms:
@@ -743,7 +854,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 185
+      ID: 195
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -759,7 +870,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 186
+      ID: 196
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -775,7 +886,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 177
+      ID: 187
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -791,10 +902,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 178
+      ID: 188
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 183
+      ID: 193
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -810,7 +921,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 184
+      ID: 194
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 162
@@ -832,7 +943,7 @@ Types:
       ID: 163
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 168
+      ID: 178
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -848,10 +959,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 169
+      ID: 179
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 166
+      ID: 176
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -867,10 +978,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 167
+      ID: 177
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 175
+      ID: 185
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -886,13 +997,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 176
+      ID: 186
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 179
+      ID: 189
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 180
+      ID: 190
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 164
@@ -911,10 +1022,144 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 166
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 168
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 170
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 172
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 174
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 165
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 174
+      ID: 167
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 169
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 171
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 173
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 175
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 184
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -930,7 +1175,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 172
+      ID: 182
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -946,10 +1191,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 173
+      ID: 183
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 170
+      ID: 180
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -965,13 +1210,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 171
+      ID: 181
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 181
+      ID: 191
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 182
+      ID: 192
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2590,7 +2835,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39232
       GoKind: 26
-MaxTypeID: 186
+MaxTypeID: 196
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -247,10 +247,12 @@ Probes:
       message: hello {s}, and hello to {s}
       template: ""
       segments:
-        - str: 'hello '
-        - dsl: {json: {ref: s}, dsl: s}
-        - str: ', and hello to '
-        - dsl: {json: {ref: s}, dsl: s}
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -272,8 +274,10 @@ Probes:
       message: '{s}{s}'
       template: ""
       segments:
-        - dsl: {json: {ref: s}, dsl: s}
-        - dsl: {json: {ref: s}, dsl: s}
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -294,7 +298,7 @@ Probes:
       tags: ['foo:bar']
       message: hello world!
       template: ""
-      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      segments: ['hello ', world, '!']
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -315,7 +319,7 @@ Probes:
       tags: ['foo:bar']
       message: hello {s}
       template: ""
-      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -336,7 +340,7 @@ Probes:
       tags: ['foo:bar']
       message: hello
       template: ""
-      segments: [{str: hello}]
+      segments: [hello]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -516,7 +520,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb5b25..0xb5b40
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
         - Name: m
           Type: 121 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
@@ -1107,54 +1111,15 @@ Types:
     - __kind: EventRootType
       ID: 167
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 169
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 171
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
       ID: 173
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 175
       Name: Probe[main.stringArg]Return

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 202 EventRootType Probe[main.PointerChainArg]
+          Type: 212 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb520c", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 203 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 213 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb5244", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 194 EventRootType Probe[main.bigMapArg]
+          Type: 204 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb56f0", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 195 EventRootType Probe[main.bigMapArg]Return
+          Type: 205 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb5764", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 200 EventRootType Probe[main.inlined]
+          Type: 210 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb502c"
               Frameless: false
             - PC: "0xb55b8"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 201 EventRootType Probe[main.inlined]Return
+          Type: 211 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb55f0", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 185 EventRootType Probe[main.intArrayArg]
+          Type: 195 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 186 EventRootType Probe[main.intArrayArg]Return
+          Type: 196 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb546c", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 191 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 201 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5590", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 183 EventRootType Probe[main.intSliceArg]
+          Type: 193 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb53a8", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 184 EventRootType Probe[main.intSliceArg]Return
+          Type: 194 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb53e4", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 192 EventRootType Probe[main.mapArg]
+          Type: 202 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5678", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 193 EventRootType Probe[main.mapArg]Return
+          Type: 203 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb56a8", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 196 EventRootType Probe[main.noArgs]
+          Type: 206 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb57a8", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 197 EventRootType Probe[main.noArgs]Return
+          Type: 207 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb57e0", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 189 EventRootType Probe[main.stringArrayArg]
+          Type: 199 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb5528", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 190 EventRootType Probe[main.stringArrayArg]Return
+          Type: 200 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb556c", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,126 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 197 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb54a8", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 198 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0xb54e4", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - str: 'hello '
+        - dsl: {json: {ref: s}, dsl: s}
+        - str: ', and hello to '
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 183 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 184 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - dsl: {json: {ref: s}, dsl: s}
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 185 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 186 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 187 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb54a8", Frameless: false}]
+          Type: 187 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 188 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb54e4", Frameless: false}]
+          Type: 188 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 189 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 190 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [{str: hello}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 191 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 192 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +360,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 208 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb5820", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 199 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 209 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb59a0", Frameless: false}]
           Condition: null
 Subprograms:
@@ -768,7 +879,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -784,7 +895,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 203
+      ID: 213
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -800,7 +911,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 194
+      ID: 204
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -816,10 +927,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 195
+      ID: 205
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 200
+      ID: 210
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -835,7 +946,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 179
@@ -857,7 +968,7 @@ Types:
       ID: 180
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 185
+      ID: 195
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -873,10 +984,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 186
+      ID: 196
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 183
+      ID: 193
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -892,10 +1003,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 184
+      ID: 194
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 202
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -911,13 +1022,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 193
+      ID: 203
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 196
+      ID: 206
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 197
+      ID: 207
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 181
@@ -936,10 +1047,144 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 183
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 185
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 187
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 189
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 191
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 182
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 191
+      ID: 184
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 186
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 188
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 190
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 192
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 201
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -955,7 +1200,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -971,10 +1216,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 190
+      ID: 200
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 187
+      ID: 197
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -990,13 +1235,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 198
+      ID: 208
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 199
+      ID: 209
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2773,7 +3018,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43232
       GoKind: 26
-MaxTypeID: 203
+MaxTypeID: 213
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191340", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -247,10 +247,12 @@ Probes:
       message: hello {s}, and hello to {s}
       template: ""
       segments:
-        - str: 'hello '
-        - dsl: {json: {ref: s}, dsl: s}
-        - str: ', and hello to '
-        - dsl: {json: {ref: s}, dsl: s}
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -272,8 +274,10 @@ Probes:
       message: '{s}{s}'
       template: ""
       segments:
-        - dsl: {json: {ref: s}, dsl: s}
-        - dsl: {json: {ref: s}, dsl: s}
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -294,7 +298,7 @@ Probes:
       tags: ['foo:bar']
       message: hello world!
       template: ""
-      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      segments: ['hello ', world, '!']
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -315,7 +319,7 @@ Probes:
       tags: ['foo:bar']
       message: hello {s}
       template: ""
-      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -336,7 +340,7 @@ Probes:
       tags: ['foo:bar']
       message: hello
       template: ""
-      segments: [{str: hello}]
+      segments: [hello]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -516,7 +520,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb59a1..0xb59c0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 12
       Name: main.inlined
@@ -1132,54 +1136,15 @@ Types:
     - __kind: EventRootType
       ID: 184
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 186
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 188
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
       ID: 190
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 192
       Name: Probe[main.stringArg]Return

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 207 EventRootType Probe[main.PointerChainArg]
+          Type: 217 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7da0", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 208 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 218 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7dd4", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 199 EventRootType Probe[main.bigMapArg]
+          Type: 209 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb8240", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 200 EventRootType Probe[main.bigMapArg]Return
+          Type: 210 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb82b0", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 205 EventRootType Probe[main.inlined]
+          Type: 215 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb7bc8"
               Frameless: false
             - PC: "0xb8108"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 206 EventRootType Probe[main.inlined]Return
+          Type: 216 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb813c", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 190 EventRootType Probe[main.intArrayArg]
+          Type: 200 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb7f98", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 191 EventRootType Probe[main.intArrayArg]Return
+          Type: 201 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb7fd8", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 196 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 206 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb80e0", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 188 EventRootType Probe[main.intSliceArg]
+          Type: 198 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb7f18", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 189 EventRootType Probe[main.intSliceArg]Return
+          Type: 199 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb7f50", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 197 EventRootType Probe[main.mapArg]
+          Type: 207 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb81c8", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 198 EventRootType Probe[main.mapArg]Return
+          Type: 208 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb81f4", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 201 EventRootType Probe[main.noArgs]
+          Type: 211 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb82e8", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 202 EventRootType Probe[main.noArgs]Return
+          Type: 212 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb831c", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 194 EventRootType Probe[main.stringArrayArg]
+          Type: 204 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb8088", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 195 EventRootType Probe[main.stringArrayArg]Return
+          Type: 205 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb80c8", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,126 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 202 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb8008", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 203 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0xb8040", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - str: 'hello '
+        - dsl: {json: {ref: s}, dsl: s}
+        - str: ', and hello to '
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 188 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 189 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - dsl: {json: {ref: s}, dsl: s}
+        - dsl: {json: {ref: s}, dsl: s}
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 190 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 191 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 192 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb8008", Frameless: false}]
+          Type: 192 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 193 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb8040", Frameless: false}]
+          Type: 193 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 194 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 195 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [{str: hello}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 196 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 197 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +360,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 213 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb8360", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 204 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 214 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb84d8", Frameless: false}]
           Condition: null
 Subprograms:
@@ -786,7 +897,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 207
+      ID: 217
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -802,7 +913,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 208
+      ID: 218
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -818,7 +929,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 199
+      ID: 209
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -834,10 +945,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 200
+      ID: 210
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 205
+      ID: 215
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -853,7 +964,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 206
+      ID: 216
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 184
@@ -875,7 +986,7 @@ Types:
       ID: 185
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 200
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -891,10 +1002,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 191
+      ID: 201
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -910,10 +1021,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 197
+      ID: 207
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -929,13 +1040,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 198
+      ID: 208
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 186
@@ -954,10 +1065,144 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 188
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 190
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 192
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 194
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 196
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 187
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 196
+      ID: 189
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 191
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 193
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 195
+      Name: Probe[main.stringArg]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 197
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 206
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -973,7 +1218,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 194
+      ID: 204
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -989,10 +1234,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 195
+      ID: 205
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 202
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -1008,13 +1253,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 193
+      ID: 203
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 213
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 204
+      ID: 214
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2826,7 +3071,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 44640
       GoKind: 26
-MaxTypeID: 208
+MaxTypeID: 218
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1a13a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -247,10 +247,12 @@ Probes:
       message: hello {s}, and hello to {s}
       template: ""
       segments:
-        - str: 'hello '
-        - dsl: {json: {ref: s}, dsl: s}
-        - str: ', and hello to '
-        - dsl: {json: {ref: s}, dsl: s}
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -272,8 +274,10 @@ Probes:
       message: '{s}{s}'
       template: ""
       segments:
-        - dsl: {json: {ref: s}, dsl: s}
-        - dsl: {json: {ref: s}, dsl: s}
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -294,7 +298,7 @@ Probes:
       tags: ['foo:bar']
       message: hello world!
       template: ""
-      segments: [{str: 'hello '}, {str: world}, {str: '!'}]
+      segments: ['hello ', world, '!']
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -315,7 +319,7 @@ Probes:
       tags: ['foo:bar']
       message: hello {s}
       template: ""
-      segments: [{str: 'hello '}, {dsl: {json: {ref: s}, dsl: s}}]
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -336,7 +340,7 @@ Probes:
       tags: ['foo:bar']
       message: hello
       template: ""
-      segments: [{str: hello}]
+      segments: [hello]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -516,7 +520,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb84d9..0xb84f0
               Pieces: []
-          IsParameter: true
+          IsParameter: false
           IsReturn: true
     - ID: 12
       Name: main.inlined
@@ -1150,54 +1154,15 @@ Types:
     - __kind: EventRootType
       ID: 189
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 191
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 193
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
       ID: 195
       Name: Probe[main.stringArg]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 197
       Name: Probe[main.stringArg]Return

--- a/pkg/dyninst/json_redaction_test.go
+++ b/pkg/dyninst/json_redaction_test.go
@@ -200,6 +200,7 @@ var defaultRedactors = []jsonRedactor{
 		matchRegexp(`/debugger/snapshot/stack/[[:digit:]]+$`),
 		replacerFunc(redactStackFrame),
 	),
+
 	redactor(
 		exactMatcher(`/debugger/snapshot/id`),
 		replacement(`"[id]"`),
@@ -211,6 +212,13 @@ var defaultRedactors = []jsonRedactor{
 	redactor(
 		exactMatcher(`/timestamp`),
 		replacement(`"[ts]"`),
+	),
+	redactor(
+		exactMatcher(`/message`),
+		regexpStringReplacer(
+			`^0x[[:xdigit:]]+$`,
+			`0x[addr]`,
+		),
 	),
 	redactor(
 		exactMatcher(`/duration`),

--- a/pkg/dyninst/rcjson/rcjson_test.go
+++ b/pkg/dyninst/rcjson/rcjson_test.go
@@ -80,9 +80,16 @@ var testCases = []testCase{
 					SnapshotsPerSecond: 1.0,
 				},
 				Template: "Hello {name}",
-				Segments: []json.RawMessage{
-					json.RawMessage(`{"str": "Hello "}`),
-					json.RawMessage(`{"dsl": "name", "json": {"ref": "name"}}`),
+				Segments: SegmentList{
+					TemplateSegment{
+						StringSegment: newStringSegment("Hello "),
+					},
+					TemplateSegment{
+						JSONSegment: &JSONSegment{
+							JSON: json.RawMessage(`{"ref": "name"}`),
+							DSL:  "name",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/dyninst/rcjson/rcjson_test.go
+++ b/pkg/dyninst/rcjson/rcjson_test.go
@@ -81,19 +81,13 @@ var testCases = []testCase{
 				},
 				Template: "Hello {name}",
 				Segments: SegmentList{
-					TemplateSegment{
-						StringSegment: newStringSegment("Hello "),
-					},
-					TemplateSegment{
-						JSONSegment: &JSONSegment{
-							JSON: json.RawMessage(`{"ref": "name"}`),
-							DSL:  "name",
-						},
-					},
+					newStringSegment("Hello "),
+					newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
 				},
 			},
 		},
 	},
+
 	{
 		name: "log probe with file and multiple lines",
 		input: `{
@@ -144,12 +138,8 @@ var testCases = []testCase{
 				},
 				Template: "Hello {name}",
 				Segments: SegmentList{
-					TemplateSegment{
-						StringSegment: newStringSegment("Hello "),
-					},
-					TemplateSegment{
-						JSONSegment: newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
-					},
+					newStringSegment("Hello "),
+					newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
 				},
 			},
 		},
@@ -205,12 +195,8 @@ var testCases = []testCase{
 				},
 				Template: "Hello {name}",
 				Segments: SegmentList{
-					TemplateSegment{
-						StringSegment: newStringSegment("Hello "),
-					},
-					TemplateSegment{
-						JSONSegment: newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
-					},
+					newStringSegment("Hello "),
+					newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
 				},
 			},
 		},
@@ -293,15 +279,9 @@ var testCases = []testCase{
 				},
 				Template: "Hello {name} world",
 				Segments: SegmentList{
-					TemplateSegment{
-						StringSegment: newStringSegment("Hello "),
-					},
-					TemplateSegment{
-						JSONSegment: newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
-					},
-					TemplateSegment{
-						StringSegment: newStringSegment(" world"),
-					},
+					newStringSegment("Hello "),
+					newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
+					newStringSegment(" world"),
 				},
 			},
 		},
@@ -330,13 +310,13 @@ func TestUnmarshalProbe(t *testing.T) {
 	}
 }
 
-func newStringSegment(value string) *StringSegment {
+func newStringSegment(value string) StringSegment {
 	s := StringSegment(value)
-	return &s
+	return s
 }
 
-func newJSONSegment(json json.RawMessage, dsl string) *JSONSegment {
-	return &JSONSegment{
+func newJSONSegment(json json.RawMessage, dsl string) JSONSegment {
+	return JSONSegment{
 		JSON: json,
 		DSL:  dsl,
 	}

--- a/pkg/dyninst/rcscrape/probe_definition.go
+++ b/pkg/dyninst/rcscrape/probe_definition.go
@@ -23,18 +23,24 @@ import (
 
 type probeDefinitionV1 struct{ probeDefinition }
 
-func (r probeDefinitionV1) GetID() string      { return rcProbeIDV1 }
-func (r probeDefinitionV1) GetWhere() ir.Where { return probeWhereV1{} }
+func (r probeDefinitionV1) GetID() string                               { return rcProbeIDV1 }
+func (r probeDefinitionV1) GetWhere() ir.Where                          { return probeWhereV1{} }
+func (r probeDefinitionV1) GetSegments() []ir.TemplateSegmentDefinition { return nil }
+func (r probeDefinitionV1) GetTemplate() ir.TemplateDefinition          { return nil }
 
 type probeDefinitionV2 struct{ probeDefinition }
 
-func (r probeDefinitionV2) GetID() string      { return rcProbeIDV2 }
-func (r probeDefinitionV2) GetWhere() ir.Where { return probeWhereV2{} }
+func (r probeDefinitionV2) GetID() string                               { return rcProbeIDV2 }
+func (r probeDefinitionV2) GetWhere() ir.Where                          { return probeWhereV2{} }
+func (r probeDefinitionV2) GetSegments() []ir.TemplateSegmentDefinition { return nil }
+func (r probeDefinitionV2) GetTemplate() ir.TemplateDefinition          { return nil }
 
 type symdbProbeDefinition struct{ probeDefinition }
 
-func (r symdbProbeDefinition) GetID() string      { return rcProbeIDSymdb }
-func (r symdbProbeDefinition) GetWhere() ir.Where { return probeWhereSymdb{} }
+func (r symdbProbeDefinition) GetID() string                               { return rcProbeIDSymdb }
+func (r symdbProbeDefinition) GetWhere() ir.Where                          { return probeWhereSymdb{} }
+func (r symdbProbeDefinition) GetSegments() []ir.TemplateSegmentDefinition { return nil }
+func (r symdbProbeDefinition) GetTemplate() ir.TemplateDefinition          { return nil }
 
 type probeDefinition struct{}
 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -96,9 +96,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -205,6 +206,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -371,6 +375,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -379,6 +386,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -419,14 +437,34 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -435,9 +473,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -518,33 +556,117 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 64-72
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 63-68
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-53])
+		Arg: failed: bool (declared at line 44, available: [44-53])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 50-55
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 49-53
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-53])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-78])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -585,11 +707,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -624,6 +751,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -676,6 +808,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -744,6 +881,17 @@ Package: main
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [18-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
 			Var: #yield1: func(int) bool (declared at line 0, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -771,6 +919,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -818,6 +970,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -874,6 +1029,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -96,10 +96,9 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
+		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
+		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -206,9 +205,6 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -375,9 +371,6 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -386,17 +379,6 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -437,34 +419,14 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
-		Arg: i: int (declared at line 95, available: [95-98])
-		Arg: result: int (declared at line 95, available: )
-		Arg: result2: int (declared at line 95, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
+		Arg: i: int (declared at line 72, available: [72-76])
+		Arg: result: int (declared at line 72, available: )
+		Arg: result2: int (declared at line 72, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -473,9 +435,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
-		Arg: i: int (declared at line 88, available: [88-89])
-		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
+		Arg: i: int (declared at line 65, available: [65-68])
+		Arg: result: int (declared at line 65, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -556,117 +518,33 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
-		Arg: v: interface {} (declared at line 60, available: [60-72])
-		Arg: ~r0: interface {} (declared at line 60, available: )
-		Scope: 64-72
-			Var: val: int (declared at line 64, available: [65-65])
-		Scope: 63-68
-			Var: &result: *int (declared at line 67, available: [68-68])
-		Scope: 60-70
-			Var: val: interface {} (declared at line 69, available: [60-72])
-		Scope: 70-72
-			Var: val: interface {} (declared at line 71, available: [60-72])
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
-		Arg: v: interface {} (declared at line 44, available: [44-53])
-		Arg: failed: bool (declared at line 44, available: [44-53])
-		Arg: ~r0: interface {} (declared at line 44, available: )
-		Arg: ~r1: error (declared at line 44, available: )
-		Scope: 50-55
-			Var: val: int (declared at line 50, available: [51-51])
-		Scope: 49-53
-			Var: val: string (declared at line 52, available: [53-53])
-		Scope: 55-55
-			Var: val: interface {} (declared at line 54, available: [44-53])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
-		Arg: failed: bool (declared at line 36, available: [36-37])
-		Arg: ~r0: error (declared at line 36, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
-		Arg: i: int (declared at line 14, available: [14-15])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
+		Arg: v: interface {} (declared at line 49, available: [49-51])
+		Arg: ~r0: interface {} (declared at line 49, available: )
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
+		Arg: v: interface {} (declared at line 41, available: [41-42])
+		Arg: failed: bool (declared at line 41, available: [41-42])
+		Arg: ~r0: interface {} (declared at line 41, available: )
+		Arg: ~r1: error (declared at line 41, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
+		Arg: failed: bool (declared at line 33, available: [33-34])
+		Arg: ~r0: error (declared at line 33, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
+		Arg: i: int (declared at line 14, available: [14-16])
 		Arg: ~r0: int (declared at line 14, available: )
-		Var: result: int (declared at line 15, available: [14-17])
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
-		Arg: i: int (declared at line 28, available: [28-31])
-		Arg: ~r0: int (declared at line 28, available: )
-		Arg: ~r1: float64 (declared at line 28, available: )
-		Var: resultInt: int (declared at line 29, available: [28-32])
-		Var: resultFloat: float64 (declared at line 30, available: [28-32])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
-		Arg: i: int (declared at line 21, available: [21-24])
-		Arg: ~r0: *int (declared at line 21, available: )
-		Var: &result: *int (declared at line 22, available: [21-24])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
-		Arg: v: interface {} (declared at line 77, available: [77-78])
-		Arg: ~r0: main.behavior (declared at line 77, available: )
-		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
+		Arg: i: int (declared at line 26, available: [26-29])
+		Arg: ~r0: int (declared at line 26, available: )
+		Arg: ~r1: float64 (declared at line 26, available: )
+		Var: f: float64 (declared at line 27, available: [26-29])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
+		Arg: i: int (declared at line 20, available: [20-20])
+		Arg: ~r0: *int (declared at line 20, available: )
+		Var: &i: *int (declared at line 20, available: [20-22])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
+		Arg: v: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: main.behavior (declared at line 55, available: )
+		Var: b: main.behavior (declared at line 56, available: [56-61])
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -707,16 +585,11 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
-		Arg: i: int (declared at line 103, available: [103-105])
-		Arg: ~r0: int (declared at line 103, available: )
-		Arg: result2: int (declared at line 103, available: )
-		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
+		Arg: i: int (declared at line 80, available: [80-82])
+		Arg: ~r0: int (declared at line 80, available: )
+		Arg: result2: int (declared at line 80, available: )
+		Arg: ~r2: int (declared at line 80, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -751,11 +624,6 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -808,11 +676,6 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -881,17 +744,6 @@ Package: main
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [18-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
 			Var: #yield1: func(int) bool (declared at line 0, available: )
-	Type: main.largeStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -919,10 +771,6 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
-	Type: main.mixedStruct
-		Field: a: int
-		Field: b: float64
-		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -970,9 +818,6 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
-	Type: main.structWithArray
-		Field: arr: [2]int
-		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -1029,18 +874,6 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
-	Type: main.wideStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
-		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -85,10 +85,9 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
+		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
+		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -195,9 +194,6 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -364,9 +360,6 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -375,17 +368,6 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -426,34 +408,14 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
-		Arg: i: int (declared at line 95, available: [95-98])
-		Arg: result: int (declared at line 95, available: )
-		Arg: result2: int (declared at line 95, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
+		Arg: i: int (declared at line 72, available: [72-76])
+		Arg: result: int (declared at line 72, available: )
+		Arg: result2: int (declared at line 72, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -462,9 +424,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
-		Arg: i: int (declared at line 88, available: [88-89])
-		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
+		Arg: i: int (declared at line 65, available: [65-68])
+		Arg: result: int (declared at line 65, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -545,117 +507,33 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
-		Arg: v: interface {} (declared at line 60, available: [60-72])
-		Arg: ~r0: interface {} (declared at line 60, available: )
-		Scope: 64-72
-			Var: val: int (declared at line 64, available: [65-65])
-		Scope: 63-68
-			Var: &result: *int (declared at line 67, available: [68-68])
-		Scope: 60-70
-			Var: val: interface {} (declared at line 69, available: [60-72])
-		Scope: 70-72
-			Var: val: interface {} (declared at line 71, available: [60-72])
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
-		Arg: v: interface {} (declared at line 44, available: [44-51])
-		Arg: failed: bool (declared at line 44, available: [44-50])
-		Arg: ~r0: interface {} (declared at line 44, available: )
-		Arg: ~r1: error (declared at line 44, available: )
-		Scope: 49-51
-			Var: val: int (declared at line 50, available: [51-51])
-		Scope: 52-55
-			Var: val: string (declared at line 52, available: [53-53])
-		Scope: 55-55
-			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
-		Arg: failed: bool (declared at line 36, available: [36-37])
-		Arg: ~r0: error (declared at line 36, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
-		Arg: i: int (declared at line 14, available: [14-15])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
+		Arg: v: interface {} (declared at line 49, available: [49-51])
+		Arg: ~r0: interface {} (declared at line 49, available: )
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
+		Arg: v: interface {} (declared at line 41, available: [41-42])
+		Arg: failed: bool (declared at line 41, available: [41-42])
+		Arg: ~r0: interface {} (declared at line 41, available: )
+		Arg: ~r1: error (declared at line 41, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
+		Arg: failed: bool (declared at line 33, available: [33-34])
+		Arg: ~r0: error (declared at line 33, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
+		Arg: i: int (declared at line 14, available: [14-16])
 		Arg: ~r0: int (declared at line 14, available: )
-		Var: result: int (declared at line 15, available: [14-17])
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
-		Arg: i: int (declared at line 28, available: [28-31])
-		Arg: ~r0: int (declared at line 28, available: )
-		Arg: ~r1: float64 (declared at line 28, available: )
-		Var: resultInt: int (declared at line 29, available: [28-32])
-		Var: resultFloat: float64 (declared at line 30, available: [28-32])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
-		Arg: i: int (declared at line 21, available: [21-24])
-		Arg: ~r0: *int (declared at line 21, available: )
-		Var: &result: *int (declared at line 22, available: [21-24])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
-		Arg: v: interface {} (declared at line 77, available: [77-78])
-		Arg: ~r0: main.behavior (declared at line 77, available: )
-		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
+		Arg: i: int (declared at line 26, available: [26-29])
+		Arg: ~r0: int (declared at line 26, available: )
+		Arg: ~r1: float64 (declared at line 26, available: )
+		Var: f: float64 (declared at line 27, available: [26-29])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
+		Arg: i: int (declared at line 20, available: [20-20])
+		Arg: ~r0: *int (declared at line 20, available: )
+		Var: &i: *int (declared at line 20, available: [20-22])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
+		Arg: v: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: main.behavior (declared at line 55, available: )
+		Var: b: main.behavior (declared at line 56, available: [56-61])
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -696,16 +574,11 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
-		Arg: i: int (declared at line 103, available: [103-105])
-		Arg: ~r0: int (declared at line 103, available: )
-		Arg: result2: int (declared at line 103, available: )
-		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
+		Arg: i: int (declared at line 80, available: [80-82])
+		Arg: ~r0: int (declared at line 80, available: )
+		Arg: result2: int (declared at line 80, available: )
+		Arg: ~r2: int (declared at line 80, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -740,11 +613,6 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -797,11 +665,6 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -869,17 +732,6 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
-	Type: main.largeStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -907,10 +759,6 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
-	Type: main.mixedStruct
-		Field: a: int
-		Field: b: float64
-		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -958,9 +806,6 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
-	Type: main.structWithArray
-		Field: arr: [2]int
-		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -1017,18 +862,6 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
-	Type: main.wideStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
-		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -85,9 +85,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -194,6 +195,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -360,6 +364,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -368,6 +375,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -408,14 +426,34 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -424,9 +462,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -507,33 +545,117 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 64-72
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 63-68
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-51])
+		Arg: failed: bool (declared at line 44, available: [44-50])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 49-51
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 52-55
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-51])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-78])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -574,11 +696,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -613,6 +740,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -665,6 +797,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -732,6 +869,17 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -759,6 +907,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -806,6 +958,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -862,6 +1017,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -84,10 +84,9 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
+		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
+		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -194,9 +193,6 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -363,9 +359,6 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -374,17 +367,6 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -425,34 +407,14 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
-		Arg: i: int (declared at line 95, available: [95-98])
-		Arg: result: int (declared at line 95, available: )
-		Arg: result2: int (declared at line 95, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
+		Arg: i: int (declared at line 72, available: [72-76])
+		Arg: result: int (declared at line 72, available: )
+		Arg: result2: int (declared at line 72, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -461,9 +423,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
-		Arg: i: int (declared at line 88, available: [88-89])
-		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
+		Arg: i: int (declared at line 65, available: [65-68])
+		Arg: result: int (declared at line 65, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -544,117 +506,33 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
-		Arg: v: interface {} (declared at line 60, available: [60-72])
-		Arg: ~r0: interface {} (declared at line 60, available: )
-		Scope: 63-65
-			Var: val: int (declared at line 64, available: [65-65])
-		Scope: 66-72
-			Var: &result: *int (declared at line 67, available: [68-68])
-		Scope: 60-70
-			Var: val: interface {} (declared at line 69, available: [60-72])
-		Scope: 70-72
-			Var: val: interface {} (declared at line 71, available: [60-72])
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
-		Arg: v: interface {} (declared at line 44, available: [44-51])
-		Arg: failed: bool (declared at line 44, available: [44-50])
-		Arg: ~r0: interface {} (declared at line 44, available: )
-		Arg: ~r1: error (declared at line 44, available: )
-		Scope: 49-51
-			Var: val: int (declared at line 50, available: [51-51])
-		Scope: 52-55
-			Var: val: string (declared at line 52, available: [53-53])
-		Scope: 55-55
-			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
-		Arg: failed: bool (declared at line 36, available: [36-37])
-		Arg: ~r0: error (declared at line 36, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
-		Arg: i: int (declared at line 14, available: [14-15])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
+		Arg: v: interface {} (declared at line 49, available: [49-51])
+		Arg: ~r0: interface {} (declared at line 49, available: )
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
+		Arg: v: interface {} (declared at line 41, available: [41-42])
+		Arg: failed: bool (declared at line 41, available: [41-42])
+		Arg: ~r0: interface {} (declared at line 41, available: )
+		Arg: ~r1: error (declared at line 41, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
+		Arg: failed: bool (declared at line 33, available: [33-34])
+		Arg: ~r0: error (declared at line 33, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
+		Arg: i: int (declared at line 14, available: [14-16])
 		Arg: ~r0: int (declared at line 14, available: )
-		Var: result: int (declared at line 15, available: [14-17])
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
-		Arg: i: int (declared at line 28, available: [28-31])
-		Arg: ~r0: int (declared at line 28, available: )
-		Arg: ~r1: float64 (declared at line 28, available: )
-		Var: resultInt: int (declared at line 29, available: [28-32])
-		Var: resultFloat: float64 (declared at line 30, available: [28-32])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
-		Arg: i: int (declared at line 21, available: [21-24])
-		Arg: ~r0: *int (declared at line 21, available: )
-		Var: &result: *int (declared at line 22, available: [21-24])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
-		Arg: v: interface {} (declared at line 77, available: [77-78])
-		Arg: ~r0: main.behavior (declared at line 77, available: )
-		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
+		Arg: i: int (declared at line 26, available: [26-29])
+		Arg: ~r0: int (declared at line 26, available: )
+		Arg: ~r1: float64 (declared at line 26, available: )
+		Var: f: float64 (declared at line 27, available: [26-29])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
+		Arg: i: int (declared at line 20, available: [20-20])
+		Arg: ~r0: *int (declared at line 20, available: )
+		Var: &i: *int (declared at line 20, available: [20-22])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
+		Arg: v: interface {} (declared at line 55, available: [55-56])
+		Arg: ~r0: main.behavior (declared at line 55, available: )
+		Var: b: main.behavior (declared at line 56, available: [56-61])
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -695,16 +573,11 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
-		Arg: i: int (declared at line 103, available: [103-105])
-		Arg: ~r0: int (declared at line 103, available: )
-		Arg: result2: int (declared at line 103, available: )
-		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
+		Arg: i: int (declared at line 80, available: [80-82])
+		Arg: ~r0: int (declared at line 80, available: )
+		Arg: result2: int (declared at line 80, available: )
+		Arg: ~r2: int (declared at line 80, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -739,11 +612,6 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -796,11 +664,6 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -868,17 +731,6 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
-	Type: main.largeStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -906,10 +758,6 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
-	Type: main.mixedStruct
-		Field: a: int
-		Field: b: float64
-		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -957,9 +805,6 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
-	Type: main.structWithArray
-		Field: arr: [2]int
-		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -1016,18 +861,6 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
-	Type: main.wideStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
-		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -84,9 +84,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -193,6 +194,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -359,6 +363,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -367,6 +374,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -407,14 +425,34 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -423,9 +461,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -506,33 +544,117 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 63-65
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 66-72
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-51])
+		Arg: failed: bool (declared at line 44, available: [44-50])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 49-51
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 52-55
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-51])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-78])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -573,11 +695,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -612,6 +739,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -664,6 +796,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -731,6 +868,17 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -758,6 +906,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -805,6 +957,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -861,6 +1016,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -96,9 +96,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -205,6 +206,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -371,6 +375,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -379,6 +387,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -419,14 +438,36 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -435,9 +476,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -518,33 +559,119 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 64-72
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 63-68
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-53])
+		Arg: failed: bool (declared at line 44, available: [44-53])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 50-55
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 49-53
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-53])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-57])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-79])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -585,11 +712,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -624,6 +756,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -676,6 +813,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -744,6 +886,17 @@ Package: main
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [18-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
 			Var: #yield1: func(int) bool (declared at line 0, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -771,6 +924,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -818,6 +975,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -874,6 +1034,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -96,10 +96,9 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
+		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
+		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -206,9 +205,6 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -375,10 +371,6 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -387,17 +379,6 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -438,36 +419,14 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
-		Arg: i: int (declared at line 95, available: [95-98])
-		Arg: result: int (declared at line 95, available: )
-		Arg: result2: int (declared at line 95, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
+		Arg: i: int (declared at line 72, available: [72-76])
+		Arg: result: int (declared at line 72, available: )
+		Arg: result2: int (declared at line 72, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -476,9 +435,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
-		Arg: i: int (declared at line 88, available: [88-89])
-		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
+		Arg: i: int (declared at line 65, available: [65-68])
+		Arg: result: int (declared at line 65, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -559,119 +518,33 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
-		Arg: v: interface {} (declared at line 60, available: [60-72])
-		Arg: ~r0: interface {} (declared at line 60, available: )
-		Scope: 64-72
-			Var: val: int (declared at line 64, available: [65-65])
-		Scope: 63-68
-			Var: &result: *int (declared at line 67, available: [68-68])
-		Scope: 60-70
-			Var: val: interface {} (declared at line 69, available: [60-72])
-		Scope: 70-72
-			Var: val: interface {} (declared at line 71, available: [60-72])
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
-		Arg: v: interface {} (declared at line 44, available: [44-53])
-		Arg: failed: bool (declared at line 44, available: [44-53])
-		Arg: ~r0: interface {} (declared at line 44, available: )
-		Arg: ~r1: error (declared at line 44, available: )
-		Scope: 50-55
-			Var: val: int (declared at line 50, available: [51-51])
-		Scope: 49-53
-			Var: val: string (declared at line 52, available: [53-53])
-		Scope: 55-55
-			Var: val: interface {} (declared at line 54, available: [44-53])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
-		Arg: failed: bool (declared at line 36, available: [36-37])
-		Arg: ~r0: error (declared at line 36, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
-		Arg: i: int (declared at line 14, available: [14-15])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
+		Arg: v: interface {} (declared at line 49, available: [49-51])
+		Arg: ~r0: interface {} (declared at line 49, available: )
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
+		Arg: v: interface {} (declared at line 41, available: [41-42])
+		Arg: failed: bool (declared at line 41, available: [41-42])
+		Arg: ~r0: interface {} (declared at line 41, available: )
+		Arg: ~r1: error (declared at line 41, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
+		Arg: failed: bool (declared at line 33, available: [33-34])
+		Arg: ~r0: error (declared at line 33, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
+		Arg: i: int (declared at line 14, available: [14-16])
 		Arg: ~r0: int (declared at line 14, available: )
-		Var: result: int (declared at line 15, available: [14-17])
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
-		Arg: i: int (declared at line 28, available: [28-31])
-		Arg: ~r0: int (declared at line 28, available: )
-		Arg: ~r1: float64 (declared at line 28, available: )
-		Var: resultInt: int (declared at line 29, available: [28-32])
-		Var: resultFloat: float64 (declared at line 30, available: [28-32])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
-		Arg: i: int (declared at line 21, available: [21-24])
-		Arg: ~r0: *int (declared at line 21, available: )
-		Var: &result: *int (declared at line 22, available: [21-24])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
-		Arg: v: interface {} (declared at line 77, available: [77-79])
-		Arg: ~r0: main.behavior (declared at line 77, available: )
-		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
+		Arg: i: int (declared at line 26, available: [26-29])
+		Arg: ~r0: int (declared at line 26, available: )
+		Arg: ~r1: float64 (declared at line 26, available: )
+		Var: f: float64 (declared at line 27, available: [26-29])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
+		Arg: i: int (declared at line 20, available: [20-20])
+		Arg: ~r0: *int (declared at line 20, available: )
+		Var: &i: *int (declared at line 20, available: [20-22])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
+		Arg: v: interface {} (declared at line 55, available: [55-57])
+		Arg: ~r0: main.behavior (declared at line 55, available: )
+		Var: b: main.behavior (declared at line 56, available: [56-61])
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -712,16 +585,11 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
-		Arg: i: int (declared at line 103, available: [103-105])
-		Arg: ~r0: int (declared at line 103, available: )
-		Arg: result2: int (declared at line 103, available: )
-		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
+		Arg: i: int (declared at line 80, available: [80-82])
+		Arg: ~r0: int (declared at line 80, available: )
+		Arg: result2: int (declared at line 80, available: )
+		Arg: ~r2: int (declared at line 80, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -756,11 +624,6 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -813,11 +676,6 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -886,17 +744,6 @@ Package: main
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [18-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
 			Var: #yield1: func(int) bool (declared at line 0, available: )
-	Type: main.largeStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -924,10 +771,6 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
-	Type: main.mixedStruct
-		Field: a: int
-		Field: b: float64
-		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -975,9 +818,6 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
-	Type: main.structWithArray
-		Field: arr: [2]int
-		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -1034,18 +874,6 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
-	Type: main.wideStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
-		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -85,9 +85,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -194,6 +195,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -360,6 +364,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -368,6 +376,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -408,14 +427,36 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -424,9 +465,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -507,33 +548,119 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 64-72
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 63-68
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-51])
+		Arg: failed: bool (declared at line 44, available: [44-50])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 49-51
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 52-55
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-51])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-57])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-79])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -574,11 +701,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -613,6 +745,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -665,6 +802,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -732,6 +874,17 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -759,6 +912,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -806,6 +963,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -862,6 +1022,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -85,10 +85,9 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
+		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
+		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -195,9 +194,6 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -364,10 +360,6 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -376,17 +368,6 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -427,36 +408,14 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
-		Arg: i: int (declared at line 95, available: [95-98])
-		Arg: result: int (declared at line 95, available: )
-		Arg: result2: int (declared at line 95, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
+		Arg: i: int (declared at line 72, available: [72-76])
+		Arg: result: int (declared at line 72, available: )
+		Arg: result2: int (declared at line 72, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -465,9 +424,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
-		Arg: i: int (declared at line 88, available: [88-89])
-		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
+		Arg: i: int (declared at line 65, available: [65-68])
+		Arg: result: int (declared at line 65, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -548,119 +507,33 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
-		Arg: v: interface {} (declared at line 60, available: [60-72])
-		Arg: ~r0: interface {} (declared at line 60, available: )
-		Scope: 64-72
-			Var: val: int (declared at line 64, available: [65-65])
-		Scope: 63-68
-			Var: &result: *int (declared at line 67, available: [68-68])
-		Scope: 60-70
-			Var: val: interface {} (declared at line 69, available: [60-72])
-		Scope: 70-72
-			Var: val: interface {} (declared at line 71, available: [60-72])
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
-		Arg: v: interface {} (declared at line 44, available: [44-51])
-		Arg: failed: bool (declared at line 44, available: [44-50])
-		Arg: ~r0: interface {} (declared at line 44, available: )
-		Arg: ~r1: error (declared at line 44, available: )
-		Scope: 49-51
-			Var: val: int (declared at line 50, available: [51-51])
-		Scope: 52-55
-			Var: val: string (declared at line 52, available: [53-53])
-		Scope: 55-55
-			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
-		Arg: failed: bool (declared at line 36, available: [36-37])
-		Arg: ~r0: error (declared at line 36, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
-		Arg: i: int (declared at line 14, available: [14-15])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
+		Arg: v: interface {} (declared at line 49, available: [49-51])
+		Arg: ~r0: interface {} (declared at line 49, available: )
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
+		Arg: v: interface {} (declared at line 41, available: [41-42])
+		Arg: failed: bool (declared at line 41, available: [41-42])
+		Arg: ~r0: interface {} (declared at line 41, available: )
+		Arg: ~r1: error (declared at line 41, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
+		Arg: failed: bool (declared at line 33, available: [33-34])
+		Arg: ~r0: error (declared at line 33, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
+		Arg: i: int (declared at line 14, available: [14-16])
 		Arg: ~r0: int (declared at line 14, available: )
-		Var: result: int (declared at line 15, available: [14-17])
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
-		Arg: i: int (declared at line 28, available: [28-31])
-		Arg: ~r0: int (declared at line 28, available: )
-		Arg: ~r1: float64 (declared at line 28, available: )
-		Var: resultInt: int (declared at line 29, available: [28-32])
-		Var: resultFloat: float64 (declared at line 30, available: [28-32])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
-		Arg: i: int (declared at line 21, available: [21-24])
-		Arg: ~r0: *int (declared at line 21, available: )
-		Var: &result: *int (declared at line 22, available: [21-24])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
-		Arg: v: interface {} (declared at line 77, available: [77-79])
-		Arg: ~r0: main.behavior (declared at line 77, available: )
-		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
+		Arg: i: int (declared at line 26, available: [26-29])
+		Arg: ~r0: int (declared at line 26, available: )
+		Arg: ~r1: float64 (declared at line 26, available: )
+		Var: f: float64 (declared at line 27, available: [26-29])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
+		Arg: i: int (declared at line 20, available: [20-20])
+		Arg: ~r0: *int (declared at line 20, available: )
+		Var: &i: *int (declared at line 20, available: [20-22])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
+		Arg: v: interface {} (declared at line 55, available: [55-57])
+		Arg: ~r0: main.behavior (declared at line 55, available: )
+		Var: b: main.behavior (declared at line 56, available: [56-61])
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -701,16 +574,11 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
-		Arg: i: int (declared at line 103, available: [103-105])
-		Arg: ~r0: int (declared at line 103, available: )
-		Arg: result2: int (declared at line 103, available: )
-		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
+		Arg: i: int (declared at line 80, available: [80-82])
+		Arg: ~r0: int (declared at line 80, available: )
+		Arg: result2: int (declared at line 80, available: )
+		Arg: ~r2: int (declared at line 80, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -745,11 +613,6 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -802,11 +665,6 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -874,17 +732,6 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
-	Type: main.largeStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -912,10 +759,6 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
-	Type: main.mixedStruct
-		Field: a: int
-		Field: b: float64
-		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -963,9 +806,6 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
-	Type: main.structWithArray
-		Field: arr: [2]int
-		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -1022,18 +862,6 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
-	Type: main.wideStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
-		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -84,9 +84,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -193,6 +194,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -359,6 +363,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -367,6 +375,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -407,14 +426,36 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-330], [332-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -423,9 +464,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -506,33 +547,119 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 63-65
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 66-72
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-51])
+		Arg: failed: bool (declared at line 44, available: [44-50])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 49-51
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 52-55
+			Var: val: string (declared at line 52, available: )
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-51])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-57])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-79])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -573,11 +700,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -612,6 +744,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -664,6 +801,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -731,6 +873,17 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -758,6 +911,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -805,6 +962,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -861,6 +1021,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -84,10 +84,9 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
+		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
+		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -194,9 +193,6 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -363,10 +359,6 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -375,17 +367,6 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -426,36 +407,14 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-330], [332-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
-		Arg: i: int (declared at line 95, available: [95-98])
-		Arg: result: int (declared at line 95, available: )
-		Arg: result2: int (declared at line 95, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
+		Arg: i: int (declared at line 72, available: [72-76])
+		Arg: result: int (declared at line 72, available: )
+		Arg: result2: int (declared at line 72, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -464,9 +423,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
-		Arg: i: int (declared at line 88, available: [88-89])
-		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
+		Arg: i: int (declared at line 65, available: [65-68])
+		Arg: result: int (declared at line 65, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -547,119 +506,33 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
-		Arg: v: interface {} (declared at line 60, available: [60-72])
-		Arg: ~r0: interface {} (declared at line 60, available: )
-		Scope: 63-65
-			Var: val: int (declared at line 64, available: [65-65])
-		Scope: 66-72
-			Var: &result: *int (declared at line 67, available: [68-68])
-		Scope: 60-70
-			Var: val: interface {} (declared at line 69, available: [60-72])
-		Scope: 70-72
-			Var: val: interface {} (declared at line 71, available: [60-72])
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
-		Arg: v: interface {} (declared at line 44, available: [44-51])
-		Arg: failed: bool (declared at line 44, available: [44-50])
-		Arg: ~r0: interface {} (declared at line 44, available: )
-		Arg: ~r1: error (declared at line 44, available: )
-		Scope: 49-51
-			Var: val: int (declared at line 50, available: [51-51])
-		Scope: 52-55
-			Var: val: string (declared at line 52, available: )
-		Scope: 55-55
-			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
-		Arg: failed: bool (declared at line 36, available: [36-37])
-		Arg: ~r0: error (declared at line 36, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
-		Arg: i: int (declared at line 14, available: [14-15])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
+		Arg: v: interface {} (declared at line 49, available: [49-51])
+		Arg: ~r0: interface {} (declared at line 49, available: )
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
+		Arg: v: interface {} (declared at line 41, available: [41-42])
+		Arg: failed: bool (declared at line 41, available: [41-42])
+		Arg: ~r0: interface {} (declared at line 41, available: )
+		Arg: ~r1: error (declared at line 41, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
+		Arg: failed: bool (declared at line 33, available: [33-34])
+		Arg: ~r0: error (declared at line 33, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
+		Arg: i: int (declared at line 14, available: [14-16])
 		Arg: ~r0: int (declared at line 14, available: )
-		Var: result: int (declared at line 15, available: [14-17])
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
-		Arg: i: int (declared at line 28, available: [28-31])
-		Arg: ~r0: int (declared at line 28, available: )
-		Arg: ~r1: float64 (declared at line 28, available: )
-		Var: resultInt: int (declared at line 29, available: [28-32])
-		Var: resultFloat: float64 (declared at line 30, available: [28-32])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
-		Arg: i: int (declared at line 21, available: [21-24])
-		Arg: ~r0: *int (declared at line 21, available: )
-		Var: &result: *int (declared at line 22, available: [21-24])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
-		Arg: v: interface {} (declared at line 77, available: [77-79])
-		Arg: ~r0: main.behavior (declared at line 77, available: )
-		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
+		Arg: i: int (declared at line 26, available: [26-29])
+		Arg: ~r0: int (declared at line 26, available: )
+		Arg: ~r1: float64 (declared at line 26, available: )
+		Var: f: float64 (declared at line 27, available: [26-29])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
+		Arg: i: int (declared at line 20, available: [20-20])
+		Arg: ~r0: *int (declared at line 20, available: )
+		Var: &i: *int (declared at line 20, available: [20-22])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
+		Arg: v: interface {} (declared at line 55, available: [55-57])
+		Arg: ~r0: main.behavior (declared at line 55, available: )
+		Var: b: main.behavior (declared at line 56, available: [56-61])
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -700,16 +573,11 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
-		Arg: i: int (declared at line 103, available: [103-105])
-		Arg: ~r0: int (declared at line 103, available: )
-		Arg: result2: int (declared at line 103, available: )
-		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
+		Arg: i: int (declared at line 80, available: [80-82])
+		Arg: ~r0: int (declared at line 80, available: )
+		Arg: result2: int (declared at line 80, available: )
+		Arg: ~r2: int (declared at line 80, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -744,11 +612,6 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -801,11 +664,6 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -873,17 +731,6 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
-	Type: main.largeStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -911,10 +758,6 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
-	Type: main.mixedStruct
-		Field: a: int
-		Field: b: float64
-		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -962,9 +805,6 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
-	Type: main.structWithArray
-		Field: arr: [2]int
-		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -1021,18 +861,6 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
-	Type: main.wideStruct
-		Field: a: int
-		Field: b: int
-		Field: c: int
-		Field: d: int
-		Field: e: int
-		Field: f: int
-		Field: g: int
-		Field: h: int
-		Field: i: int
-		Field: j: int
-		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/testdata/decoded/fault/callMe.json
+++ b/pkg/dyninst/testdata/decoded/fault/callMe.json
@@ -65,6 +65,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -70,6 +70,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -73,7 +73,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -149,7 +150,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -225,7 +227,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -301,7 +304,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -377,7 +381,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -453,7 +458,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -528,7 +534,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -604,7 +611,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -681,7 +689,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -757,6 +766,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -68,7 +68,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -144,7 +145,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -221,7 +223,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -298,7 +301,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -381,7 +385,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -470,6 +475,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -96,6 +96,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -89,6 +89,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -129,6 +129,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -113,6 +113,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
@@ -87,6 +87,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -85,6 +85,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]bool{true, true}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -67,6 +67,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -76,6 +76,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -101,6 +101,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -70,6 +70,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -82,6 +82,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -82,6 +82,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -100,6 +100,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -63,6 +63,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -59,7 +59,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -121,6 +122,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "main.emptyStruct{ }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
@@ -60,6 +60,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -70,6 +70,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -131,6 +131,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -92,6 +92,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -68,6 +68,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -90,6 +90,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -89,6 +89,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
@@ -65,6 +65,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
@@ -70,6 +70,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -60,6 +60,7 @@
         "captures": {}
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -56,6 +56,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -60,6 +60,7 @@
         "captures": {}
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
@@ -66,6 +66,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -60,6 +60,7 @@
         "captures": {}
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
@@ -66,6 +66,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -64,7 +64,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -136,7 +137,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -208,7 +210,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -285,7 +288,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -353,6 +357,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
@@ -68,7 +68,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -144,7 +145,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -220,7 +222,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -301,7 +304,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -372,6 +376,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -64,6 +64,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
@@ -68,6 +68,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -81,7 +81,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -170,6 +171,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -69,7 +69,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -142,7 +143,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -214,7 +216,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -287,7 +290,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -354,7 +358,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -420,6 +425,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -150,6 +150,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -88,6 +88,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -56,6 +56,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -67,7 +67,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -137,7 +138,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -207,7 +209,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -277,7 +280,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -347,7 +351,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -417,7 +422,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -487,7 +493,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -557,7 +564,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -627,7 +635,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -697,6 +706,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -67,7 +67,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -137,7 +138,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -207,7 +209,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -277,7 +280,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -347,7 +351,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -417,7 +422,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -487,7 +493,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -557,7 +564,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -627,7 +635,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -697,6 +706,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -110,6 +110,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -175,6 +175,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -646,6 +646,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -71,6 +71,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -71,6 +71,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -71,6 +71,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -521,6 +521,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -145,6 +145,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -145,6 +145,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -101,6 +101,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -99,6 +99,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -270,6 +270,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -2611,6 +2611,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -141,6 +141,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -110,6 +110,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -195,6 +195,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -72,6 +72,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -75,6 +75,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -68,6 +68,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testSliceEmptyStructs",
+      "method": "main.testNamedReturn",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,19 +16,19 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testSliceEmptyStructs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 69
+            "function": "main.testNamedReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 68
           },
           {
-            "function": "main.executeSliceFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 96
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 104
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 50
           },
           {
             "function": "runtime.main",
@@ -42,27 +42,29 @@
           }
         ],
         "probe": {
-          "id": "testSliceEmptyStructs",
+          "id": "testNamedReturnWithTemplate",
           "location": {
-            "method": "main.testSliceEmptyStructs"
+            "method": "main.testNamedReturn"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "xs": {
-                "type": "[]struct {}",
-                "size": "2",
-                "elements": [
-                  {
-                    "type": "struct {}",
-                    "fields": {}
-                  },
-                  {
-                    "type": "struct {}",
-                    "fields": {}
-                  }
-                ]
+              "i": {
+                "type": "int",
+                "value": "40"
+              },
+              "result": {
+                "type": "int",
+                "notCapturedReason": "unavailable"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "result": {
+                "type": "int",
+                "notCapturedReason": "unavailable"
               }
             }
           }
@@ -70,6 +72,7 @@
       }
     },
     "timestamp": "[ts]",
+    "duration": "[duration]",
     "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testNamedReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 68
+            "lineNumber": 91
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 104
+            "lineNumber": 393
           },
           {
             "function": "main.main",
@@ -53,10 +53,6 @@
               "i": {
                 "type": "int",
                 "value": "40"
-              },
-              "result": {
-                "type": "int",
-                "notCapturedReason": "unavailable"
               }
             }
           },
@@ -64,7 +60,7 @@
             "locals": {
               "result": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "80"
               }
             }
           }
@@ -73,6 +69,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": ""
+    "message": "Parameter 40 * 2 = result 80"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -63,6 +63,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -63,6 +63,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -67,6 +67,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -65,6 +65,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -70,6 +70,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -82,6 +82,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -76,7 +76,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -157,7 +158,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -240,6 +242,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -96,7 +96,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -189,6 +190,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -74,6 +74,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -66,6 +66,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -61,6 +61,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -92,6 +92,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -56,7 +56,7 @@
               },
               "~r1": {
                 "type": "uintptr",
-                "value": "0x1234"
+                "value": "4660"
               }
             }
           }
@@ -64,6 +64,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -64,6 +64,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -79,7 +79,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -154,6 +155,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -68,6 +68,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -72,6 +72,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -77,7 +77,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -168,7 +169,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -260,6 +262,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -101,6 +101,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -121,6 +121,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -76,6 +76,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -60,6 +60,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -64,6 +64,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -60,6 +60,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -88,6 +88,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -79,6 +79,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -105,6 +105,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "parameter = -16"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "parameter = -8"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "abc"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -103,6 +103,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -81,6 +81,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -76,6 +76,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -98,6 +98,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -60,6 +60,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -73,6 +73,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -60,6 +60,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct.json
@@ -86,6 +86,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "main.aStruct{ aBool = true aString = one aNumber = 2 nested = main.nestedStruct{ anotherInt = 3 anotherString = four } }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -91,6 +91,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -79,6 +79,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -110,6 +110,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
@@ -85,6 +85,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -472,6 +472,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -76,6 +76,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -67,6 +67,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
@@ -73,6 +73,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -73,6 +73,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -60,6 +60,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -73,6 +73,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[]uint{1, 2, 3}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -461,6 +461,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -318,6 +318,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
@@ -318,6 +318,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -78,6 +78,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -54,6 +54,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -55,6 +55,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -615,6 +615,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -54,7 +54,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "simple",
@@ -117,6 +118,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -55,6 +55,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -68,6 +68,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/mapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapArg.json
@@ -67,6 +67,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/noArgs.json
+++ b/pkg/dyninst/testdata/decoded/simple/noArgs.json
@@ -46,6 +46,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateDSLAndStringSegments.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateDSLAndStringSegments.json
@@ -37,7 +37,7 @@
           }
         ],
         "probe": {
-          "id": "stringArg",
+          "id": "testTemplateDSLAndStringSegments",
           "location": {
             "method": "main.stringArg"
           }
@@ -50,12 +50,20 @@
                 "value": "d"
               }
             }
+          },
+          "return": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "notCapturedReason": "unavailable"
+              }
+            }
           }
         }
       }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": ""
+    "message": "hello d, and hello to d"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateDSLAndStringSegments.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateDSLAndStringSegments.json
@@ -50,14 +50,6 @@
                 "value": "d"
               }
             }
-          },
-          "return": {
-            "arguments": {
-              "s": {
-                "type": "string",
-                "notCapturedReason": "unavailable"
-              }
-            }
           }
         }
       }

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleDSLSegment.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleDSLSegment.json
@@ -37,7 +37,7 @@
           }
         ],
         "probe": {
-          "id": "stringArg",
+          "id": "testTemplateMultipleDSLSegment",
           "location": {
             "method": "main.stringArg"
           }
@@ -50,12 +50,20 @@
                 "value": "d"
               }
             }
+          },
+          "return": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "notCapturedReason": "unavailable"
+              }
+            }
           }
         }
       }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": ""
+    "message": "dd"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleDSLSegment.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleDSLSegment.json
@@ -50,14 +50,6 @@
                 "value": "d"
               }
             }
-          },
-          "return": {
-            "arguments": {
-              "s": {
-                "type": "string",
-                "notCapturedReason": "unavailable"
-              }
-            }
           }
         }
       }

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleStringSegments.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleStringSegments.json
@@ -37,7 +37,7 @@
           }
         ],
         "probe": {
-          "id": "stringArg",
+          "id": "testTemplateMultipleStringSegments",
           "location": {
             "method": "main.stringArg"
           }
@@ -56,6 +56,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": ""
+    "message": "hello world!"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateStringAndDSLSegment.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateStringAndDSLSegment.json
@@ -37,7 +37,7 @@
           }
         ],
         "probe": {
-          "id": "stringArg",
+          "id": "testTemplateStringAndDSLSegment",
           "location": {
             "method": "main.stringArg"
           }
@@ -50,12 +50,20 @@
                 "value": "d"
               }
             }
+          },
+          "return": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "notCapturedReason": "unavailable"
+              }
+            }
           }
         }
       }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": ""
+    "message": "hello d"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateStringAndDSLSegment.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateStringAndDSLSegment.json
@@ -50,14 +50,6 @@
                 "value": "d"
               }
             }
-          },
-          "return": {
-            "arguments": {
-              "s": {
-                "type": "string",
-                "notCapturedReason": "unavailable"
-              }
-            }
           }
         }
       }

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateStringSegment.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateStringSegment.json
@@ -37,7 +37,7 @@
           }
         ],
         "probe": {
-          "id": "stringArg",
+          "id": "testTemplateStringSegment",
           "location": {
             "method": "main.stringArg"
           }
@@ -56,6 +56,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": ""
+    "message": "hello"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -84,6 +84,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -34,7 +34,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -233,7 +234,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -270,7 +272,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -469,7 +472,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -506,7 +510,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -705,6 +710,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   }
 ]

--- a/pkg/dyninst/testdata/e2e/rc_tester_v1.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester_v1.json
@@ -34,7 +34,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -233,7 +234,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -270,7 +272,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -469,7 +472,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -506,7 +510,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -705,6 +710,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   }
 ]

--- a/pkg/dyninst/testprogs/testdata/probes/fault.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/fault.yaml
@@ -7,3 +7,5 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: ""
+    segments:

--- a/pkg/dyninst/testprogs/testdata/probes/rc_tester.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/rc_tester.yaml
@@ -7,6 +7,9 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: "test log message"
+    segments:
+      - str: "test log message"
   - id: http_handler
     type: LOG_PROBE
     where:
@@ -14,3 +17,6 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: "test log message"
+    segments:
+      - str: "test log message"

--- a/pkg/dyninst/testprogs/testdata/probes/rc_tester_v1.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/rc_tester_v1.yaml
@@ -7,6 +7,9 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: "test log message"
+    segments:
+      - str: "test log message"
   - id: http_handler
     type: LOG_PROBE
     where:
@@ -14,3 +17,7 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: "test log message"
+    segments:
+      - str: "test log message"
+

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -980,11 +980,12 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testNamedReturn
-    message: "hello {result}"
+    message: "The returned value is: {result}"
     segments:
-      - json: 
+      - str: "The returned value is: "
+      - dsl: "result"
+        json:
           ref: "result"
-        dsl: "result"
     captureSnapshot: true
   - id: testMultipleNamedReturn
     type: LOG_PROBE

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -34,6 +34,12 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt8
+    message: "hello {x}"
+    segments:
+      - str: "hello"
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt16
     type: LOG_PROBE
@@ -41,6 +47,12 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt16
+    message: "hello {x}"
+    segments:
+      - str: "hello"
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt32
     type: LOG_PROBE
@@ -119,6 +131,11 @@ probes:
     where:
       methodName: main.testSingleString
     captureSnapshot: true
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"  
   - id: testUnitializedString
     type: LOG_PROBE
     tags:
@@ -214,6 +231,11 @@ probes:
     where:
       methodName: main.testBoolArray
     captureSnapshot: true
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
   - id: testIntArray
     type: LOG_PROBE
     tags:
@@ -324,6 +346,11 @@ probes:
     where:
       methodName: main.testUintSlice
     captureSnapshot: true
+    message: "{u}"
+    segments:
+      - json: 
+          ref: "u"
+        dsl: "u"
   - id: testVeryLargeSlice
     type: LOG_PROBE
     tags:
@@ -416,6 +443,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStruct
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testEmptyStruct
     type: LOG_PROBE
@@ -424,6 +456,11 @@ probes:
     where:
       methodName: main.testEmptyStruct
     captureSnapshot: true
+    message: "{e}"
+    segments:
+      - json: 
+          ref: "e"
+        dsl: "e"
   - id: testUintPointer
     type: LOG_PROBE
     tags:
@@ -431,6 +468,11 @@ probes:
     where:
       methodName: main.testUintPointer
     captureSnapshot: true
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
   - id: testStringPointer
     type: LOG_PROBE
     tags:

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -34,9 +34,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt8
-    message: "hello {x}"
+    message: "parameter = {x}"
     segments:
-      - str: "hello"
+      - str: "parameter = "
       - json: 
           ref: "x"
         dsl: "x"
@@ -47,9 +47,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt16
-    message: "hello {x}"
+    message: "parameter = {x}"
     segments:
-      - str: "hello"
+      - str: "parameter = "
       - json: 
           ref: "x"
         dsl: "x"
@@ -980,9 +980,13 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testNamedReturn
-    message: "The returned value is: {result}"
+    message: "Parameter {i} * 2 = result {result}"
     segments:
-      - str: "The returned value is: "
+      - str: "Parameter "
+      - dsl: "i"
+        json:
+          ref: "i"
+      - str: " * 2 = result "
       - dsl: "result"
         json:
           ref: "result"
@@ -1077,6 +1081,15 @@ probes:
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
+    message: "{a} and {b}"
+    segments:
+      - dsl: "a"
+        json:
+          ref: "a"
+      - str: " and "
+      - dsl: "b"
+        json:
+          ref: "b"
   - id: testReturnsPrimitives
     type: LOG_PROBE
     where:

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -976,6 +976,16 @@ probes:
     where:
       methodName: main.testNamedReturn
     captureSnapshot: true
+  - id: testNamedReturnWithTemplate
+    type: LOG_PROBE
+    where:
+      methodName: main.testNamedReturn
+    message: "hello {result}"
+    segments:
+      - json: 
+          ref: "result"
+        dsl: "result"
+    captureSnapshot: true
   - id: testMultipleNamedReturn
     type: LOG_PROBE
     where:

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -77,3 +77,70 @@ probes:
   captureSnapshot: true
   where:
     methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+- id: testTemplateStringSegment
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "hello"
+  segments:
+    - str: "hello"
+- id: testTemplateMultipleStringSegments
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "hello world!"
+  segments:
+    - str: "hello "
+    - str: "world"
+    - str: "!"
+- id: testTemplateStringAndDSLSegment
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "hello {s}"
+  segments:
+    - str: "hello "
+    - dsl: "s"
+      json:
+        ref: "s"
+- id: testTemplateMultipleDSLSegment
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "{s}{s}"
+  segments:
+    - dsl: "s"
+      json:
+        ref: "s"
+    - dsl: "s"
+      json:
+        ref: "s"
+- id: testTemplateDSLAndStringSegments
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "hello {s}, and hello to {s}"
+  segments:
+    - str: "hello "
+    - dsl: "s"
+      json:
+        ref: "s"
+    - str: ", and hello to "
+    - dsl: "s"
+      json:
+        ref: "s"


### PR DESCRIPTION
### What does this PR do?

Adds support for templates in snapshot/log probes. For now only DSLs that directly reference parameter names are supported.

### Motivation

### Describe how you validated your changes

Run `TestDecoderWithTemplate` in pkg/dyninst/decode

### Additional Notes

```
=== RUN   TestDecoderWithTemplate/testTemplateDSLAndStringSegments
{"service":"foo","ddsource":"dd_debugger","logger":{"name":"","method":"main.stringArg","version":0,"thread_id":0,"thread_name":""},"debugger":{"snapshot":{"id":"eff6feed-2450-4e14-b706-ebd8386a736b","timestamp":1758481338470,"language":"go","stack":[],"probe":{"id":"testTemplateDSLAndStringSegments","location":{"method":"main.stringArg"}},"captures":{"entry":{"arguments":{"s":{"type":"string","value":"abcdefghijklmnop"}}}}},"evaluationErrors":["error symbolicating stack: no stack pcs found"]},"timestamp":1758481338470,"message":"hello abcdefghijklmnop, and hello to abcdefghijklmnop"}
```