### PR TITLE
Adding spec.yaml for Windows Certificate and Network Path integrations

### DIFF
--- a/cmd/agent/dist/assets/network_path/spec.yaml
+++ b/cmd/agent/dist/assets/network_path/spec.yaml
@@ -1,0 +1,113 @@
+name: network_path
+version: 1.0.0
+files:
+- name: network_path.yaml
+  options:
+  - template: init_config
+    options:
+    - name: min_collection_interval
+      value:
+        type: number
+        example: 60
+        default: 60
+      description: |
+        Specifies how frequently we should probe the endpoint.
+        Min collection interval is defined in seconds.
+      required: false
+    - name: timeout
+      value:
+        type: integer
+        example: 1000
+        default: 1000
+      description: |
+        Specifies how much time in milliseconds the traceroute should
+        wait for a response from each hop before timing out.
+      required: false
+  - template: instances
+    options:
+    - name: hostname
+      value:
+        type: string
+        example: "<HOSTNAME>"
+      description: |
+        Hostname or IP of the target endpoint to monitor via Network Path.
+      required: true
+    - name: port
+      value:
+        type: integer
+        example: "<PORT>"
+      description: |
+        Port of the target endpoint to monitor via Network Path.
+        For UDP, we do not recommend setting the port since it can make probes less reliable.
+        If port is not set, a random port will be used.
+      required: false
+    - name: protocol
+      value:
+        type: string
+        example: "<PROTOCOL>"
+        default: "UDP"
+      description: |
+        Protocol used to monitor an endpoint via Network Path.
+        Available protocols: UDP, TCP, ICMP
+      required: false
+    - name: max_ttl
+      value:
+        type: integer
+        example: "<PORT>"
+        default: 30
+      description: |
+        Specifies the maximum number of hops (max time-to-live value) traceroute will probe.
+      required: false
+    - name: timeout
+      value:
+        type: integer
+        example: 1000
+        default: 1000
+      description: |
+        Specifies how much time in milliseconds the traceroute should
+        wait for a response from each hop before timing out.
+      required: false
+    - name: min_collection_interval
+      value:
+        type: number
+        example: 60
+        default: 60
+      description: |
+        Specifies how frequently we should probe the endpoint.
+        Min collection interval is defined in seconds.
+      required: false
+    - name: source_service
+      value:
+        type: string
+        example: "<SOURCE_SERVICE>"
+      description: |
+        Source service name.
+      required: false
+    - name: destination_service
+      value:
+        type: string
+        example: "<DESTINATION_SERVICE>"
+      description: |
+        Destination service name.
+      required: false
+    - name: tcp_method
+      value:
+        type: string
+        example: "<METHOD>"
+        default: "syn"
+      description: |
+        Traceroute method used to monitor an endpoint via Network Path
+        Available methods: syn, sack, prefer_sack, syn_socket (syn_socket only works on Windows OSes)
+        Note: Windows client versions only support syn_socket
+      required: false
+    - name: tags
+      value:
+        type: array
+        items:
+          type: string
+        example: ["<KEY_1>:<VALUE_1>", "<KEY_2>:<VALUE_2>"]
+      description: |
+        A list of tags to attach to every metric and service check emitted by this instance.
+        
+        Learn more about tagging at https://docs.datadoghq.com/tagging
+      required: false

--- a/cmd/agent/dist/assets/windows_certificate/spec.yaml
+++ b/cmd/agent/dist/assets/windows_certificate/spec.yaml
@@ -1,0 +1,218 @@
+name: windows_certificate
+version: 1.0.0
+files:
+- name: windows_certificate.yaml
+  options:
+  - template: init_config
+    options:
+    - name: service
+      value:
+        type: string
+        example: "<SERVICE>"
+      description: |
+        Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+        
+        Additionally, this sets the default `service` for every log source.
+      required: false
+  - template: instances
+    options:
+    - name: certificate_store
+      value:
+        type: string
+        example: "MY"
+      description: |
+        The certificate store to query from when verifying the Windows certificates.
+        This check can only query from local machine certificates.
+        Enter the store name as found in `HKEY_LOCAL_MACHINE\Software\Microsoft\SystemCertificates`
+      required: true
+    - name: certificate_subjects
+      value:
+        type: array
+        items:
+          type: string
+        example: ["<SUBJECT_1>", "<SUBJECT_2>"]
+      description: |
+        A list of strings to filter by the subjects of the certificates.
+        For example if you have `Microsoft Root Authority` in `certificate_subjects`
+        and you have a certificate with subject,
+        "CN=Microsoft Root Authority, OU=Microsoft Corporation, OU=Copyright (c) 1997 Microsoft Corp."
+        then the certificate will be matched and metrics will be collected for that certificate.
+        If `certificate_subjects` is empty then all certificates in `certificate_store` are collected.
+      required: false
+    - name: server
+      value:
+        type: string
+        example: "<SERVER>"
+      description: |
+        The server with which to connect, defaulting to the local machine.
+      required: false
+    - name: username
+      value:
+        type: string
+        example: "<USERNAME>"
+      description: |
+        The username used to connect to the `server`.
+      required: false
+    - name: password
+      value:
+        type: string
+        example: "<PASSWORD>"
+      description: |
+        The password of `username`.
+      required: false
+    - name: days_warning
+      value:
+        type: integer
+        example: 14
+        default: 14
+      description: |
+        Number of days before certificate expiration from which the service check
+        `windows_certificate.cert_expiration` begins emitting WARNING.
+      required: false
+    - name: days_critical
+      value:
+        type: integer
+        example: 7
+        default: 7
+      description: |
+        Number of days before certificate expiration from which the service check
+        `windows_certificate.cert_expiration` begins emitting CRITICAL.
+      required: false
+    - name: enable_crl_monitoring
+      value:
+        type: boolean
+        example: false
+        default: false
+      description: |
+        Enables monitoring of expiration of all Certificate Revocation Lists (CRLs) in `certificate_store`.
+      required: false
+    - name: crl_days_warning
+      value:
+        type: integer
+        example: 0
+        default: 0
+      description: |
+        Number of days before CRL expiration from which the service check
+        `windows_certificate.crl_expiration` begins emitting WARNING.
+        If the CRLs in the store are updated automatically, set to 0 to avoid getting WARNING alerts.
+        If the CRLs are updated manually, set to the number days beforehand that you would like to receive a WARNING.
+      required: false
+    - name: cert_chain_validation
+      value:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            example: false
+            default: false
+            description: |
+              Set to `true` to enable certificate chain validation.
+          policy_validation_flags:
+            type: array
+            items:
+              type: string
+              enum:
+                - "CERT_CHAIN_POLICY_IGNORE_NOT_TIME_VALID_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_CTL_NOT_TIME_VALID_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_NOT_TIME_NESTED_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_ALL_NOT_TIME_VALID_FLAGS"
+                - "CERT_CHAIN_POLICY_IGNORE_INVALID_BASIC_CONSTRAINTS_FLAG"
+                - "CERT_CHAIN_POLICY_ALLOW_UNKNOWN_CA_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_WRONG_USAGE_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_INVALID_NAME_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_INVALID_POLICY_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_END_REV_UNKNOWN_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_CTL_SIGNER_REV_UNKNOWN_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_CA_REV_UNKNOWN_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_ROOT_REV_UNKNOWN_FLAG"
+                - "CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS"
+            example: ["CERT_CHAIN_POLICY_IGNORE_ALL_NOT_TIME_VALID_FLAGS", "CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS"]
+            description: |
+              A list of certificate chain policy validation flags to ignore during validation.
+              These flags allow you to suppress specific validation errors that may not be relevant
+              to your environment or use case. Available flags include:
+              
+              Time-related flags:
+              - `CERT_CHAIN_POLICY_IGNORE_NOT_TIME_VALID_FLAG`: Ignore certificates that are not yet valid or have expired
+              - `CERT_CHAIN_POLICY_IGNORE_CTL_NOT_TIME_VALID_FLAG`: Ignore Certificate Trust Lists (CTLs) that are not time valid
+              - `CERT_CHAIN_POLICY_IGNORE_NOT_TIME_NESTED_FLAG`: Ignore certificates in the chain that are not time nested
+              - `CERT_CHAIN_POLICY_IGNORE_ALL_NOT_TIME_VALID_FLAGS`: Ignore all time-related validation errors
+              
+              Constraint and usage flags:
+              - `CERT_CHAIN_POLICY_IGNORE_INVALID_BASIC_CONSTRAINTS_FLAG`: Ignore invalid basic constraints
+              - `CERT_CHAIN_POLICY_ALLOW_UNKNOWN_CA_FLAG`: Allow unknown Certificate Authorities
+              - `CERT_CHAIN_POLICY_IGNORE_WRONG_USAGE_FLAG`: Ignore wrong usage errors
+              - `CERT_CHAIN_POLICY_IGNORE_INVALID_NAME_FLAG`: Ignore invalid name errors
+              - `CERT_CHAIN_POLICY_IGNORE_INVALID_POLICY_FLAG`: Ignore invalid policy errors
+              
+              Revocation-related flags:
+              - `CERT_CHAIN_POLICY_IGNORE_END_REV_UNKNOWN_FLAG`: Ignore end entity certificate revocation unknown errors
+              - `CERT_CHAIN_POLICY_IGNORE_CTL_SIGNER_REV_UNKNOWN_FLAG`: Ignore CTL signer revocation unknown errors
+              - `CERT_CHAIN_POLICY_IGNORE_CA_REV_UNKNOWN_FLAG`: Ignore CA certificate revocation unknown errors
+              - `CERT_CHAIN_POLICY_IGNORE_ROOT_REV_UNKNOWN_FLAG`: Ignore root certificate revocation unknown errors
+              - `CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS`: Ignore all revocation unknown errors
+              
+              For detailed documentation, see the following resources:
+                - https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_policy_para
+                - https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certverifycertificatechainpolicy
+      description: |
+        Configure Certificate Chain and Certificate Chain Policy validation
+      required: false
+    - name: tags
+      value:
+        type: array
+        items:
+          type: string
+        example: ["<KEY_1>:<VALUE_1>", "<KEY_2>:<VALUE_2>"]
+      description: |
+        A list of tags to attach to every metric and service check emitted by this instance.
+        
+        Learn more about tagging at https://docs.datadoghq.com/tagging
+      required: false
+    - name: service
+      value:
+        type: string
+        example: "<SERVICE>"
+      description: |
+        Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+        
+        Overrides any `service` defined in the `init_config` section.
+      required: false
+    - name: min_collection_interval
+      value:
+        type: number
+        example: 300
+        default: 300
+      description: |
+        This changes the collection interval of the check. For more information, see:
+        https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+      required: false
+    - name: empty_default_hostname
+      value:
+        type: boolean
+        example: false
+        default: false
+      description: |
+        This forces the check to send metrics with no hostname.
+        
+        This is useful for cluster-level checks.
+      required: false
+    - name: metric_patterns
+      value:
+        type: object
+        properties:
+          include:
+            type: array
+            items:
+              type: string
+            example: ["<INCLUDE_REGEX>"]
+          exclude:
+            type: array
+            items:
+              type: string
+            example: ["<EXCLUDE_REGEX>"]
+      description: |
+        A mapping of metrics to include or exclude, with each entry being a regular expression.
+        
+        Metrics defined in `exclude` will take precedence in case of overlap.
+      required: false


### PR DESCRIPTION
### What does this PR do?
This PR adds spec.yaml files for the Windows Certificate and Network Path Go integrations. Fleet Automation uses the `spec.yaml` of an integration for remote configurations of integrations. Go integrations do not have these so we are adding some under a new folder: `/cmd/agent/dist/assets`

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1808

### Describe how you validated your changes
Tested these `spec.yaml` files manually on Fleet automation:
<img width="2390" height="1112" alt="image" src="https://github.com/user-attachments/assets/bead1adf-e708-4515-b08a-254bbd4a4e87" />

<img width="2374" height="1424" alt="image" src="https://github.com/user-attachments/assets/fe910178-0ac7-426b-99b5-9edf8d6869d5" />

### Additional Notes
