### PR TITLE
Add version headers on diagnose payloads

### DIFF
--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -25,6 +25,7 @@ import (
 	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	logstcp "github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 func getLogsEndpoints(useTCP bool) (*logsConfig.Endpoints, error) {
@@ -204,8 +205,10 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 	url := createEndpointURL(domain, endpointInfo)
 
 	headers := map[string]string{
-		"Content-Type": endpointInfo.ContentType,
-		"DD-API-KEY":   apiKey,
+		"Content-Type":     endpointInfo.ContentType,
+		"DD-API-KEY":       apiKey,
+		"DD-Agent-Version": version.AgentVersion,
+		"User-Agent":       fmt.Sprintf("datadog-agent/%s", version.AgentVersion),
 	}
 
 	return sendRequest(ctx, client, url, endpointInfo.Method, endpointInfo.Payload, headers)

--- a/pkg/diagnose/connectivity/core_endpoint_test.go
+++ b/pkg/diagnose/connectivity/core_endpoint_test.go
@@ -7,6 +7,7 @@ package connectivity
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 var (
@@ -157,4 +159,31 @@ func mustMarshalProto(msg proto.Message, t *testing.T) []byte {
 		t.Fatalf("Failed to marshal proto: %v", err)
 	}
 	return data
+}
+
+func TestSendHTTPRequestHeaders(t *testing.T) {
+	mockConfig := configmock.New(t)
+	log := logmock.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "api_key1", r.Header.Get("DD-API-KEY"))
+		assert.Equal(t, "application/x-protobuf", r.Header.Get("Content-Type"))
+		assert.Equal(t, version.AgentVersion, r.Header.Get("DD-Agent-Version"))
+		assert.Equal(t, fmt.Sprintf("datadog-agent/%s", version.AgentVersion), r.Header.Get("User-Agent"))
+		w.Write([]byte("Received Protobuf"))
+	}))
+	defer ts.Close()
+
+	client := defaultforwarder.NewHTTPClient(mockConfig, 1, log)
+
+	endpointInfo := endpointInfo{
+		Endpoint:    transaction.Endpoint{Route: "/", Name: "sketch"},
+		Method:      "POST",
+		Payload:     mustMarshalProto(buildSketchPayload(), t),
+		ContentType: "application/x-protobuf",
+	}
+
+	statusCode, _, _, err := sendHTTPRequestToEndpoint(context.Background(), client, ts.URL, endpointInfo, "api_key1")
+	assert.NoError(t, err)
+	assert.Equal(t, 200, statusCode)
 }


### PR DESCRIPTION
### What does this PR do?
Add version headers on diagnose payloads.

### Motivation
Ease debugging backend-side.
We've seen an issue around payloads being received without version headers, which made it difficult to troubleshoot.

### Describe how you validated your changes
CI

### Additional Notes
