### PR TITLE
[CWS] add support for release/epoch fields for packages

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -554,6 +554,26 @@ Workload Protection events for Linux systems have the following JSON schema:
                     "type": "string",
                     "description": "System package version"
                 },
+                "package_epoch": {
+                    "type": "integer",
+                    "description": "System package epoch"
+                },
+                "package_release": {
+                    "type": "string",
+                    "description": "System package release"
+                },
+                "package_source_version": {
+                    "type": "string",
+                    "description": "System package source version"
+                },
+                "package_source_epoch": {
+                    "type": "integer",
+                    "description": "System package source epoch"
+                },
+                "package_source_release": {
+                    "type": "string",
+                    "description": "System package source release"
+                },
                 "hashes": {
                     "items": {
                         "type": "string"
@@ -688,6 +708,26 @@ Workload Protection events for Linux systems have the following JSON schema:
                 "package_version": {
                     "type": "string",
                     "description": "System package version"
+                },
+                "package_epoch": {
+                    "type": "integer",
+                    "description": "System package epoch"
+                },
+                "package_release": {
+                    "type": "string",
+                    "description": "System package release"
+                },
+                "package_source_version": {
+                    "type": "string",
+                    "description": "System package source version"
+                },
+                "package_source_epoch": {
+                    "type": "integer",
+                    "description": "System package source epoch"
+                },
+                "package_source_release": {
+                    "type": "string",
+                    "description": "System package source release"
                 },
                 "hashes": {
                     "items": {
@@ -3148,6 +3188,26 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "string",
             "description": "System package version"
         },
+        "package_epoch": {
+            "type": "integer",
+            "description": "System package epoch"
+        },
+        "package_release": {
+            "type": "string",
+            "description": "System package release"
+        },
+        "package_source_version": {
+            "type": "string",
+            "description": "System package source version"
+        },
+        "package_source_epoch": {
+            "type": "integer",
+            "description": "System package source epoch"
+        },
+        "package_source_release": {
+            "type": "string",
+            "description": "System package source release"
+        },
         "hashes": {
             "items": {
                 "type": "string"
@@ -3217,6 +3277,11 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `change_time` | File change time |
 | `package_name` | System package name |
 | `package_version` | System package version |
+| `package_epoch` | System package epoch |
+| `package_release` | System package release |
+| `package_source_version` | System package source version |
+| `package_source_epoch` | System package source epoch |
+| `package_source_release` | System package source release |
 | `hashes` | List of cryptographic hashes of the file |
 | `hash_state` | State of the hashes or reason why they weren't computed |
 | `mount_path` | MountPath path of the mount |
@@ -3325,6 +3390,26 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "string",
             "description": "System package version"
         },
+        "package_epoch": {
+            "type": "integer",
+            "description": "System package epoch"
+        },
+        "package_release": {
+            "type": "string",
+            "description": "System package release"
+        },
+        "package_source_version": {
+            "type": "string",
+            "description": "System package source version"
+        },
+        "package_source_epoch": {
+            "type": "integer",
+            "description": "System package source epoch"
+        },
+        "package_source_release": {
+            "type": "string",
+            "description": "System package source release"
+        },
         "hashes": {
             "items": {
                 "type": "string"
@@ -3410,6 +3495,11 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `change_time` | File change time |
 | `package_name` | System package name |
 | `package_version` | System package version |
+| `package_epoch` | System package epoch |
+| `package_release` | System package release |
+| `package_source_version` | System package source version |
+| `package_source_epoch` | System package source epoch |
+| `package_source_release` | System package source release |
 | `hashes` | List of cryptographic hashes of the file |
 | `hash_state` | State of the hashes or reason why they weren't computed |
 | `mount_path` | MountPath path of the mount |

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -543,6 +543,26 @@
           "type": "string",
           "description": "System package version"
         },
+        "package_epoch": {
+          "type": "integer",
+          "description": "System package epoch"
+        },
+        "package_release": {
+          "type": "string",
+          "description": "System package release"
+        },
+        "package_source_version": {
+          "type": "string",
+          "description": "System package source version"
+        },
+        "package_source_epoch": {
+          "type": "integer",
+          "description": "System package source epoch"
+        },
+        "package_source_release": {
+          "type": "string",
+          "description": "System package source release"
+        },
         "hashes": {
           "items": {
             "type": "string"
@@ -677,6 +697,26 @@
         "package_version": {
           "type": "string",
           "description": "System package version"
+        },
+        "package_epoch": {
+          "type": "integer",
+          "description": "System package epoch"
+        },
+        "package_release": {
+          "type": "string",
+          "description": "System package release"
+        },
+        "package_source_version": {
+          "type": "string",
+          "description": "System package source version"
+        },
+        "package_source_epoch": {
+          "type": "integer",
+          "description": "System package source epoch"
+        },
+        "package_source_release": {
+          "type": "string",
+          "description": "System package source release"
         },
         "hashes": {
           "items": {

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -235,7 +235,11 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.ancestors.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`process.ancestors.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`process.ancestors.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`process.ancestors.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`process.ancestors.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`process.ancestors.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`process.ancestors.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`process.ancestors.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`process.ancestors.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`process.ancestors.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`process.ancestors.file.path`](#common-fileevent-path-doc) | File's path |
@@ -264,7 +268,11 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.ancestors.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`process.ancestors.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`process.ancestors.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`process.ancestors.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`process.ancestors.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`process.ancestors.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`process.ancestors.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`process.ancestors.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`process.ancestors.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`process.ancestors.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`process.ancestors.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -325,7 +333,11 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`process.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`process.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`process.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`process.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`process.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`process.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`process.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`process.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`process.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`process.file.path`](#common-fileevent-path-doc) | File's path |
@@ -354,7 +366,11 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`process.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`process.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`process.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`process.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`process.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`process.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`process.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`process.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`process.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`process.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -405,7 +421,11 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.parent.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`process.parent.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`process.parent.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`process.parent.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`process.parent.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`process.parent.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`process.parent.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`process.parent.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`process.parent.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`process.parent.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`process.parent.file.path`](#common-fileevent-path-doc) | File's path |
@@ -434,7 +454,11 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.parent.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`process.parent.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`process.parent.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`process.parent.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`process.parent.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`process.parent.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`process.parent.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`process.parent.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`process.parent.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`process.parent.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`process.parent.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -547,7 +571,11 @@ A process migrated another process to a cgroup
 | [`cgroup_write.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`cgroup_write.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`cgroup_write.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`cgroup_write.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`cgroup_write.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`cgroup_write.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`cgroup_write.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`cgroup_write.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`cgroup_write.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`cgroup_write.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`cgroup_write.file.path`](#common-fileevent-path-doc) | File's path |
@@ -580,7 +608,11 @@ A process changed the current directory
 | [`chdir.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`chdir.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`chdir.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`chdir.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`chdir.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`chdir.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`chdir.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`chdir.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`chdir.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`chdir.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`chdir.file.path`](#common-fileevent-path-doc) | File's path |
@@ -614,7 +646,11 @@ A file's permissions were changed
 | [`chmod.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`chmod.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`chmod.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`chmod.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`chmod.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`chmod.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`chmod.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`chmod.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`chmod.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`chmod.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`chmod.file.path`](#common-fileevent-path-doc) | File's path |
@@ -651,7 +687,11 @@ A file's owner was changed
 | [`chown.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`chown.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`chown.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`chown.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`chown.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`chown.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`chown.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`chown.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`chown.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`chown.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`chown.file.path`](#common-fileevent-path-doc) | File's path |
@@ -759,7 +799,11 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`exec.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`exec.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`exec.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`exec.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`exec.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`exec.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`exec.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`exec.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`exec.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`exec.file.path`](#common-fileevent-path-doc) | File's path |
@@ -788,7 +832,11 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`exec.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`exec.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`exec.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`exec.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`exec.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`exec.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`exec.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`exec.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`exec.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`exec.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -858,7 +906,11 @@ A process was terminated
 | [`exit.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`exit.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`exit.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`exit.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`exit.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`exit.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`exit.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`exit.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`exit.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`exit.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`exit.file.path`](#common-fileevent-path-doc) | File's path |
@@ -887,7 +939,11 @@ A process was terminated
 | [`exit.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`exit.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`exit.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`exit.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`exit.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`exit.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`exit.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`exit.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`exit.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`exit.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`exit.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -957,7 +1013,11 @@ Create a new name/alias for a file
 | [`link.file.destination.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`link.file.destination.name`](#common-fileevent-name-doc) | File's basename |
 | [`link.file.destination.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`link.file.destination.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`link.file.destination.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`link.file.destination.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`link.file.destination.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`link.file.destination.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`link.file.destination.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`link.file.destination.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`link.file.destination.path`](#common-fileevent-path-doc) | File's path |
@@ -979,7 +1039,11 @@ Create a new name/alias for a file
 | [`link.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`link.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`link.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`link.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`link.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`link.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`link.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`link.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`link.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`link.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`link.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1015,7 +1079,11 @@ A new kernel module was loaded
 | [`load_module.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`load_module.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`load_module.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`load_module.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`load_module.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`load_module.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`load_module.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`load_module.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`load_module.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`load_module.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`load_module.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1050,7 +1118,11 @@ A directory was created
 | [`mkdir.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`mkdir.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`mkdir.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`mkdir.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`mkdir.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`mkdir.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`mkdir.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`mkdir.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`mkdir.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`mkdir.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`mkdir.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1083,7 +1155,11 @@ A mmap command was executed
 | [`mmap.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`mmap.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`mmap.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`mmap.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`mmap.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`mmap.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`mmap.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`mmap.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`mmap.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`mmap.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`mmap.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1167,7 +1243,11 @@ A file was opened
 | [`open.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`open.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`open.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`open.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`open.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`open.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`open.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`open.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`open.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`open.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`open.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1273,7 +1353,11 @@ A ptrace command was executed
 | [`ptrace.tracee.ancestors.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`ptrace.tracee.ancestors.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`ptrace.tracee.ancestors.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`ptrace.tracee.ancestors.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`ptrace.tracee.ancestors.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`ptrace.tracee.ancestors.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`ptrace.tracee.ancestors.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`ptrace.tracee.ancestors.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`ptrace.tracee.ancestors.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`ptrace.tracee.ancestors.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`ptrace.tracee.ancestors.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1302,7 +1386,11 @@ A ptrace command was executed
 | [`ptrace.tracee.ancestors.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`ptrace.tracee.ancestors.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`ptrace.tracee.ancestors.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`ptrace.tracee.ancestors.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`ptrace.tracee.ancestors.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`ptrace.tracee.ancestors.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`ptrace.tracee.ancestors.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`ptrace.tracee.ancestors.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`ptrace.tracee.ancestors.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`ptrace.tracee.ancestors.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`ptrace.tracee.ancestors.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1363,7 +1451,11 @@ A ptrace command was executed
 | [`ptrace.tracee.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`ptrace.tracee.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`ptrace.tracee.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`ptrace.tracee.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`ptrace.tracee.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`ptrace.tracee.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`ptrace.tracee.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`ptrace.tracee.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`ptrace.tracee.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`ptrace.tracee.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`ptrace.tracee.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1392,7 +1484,11 @@ A ptrace command was executed
 | [`ptrace.tracee.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`ptrace.tracee.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`ptrace.tracee.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`ptrace.tracee.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`ptrace.tracee.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`ptrace.tracee.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`ptrace.tracee.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`ptrace.tracee.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`ptrace.tracee.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`ptrace.tracee.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`ptrace.tracee.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1443,7 +1539,11 @@ A ptrace command was executed
 | [`ptrace.tracee.parent.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`ptrace.tracee.parent.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`ptrace.tracee.parent.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`ptrace.tracee.parent.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`ptrace.tracee.parent.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`ptrace.tracee.parent.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`ptrace.tracee.parent.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`ptrace.tracee.parent.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`ptrace.tracee.parent.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`ptrace.tracee.parent.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`ptrace.tracee.parent.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1472,7 +1572,11 @@ A ptrace command was executed
 | [`ptrace.tracee.parent.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`ptrace.tracee.parent.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`ptrace.tracee.parent.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`ptrace.tracee.parent.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`ptrace.tracee.parent.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`ptrace.tracee.parent.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`ptrace.tracee.parent.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`ptrace.tracee.parent.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`ptrace.tracee.parent.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`ptrace.tracee.parent.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`ptrace.tracee.parent.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1525,7 +1629,11 @@ Remove extended attributes
 | [`removexattr.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`removexattr.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`removexattr.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`removexattr.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`removexattr.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`removexattr.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`removexattr.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`removexattr.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`removexattr.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`removexattr.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`removexattr.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1557,7 +1665,11 @@ A file/directory was renamed
 | [`rename.file.destination.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`rename.file.destination.name`](#common-fileevent-name-doc) | File's basename |
 | [`rename.file.destination.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`rename.file.destination.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`rename.file.destination.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`rename.file.destination.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`rename.file.destination.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`rename.file.destination.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`rename.file.destination.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`rename.file.destination.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`rename.file.destination.path`](#common-fileevent-path-doc) | File's path |
@@ -1579,7 +1691,11 @@ A file/directory was renamed
 | [`rename.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`rename.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`rename.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`rename.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`rename.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`rename.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`rename.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`rename.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`rename.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`rename.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`rename.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1612,7 +1728,11 @@ A directory was removed
 | [`rmdir.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`rmdir.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`rmdir.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`rmdir.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`rmdir.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`rmdir.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`rmdir.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`rmdir.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`rmdir.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`rmdir.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`rmdir.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1697,7 +1817,11 @@ A setrlimit command was executed
 | [`setrlimit.target.ancestors.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`setrlimit.target.ancestors.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`setrlimit.target.ancestors.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`setrlimit.target.ancestors.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`setrlimit.target.ancestors.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`setrlimit.target.ancestors.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`setrlimit.target.ancestors.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`setrlimit.target.ancestors.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`setrlimit.target.ancestors.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`setrlimit.target.ancestors.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`setrlimit.target.ancestors.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1726,7 +1850,11 @@ A setrlimit command was executed
 | [`setrlimit.target.ancestors.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`setrlimit.target.ancestors.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`setrlimit.target.ancestors.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`setrlimit.target.ancestors.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`setrlimit.target.ancestors.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`setrlimit.target.ancestors.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`setrlimit.target.ancestors.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`setrlimit.target.ancestors.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`setrlimit.target.ancestors.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`setrlimit.target.ancestors.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`setrlimit.target.ancestors.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1787,7 +1915,11 @@ A setrlimit command was executed
 | [`setrlimit.target.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`setrlimit.target.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`setrlimit.target.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`setrlimit.target.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`setrlimit.target.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`setrlimit.target.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`setrlimit.target.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`setrlimit.target.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`setrlimit.target.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`setrlimit.target.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`setrlimit.target.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1816,7 +1948,11 @@ A setrlimit command was executed
 | [`setrlimit.target.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`setrlimit.target.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`setrlimit.target.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`setrlimit.target.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`setrlimit.target.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`setrlimit.target.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`setrlimit.target.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`setrlimit.target.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`setrlimit.target.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`setrlimit.target.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`setrlimit.target.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1867,7 +2003,11 @@ A setrlimit command was executed
 | [`setrlimit.target.parent.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`setrlimit.target.parent.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`setrlimit.target.parent.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`setrlimit.target.parent.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`setrlimit.target.parent.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`setrlimit.target.parent.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`setrlimit.target.parent.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`setrlimit.target.parent.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`setrlimit.target.parent.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`setrlimit.target.parent.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`setrlimit.target.parent.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1896,7 +2036,11 @@ A setrlimit command was executed
 | [`setrlimit.target.parent.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`setrlimit.target.parent.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`setrlimit.target.parent.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`setrlimit.target.parent.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`setrlimit.target.parent.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`setrlimit.target.parent.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`setrlimit.target.parent.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`setrlimit.target.parent.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`setrlimit.target.parent.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`setrlimit.target.parent.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`setrlimit.target.parent.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -1980,7 +2124,11 @@ Set exteneded attributes
 | [`setxattr.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`setxattr.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`setxattr.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`setxattr.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`setxattr.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`setxattr.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`setxattr.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`setxattr.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`setxattr.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`setxattr.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`setxattr.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2038,7 +2186,11 @@ A signal was sent
 | [`signal.target.ancestors.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`signal.target.ancestors.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`signal.target.ancestors.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`signal.target.ancestors.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`signal.target.ancestors.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`signal.target.ancestors.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`signal.target.ancestors.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`signal.target.ancestors.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`signal.target.ancestors.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`signal.target.ancestors.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`signal.target.ancestors.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2067,7 +2219,11 @@ A signal was sent
 | [`signal.target.ancestors.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`signal.target.ancestors.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`signal.target.ancestors.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`signal.target.ancestors.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`signal.target.ancestors.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`signal.target.ancestors.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`signal.target.ancestors.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`signal.target.ancestors.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`signal.target.ancestors.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`signal.target.ancestors.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`signal.target.ancestors.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2128,7 +2284,11 @@ A signal was sent
 | [`signal.target.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`signal.target.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`signal.target.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`signal.target.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`signal.target.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`signal.target.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`signal.target.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`signal.target.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`signal.target.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`signal.target.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`signal.target.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2157,7 +2317,11 @@ A signal was sent
 | [`signal.target.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`signal.target.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`signal.target.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`signal.target.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`signal.target.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`signal.target.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`signal.target.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`signal.target.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`signal.target.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`signal.target.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`signal.target.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2208,7 +2372,11 @@ A signal was sent
 | [`signal.target.parent.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`signal.target.parent.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`signal.target.parent.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`signal.target.parent.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`signal.target.parent.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`signal.target.parent.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`signal.target.parent.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`signal.target.parent.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`signal.target.parent.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`signal.target.parent.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`signal.target.parent.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2237,7 +2405,11 @@ A signal was sent
 | [`signal.target.parent.interpreter.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`signal.target.parent.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`signal.target.parent.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`signal.target.parent.interpreter.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`signal.target.parent.interpreter.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`signal.target.parent.interpreter.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`signal.target.parent.interpreter.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`signal.target.parent.interpreter.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`signal.target.parent.interpreter.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`signal.target.parent.interpreter.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`signal.target.parent.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2289,7 +2461,11 @@ A splice command was executed
 | [`splice.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`splice.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`splice.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`splice.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`splice.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`splice.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`splice.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`splice.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`splice.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`splice.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`splice.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2337,7 +2513,11 @@ A file was deleted
 | [`unlink.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`unlink.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`unlink.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`unlink.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`unlink.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`unlink.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`unlink.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`unlink.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`unlink.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`unlink.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`unlink.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2381,7 +2561,11 @@ Change file access/modification times
 | [`utimes.file.mount_visible`](#common-fileevent-mount_visible-doc) | Indicates whether the file's mount is visible in the VFS |
 | [`utimes.file.name`](#common-fileevent-name-doc) | File's basename |
 | [`utimes.file.name.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`utimes.file.package.epoch`](#common-fileevent-package-epoch-doc) | [Experimental] Epoch of the package that provided this file |
 | [`utimes.file.package.name`](#common-fileevent-package-name-doc) | [Experimental] Name of the package that provided this file |
+| [`utimes.file.package.release`](#common-fileevent-package-release-doc) | [Experimental] Release of the package that provided this file |
+| [`utimes.file.package.source_epoch`](#common-fileevent-package-source_epoch-doc) | [Experimental] Epoch of the source package of the package that provided this file |
+| [`utimes.file.package.source_release`](#common-fileevent-package-source_release-doc) | [Experimental] Release of the source package of the package that provided this file |
 | [`utimes.file.package.source_version`](#common-fileevent-package-source_version-doc) | [Experimental] Full version of the source package of the package that provided this file |
 | [`utimes.file.package.version`](#common-fileevent-package-version-doc) | [Experimental] Full version of the package that provided this file |
 | [`utimes.file.path`](#common-fileevent-path-doc) | File's path |
@@ -2995,12 +3179,48 @@ Constants: [Network directions](#network-directions)
 
 
 
+### `*.package.epoch` {#common-fileevent-package-epoch-doc}
+Type: int
+
+Definition: [Experimental] Epoch of the package that provided this file
+
+`*.package.epoch` has 46 possible prefixes:
+`cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
 ### `*.package.name` {#common-fileevent-package-name-doc}
 Type: string
 
 Definition: [Experimental] Name of the package that provided this file
 
 `*.package.name` has 46 possible prefixes:
+`cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.package.release` {#common-fileevent-package-release-doc}
+Type: string
+
+Definition: [Experimental] Release of the package that provided this file
+
+`*.package.release` has 46 possible prefixes:
+`cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.package.source_epoch` {#common-fileevent-package-source_epoch-doc}
+Type: int
+
+Definition: [Experimental] Epoch of the source package of the package that provided this file
+
+`*.package.source_epoch` has 46 possible prefixes:
+`cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.package.source_release` {#common-fileevent-package-source_release-doc}
+Type: string
+
+Definition: [Experimental] Release of the source package of the package that provided this file
+
+`*.package.source_release` has 46 possible prefixes:
 `cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -283,9 +283,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "process.ancestors.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "process.ancestors.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "process.ancestors.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "process.ancestors.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "process.ancestors.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "process.ancestors.file.package.source_version",
@@ -428,9 +448,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "process.ancestors.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "process.ancestors.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "process.ancestors.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "process.ancestors.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "process.ancestors.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.package.source_version",
@@ -733,9 +773,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "process.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "process.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "process.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "process.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "process.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "process.file.package.source_version",
@@ -878,9 +938,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "process.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "process.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "process.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "process.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "process.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "process.interpreter.file.package.source_version",
@@ -1133,9 +1213,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "process.parent.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "process.parent.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "process.parent.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "process.parent.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "process.parent.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "process.parent.file.package.source_version",
@@ -1278,9 +1378,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "process.parent.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "process.parent.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "process.parent.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "process.parent.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "process.parent.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "process.parent.interpreter.file.package.source_version",
@@ -1677,9 +1797,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "cgroup_write.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "cgroup_write.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "cgroup_write.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "cgroup_write.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "cgroup_write.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "cgroup_write.file.package.source_version",
@@ -1806,9 +1946,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "chdir.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "chdir.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "chdir.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "chdir.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "chdir.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "chdir.file.package.source_version",
@@ -1950,9 +2110,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "chmod.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "chmod.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "chmod.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "chmod.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "chmod.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "chmod.file.package.source_version",
@@ -2109,9 +2289,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "chown.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "chown.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "chown.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "chown.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "chown.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "chown.file.package.source_version",
@@ -2571,9 +2771,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "exec.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "exec.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "exec.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "exec.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "exec.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "exec.file.package.source_version",
@@ -2716,9 +2936,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "exec.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "exec.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "exec.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "exec.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "exec.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "exec.interpreter.file.package.source_version",
@@ -3040,9 +3280,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "exit.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "exit.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "exit.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "exit.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "exit.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "exit.file.package.source_version",
@@ -3185,9 +3445,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "exit.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "exit.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "exit.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "exit.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "exit.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "exit.interpreter.file.package.source_version",
@@ -3483,9 +3763,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "link.file.destination.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "link.file.destination.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "link.file.destination.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "link.file.destination.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "link.file.destination.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "link.file.destination.package.source_version",
@@ -3593,9 +3893,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "link.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "link.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "link.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "link.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "link.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "link.file.package.source_version",
@@ -3747,9 +4067,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "load_module.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "load_module.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "load_module.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "load_module.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "load_module.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "load_module.file.package.source_version",
@@ -3896,9 +4236,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "mkdir.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "mkdir.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "mkdir.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "mkdir.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "mkdir.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "mkdir.file.package.source_version",
@@ -4035,9 +4395,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "mmap.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "mmap.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "mmap.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "mmap.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "mmap.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "mmap.file.package.source_version",
@@ -4341,9 +4721,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "open.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "open.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "open.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "open.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "open.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "open.file.package.source_version",
@@ -4793,9 +5193,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "ptrace.tracee.ancestors.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "ptrace.tracee.ancestors.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.package.source_version",
@@ -4938,9 +5358,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "ptrace.tracee.ancestors.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "ptrace.tracee.ancestors.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.package.source_version",
@@ -5243,9 +5683,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "ptrace.tracee.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "ptrace.tracee.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "ptrace.tracee.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "ptrace.tracee.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "ptrace.tracee.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "ptrace.tracee.file.package.source_version",
@@ -5388,9 +5848,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "ptrace.tracee.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "ptrace.tracee.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "ptrace.tracee.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "ptrace.tracee.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "ptrace.tracee.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.package.source_version",
@@ -5643,9 +6123,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "ptrace.tracee.parent.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "ptrace.tracee.parent.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.package.source_version",
@@ -5788,9 +6288,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "ptrace.tracee.parent.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "ptrace.tracee.parent.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.package.source_version",
@@ -6027,9 +6547,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "removexattr.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "removexattr.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "removexattr.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "removexattr.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "removexattr.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "removexattr.file.package.source_version",
@@ -6161,9 +6701,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "rename.file.destination.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "rename.file.destination.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "rename.file.destination.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "rename.file.destination.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "rename.file.destination.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "rename.file.destination.package.source_version",
@@ -6271,9 +6831,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "rename.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "rename.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "rename.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "rename.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "rename.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "rename.file.package.source_version",
@@ -6410,9 +6990,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "rmdir.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "rmdir.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "rmdir.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "rmdir.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "rmdir.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "rmdir.file.package.source_version",
@@ -6757,9 +7357,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "setrlimit.target.ancestors.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "setrlimit.target.ancestors.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "setrlimit.target.ancestors.file.package.source_version",
@@ -6902,9 +7522,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "setrlimit.target.ancestors.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "setrlimit.target.ancestors.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "setrlimit.target.ancestors.interpreter.file.package.source_version",
@@ -7207,9 +7847,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "setrlimit.target.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "setrlimit.target.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "setrlimit.target.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "setrlimit.target.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "setrlimit.target.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "setrlimit.target.file.package.source_version",
@@ -7352,9 +8012,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "setrlimit.target.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "setrlimit.target.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "setrlimit.target.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "setrlimit.target.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "setrlimit.target.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "setrlimit.target.interpreter.file.package.source_version",
@@ -7607,9 +8287,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "setrlimit.target.parent.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "setrlimit.target.parent.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "setrlimit.target.parent.file.package.source_version",
@@ -7752,9 +8452,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "setrlimit.target.parent.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "setrlimit.target.parent.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "setrlimit.target.parent.interpreter.file.package.source_version",
@@ -8094,9 +8814,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "setxattr.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "setxattr.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "setxattr.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "setxattr.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "setxattr.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "setxattr.file.package.source_version",
@@ -8358,9 +9098,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "signal.target.ancestors.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "signal.target.ancestors.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "signal.target.ancestors.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "signal.target.ancestors.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "signal.target.ancestors.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "signal.target.ancestors.file.package.source_version",
@@ -8503,9 +9263,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "signal.target.ancestors.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "signal.target.ancestors.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "signal.target.ancestors.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "signal.target.ancestors.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "signal.target.ancestors.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.package.source_version",
@@ -8808,9 +9588,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "signal.target.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "signal.target.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "signal.target.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "signal.target.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "signal.target.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "signal.target.file.package.source_version",
@@ -8953,9 +9753,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "signal.target.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "signal.target.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "signal.target.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "signal.target.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "signal.target.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "signal.target.interpreter.file.package.source_version",
@@ -9208,9 +10028,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "signal.target.parent.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "signal.target.parent.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "signal.target.parent.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "signal.target.parent.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "signal.target.parent.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "signal.target.parent.file.package.source_version",
@@ -9353,9 +10193,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "signal.target.parent.interpreter.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "signal.target.parent.interpreter.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "signal.target.parent.interpreter.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "signal.target.parent.interpreter.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "signal.target.parent.interpreter.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.package.source_version",
@@ -9587,9 +10447,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "splice.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "splice.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "splice.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "splice.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "splice.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "splice.file.package.source_version",
@@ -9775,9 +10655,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "unlink.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "unlink.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "unlink.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "unlink.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "unlink.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "unlink.file.package.source_version",
@@ -9943,9 +10843,29 @@
           "property_doc_link": "common-string-length-doc"
         },
         {
+          "name": "utimes.file.package.epoch",
+          "definition": "[Experimental] Epoch of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-epoch-doc"
+        },
+        {
           "name": "utimes.file.package.name",
           "definition": "[Experimental] Name of the package that provided this file",
           "property_doc_link": "common-fileevent-package-name-doc"
+        },
+        {
+          "name": "utimes.file.package.release",
+          "definition": "[Experimental] Release of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-release-doc"
+        },
+        {
+          "name": "utimes.file.package.source_epoch",
+          "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_epoch-doc"
+        },
+        {
+          "name": "utimes.file.package.source_release",
+          "definition": "[Experimental] Release of the source package of the package that provided this file",
+          "property_doc_link": "common-fileevent-package-source_release-doc"
         },
         {
           "name": "utimes.file.package.source_version",
@@ -11946,10 +12866,238 @@
       "examples": []
     },
     {
+      "name": "*.package.epoch",
+      "link": "common-fileevent-package-epoch-doc",
+      "type": "int",
+      "definition": "[Experimental] Epoch of the package that provided this file",
+      "prefixes": [
+        "cgroup_write.file",
+        "chdir.file",
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setrlimit.target.ancestors.file",
+        "setrlimit.target.ancestors.interpreter.file",
+        "setrlimit.target.file",
+        "setrlimit.target.interpreter.file",
+        "setrlimit.target.parent.file",
+        "setrlimit.target.parent.interpreter.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
       "name": "*.package.name",
       "link": "common-fileevent-package-name-doc",
       "type": "string",
       "definition": "[Experimental] Name of the package that provided this file",
+      "prefixes": [
+        "cgroup_write.file",
+        "chdir.file",
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setrlimit.target.ancestors.file",
+        "setrlimit.target.ancestors.interpreter.file",
+        "setrlimit.target.file",
+        "setrlimit.target.interpreter.file",
+        "setrlimit.target.parent.file",
+        "setrlimit.target.parent.interpreter.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.package.release",
+      "link": "common-fileevent-package-release-doc",
+      "type": "string",
+      "definition": "[Experimental] Release of the package that provided this file",
+      "prefixes": [
+        "cgroup_write.file",
+        "chdir.file",
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setrlimit.target.ancestors.file",
+        "setrlimit.target.ancestors.interpreter.file",
+        "setrlimit.target.file",
+        "setrlimit.target.interpreter.file",
+        "setrlimit.target.parent.file",
+        "setrlimit.target.parent.interpreter.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.package.source_epoch",
+      "link": "common-fileevent-package-source_epoch-doc",
+      "type": "int",
+      "definition": "[Experimental] Epoch of the source package of the package that provided this file",
+      "prefixes": [
+        "cgroup_write.file",
+        "chdir.file",
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setrlimit.target.ancestors.file",
+        "setrlimit.target.ancestors.interpreter.file",
+        "setrlimit.target.file",
+        "setrlimit.target.interpreter.file",
+        "setrlimit.target.parent.file",
+        "setrlimit.target.parent.interpreter.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.package.source_release",
+      "link": "common-fileevent-package-source_release-doc",
+      "type": "string",
+      "definition": "[Experimental] Release of the source package of the package that provided this file",
       "prefixes": [
         "cgroup_write.file",
         "chdir.file",

--- a/go.mod
+++ b/go.mod
@@ -283,6 +283,7 @@ require (
 	github.com/judwhite/go-svc v1.2.1
 	github.com/justincormack/go-memfd v0.0.0-20170219213707-6e4af0518993
 	github.com/klauspost/compress v1.18.0
+	github.com/knqyf263/go-deb-version v0.0.0-20241115132648-6f4aee6ccd23
 	github.com/knqyf263/go-rpmdb v0.1.2-0.20241125135340-7670f0f23c16
 	github.com/kouhin/envflag v0.0.0-20150818174321-0e9a86061649
 	github.com/kr/pretty v0.3.1
@@ -660,7 +661,6 @@ require (
 	github.com/knadh/koanf/providers/confmap v1.0.0 // indirect
 	github.com/knadh/koanf/v2 v2.2.2 // indirect
 	github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f // indirect
-	github.com/knqyf263/go-deb-version v0.0.0-20241115132648-6f4aee6ccd23 // indirect
 	github.com/knqyf263/go-rpm-version v0.0.0-20220614171824-631e686d1075 // indirect
 	github.com/knqyf263/nested v0.0.1 // indirect
 	github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b // indirect

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -467,7 +467,11 @@ func (fh *EBPFFieldHandlers) resolveSBOMFields(ev *model.Event, f *model.FileEve
 	if pkg := fh.resolvers.SBOMResolver.ResolvePackage(ev.ContainerContext.ContainerID, f); pkg != nil {
 		f.PkgName = pkg.Name
 		f.PkgVersion = pkg.Version
+		f.PkgEpoch = pkg.Epoch
+		f.PkgRelease = pkg.Release
 		f.PkgSrcVersion = pkg.SrcVersion
+		f.PkgSrcEpoch = pkg.SrcEpoch
+		f.PkgSrcRelease = pkg.SrcRelease
 	}
 }
 

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -487,12 +487,44 @@ func (fh *EBPFFieldHandlers) ResolvePackageVersion(ev *model.Event, f *model.Fil
 	return f.PkgVersion
 }
 
+// ResolvePackageEpoch resolves the epoch of the package providing this file
+func (fh *EBPFFieldHandlers) ResolvePackageEpoch(ev *model.Event, f *model.FileEvent) int {
+	if f.PkgEpoch == 0 {
+		fh.resolveSBOMFields(ev, f)
+	}
+	return f.PkgEpoch
+}
+
+// ResolvePackageRelease resolves the release of the package providing this file
+func (fh *EBPFFieldHandlers) ResolvePackageRelease(ev *model.Event, f *model.FileEvent) string {
+	if f.PkgRelease == "" {
+		fh.resolveSBOMFields(ev, f)
+	}
+	return f.PkgRelease
+}
+
 // ResolvePackageSourceVersion resolves the version of the source package of the package providing this file
 func (fh *EBPFFieldHandlers) ResolvePackageSourceVersion(ev *model.Event, f *model.FileEvent) string {
 	if f.PkgSrcVersion == "" {
 		fh.resolveSBOMFields(ev, f)
 	}
 	return f.PkgSrcVersion
+}
+
+// ResolvePackageSourceEpoch resolves the epoch of the source package of the package providing this file
+func (fh *EBPFFieldHandlers) ResolvePackageSourceEpoch(ev *model.Event, f *model.FileEvent) int {
+	if f.PkgSrcEpoch == 0 {
+		fh.resolveSBOMFields(ev, f)
+	}
+	return f.PkgSrcEpoch
+}
+
+// ResolvePackageSourceRelease resolves the release of the source package of the package providing this file
+func (fh *EBPFFieldHandlers) ResolvePackageSourceRelease(ev *model.Event, f *model.FileEvent) string {
+	if f.PkgSrcRelease == "" {
+		fh.resolveSBOMFields(ev, f)
+	}
+	return f.PkgSrcRelease
 }
 
 // ResolveModuleArgv resolves the unscrubbed args of the module as an array. Use with caution.

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -347,14 +347,34 @@ func (fh *EBPFLessFieldHandlers) ResolvePackageName(_ *model.Event, e *model.Fil
 	return e.PkgName
 }
 
+// ResolvePackageVersion resolves the version of the package providing this file
+func (fh *EBPFLessFieldHandlers) ResolvePackageVersion(_ *model.Event, e *model.FileEvent) string {
+	return e.PkgVersion
+}
+
+// ResolvePackageEpoch resolves the epoch of the package providing this file
+func (fh *EBPFLessFieldHandlers) ResolvePackageEpoch(_ *model.Event, e *model.FileEvent) int {
+	return e.PkgEpoch
+}
+
+// ResolvePackageRelease resolves the release of the package providing this file
+func (fh *EBPFLessFieldHandlers) ResolvePackageRelease(_ *model.Event, e *model.FileEvent) string {
+	return e.PkgRelease
+}
+
 // ResolvePackageSourceVersion resolves the version of the source package of the package providing this file
 func (fh *EBPFLessFieldHandlers) ResolvePackageSourceVersion(_ *model.Event, e *model.FileEvent) string {
 	return e.PkgSrcVersion
 }
 
-// ResolvePackageVersion resolves the version of the package providing this file
-func (fh *EBPFLessFieldHandlers) ResolvePackageVersion(_ *model.Event, e *model.FileEvent) string {
-	return e.PkgVersion
+// ResolvePackageSourceEpoch resolves the epoch of the source package of the package providing this file
+func (fh *EBPFLessFieldHandlers) ResolvePackageSourceEpoch(_ *model.Event, e *model.FileEvent) int {
+	return e.PkgSrcEpoch
+}
+
+// ResolvePackageSourceRelease resolves the release of the source package of the package providing this file
+func (fh *EBPFLessFieldHandlers) ResolvePackageSourceRelease(_ *model.Event, e *model.FileEvent) string {
+	return e.PkgSrcRelease
 }
 
 // ResolveRights resolves the rights of a file

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -107,7 +107,6 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 	var versionResolver func(servicePath string) string
 	if config.RuntimeSecurity.SBOMResolverEnabled && sbomResolver != nil {
 		versionResolver = func(servicePath string) string {
-
 			if pkg := sbomResolver.ResolvePackage("", &model.FileEvent{PathnameStr: servicePath}); pkg != nil {
 				return pkg.Version
 			}

--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -18,7 +18,10 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
+
+	debVersion "github.com/knqyf263/go-deb-version"
 
 	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -189,6 +192,8 @@ func (s *dpkgScanner) parseInfoFile(root *os.Root, path string) ([]string, error
 	return installedFiles, nil
 }
 
+var dpkgSrcCaptureRegexp = regexp.MustCompile(`([^\s]*)(?: \((.*)\))?`)
+
 func (s *dpkgScanner) parseStatusFile(root *os.Root, path string) ([]sbomtypes.Package, error) {
 	f, err := root.Open(path)
 	if err != nil {
@@ -220,7 +225,34 @@ func (s *dpkgScanner) parseStatusFile(root *os.Root, path string) ([]sbomtypes.P
 		if pkg.Name == "" || pkg.Version == "" {
 			continue
 		}
-		pkg.SrcVersion = pkg.Version // TODO(paulcacheux): parse source
+
+		if src := header.Get("Source"); src != "" {
+			matches := dpkgSrcCaptureRegexp.FindStringSubmatch(src)
+			if matches != nil {
+				// name would be in matches[1], but we don't use it for now
+				pkg.SrcVersion = strings.TrimSpace(matches[2])
+			}
+		}
+
+		if pkg.SrcVersion == "" {
+			pkg.SrcVersion = pkg.Version
+		}
+
+		if v, err := debVersion.NewVersion(pkg.Version); err != nil {
+			seclog.Warnf("failed to parse dpkg package version, filepath=%s, package=%s, version=%s: %v", path, pkg.Name, pkg.Version, err)
+		} else {
+			pkg.Version = v.Version()
+			pkg.Epoch = v.Epoch()
+			pkg.Release = v.Revision()
+		}
+
+		if v, err := debVersion.NewVersion(pkg.SrcVersion); err != nil {
+			seclog.Warnf("failed to parse dpkg package source version, filepath=%s, package=%s, version=%s: %v", path, pkg.Name, pkg.SrcVersion, err)
+		} else {
+			pkg.SrcVersion = v.Version()
+			pkg.SrcEpoch = v.Epoch()
+			pkg.SrcRelease = v.Revision()
+		}
 
 		pkgs = append(pkgs, pkg)
 	}

--- a/pkg/security/resolvers/sbom/trivy.go
+++ b/pkg/security/resolvers/sbom/trivy.go
@@ -47,7 +47,11 @@ func (tc *trivyCollector) ScanInstalledPackages(ctx context.Context, root string
 				Package: types.Package{
 					Name:       resultPkg.Name,
 					Version:    resultPkg.Version,
+					Epoch:      resultPkg.Epoch,
+					Release:    resultPkg.Release,
 					SrcVersion: resultPkg.SrcVersion,
+					SrcEpoch:   resultPkg.SrcEpoch,
+					SrcRelease: resultPkg.SrcRelease,
 				},
 				InstalledFiles: resultPkg.InstalledFiles,
 			}

--- a/pkg/security/resolvers/sbom/types/package.go
+++ b/pkg/security/resolvers/sbom/types/package.go
@@ -10,7 +10,11 @@ package types
 type Package struct {
 	Name       string
 	Version    string
+	Epoch      int
+	Release    string
 	SrcVersion string
+	SrcEpoch   int
+	SrcRelease string
 }
 
 // PackageWithInstalledFiles describes a system package with its installed files

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -587,12 +587,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "cgroup_write.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.CgroupWrite.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "cgroup_write.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.CgroupWrite.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "cgroup_write.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.CgroupWrite.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "cgroup_write.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.CgroupWrite.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "cgroup_write.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.CgroupWrite.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -855,12 +899,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "chdir.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Chdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "chdir.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Chdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chdir.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Chdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chdir.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Chdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chdir.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Chdir.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1156,12 +1244,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "chmod.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Chmod.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "chmod.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Chmod.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chmod.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Chmod.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chmod.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Chmod.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chmod.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Chmod.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1490,12 +1622,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "chown.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Chown.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "chown.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Chown.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chown.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Chown.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chown.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Chown.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "chown.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Chown.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -2487,6 +2663,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "exec.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exec.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Exec.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exec.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2496,6 +2686,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Exec.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exec.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Exec.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exec.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Exec.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exec.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Exec.Process.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -2873,6 +3105,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "exec.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exec.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exec.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2882,6 +3128,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exec.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exec.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exec.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3633,6 +3921,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "exit.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exit.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Exit.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exit.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3642,6 +3944,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Exit.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exit.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Exit.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exit.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Exit.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exit.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Exit.Process.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4019,6 +4363,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "exit.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exit.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exit.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -4028,6 +4386,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exit.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exit.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Exit.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4528,12 +4928,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "link.file.destination.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Link.Target)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "link.file.destination.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Link.Target)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "link.file.destination.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Link.Target)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "link.file.destination.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Link.Target)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "link.file.destination.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Link.Target)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4774,12 +5218,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "link.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Link.Source)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "link.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Link.Source)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "link.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Link.Source)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "link.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Link.Source)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "link.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Link.Source)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5097,12 +5585,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "load_module.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.LoadModule.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "load_module.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.LoadModule.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "load_module.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.LoadModule.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "load_module.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.LoadModule.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "load_module.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.LoadModule.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5409,12 +5941,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "mkdir.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Mkdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "mkdir.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Mkdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "mkdir.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Mkdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "mkdir.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Mkdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "mkdir.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Mkdir.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -5699,12 +6275,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "mmap.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.MMap.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "mmap.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.MMap.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "mmap.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.MMap.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "mmap.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.MMap.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "mmap.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.MMap.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -6777,12 +7397,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "open.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Open.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "open.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Open.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "open.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Open.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "open.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Open.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "open.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Open.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -8287,6 +8951,39 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "process.ancestors.file.package.epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageEpoch(ev, &element.ProcessContext.Process.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageEpoch(ev, &current.ProcessContext.Process.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.ancestors.file.package.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -8312,6 +9009,105 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						return ""
 					}
 					return ev.FieldHandlers.ResolvePackageName(ev, &current.ProcessContext.Process.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.file.package.release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageRelease(ev, &element.ProcessContext.Process.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageRelease(ev, &current.ProcessContext.Process.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.file.package.source_epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &element.ProcessContext.Process.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &current.ProcessContext.Process.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.file.package.source_release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageSourceRelease(ev, &element.ProcessContext.Process.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &current.ProcessContext.Process.FileEvent)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -9200,6 +9996,39 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "process.ancestors.interpreter.file.package.epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageEpoch(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageEpoch(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.ancestors.interpreter.file.package.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -9225,6 +10054,105 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						return ""
 					}
 					return ev.FieldHandlers.ResolvePackageName(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.interpreter.file.package.release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageRelease(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageRelease(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.interpreter.file.package.source_epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.interpreter.file.package.source_release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageSourceRelease(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -10279,6 +11207,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "process.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -10288,6 +11230,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -10665,6 +11649,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "process.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -10674,6 +11672,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -11410,6 +12450,23 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "process.parent.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				if !ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.parent.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -11422,6 +12479,57 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				if !ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				if !ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				if !ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -11877,6 +12985,23 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "process.parent.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				if !ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.parent.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -11889,6 +13014,57 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				if !ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				if !ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				if !ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -13464,6 +14640,39 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.ancestors.file.package.epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageEpoch(ev, &element.ProcessContext.Process.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageEpoch(ev, &current.ProcessContext.Process.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.ancestors.file.package.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -13489,6 +14698,105 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						return ""
 					}
 					return ev.FieldHandlers.ResolvePackageName(ev, &current.ProcessContext.Process.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.file.package.release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageRelease(ev, &element.ProcessContext.Process.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageRelease(ev, &current.ProcessContext.Process.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.file.package.source_epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &element.ProcessContext.Process.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &current.ProcessContext.Process.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.file.package.source_release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageSourceRelease(ev, &element.ProcessContext.Process.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &current.ProcessContext.Process.FileEvent)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -14377,6 +15685,39 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.ancestors.interpreter.file.package.epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageEpoch(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageEpoch(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.ancestors.interpreter.file.package.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -14402,6 +15743,105 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						return ""
 					}
 					return ev.FieldHandlers.ResolvePackageName(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.interpreter.file.package.release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageRelease(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageRelease(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.interpreter.file.package.source_epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.interpreter.file.package.source_release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageSourceRelease(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -15456,6 +16896,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.PTrace.Tracee.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -15465,6 +16919,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.PTrace.Tracee.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.PTrace.Tracee.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.PTrace.Tracee.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.PTrace.Tracee.Process.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -15842,6 +17338,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -15851,6 +17361,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -16587,6 +18139,23 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.parent.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				if !ev.PTrace.Tracee.Parent.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.PTrace.Tracee.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.parent.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -16599,6 +18168,57 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.PTrace.Tracee.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return ""
+				}
+				if !ev.PTrace.Tracee.Parent.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.PTrace.Tracee.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				if !ev.PTrace.Tracee.Parent.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.PTrace.Tracee.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return ""
+				}
+				if !ev.PTrace.Tracee.Parent.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.PTrace.Tracee.Parent.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -17054,6 +18674,23 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.parent.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				if !ev.PTrace.Tracee.Parent.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.parent.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -17066,6 +18703,57 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return ""
+				}
+				if !ev.PTrace.Tracee.Parent.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				if !ev.PTrace.Tracee.Parent.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return ""
+				}
+				if !ev.PTrace.Tracee.Parent.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -17642,12 +19330,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "removexattr.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.RemoveXAttr.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "removexattr.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.RemoveXAttr.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "removexattr.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.RemoveXAttr.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "removexattr.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.RemoveXAttr.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "removexattr.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.RemoveXAttr.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -17921,12 +19653,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "rename.file.destination.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Rename.New)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "rename.file.destination.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Rename.New)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rename.file.destination.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Rename.New)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rename.file.destination.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Rename.New)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rename.file.destination.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Rename.New)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -18167,12 +19943,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "rename.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Rename.Old)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "rename.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Rename.Old)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rename.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Rename.Old)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rename.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Rename.Old)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rename.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Rename.Old)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -18457,12 +20277,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "rmdir.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Rmdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "rmdir.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Rmdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rmdir.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Rmdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rmdir.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Rmdir.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "rmdir.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Rmdir.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -19889,6 +21753,39 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.ancestors.file.package.epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageEpoch(ev, &element.ProcessContext.Process.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageEpoch(ev, &current.ProcessContext.Process.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.ancestors.file.package.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -19914,6 +21811,105 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						return ""
 					}
 					return ev.FieldHandlers.ResolvePackageName(ev, &current.ProcessContext.Process.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.file.package.release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageRelease(ev, &element.ProcessContext.Process.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageRelease(ev, &current.ProcessContext.Process.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.file.package.source_epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &element.ProcessContext.Process.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &current.ProcessContext.Process.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.file.package.source_release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageSourceRelease(ev, &element.ProcessContext.Process.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &current.ProcessContext.Process.FileEvent)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -20802,6 +22798,39 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.ancestors.interpreter.file.package.epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageEpoch(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageEpoch(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.ancestors.interpreter.file.package.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -20827,6 +22856,105 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						return ""
 					}
 					return ev.FieldHandlers.ResolvePackageName(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.interpreter.file.package.release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageRelease(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageRelease(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.interpreter.file.package.source_epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.interpreter.file.package.source_release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageSourceRelease(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -21881,6 +24009,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Setrlimit.Target.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -21890,6 +24032,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Setrlimit.Target.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Setrlimit.Target.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Setrlimit.Target.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Setrlimit.Target.Process.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -22267,6 +24451,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -22276,6 +24474,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -23012,6 +25252,23 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.parent.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				if !ev.Setrlimit.Target.Parent.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Setrlimit.Target.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.parent.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -23024,6 +25281,57 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Setrlimit.Target.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return ""
+				}
+				if !ev.Setrlimit.Target.Parent.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Setrlimit.Target.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				if !ev.Setrlimit.Target.Parent.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Setrlimit.Target.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return ""
+				}
+				if !ev.Setrlimit.Target.Parent.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Setrlimit.Target.Parent.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -23479,6 +25787,23 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.parent.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				if !ev.Setrlimit.Target.Parent.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.parent.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -23491,6 +25816,57 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return ""
+				}
+				if !ev.Setrlimit.Target.Parent.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				if !ev.Setrlimit.Target.Parent.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return ""
+				}
+				if !ev.Setrlimit.Target.Parent.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -24254,12 +26630,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "setxattr.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.SetXAttr.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setxattr.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.SetXAttr.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setxattr.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.SetXAttr.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setxattr.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.SetXAttr.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setxattr.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.SetXAttr.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -25543,6 +27963,39 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.ancestors.file.package.epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageEpoch(ev, &element.ProcessContext.Process.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageEpoch(ev, &current.ProcessContext.Process.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.ancestors.file.package.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -25568,6 +28021,105 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						return ""
 					}
 					return ev.FieldHandlers.ResolvePackageName(ev, &current.ProcessContext.Process.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.file.package.release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageRelease(ev, &element.ProcessContext.Process.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageRelease(ev, &current.ProcessContext.Process.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.file.package.source_epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &element.ProcessContext.Process.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &current.ProcessContext.Process.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.file.package.source_release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.IsNotKworker() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageSourceRelease(ev, &element.ProcessContext.Process.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.IsNotKworker() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &current.ProcessContext.Process.FileEvent)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -26456,6 +29008,39 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.ancestors.interpreter.file.package.epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageEpoch(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageEpoch(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.ancestors.interpreter.file.package.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -26481,6 +29066,105 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						return ""
 					}
 					return ev.FieldHandlers.ResolvePackageName(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.interpreter.file.package.release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageRelease(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageRelease(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.interpreter.file.package.source_epoch":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []int{0}
+					}
+					result := int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return 0
+					}
+					return int(ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.interpreter.file.package.source_release":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					if !element.ProcessContext.Process.HasInterpreter() {
+						return []string{""}
+					}
+					result := ev.FieldHandlers.ResolvePackageSourceRelease(ev, &element.ProcessContext.Process.LinuxBinprm.FileEvent)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					if !current.ProcessContext.Process.HasInterpreter() {
+						return ""
+					}
+					return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &current.ProcessContext.Process.LinuxBinprm.FileEvent)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -27535,6 +30219,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Signal.Target.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -27544,6 +30242,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Signal.Target.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Signal.Target.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.Process.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Signal.Target.Process.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.Process.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Signal.Target.Process.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -27921,6 +30661,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -27930,6 +30684,48 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.Process.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.Process.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -28666,6 +31462,23 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.parent.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				if !ev.Signal.Target.Parent.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Signal.Target.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.parent.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -28678,6 +31491,57 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Signal.Target.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return ""
+				}
+				if !ev.Signal.Target.Parent.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Signal.Target.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				if !ev.Signal.Target.Parent.IsNotKworker() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Signal.Target.Parent.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return ""
+				}
+				if !ev.Signal.Target.Parent.IsNotKworker() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Signal.Target.Parent.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -29133,6 +31997,23 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.parent.interpreter.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				if !ev.Signal.Target.Parent.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.parent.interpreter.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -29145,6 +32026,57 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.interpreter.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return ""
+				}
+				if !ev.Signal.Target.Parent.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.interpreter.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				if !ev.Signal.Target.Parent.HasInterpreter() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.interpreter.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return ""
+				}
+				if !ev.Signal.Target.Parent.HasInterpreter() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -29710,12 +32642,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "splice.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Splice.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "splice.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Splice.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "splice.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Splice.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "splice.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Splice.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "splice.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Splice.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -30088,12 +33064,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "unlink.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Unlink.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "unlink.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Unlink.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "unlink.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Unlink.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "unlink.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Unlink.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "unlink.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Unlink.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -30422,12 +33442,56 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "utimes.file.package.epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Utimes.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "utimes.file.package.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.FieldHandlers.ResolvePackageName(ev, &ev.Utimes.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "utimes.file.package.release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Utimes.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "utimes.file.package.source_epoch":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Utimes.File)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "utimes.file.package.source_release":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Utimes.File)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -30583,7 +33647,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"cgroup_write.file.mount_visible",
 		"cgroup_write.file.name",
 		"cgroup_write.file.name.length",
+		"cgroup_write.file.package.epoch",
 		"cgroup_write.file.package.name",
+		"cgroup_write.file.package.release",
+		"cgroup_write.file.package.source_epoch",
+		"cgroup_write.file.package.source_release",
 		"cgroup_write.file.package.source_version",
 		"cgroup_write.file.package.version",
 		"cgroup_write.file.path",
@@ -30607,7 +33675,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"chdir.file.mount_visible",
 		"chdir.file.name",
 		"chdir.file.name.length",
+		"chdir.file.package.epoch",
 		"chdir.file.package.name",
+		"chdir.file.package.release",
+		"chdir.file.package.source_epoch",
+		"chdir.file.package.source_release",
 		"chdir.file.package.source_version",
 		"chdir.file.package.version",
 		"chdir.file.path",
@@ -30634,7 +33706,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"chmod.file.mount_visible",
 		"chmod.file.name",
 		"chmod.file.name.length",
+		"chmod.file.package.epoch",
 		"chmod.file.package.name",
+		"chmod.file.package.release",
+		"chmod.file.package.source_epoch",
+		"chmod.file.package.source_release",
 		"chmod.file.package.source_version",
 		"chmod.file.package.version",
 		"chmod.file.path",
@@ -30664,7 +33740,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"chown.file.mount_visible",
 		"chown.file.name",
 		"chown.file.name.length",
+		"chown.file.package.epoch",
 		"chown.file.package.name",
+		"chown.file.package.release",
+		"chown.file.package.source_epoch",
+		"chown.file.package.source_release",
 		"chown.file.package.source_version",
 		"chown.file.package.version",
 		"chown.file.path",
@@ -30750,7 +33830,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.file.mount_visible",
 		"exec.file.name",
 		"exec.file.name.length",
+		"exec.file.package.epoch",
 		"exec.file.package.name",
+		"exec.file.package.release",
+		"exec.file.package.source_epoch",
+		"exec.file.package.source_release",
 		"exec.file.package.source_version",
 		"exec.file.package.version",
 		"exec.file.path",
@@ -30779,7 +33863,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.interpreter.file.mount_visible",
 		"exec.interpreter.file.name",
 		"exec.interpreter.file.name.length",
+		"exec.interpreter.file.package.epoch",
 		"exec.interpreter.file.package.name",
+		"exec.interpreter.file.package.release",
+		"exec.interpreter.file.package.source_epoch",
+		"exec.interpreter.file.package.source_release",
 		"exec.interpreter.file.package.source_version",
 		"exec.interpreter.file.package.version",
 		"exec.interpreter.file.path",
@@ -30842,7 +33930,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.file.mount_visible",
 		"exit.file.name",
 		"exit.file.name.length",
+		"exit.file.package.epoch",
 		"exit.file.package.name",
+		"exit.file.package.release",
+		"exit.file.package.source_epoch",
+		"exit.file.package.source_release",
 		"exit.file.package.source_version",
 		"exit.file.package.version",
 		"exit.file.path",
@@ -30871,7 +33963,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.interpreter.file.mount_visible",
 		"exit.interpreter.file.name",
 		"exit.interpreter.file.name.length",
+		"exit.interpreter.file.package.epoch",
 		"exit.interpreter.file.package.name",
+		"exit.interpreter.file.package.release",
+		"exit.interpreter.file.package.source_epoch",
+		"exit.interpreter.file.package.source_release",
 		"exit.interpreter.file.package.source_version",
 		"exit.interpreter.file.package.version",
 		"exit.interpreter.file.path",
@@ -30915,7 +34011,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"link.file.destination.mount_visible",
 		"link.file.destination.name",
 		"link.file.destination.name.length",
+		"link.file.destination.package.epoch",
 		"link.file.destination.package.name",
+		"link.file.destination.package.release",
+		"link.file.destination.package.source_epoch",
+		"link.file.destination.package.source_release",
 		"link.file.destination.package.source_version",
 		"link.file.destination.package.version",
 		"link.file.destination.path",
@@ -30937,7 +34037,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"link.file.mount_visible",
 		"link.file.name",
 		"link.file.name.length",
+		"link.file.package.epoch",
 		"link.file.package.name",
+		"link.file.package.release",
+		"link.file.package.source_epoch",
+		"link.file.package.source_release",
 		"link.file.package.source_version",
 		"link.file.package.version",
 		"link.file.path",
@@ -30966,7 +34070,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"load_module.file.mount_visible",
 		"load_module.file.name",
 		"load_module.file.name.length",
+		"load_module.file.package.epoch",
 		"load_module.file.package.name",
+		"load_module.file.package.release",
+		"load_module.file.package.source_epoch",
+		"load_module.file.package.source_release",
 		"load_module.file.package.source_version",
 		"load_module.file.package.version",
 		"load_module.file.path",
@@ -30994,7 +34102,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"mkdir.file.mount_visible",
 		"mkdir.file.name",
 		"mkdir.file.name.length",
+		"mkdir.file.package.epoch",
 		"mkdir.file.package.name",
+		"mkdir.file.package.release",
+		"mkdir.file.package.source_epoch",
+		"mkdir.file.package.source_release",
 		"mkdir.file.package.source_version",
 		"mkdir.file.package.version",
 		"mkdir.file.path",
@@ -31020,7 +34132,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"mmap.file.mount_visible",
 		"mmap.file.name",
 		"mmap.file.name.length",
+		"mmap.file.package.epoch",
 		"mmap.file.package.name",
+		"mmap.file.package.release",
+		"mmap.file.package.source_epoch",
+		"mmap.file.package.source_release",
 		"mmap.file.package.source_version",
 		"mmap.file.package.version",
 		"mmap.file.path",
@@ -31099,7 +34215,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"open.file.mount_visible",
 		"open.file.name",
 		"open.file.name.length",
+		"open.file.package.epoch",
 		"open.file.package.name",
+		"open.file.package.release",
+		"open.file.package.source_epoch",
+		"open.file.package.source_release",
 		"open.file.package.source_version",
 		"open.file.package.version",
 		"open.file.path",
@@ -31170,7 +34290,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.file.mount_visible",
 		"process.ancestors.file.name",
 		"process.ancestors.file.name.length",
+		"process.ancestors.file.package.epoch",
 		"process.ancestors.file.package.name",
+		"process.ancestors.file.package.release",
+		"process.ancestors.file.package.source_epoch",
+		"process.ancestors.file.package.source_release",
 		"process.ancestors.file.package.source_version",
 		"process.ancestors.file.package.version",
 		"process.ancestors.file.path",
@@ -31199,7 +34323,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.interpreter.file.mount_visible",
 		"process.ancestors.interpreter.file.name",
 		"process.ancestors.interpreter.file.name.length",
+		"process.ancestors.interpreter.file.package.epoch",
 		"process.ancestors.interpreter.file.package.name",
+		"process.ancestors.interpreter.file.package.release",
+		"process.ancestors.interpreter.file.package.source_epoch",
+		"process.ancestors.interpreter.file.package.source_release",
 		"process.ancestors.interpreter.file.package.source_version",
 		"process.ancestors.interpreter.file.package.version",
 		"process.ancestors.interpreter.file.path",
@@ -31260,7 +34388,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.file.mount_visible",
 		"process.file.name",
 		"process.file.name.length",
+		"process.file.package.epoch",
 		"process.file.package.name",
+		"process.file.package.release",
+		"process.file.package.source_epoch",
+		"process.file.package.source_release",
 		"process.file.package.source_version",
 		"process.file.package.version",
 		"process.file.path",
@@ -31289,7 +34421,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.interpreter.file.mount_visible",
 		"process.interpreter.file.name",
 		"process.interpreter.file.name.length",
+		"process.interpreter.file.package.epoch",
 		"process.interpreter.file.package.name",
+		"process.interpreter.file.package.release",
+		"process.interpreter.file.package.source_epoch",
+		"process.interpreter.file.package.source_release",
 		"process.interpreter.file.package.source_version",
 		"process.interpreter.file.package.version",
 		"process.interpreter.file.path",
@@ -31340,7 +34476,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.file.mount_visible",
 		"process.parent.file.name",
 		"process.parent.file.name.length",
+		"process.parent.file.package.epoch",
 		"process.parent.file.package.name",
+		"process.parent.file.package.release",
+		"process.parent.file.package.source_epoch",
+		"process.parent.file.package.source_release",
 		"process.parent.file.package.source_version",
 		"process.parent.file.package.version",
 		"process.parent.file.path",
@@ -31369,7 +34509,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.interpreter.file.mount_visible",
 		"process.parent.interpreter.file.name",
 		"process.parent.interpreter.file.name.length",
+		"process.parent.interpreter.file.package.epoch",
 		"process.parent.interpreter.file.package.name",
+		"process.parent.interpreter.file.package.release",
+		"process.parent.interpreter.file.package.source_epoch",
+		"process.parent.interpreter.file.package.source_release",
 		"process.parent.interpreter.file.package.source_version",
 		"process.parent.interpreter.file.package.version",
 		"process.parent.interpreter.file.path",
@@ -31440,7 +34584,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.ancestors.file.mount_visible",
 		"ptrace.tracee.ancestors.file.name",
 		"ptrace.tracee.ancestors.file.name.length",
+		"ptrace.tracee.ancestors.file.package.epoch",
 		"ptrace.tracee.ancestors.file.package.name",
+		"ptrace.tracee.ancestors.file.package.release",
+		"ptrace.tracee.ancestors.file.package.source_epoch",
+		"ptrace.tracee.ancestors.file.package.source_release",
 		"ptrace.tracee.ancestors.file.package.source_version",
 		"ptrace.tracee.ancestors.file.package.version",
 		"ptrace.tracee.ancestors.file.path",
@@ -31469,7 +34617,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.ancestors.interpreter.file.mount_visible",
 		"ptrace.tracee.ancestors.interpreter.file.name",
 		"ptrace.tracee.ancestors.interpreter.file.name.length",
+		"ptrace.tracee.ancestors.interpreter.file.package.epoch",
 		"ptrace.tracee.ancestors.interpreter.file.package.name",
+		"ptrace.tracee.ancestors.interpreter.file.package.release",
+		"ptrace.tracee.ancestors.interpreter.file.package.source_epoch",
+		"ptrace.tracee.ancestors.interpreter.file.package.source_release",
 		"ptrace.tracee.ancestors.interpreter.file.package.source_version",
 		"ptrace.tracee.ancestors.interpreter.file.package.version",
 		"ptrace.tracee.ancestors.interpreter.file.path",
@@ -31530,7 +34682,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.file.mount_visible",
 		"ptrace.tracee.file.name",
 		"ptrace.tracee.file.name.length",
+		"ptrace.tracee.file.package.epoch",
 		"ptrace.tracee.file.package.name",
+		"ptrace.tracee.file.package.release",
+		"ptrace.tracee.file.package.source_epoch",
+		"ptrace.tracee.file.package.source_release",
 		"ptrace.tracee.file.package.source_version",
 		"ptrace.tracee.file.package.version",
 		"ptrace.tracee.file.path",
@@ -31559,7 +34715,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.interpreter.file.mount_visible",
 		"ptrace.tracee.interpreter.file.name",
 		"ptrace.tracee.interpreter.file.name.length",
+		"ptrace.tracee.interpreter.file.package.epoch",
 		"ptrace.tracee.interpreter.file.package.name",
+		"ptrace.tracee.interpreter.file.package.release",
+		"ptrace.tracee.interpreter.file.package.source_epoch",
+		"ptrace.tracee.interpreter.file.package.source_release",
 		"ptrace.tracee.interpreter.file.package.source_version",
 		"ptrace.tracee.interpreter.file.package.version",
 		"ptrace.tracee.interpreter.file.path",
@@ -31610,7 +34770,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.parent.file.mount_visible",
 		"ptrace.tracee.parent.file.name",
 		"ptrace.tracee.parent.file.name.length",
+		"ptrace.tracee.parent.file.package.epoch",
 		"ptrace.tracee.parent.file.package.name",
+		"ptrace.tracee.parent.file.package.release",
+		"ptrace.tracee.parent.file.package.source_epoch",
+		"ptrace.tracee.parent.file.package.source_release",
 		"ptrace.tracee.parent.file.package.source_version",
 		"ptrace.tracee.parent.file.package.version",
 		"ptrace.tracee.parent.file.path",
@@ -31639,7 +34803,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.parent.interpreter.file.mount_visible",
 		"ptrace.tracee.parent.interpreter.file.name",
 		"ptrace.tracee.parent.interpreter.file.name.length",
+		"ptrace.tracee.parent.interpreter.file.package.epoch",
 		"ptrace.tracee.parent.interpreter.file.package.name",
+		"ptrace.tracee.parent.interpreter.file.package.release",
+		"ptrace.tracee.parent.interpreter.file.package.source_epoch",
+		"ptrace.tracee.parent.interpreter.file.package.source_release",
 		"ptrace.tracee.parent.interpreter.file.package.source_version",
 		"ptrace.tracee.parent.interpreter.file.package.version",
 		"ptrace.tracee.parent.interpreter.file.path",
@@ -31685,7 +34853,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"removexattr.file.mount_visible",
 		"removexattr.file.name",
 		"removexattr.file.name.length",
+		"removexattr.file.package.epoch",
 		"removexattr.file.package.name",
+		"removexattr.file.package.release",
+		"removexattr.file.package.source_epoch",
+		"removexattr.file.package.source_release",
 		"removexattr.file.package.source_version",
 		"removexattr.file.package.version",
 		"removexattr.file.path",
@@ -31710,7 +34882,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"rename.file.destination.mount_visible",
 		"rename.file.destination.name",
 		"rename.file.destination.name.length",
+		"rename.file.destination.package.epoch",
 		"rename.file.destination.package.name",
+		"rename.file.destination.package.release",
+		"rename.file.destination.package.source_epoch",
+		"rename.file.destination.package.source_release",
 		"rename.file.destination.package.source_version",
 		"rename.file.destination.package.version",
 		"rename.file.destination.path",
@@ -31732,7 +34908,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"rename.file.mount_visible",
 		"rename.file.name",
 		"rename.file.name.length",
+		"rename.file.package.epoch",
 		"rename.file.package.name",
+		"rename.file.package.release",
+		"rename.file.package.source_epoch",
+		"rename.file.package.source_release",
 		"rename.file.package.source_version",
 		"rename.file.package.version",
 		"rename.file.path",
@@ -31758,7 +34938,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"rmdir.file.mount_visible",
 		"rmdir.file.name",
 		"rmdir.file.name.length",
+		"rmdir.file.package.epoch",
 		"rmdir.file.package.name",
+		"rmdir.file.package.release",
+		"rmdir.file.package.source_epoch",
+		"rmdir.file.package.source_release",
 		"rmdir.file.package.source_version",
 		"rmdir.file.package.version",
 		"rmdir.file.path",
@@ -31822,7 +35006,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.ancestors.file.mount_visible",
 		"setrlimit.target.ancestors.file.name",
 		"setrlimit.target.ancestors.file.name.length",
+		"setrlimit.target.ancestors.file.package.epoch",
 		"setrlimit.target.ancestors.file.package.name",
+		"setrlimit.target.ancestors.file.package.release",
+		"setrlimit.target.ancestors.file.package.source_epoch",
+		"setrlimit.target.ancestors.file.package.source_release",
 		"setrlimit.target.ancestors.file.package.source_version",
 		"setrlimit.target.ancestors.file.package.version",
 		"setrlimit.target.ancestors.file.path",
@@ -31851,7 +35039,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.ancestors.interpreter.file.mount_visible",
 		"setrlimit.target.ancestors.interpreter.file.name",
 		"setrlimit.target.ancestors.interpreter.file.name.length",
+		"setrlimit.target.ancestors.interpreter.file.package.epoch",
 		"setrlimit.target.ancestors.interpreter.file.package.name",
+		"setrlimit.target.ancestors.interpreter.file.package.release",
+		"setrlimit.target.ancestors.interpreter.file.package.source_epoch",
+		"setrlimit.target.ancestors.interpreter.file.package.source_release",
 		"setrlimit.target.ancestors.interpreter.file.package.source_version",
 		"setrlimit.target.ancestors.interpreter.file.package.version",
 		"setrlimit.target.ancestors.interpreter.file.path",
@@ -31912,7 +35104,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.file.mount_visible",
 		"setrlimit.target.file.name",
 		"setrlimit.target.file.name.length",
+		"setrlimit.target.file.package.epoch",
 		"setrlimit.target.file.package.name",
+		"setrlimit.target.file.package.release",
+		"setrlimit.target.file.package.source_epoch",
+		"setrlimit.target.file.package.source_release",
 		"setrlimit.target.file.package.source_version",
 		"setrlimit.target.file.package.version",
 		"setrlimit.target.file.path",
@@ -31941,7 +35137,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.interpreter.file.mount_visible",
 		"setrlimit.target.interpreter.file.name",
 		"setrlimit.target.interpreter.file.name.length",
+		"setrlimit.target.interpreter.file.package.epoch",
 		"setrlimit.target.interpreter.file.package.name",
+		"setrlimit.target.interpreter.file.package.release",
+		"setrlimit.target.interpreter.file.package.source_epoch",
+		"setrlimit.target.interpreter.file.package.source_release",
 		"setrlimit.target.interpreter.file.package.source_version",
 		"setrlimit.target.interpreter.file.package.version",
 		"setrlimit.target.interpreter.file.path",
@@ -31992,7 +35192,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.parent.file.mount_visible",
 		"setrlimit.target.parent.file.name",
 		"setrlimit.target.parent.file.name.length",
+		"setrlimit.target.parent.file.package.epoch",
 		"setrlimit.target.parent.file.package.name",
+		"setrlimit.target.parent.file.package.release",
+		"setrlimit.target.parent.file.package.source_epoch",
+		"setrlimit.target.parent.file.package.source_release",
 		"setrlimit.target.parent.file.package.source_version",
 		"setrlimit.target.parent.file.package.version",
 		"setrlimit.target.parent.file.path",
@@ -32021,7 +35225,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.parent.interpreter.file.mount_visible",
 		"setrlimit.target.parent.interpreter.file.name",
 		"setrlimit.target.parent.interpreter.file.name.length",
+		"setrlimit.target.parent.interpreter.file.package.epoch",
 		"setrlimit.target.parent.interpreter.file.package.name",
+		"setrlimit.target.parent.interpreter.file.package.release",
+		"setrlimit.target.parent.interpreter.file.package.source_epoch",
+		"setrlimit.target.parent.interpreter.file.package.source_release",
 		"setrlimit.target.parent.interpreter.file.package.source_version",
 		"setrlimit.target.parent.interpreter.file.package.version",
 		"setrlimit.target.parent.interpreter.file.path",
@@ -32084,7 +35292,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"setxattr.file.mount_visible",
 		"setxattr.file.name",
 		"setxattr.file.name.length",
+		"setxattr.file.package.epoch",
 		"setxattr.file.package.name",
+		"setxattr.file.package.release",
+		"setxattr.file.package.source_epoch",
+		"setxattr.file.package.source_release",
 		"setxattr.file.package.source_version",
 		"setxattr.file.package.version",
 		"setxattr.file.path",
@@ -32135,7 +35347,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.ancestors.file.mount_visible",
 		"signal.target.ancestors.file.name",
 		"signal.target.ancestors.file.name.length",
+		"signal.target.ancestors.file.package.epoch",
 		"signal.target.ancestors.file.package.name",
+		"signal.target.ancestors.file.package.release",
+		"signal.target.ancestors.file.package.source_epoch",
+		"signal.target.ancestors.file.package.source_release",
 		"signal.target.ancestors.file.package.source_version",
 		"signal.target.ancestors.file.package.version",
 		"signal.target.ancestors.file.path",
@@ -32164,7 +35380,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.ancestors.interpreter.file.mount_visible",
 		"signal.target.ancestors.interpreter.file.name",
 		"signal.target.ancestors.interpreter.file.name.length",
+		"signal.target.ancestors.interpreter.file.package.epoch",
 		"signal.target.ancestors.interpreter.file.package.name",
+		"signal.target.ancestors.interpreter.file.package.release",
+		"signal.target.ancestors.interpreter.file.package.source_epoch",
+		"signal.target.ancestors.interpreter.file.package.source_release",
 		"signal.target.ancestors.interpreter.file.package.source_version",
 		"signal.target.ancestors.interpreter.file.package.version",
 		"signal.target.ancestors.interpreter.file.path",
@@ -32225,7 +35445,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.file.mount_visible",
 		"signal.target.file.name",
 		"signal.target.file.name.length",
+		"signal.target.file.package.epoch",
 		"signal.target.file.package.name",
+		"signal.target.file.package.release",
+		"signal.target.file.package.source_epoch",
+		"signal.target.file.package.source_release",
 		"signal.target.file.package.source_version",
 		"signal.target.file.package.version",
 		"signal.target.file.path",
@@ -32254,7 +35478,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.interpreter.file.mount_visible",
 		"signal.target.interpreter.file.name",
 		"signal.target.interpreter.file.name.length",
+		"signal.target.interpreter.file.package.epoch",
 		"signal.target.interpreter.file.package.name",
+		"signal.target.interpreter.file.package.release",
+		"signal.target.interpreter.file.package.source_epoch",
+		"signal.target.interpreter.file.package.source_release",
 		"signal.target.interpreter.file.package.source_version",
 		"signal.target.interpreter.file.package.version",
 		"signal.target.interpreter.file.path",
@@ -32305,7 +35533,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.parent.file.mount_visible",
 		"signal.target.parent.file.name",
 		"signal.target.parent.file.name.length",
+		"signal.target.parent.file.package.epoch",
 		"signal.target.parent.file.package.name",
+		"signal.target.parent.file.package.release",
+		"signal.target.parent.file.package.source_epoch",
+		"signal.target.parent.file.package.source_release",
 		"signal.target.parent.file.package.source_version",
 		"signal.target.parent.file.package.version",
 		"signal.target.parent.file.path",
@@ -32334,7 +35566,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.parent.interpreter.file.mount_visible",
 		"signal.target.parent.interpreter.file.name",
 		"signal.target.parent.interpreter.file.name.length",
+		"signal.target.parent.interpreter.file.package.epoch",
 		"signal.target.parent.interpreter.file.package.name",
+		"signal.target.parent.interpreter.file.package.release",
+		"signal.target.parent.interpreter.file.package.source_epoch",
+		"signal.target.parent.interpreter.file.package.source_release",
 		"signal.target.parent.interpreter.file.package.source_version",
 		"signal.target.parent.interpreter.file.package.version",
 		"signal.target.parent.interpreter.file.path",
@@ -32379,7 +35615,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"splice.file.mount_visible",
 		"splice.file.name",
 		"splice.file.name.length",
+		"splice.file.package.epoch",
 		"splice.file.package.name",
+		"splice.file.package.release",
+		"splice.file.package.source_epoch",
+		"splice.file.package.source_release",
 		"splice.file.package.source_version",
 		"splice.file.package.version",
 		"splice.file.path",
@@ -32413,7 +35653,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"unlink.file.mount_visible",
 		"unlink.file.name",
 		"unlink.file.name.length",
+		"unlink.file.package.epoch",
 		"unlink.file.package.name",
+		"unlink.file.package.release",
+		"unlink.file.package.source_epoch",
+		"unlink.file.package.source_release",
 		"unlink.file.package.source_version",
 		"unlink.file.package.version",
 		"unlink.file.path",
@@ -32443,7 +35687,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"utimes.file.mount_visible",
 		"utimes.file.name",
 		"utimes.file.name.length",
+		"utimes.file.package.epoch",
 		"utimes.file.package.name",
+		"utimes.file.package.release",
+		"utimes.file.package.source_epoch",
+		"utimes.file.package.source_release",
 		"utimes.file.package.source_version",
 		"utimes.file.package.version",
 		"utimes.file.path",
@@ -32545,7 +35793,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "cgroup_write", reflect.String, "string", nil
 	case "cgroup_write.file.name.length":
 		return "cgroup_write", reflect.Int, "int", nil
+	case "cgroup_write.file.package.epoch":
+		return "cgroup_write", reflect.Int, "int", nil
 	case "cgroup_write.file.package.name":
+		return "cgroup_write", reflect.String, "string", nil
+	case "cgroup_write.file.package.release":
+		return "cgroup_write", reflect.String, "string", nil
+	case "cgroup_write.file.package.source_epoch":
+		return "cgroup_write", reflect.Int, "int", nil
+	case "cgroup_write.file.package.source_release":
 		return "cgroup_write", reflect.String, "string", nil
 	case "cgroup_write.file.package.source_version":
 		return "cgroup_write", reflect.String, "string", nil
@@ -32593,7 +35849,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "chdir", reflect.String, "string", nil
 	case "chdir.file.name.length":
 		return "chdir", reflect.Int, "int", nil
+	case "chdir.file.package.epoch":
+		return "chdir", reflect.Int, "int", nil
 	case "chdir.file.package.name":
+		return "chdir", reflect.String, "string", nil
+	case "chdir.file.package.release":
+		return "chdir", reflect.String, "string", nil
+	case "chdir.file.package.source_epoch":
+		return "chdir", reflect.Int, "int", nil
+	case "chdir.file.package.source_release":
 		return "chdir", reflect.String, "string", nil
 	case "chdir.file.package.source_version":
 		return "chdir", reflect.String, "string", nil
@@ -32647,7 +35911,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "chmod", reflect.String, "string", nil
 	case "chmod.file.name.length":
 		return "chmod", reflect.Int, "int", nil
+	case "chmod.file.package.epoch":
+		return "chmod", reflect.Int, "int", nil
 	case "chmod.file.package.name":
+		return "chmod", reflect.String, "string", nil
+	case "chmod.file.package.release":
+		return "chmod", reflect.String, "string", nil
+	case "chmod.file.package.source_epoch":
+		return "chmod", reflect.Int, "int", nil
+	case "chmod.file.package.source_release":
 		return "chmod", reflect.String, "string", nil
 	case "chmod.file.package.source_version":
 		return "chmod", reflect.String, "string", nil
@@ -32707,7 +35979,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "chown", reflect.String, "string", nil
 	case "chown.file.name.length":
 		return "chown", reflect.Int, "int", nil
+	case "chown.file.package.epoch":
+		return "chown", reflect.Int, "int", nil
 	case "chown.file.package.name":
+		return "chown", reflect.String, "string", nil
+	case "chown.file.package.release":
+		return "chown", reflect.String, "string", nil
+	case "chown.file.package.source_epoch":
+		return "chown", reflect.Int, "int", nil
+	case "chown.file.package.source_release":
 		return "chown", reflect.String, "string", nil
 	case "chown.file.package.source_version":
 		return "chown", reflect.String, "string", nil
@@ -32879,7 +36159,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.String, "string", nil
 	case "exec.file.name.length":
 		return "exec", reflect.Int, "int", nil
+	case "exec.file.package.epoch":
+		return "exec", reflect.Int, "int", nil
 	case "exec.file.package.name":
+		return "exec", reflect.String, "string", nil
+	case "exec.file.package.release":
+		return "exec", reflect.String, "string", nil
+	case "exec.file.package.source_epoch":
+		return "exec", reflect.Int, "int", nil
+	case "exec.file.package.source_release":
 		return "exec", reflect.String, "string", nil
 	case "exec.file.package.source_version":
 		return "exec", reflect.String, "string", nil
@@ -32937,7 +36225,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.String, "string", nil
 	case "exec.interpreter.file.name.length":
 		return "exec", reflect.Int, "int", nil
+	case "exec.interpreter.file.package.epoch":
+		return "exec", reflect.Int, "int", nil
 	case "exec.interpreter.file.package.name":
+		return "exec", reflect.String, "string", nil
+	case "exec.interpreter.file.package.release":
+		return "exec", reflect.String, "string", nil
+	case "exec.interpreter.file.package.source_epoch":
+		return "exec", reflect.Int, "int", nil
+	case "exec.interpreter.file.package.source_release":
 		return "exec", reflect.String, "string", nil
 	case "exec.interpreter.file.package.source_version":
 		return "exec", reflect.String, "string", nil
@@ -33063,7 +36359,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.String, "string", nil
 	case "exit.file.name.length":
 		return "exit", reflect.Int, "int", nil
+	case "exit.file.package.epoch":
+		return "exit", reflect.Int, "int", nil
 	case "exit.file.package.name":
+		return "exit", reflect.String, "string", nil
+	case "exit.file.package.release":
+		return "exit", reflect.String, "string", nil
+	case "exit.file.package.source_epoch":
+		return "exit", reflect.Int, "int", nil
+	case "exit.file.package.source_release":
 		return "exit", reflect.String, "string", nil
 	case "exit.file.package.source_version":
 		return "exit", reflect.String, "string", nil
@@ -33121,7 +36425,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.String, "string", nil
 	case "exit.interpreter.file.name.length":
 		return "exit", reflect.Int, "int", nil
+	case "exit.interpreter.file.package.epoch":
+		return "exit", reflect.Int, "int", nil
 	case "exit.interpreter.file.package.name":
+		return "exit", reflect.String, "string", nil
+	case "exit.interpreter.file.package.release":
+		return "exit", reflect.String, "string", nil
+	case "exit.interpreter.file.package.source_epoch":
+		return "exit", reflect.Int, "int", nil
+	case "exit.interpreter.file.package.source_release":
 		return "exit", reflect.String, "string", nil
 	case "exit.interpreter.file.package.source_version":
 		return "exit", reflect.String, "string", nil
@@ -33209,7 +36521,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "link", reflect.String, "string", nil
 	case "link.file.destination.name.length":
 		return "link", reflect.Int, "int", nil
+	case "link.file.destination.package.epoch":
+		return "link", reflect.Int, "int", nil
 	case "link.file.destination.package.name":
+		return "link", reflect.String, "string", nil
+	case "link.file.destination.package.release":
+		return "link", reflect.String, "string", nil
+	case "link.file.destination.package.source_epoch":
+		return "link", reflect.Int, "int", nil
+	case "link.file.destination.package.source_release":
 		return "link", reflect.String, "string", nil
 	case "link.file.destination.package.source_version":
 		return "link", reflect.String, "string", nil
@@ -33253,7 +36573,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "link", reflect.String, "string", nil
 	case "link.file.name.length":
 		return "link", reflect.Int, "int", nil
+	case "link.file.package.epoch":
+		return "link", reflect.Int, "int", nil
 	case "link.file.package.name":
+		return "link", reflect.String, "string", nil
+	case "link.file.package.release":
+		return "link", reflect.String, "string", nil
+	case "link.file.package.source_epoch":
+		return "link", reflect.Int, "int", nil
+	case "link.file.package.source_release":
 		return "link", reflect.String, "string", nil
 	case "link.file.package.source_version":
 		return "link", reflect.String, "string", nil
@@ -33311,7 +36639,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "load_module", reflect.String, "string", nil
 	case "load_module.file.name.length":
 		return "load_module", reflect.Int, "int", nil
+	case "load_module.file.package.epoch":
+		return "load_module", reflect.Int, "int", nil
 	case "load_module.file.package.name":
+		return "load_module", reflect.String, "string", nil
+	case "load_module.file.package.release":
+		return "load_module", reflect.String, "string", nil
+	case "load_module.file.package.source_epoch":
+		return "load_module", reflect.Int, "int", nil
+	case "load_module.file.package.source_release":
 		return "load_module", reflect.String, "string", nil
 	case "load_module.file.package.source_version":
 		return "load_module", reflect.String, "string", nil
@@ -33367,7 +36703,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "mkdir", reflect.String, "string", nil
 	case "mkdir.file.name.length":
 		return "mkdir", reflect.Int, "int", nil
+	case "mkdir.file.package.epoch":
+		return "mkdir", reflect.Int, "int", nil
 	case "mkdir.file.package.name":
+		return "mkdir", reflect.String, "string", nil
+	case "mkdir.file.package.release":
+		return "mkdir", reflect.String, "string", nil
+	case "mkdir.file.package.source_epoch":
+		return "mkdir", reflect.Int, "int", nil
+	case "mkdir.file.package.source_release":
 		return "mkdir", reflect.String, "string", nil
 	case "mkdir.file.package.source_version":
 		return "mkdir", reflect.String, "string", nil
@@ -33419,7 +36763,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "mmap", reflect.String, "string", nil
 	case "mmap.file.name.length":
 		return "mmap", reflect.Int, "int", nil
+	case "mmap.file.package.epoch":
+		return "mmap", reflect.Int, "int", nil
 	case "mmap.file.package.name":
+		return "mmap", reflect.String, "string", nil
+	case "mmap.file.package.release":
+		return "mmap", reflect.String, "string", nil
+	case "mmap.file.package.source_epoch":
+		return "mmap", reflect.Int, "int", nil
+	case "mmap.file.package.source_release":
 		return "mmap", reflect.String, "string", nil
 	case "mmap.file.package.source_version":
 		return "mmap", reflect.String, "string", nil
@@ -33577,7 +36929,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "open", reflect.String, "string", nil
 	case "open.file.name.length":
 		return "open", reflect.Int, "int", nil
+	case "open.file.package.epoch":
+		return "open", reflect.Int, "int", nil
 	case "open.file.package.name":
+		return "open", reflect.String, "string", nil
+	case "open.file.package.release":
+		return "open", reflect.String, "string", nil
+	case "open.file.package.source_epoch":
+		return "open", reflect.Int, "int", nil
+	case "open.file.package.source_release":
 		return "open", reflect.String, "string", nil
 	case "open.file.package.source_version":
 		return "open", reflect.String, "string", nil
@@ -33719,7 +37079,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.ancestors.file.name.length":
 		return "", reflect.Int, "int", nil
+	case "process.ancestors.file.package.epoch":
+		return "", reflect.Int, "int", nil
 	case "process.ancestors.file.package.name":
+		return "", reflect.String, "string", nil
+	case "process.ancestors.file.package.release":
+		return "", reflect.String, "string", nil
+	case "process.ancestors.file.package.source_epoch":
+		return "", reflect.Int, "int", nil
+	case "process.ancestors.file.package.source_release":
 		return "", reflect.String, "string", nil
 	case "process.ancestors.file.package.source_version":
 		return "", reflect.String, "string", nil
@@ -33777,7 +37145,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.ancestors.interpreter.file.name.length":
 		return "", reflect.Int, "int", nil
+	case "process.ancestors.interpreter.file.package.epoch":
+		return "", reflect.Int, "int", nil
 	case "process.ancestors.interpreter.file.package.name":
+		return "", reflect.String, "string", nil
+	case "process.ancestors.interpreter.file.package.release":
+		return "", reflect.String, "string", nil
+	case "process.ancestors.interpreter.file.package.source_epoch":
+		return "", reflect.Int, "int", nil
+	case "process.ancestors.interpreter.file.package.source_release":
 		return "", reflect.String, "string", nil
 	case "process.ancestors.interpreter.file.package.source_version":
 		return "", reflect.String, "string", nil
@@ -33899,7 +37275,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.file.name.length":
 		return "", reflect.Int, "int", nil
+	case "process.file.package.epoch":
+		return "", reflect.Int, "int", nil
 	case "process.file.package.name":
+		return "", reflect.String, "string", nil
+	case "process.file.package.release":
+		return "", reflect.String, "string", nil
+	case "process.file.package.source_epoch":
+		return "", reflect.Int, "int", nil
+	case "process.file.package.source_release":
 		return "", reflect.String, "string", nil
 	case "process.file.package.source_version":
 		return "", reflect.String, "string", nil
@@ -33957,7 +37341,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.interpreter.file.name.length":
 		return "", reflect.Int, "int", nil
+	case "process.interpreter.file.package.epoch":
+		return "", reflect.Int, "int", nil
 	case "process.interpreter.file.package.name":
+		return "", reflect.String, "string", nil
+	case "process.interpreter.file.package.release":
+		return "", reflect.String, "string", nil
+	case "process.interpreter.file.package.source_epoch":
+		return "", reflect.Int, "int", nil
+	case "process.interpreter.file.package.source_release":
 		return "", reflect.String, "string", nil
 	case "process.interpreter.file.package.source_version":
 		return "", reflect.String, "string", nil
@@ -34059,7 +37451,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.parent.file.name.length":
 		return "", reflect.Int, "int", nil
+	case "process.parent.file.package.epoch":
+		return "", reflect.Int, "int", nil
 	case "process.parent.file.package.name":
+		return "", reflect.String, "string", nil
+	case "process.parent.file.package.release":
+		return "", reflect.String, "string", nil
+	case "process.parent.file.package.source_epoch":
+		return "", reflect.Int, "int", nil
+	case "process.parent.file.package.source_release":
 		return "", reflect.String, "string", nil
 	case "process.parent.file.package.source_version":
 		return "", reflect.String, "string", nil
@@ -34117,7 +37517,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.parent.interpreter.file.name.length":
 		return "", reflect.Int, "int", nil
+	case "process.parent.interpreter.file.package.epoch":
+		return "", reflect.Int, "int", nil
 	case "process.parent.interpreter.file.package.name":
+		return "", reflect.String, "string", nil
+	case "process.parent.interpreter.file.package.release":
+		return "", reflect.String, "string", nil
+	case "process.parent.interpreter.file.package.source_epoch":
+		return "", reflect.Int, "int", nil
+	case "process.parent.interpreter.file.package.source_release":
 		return "", reflect.String, "string", nil
 	case "process.parent.interpreter.file.package.source_version":
 		return "", reflect.String, "string", nil
@@ -34259,7 +37667,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.ancestors.file.name.length":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.ancestors.file.package.epoch":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.ancestors.file.package.name":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.ancestors.file.package.release":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.ancestors.file.package.source_epoch":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.ancestors.file.package.source_release":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.ancestors.file.package.source_version":
 		return "ptrace", reflect.String, "string", nil
@@ -34317,7 +37733,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.ancestors.interpreter.file.name.length":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.ancestors.interpreter.file.package.epoch":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.ancestors.interpreter.file.package.name":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.ancestors.interpreter.file.package.release":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.ancestors.interpreter.file.package.source_epoch":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.ancestors.interpreter.file.package.source_release":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.ancestors.interpreter.file.package.source_version":
 		return "ptrace", reflect.String, "string", nil
@@ -34439,7 +37863,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.file.name.length":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.file.package.epoch":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.file.package.name":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.file.package.release":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.file.package.source_epoch":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.file.package.source_release":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.file.package.source_version":
 		return "ptrace", reflect.String, "string", nil
@@ -34497,7 +37929,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.interpreter.file.name.length":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.interpreter.file.package.epoch":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.interpreter.file.package.name":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.interpreter.file.package.release":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.interpreter.file.package.source_epoch":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.interpreter.file.package.source_release":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.interpreter.file.package.source_version":
 		return "ptrace", reflect.String, "string", nil
@@ -34599,7 +38039,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.parent.file.name.length":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.parent.file.package.epoch":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.parent.file.package.name":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.parent.file.package.release":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.parent.file.package.source_epoch":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.parent.file.package.source_release":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.parent.file.package.source_version":
 		return "ptrace", reflect.String, "string", nil
@@ -34657,7 +38105,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.parent.interpreter.file.name.length":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.parent.interpreter.file.package.epoch":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.parent.interpreter.file.package.name":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.parent.interpreter.file.package.release":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.parent.interpreter.file.package.source_epoch":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.parent.interpreter.file.package.source_release":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.parent.interpreter.file.package.source_version":
 		return "ptrace", reflect.String, "string", nil
@@ -34749,7 +38205,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "removexattr", reflect.String, "string", nil
 	case "removexattr.file.name.length":
 		return "removexattr", reflect.Int, "int", nil
+	case "removexattr.file.package.epoch":
+		return "removexattr", reflect.Int, "int", nil
 	case "removexattr.file.package.name":
+		return "removexattr", reflect.String, "string", nil
+	case "removexattr.file.package.release":
+		return "removexattr", reflect.String, "string", nil
+	case "removexattr.file.package.source_epoch":
+		return "removexattr", reflect.Int, "int", nil
+	case "removexattr.file.package.source_release":
 		return "removexattr", reflect.String, "string", nil
 	case "removexattr.file.package.source_version":
 		return "removexattr", reflect.String, "string", nil
@@ -34799,7 +38263,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "rename", reflect.String, "string", nil
 	case "rename.file.destination.name.length":
 		return "rename", reflect.Int, "int", nil
+	case "rename.file.destination.package.epoch":
+		return "rename", reflect.Int, "int", nil
 	case "rename.file.destination.package.name":
+		return "rename", reflect.String, "string", nil
+	case "rename.file.destination.package.release":
+		return "rename", reflect.String, "string", nil
+	case "rename.file.destination.package.source_epoch":
+		return "rename", reflect.Int, "int", nil
+	case "rename.file.destination.package.source_release":
 		return "rename", reflect.String, "string", nil
 	case "rename.file.destination.package.source_version":
 		return "rename", reflect.String, "string", nil
@@ -34843,7 +38315,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "rename", reflect.String, "string", nil
 	case "rename.file.name.length":
 		return "rename", reflect.Int, "int", nil
+	case "rename.file.package.epoch":
+		return "rename", reflect.Int, "int", nil
 	case "rename.file.package.name":
+		return "rename", reflect.String, "string", nil
+	case "rename.file.package.release":
+		return "rename", reflect.String, "string", nil
+	case "rename.file.package.source_epoch":
+		return "rename", reflect.Int, "int", nil
+	case "rename.file.package.source_release":
 		return "rename", reflect.String, "string", nil
 	case "rename.file.package.source_version":
 		return "rename", reflect.String, "string", nil
@@ -34895,7 +38375,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "rmdir", reflect.String, "string", nil
 	case "rmdir.file.name.length":
 		return "rmdir", reflect.Int, "int", nil
+	case "rmdir.file.package.epoch":
+		return "rmdir", reflect.Int, "int", nil
 	case "rmdir.file.package.name":
+		return "rmdir", reflect.String, "string", nil
+	case "rmdir.file.package.release":
+		return "rmdir", reflect.String, "string", nil
+	case "rmdir.file.package.source_epoch":
+		return "rmdir", reflect.Int, "int", nil
+	case "rmdir.file.package.source_release":
 		return "rmdir", reflect.String, "string", nil
 	case "rmdir.file.package.source_version":
 		return "rmdir", reflect.String, "string", nil
@@ -35023,7 +38511,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.ancestors.file.name.length":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.ancestors.file.package.epoch":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.ancestors.file.package.name":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.ancestors.file.package.release":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.ancestors.file.package.source_epoch":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.ancestors.file.package.source_release":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.ancestors.file.package.source_version":
 		return "setrlimit", reflect.String, "string", nil
@@ -35081,7 +38577,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.ancestors.interpreter.file.name.length":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.ancestors.interpreter.file.package.epoch":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.ancestors.interpreter.file.package.name":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.ancestors.interpreter.file.package.release":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.ancestors.interpreter.file.package.source_epoch":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.ancestors.interpreter.file.package.source_release":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.ancestors.interpreter.file.package.source_version":
 		return "setrlimit", reflect.String, "string", nil
@@ -35203,7 +38707,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.file.name.length":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.file.package.epoch":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.file.package.name":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.file.package.release":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.file.package.source_epoch":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.file.package.source_release":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.file.package.source_version":
 		return "setrlimit", reflect.String, "string", nil
@@ -35261,7 +38773,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.interpreter.file.name.length":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.interpreter.file.package.epoch":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.interpreter.file.package.name":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.interpreter.file.package.release":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.interpreter.file.package.source_epoch":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.interpreter.file.package.source_release":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.interpreter.file.package.source_version":
 		return "setrlimit", reflect.String, "string", nil
@@ -35363,7 +38883,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.parent.file.name.length":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.parent.file.package.epoch":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.parent.file.package.name":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.parent.file.package.release":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.parent.file.package.source_epoch":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.parent.file.package.source_release":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.parent.file.package.source_version":
 		return "setrlimit", reflect.String, "string", nil
@@ -35421,7 +38949,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.parent.interpreter.file.name.length":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.parent.interpreter.file.package.epoch":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.parent.interpreter.file.package.name":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.parent.interpreter.file.package.release":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.parent.interpreter.file.package.source_epoch":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.parent.interpreter.file.package.source_release":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.parent.interpreter.file.package.source_version":
 		return "setrlimit", reflect.String, "string", nil
@@ -35547,7 +39083,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setxattr", reflect.String, "string", nil
 	case "setxattr.file.name.length":
 		return "setxattr", reflect.Int, "int", nil
+	case "setxattr.file.package.epoch":
+		return "setxattr", reflect.Int, "int", nil
 	case "setxattr.file.package.name":
+		return "setxattr", reflect.String, "string", nil
+	case "setxattr.file.package.release":
+		return "setxattr", reflect.String, "string", nil
+	case "setxattr.file.package.source_epoch":
+		return "setxattr", reflect.Int, "int", nil
+	case "setxattr.file.package.source_release":
 		return "setxattr", reflect.String, "string", nil
 	case "setxattr.file.package.source_version":
 		return "setxattr", reflect.String, "string", nil
@@ -35649,7 +39193,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.ancestors.file.name.length":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.ancestors.file.package.epoch":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.ancestors.file.package.name":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.ancestors.file.package.release":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.ancestors.file.package.source_epoch":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.ancestors.file.package.source_release":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.ancestors.file.package.source_version":
 		return "signal", reflect.String, "string", nil
@@ -35707,7 +39259,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.ancestors.interpreter.file.name.length":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.ancestors.interpreter.file.package.epoch":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.ancestors.interpreter.file.package.name":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.ancestors.interpreter.file.package.release":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.ancestors.interpreter.file.package.source_epoch":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.ancestors.interpreter.file.package.source_release":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.ancestors.interpreter.file.package.source_version":
 		return "signal", reflect.String, "string", nil
@@ -35829,7 +39389,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.file.name.length":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.file.package.epoch":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.file.package.name":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.file.package.release":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.file.package.source_epoch":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.file.package.source_release":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.file.package.source_version":
 		return "signal", reflect.String, "string", nil
@@ -35887,7 +39455,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.interpreter.file.name.length":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.interpreter.file.package.epoch":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.interpreter.file.package.name":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.interpreter.file.package.release":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.interpreter.file.package.source_epoch":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.interpreter.file.package.source_release":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.interpreter.file.package.source_version":
 		return "signal", reflect.String, "string", nil
@@ -35989,7 +39565,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.parent.file.name.length":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.parent.file.package.epoch":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.parent.file.package.name":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.parent.file.package.release":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.parent.file.package.source_epoch":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.parent.file.package.source_release":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.parent.file.package.source_version":
 		return "signal", reflect.String, "string", nil
@@ -36047,7 +39631,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.parent.interpreter.file.name.length":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.parent.interpreter.file.package.epoch":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.parent.interpreter.file.package.name":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.parent.interpreter.file.package.release":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.parent.interpreter.file.package.source_epoch":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.parent.interpreter.file.package.source_release":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.parent.interpreter.file.package.source_version":
 		return "signal", reflect.String, "string", nil
@@ -36137,7 +39729,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "splice", reflect.String, "string", nil
 	case "splice.file.name.length":
 		return "splice", reflect.Int, "int", nil
+	case "splice.file.package.epoch":
+		return "splice", reflect.Int, "int", nil
 	case "splice.file.package.name":
+		return "splice", reflect.String, "string", nil
+	case "splice.file.package.release":
+		return "splice", reflect.String, "string", nil
+	case "splice.file.package.source_epoch":
+		return "splice", reflect.Int, "int", nil
+	case "splice.file.package.source_release":
 		return "splice", reflect.String, "string", nil
 	case "splice.file.package.source_version":
 		return "splice", reflect.String, "string", nil
@@ -36205,7 +39805,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "unlink", reflect.String, "string", nil
 	case "unlink.file.name.length":
 		return "unlink", reflect.Int, "int", nil
+	case "unlink.file.package.epoch":
+		return "unlink", reflect.Int, "int", nil
 	case "unlink.file.package.name":
+		return "unlink", reflect.String, "string", nil
+	case "unlink.file.package.release":
+		return "unlink", reflect.String, "string", nil
+	case "unlink.file.package.source_epoch":
+		return "unlink", reflect.Int, "int", nil
+	case "unlink.file.package.source_release":
 		return "unlink", reflect.String, "string", nil
 	case "unlink.file.package.source_version":
 		return "unlink", reflect.String, "string", nil
@@ -36265,7 +39873,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "utimes", reflect.String, "string", nil
 	case "utimes.file.name.length":
 		return "utimes", reflect.Int, "int", nil
+	case "utimes.file.package.epoch":
+		return "utimes", reflect.Int, "int", nil
 	case "utimes.file.package.name":
+		return "utimes", reflect.String, "string", nil
+	case "utimes.file.package.release":
+		return "utimes", reflect.String, "string", nil
+	case "utimes.file.package.source_epoch":
+		return "utimes", reflect.Int, "int", nil
+	case "utimes.file.package.source_release":
 		return "utimes", reflect.String, "string", nil
 	case "utimes.file.package.source_version":
 		return "utimes", reflect.String, "string", nil
@@ -36418,8 +40034,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("cgroup_write.file.name", &ev.CgroupWrite.File.BasenameStr, value)
 	case "cgroup_write.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "cgroup_write.file.name.length"}
+	case "cgroup_write.file.package.epoch":
+		return ev.setIntFieldValue("cgroup_write.file.package.epoch", &ev.CgroupWrite.File.PkgEpoch, value)
 	case "cgroup_write.file.package.name":
 		return ev.setStringFieldValue("cgroup_write.file.package.name", &ev.CgroupWrite.File.PkgName, value)
+	case "cgroup_write.file.package.release":
+		return ev.setStringFieldValue("cgroup_write.file.package.release", &ev.CgroupWrite.File.PkgRelease, value)
+	case "cgroup_write.file.package.source_epoch":
+		return ev.setIntFieldValue("cgroup_write.file.package.source_epoch", &ev.CgroupWrite.File.PkgSrcEpoch, value)
+	case "cgroup_write.file.package.source_release":
+		return ev.setStringFieldValue("cgroup_write.file.package.source_release", &ev.CgroupWrite.File.PkgSrcRelease, value)
 	case "cgroup_write.file.package.source_version":
 		return ev.setStringFieldValue("cgroup_write.file.package.source_version", &ev.CgroupWrite.File.PkgSrcVersion, value)
 	case "cgroup_write.file.package.version":
@@ -36466,8 +40090,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("chdir.file.name", &ev.Chdir.File.BasenameStr, value)
 	case "chdir.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "chdir.file.name.length"}
+	case "chdir.file.package.epoch":
+		return ev.setIntFieldValue("chdir.file.package.epoch", &ev.Chdir.File.PkgEpoch, value)
 	case "chdir.file.package.name":
 		return ev.setStringFieldValue("chdir.file.package.name", &ev.Chdir.File.PkgName, value)
+	case "chdir.file.package.release":
+		return ev.setStringFieldValue("chdir.file.package.release", &ev.Chdir.File.PkgRelease, value)
+	case "chdir.file.package.source_epoch":
+		return ev.setIntFieldValue("chdir.file.package.source_epoch", &ev.Chdir.File.PkgSrcEpoch, value)
+	case "chdir.file.package.source_release":
+		return ev.setStringFieldValue("chdir.file.package.source_release", &ev.Chdir.File.PkgSrcRelease, value)
 	case "chdir.file.package.source_version":
 		return ev.setStringFieldValue("chdir.file.package.source_version", &ev.Chdir.File.PkgSrcVersion, value)
 	case "chdir.file.package.version":
@@ -36520,8 +40152,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("chmod.file.name", &ev.Chmod.File.BasenameStr, value)
 	case "chmod.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "chmod.file.name.length"}
+	case "chmod.file.package.epoch":
+		return ev.setIntFieldValue("chmod.file.package.epoch", &ev.Chmod.File.PkgEpoch, value)
 	case "chmod.file.package.name":
 		return ev.setStringFieldValue("chmod.file.package.name", &ev.Chmod.File.PkgName, value)
+	case "chmod.file.package.release":
+		return ev.setStringFieldValue("chmod.file.package.release", &ev.Chmod.File.PkgRelease, value)
+	case "chmod.file.package.source_epoch":
+		return ev.setIntFieldValue("chmod.file.package.source_epoch", &ev.Chmod.File.PkgSrcEpoch, value)
+	case "chmod.file.package.source_release":
+		return ev.setStringFieldValue("chmod.file.package.source_release", &ev.Chmod.File.PkgSrcRelease, value)
 	case "chmod.file.package.source_version":
 		return ev.setStringFieldValue("chmod.file.package.source_version", &ev.Chmod.File.PkgSrcVersion, value)
 	case "chmod.file.package.version":
@@ -36580,8 +40220,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("chown.file.name", &ev.Chown.File.BasenameStr, value)
 	case "chown.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "chown.file.name.length"}
+	case "chown.file.package.epoch":
+		return ev.setIntFieldValue("chown.file.package.epoch", &ev.Chown.File.PkgEpoch, value)
 	case "chown.file.package.name":
 		return ev.setStringFieldValue("chown.file.package.name", &ev.Chown.File.PkgName, value)
+	case "chown.file.package.release":
+		return ev.setStringFieldValue("chown.file.package.release", &ev.Chown.File.PkgRelease, value)
+	case "chown.file.package.source_epoch":
+		return ev.setIntFieldValue("chown.file.package.source_epoch", &ev.Chown.File.PkgSrcEpoch, value)
+	case "chown.file.package.source_release":
+		return ev.setStringFieldValue("chown.file.package.source_release", &ev.Chown.File.PkgSrcRelease, value)
 	case "chown.file.package.source_version":
 		return ev.setStringFieldValue("chown.file.package.source_version", &ev.Chown.File.PkgSrcVersion, value)
 	case "chown.file.package.version":
@@ -36784,8 +40432,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("exec.file.name", &ev.Exec.Process.FileEvent.BasenameStr, value)
 	case "exec.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "exec.file.name.length"}
+	case "exec.file.package.epoch":
+		return ev.setIntFieldValue("exec.file.package.epoch", &ev.Exec.Process.FileEvent.PkgEpoch, value)
 	case "exec.file.package.name":
 		return ev.setStringFieldValue("exec.file.package.name", &ev.Exec.Process.FileEvent.PkgName, value)
+	case "exec.file.package.release":
+		return ev.setStringFieldValue("exec.file.package.release", &ev.Exec.Process.FileEvent.PkgRelease, value)
+	case "exec.file.package.source_epoch":
+		return ev.setIntFieldValue("exec.file.package.source_epoch", &ev.Exec.Process.FileEvent.PkgSrcEpoch, value)
+	case "exec.file.package.source_release":
+		return ev.setStringFieldValue("exec.file.package.source_release", &ev.Exec.Process.FileEvent.PkgSrcRelease, value)
 	case "exec.file.package.source_version":
 		return ev.setStringFieldValue("exec.file.package.source_version", &ev.Exec.Process.FileEvent.PkgSrcVersion, value)
 	case "exec.file.package.version":
@@ -36898,12 +40554,36 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("exec.interpreter.file.name", &ev.Exec.Process.LinuxBinprm.FileEvent.BasenameStr, value)
 	case "exec.interpreter.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "exec.interpreter.file.name.length"}
+	case "exec.interpreter.file.package.epoch":
+		cont, err := SetInterpreterFields(&ev.Exec.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("exec.interpreter.file.package.epoch", &ev.Exec.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "exec.interpreter.file.package.name":
 		cont, err := SetInterpreterFields(&ev.Exec.Process.LinuxBinprm, "file.package.name", value)
 		if err != nil || !cont {
 			return err
 		}
 		return ev.setStringFieldValue("exec.interpreter.file.package.name", &ev.Exec.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "exec.interpreter.file.package.release":
+		cont, err := SetInterpreterFields(&ev.Exec.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("exec.interpreter.file.package.release", &ev.Exec.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "exec.interpreter.file.package.source_epoch":
+		cont, err := SetInterpreterFields(&ev.Exec.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("exec.interpreter.file.package.source_epoch", &ev.Exec.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "exec.interpreter.file.package.source_release":
+		cont, err := SetInterpreterFields(&ev.Exec.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("exec.interpreter.file.package.source_release", &ev.Exec.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "exec.interpreter.file.package.source_version":
 		cont, err := SetInterpreterFields(&ev.Exec.Process.LinuxBinprm, "file.package.source_version", value)
 		if err != nil || !cont {
@@ -37182,11 +40862,31 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Exit.Process = &Process{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "exit.file.name.length"}
+	case "exit.file.package.epoch":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setIntFieldValue("exit.file.package.epoch", &ev.Exit.Process.FileEvent.PkgEpoch, value)
 	case "exit.file.package.name":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
 		return ev.setStringFieldValue("exit.file.package.name", &ev.Exit.Process.FileEvent.PkgName, value)
+	case "exit.file.package.release":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setStringFieldValue("exit.file.package.release", &ev.Exit.Process.FileEvent.PkgRelease, value)
+	case "exit.file.package.source_epoch":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setIntFieldValue("exit.file.package.source_epoch", &ev.Exit.Process.FileEvent.PkgSrcEpoch, value)
+	case "exit.file.package.source_release":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setStringFieldValue("exit.file.package.source_release", &ev.Exit.Process.FileEvent.PkgSrcRelease, value)
 	case "exit.file.package.source_version":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -37383,6 +41083,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Exit.Process = &Process{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "exit.interpreter.file.name.length"}
+	case "exit.interpreter.file.package.epoch":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Exit.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("exit.interpreter.file.package.epoch", &ev.Exit.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "exit.interpreter.file.package.name":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -37392,6 +41101,33 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("exit.interpreter.file.package.name", &ev.Exit.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "exit.interpreter.file.package.release":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Exit.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("exit.interpreter.file.package.release", &ev.Exit.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "exit.interpreter.file.package.source_epoch":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Exit.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("exit.interpreter.file.package.source_epoch", &ev.Exit.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "exit.interpreter.file.package.source_release":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Exit.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("exit.interpreter.file.package.source_release", &ev.Exit.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "exit.interpreter.file.package.source_version":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -37559,8 +41295,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("link.file.destination.name", &ev.Link.Target.BasenameStr, value)
 	case "link.file.destination.name.length":
 		return &eval.ErrFieldReadOnly{Field: "link.file.destination.name.length"}
+	case "link.file.destination.package.epoch":
+		return ev.setIntFieldValue("link.file.destination.package.epoch", &ev.Link.Target.PkgEpoch, value)
 	case "link.file.destination.package.name":
 		return ev.setStringFieldValue("link.file.destination.package.name", &ev.Link.Target.PkgName, value)
+	case "link.file.destination.package.release":
+		return ev.setStringFieldValue("link.file.destination.package.release", &ev.Link.Target.PkgRelease, value)
+	case "link.file.destination.package.source_epoch":
+		return ev.setIntFieldValue("link.file.destination.package.source_epoch", &ev.Link.Target.PkgSrcEpoch, value)
+	case "link.file.destination.package.source_release":
+		return ev.setStringFieldValue("link.file.destination.package.source_release", &ev.Link.Target.PkgSrcRelease, value)
 	case "link.file.destination.package.source_version":
 		return ev.setStringFieldValue("link.file.destination.package.source_version", &ev.Link.Target.PkgSrcVersion, value)
 	case "link.file.destination.package.version":
@@ -37603,8 +41347,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("link.file.name", &ev.Link.Source.BasenameStr, value)
 	case "link.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "link.file.name.length"}
+	case "link.file.package.epoch":
+		return ev.setIntFieldValue("link.file.package.epoch", &ev.Link.Source.PkgEpoch, value)
 	case "link.file.package.name":
 		return ev.setStringFieldValue("link.file.package.name", &ev.Link.Source.PkgName, value)
+	case "link.file.package.release":
+		return ev.setStringFieldValue("link.file.package.release", &ev.Link.Source.PkgRelease, value)
+	case "link.file.package.source_epoch":
+		return ev.setIntFieldValue("link.file.package.source_epoch", &ev.Link.Source.PkgSrcEpoch, value)
+	case "link.file.package.source_release":
+		return ev.setStringFieldValue("link.file.package.source_release", &ev.Link.Source.PkgSrcRelease, value)
 	case "link.file.package.source_version":
 		return ev.setStringFieldValue("link.file.package.source_version", &ev.Link.Source.PkgSrcVersion, value)
 	case "link.file.package.version":
@@ -37661,8 +41413,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("load_module.file.name", &ev.LoadModule.File.BasenameStr, value)
 	case "load_module.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "load_module.file.name.length"}
+	case "load_module.file.package.epoch":
+		return ev.setIntFieldValue("load_module.file.package.epoch", &ev.LoadModule.File.PkgEpoch, value)
 	case "load_module.file.package.name":
 		return ev.setStringFieldValue("load_module.file.package.name", &ev.LoadModule.File.PkgName, value)
+	case "load_module.file.package.release":
+		return ev.setStringFieldValue("load_module.file.package.release", &ev.LoadModule.File.PkgRelease, value)
+	case "load_module.file.package.source_epoch":
+		return ev.setIntFieldValue("load_module.file.package.source_epoch", &ev.LoadModule.File.PkgSrcEpoch, value)
+	case "load_module.file.package.source_release":
+		return ev.setStringFieldValue("load_module.file.package.source_release", &ev.LoadModule.File.PkgSrcRelease, value)
 	case "load_module.file.package.source_version":
 		return ev.setStringFieldValue("load_module.file.package.source_version", &ev.LoadModule.File.PkgSrcVersion, value)
 	case "load_module.file.package.version":
@@ -37717,8 +41477,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("mkdir.file.name", &ev.Mkdir.File.BasenameStr, value)
 	case "mkdir.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "mkdir.file.name.length"}
+	case "mkdir.file.package.epoch":
+		return ev.setIntFieldValue("mkdir.file.package.epoch", &ev.Mkdir.File.PkgEpoch, value)
 	case "mkdir.file.package.name":
 		return ev.setStringFieldValue("mkdir.file.package.name", &ev.Mkdir.File.PkgName, value)
+	case "mkdir.file.package.release":
+		return ev.setStringFieldValue("mkdir.file.package.release", &ev.Mkdir.File.PkgRelease, value)
+	case "mkdir.file.package.source_epoch":
+		return ev.setIntFieldValue("mkdir.file.package.source_epoch", &ev.Mkdir.File.PkgSrcEpoch, value)
+	case "mkdir.file.package.source_release":
+		return ev.setStringFieldValue("mkdir.file.package.source_release", &ev.Mkdir.File.PkgSrcRelease, value)
 	case "mkdir.file.package.source_version":
 		return ev.setStringFieldValue("mkdir.file.package.source_version", &ev.Mkdir.File.PkgSrcVersion, value)
 	case "mkdir.file.package.version":
@@ -37769,8 +41537,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("mmap.file.name", &ev.MMap.File.BasenameStr, value)
 	case "mmap.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "mmap.file.name.length"}
+	case "mmap.file.package.epoch":
+		return ev.setIntFieldValue("mmap.file.package.epoch", &ev.MMap.File.PkgEpoch, value)
 	case "mmap.file.package.name":
 		return ev.setStringFieldValue("mmap.file.package.name", &ev.MMap.File.PkgName, value)
+	case "mmap.file.package.release":
+		return ev.setStringFieldValue("mmap.file.package.release", &ev.MMap.File.PkgRelease, value)
+	case "mmap.file.package.source_epoch":
+		return ev.setIntFieldValue("mmap.file.package.source_epoch", &ev.MMap.File.PkgSrcEpoch, value)
+	case "mmap.file.package.source_release":
+		return ev.setStringFieldValue("mmap.file.package.source_release", &ev.MMap.File.PkgSrcRelease, value)
 	case "mmap.file.package.source_version":
 		return ev.setStringFieldValue("mmap.file.package.source_version", &ev.MMap.File.PkgSrcVersion, value)
 	case "mmap.file.package.version":
@@ -37986,8 +41762,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("open.file.name", &ev.Open.File.BasenameStr, value)
 	case "open.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "open.file.name.length"}
+	case "open.file.package.epoch":
+		return ev.setIntFieldValue("open.file.package.epoch", &ev.Open.File.PkgEpoch, value)
 	case "open.file.package.name":
 		return ev.setStringFieldValue("open.file.package.name", &ev.Open.File.PkgName, value)
+	case "open.file.package.release":
+		return ev.setStringFieldValue("open.file.package.release", &ev.Open.File.PkgRelease, value)
+	case "open.file.package.source_epoch":
+		return ev.setIntFieldValue("open.file.package.source_epoch", &ev.Open.File.PkgSrcEpoch, value)
+	case "open.file.package.source_release":
+		return ev.setStringFieldValue("open.file.package.source_release", &ev.Open.File.PkgSrcRelease, value)
 	case "open.file.package.source_version":
 		return ev.setStringFieldValue("open.file.package.source_version", &ev.Open.File.PkgSrcVersion, value)
 	case "open.file.package.version":
@@ -38148,8 +41932,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.ancestors.file.name", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.BasenameStr, value)
 	case "process.ancestors.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "process.ancestors.file.name.length"}
+	case "process.ancestors.file.package.epoch":
+		return ev.setIntFieldValue("process.ancestors.file.package.epoch", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PkgEpoch, value)
 	case "process.ancestors.file.package.name":
 		return ev.setStringFieldValue("process.ancestors.file.package.name", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PkgName, value)
+	case "process.ancestors.file.package.release":
+		return ev.setStringFieldValue("process.ancestors.file.package.release", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PkgRelease, value)
+	case "process.ancestors.file.package.source_epoch":
+		return ev.setIntFieldValue("process.ancestors.file.package.source_epoch", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PkgSrcEpoch, value)
+	case "process.ancestors.file.package.source_release":
+		return ev.setStringFieldValue("process.ancestors.file.package.source_release", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PkgSrcRelease, value)
 	case "process.ancestors.file.package.source_version":
 		return ev.setStringFieldValue("process.ancestors.file.package.source_version", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.FileEvent.PkgSrcVersion, value)
 	case "process.ancestors.file.package.version":
@@ -38262,12 +42054,36 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.ancestors.interpreter.file.name", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.BasenameStr, value)
 	case "process.ancestors.interpreter.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "process.ancestors.interpreter.file.name.length"}
+	case "process.ancestors.interpreter.file.package.epoch":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("process.ancestors.interpreter.file.package.epoch", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "process.ancestors.interpreter.file.package.name":
 		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.name", value)
 		if err != nil || !cont {
 			return err
 		}
 		return ev.setStringFieldValue("process.ancestors.interpreter.file.package.name", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "process.ancestors.interpreter.file.package.release":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("process.ancestors.interpreter.file.package.release", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "process.ancestors.interpreter.file.package.source_epoch":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("process.ancestors.interpreter.file.package.source_epoch", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "process.ancestors.interpreter.file.package.source_release":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("process.ancestors.interpreter.file.package.source_release", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "process.ancestors.interpreter.file.package.source_version":
 		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_version", value)
 		if err != nil || !cont {
@@ -38422,8 +42238,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.file.name", &ev.BaseEvent.ProcessContext.Process.FileEvent.BasenameStr, value)
 	case "process.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "process.file.name.length"}
+	case "process.file.package.epoch":
+		return ev.setIntFieldValue("process.file.package.epoch", &ev.BaseEvent.ProcessContext.Process.FileEvent.PkgEpoch, value)
 	case "process.file.package.name":
 		return ev.setStringFieldValue("process.file.package.name", &ev.BaseEvent.ProcessContext.Process.FileEvent.PkgName, value)
+	case "process.file.package.release":
+		return ev.setStringFieldValue("process.file.package.release", &ev.BaseEvent.ProcessContext.Process.FileEvent.PkgRelease, value)
+	case "process.file.package.source_epoch":
+		return ev.setIntFieldValue("process.file.package.source_epoch", &ev.BaseEvent.ProcessContext.Process.FileEvent.PkgSrcEpoch, value)
+	case "process.file.package.source_release":
+		return ev.setStringFieldValue("process.file.package.source_release", &ev.BaseEvent.ProcessContext.Process.FileEvent.PkgSrcRelease, value)
 	case "process.file.package.source_version":
 		return ev.setStringFieldValue("process.file.package.source_version", &ev.BaseEvent.ProcessContext.Process.FileEvent.PkgSrcVersion, value)
 	case "process.file.package.version":
@@ -38536,12 +42360,36 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.interpreter.file.name", &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent.BasenameStr, value)
 	case "process.interpreter.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "process.interpreter.file.name.length"}
+	case "process.interpreter.file.package.epoch":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("process.interpreter.file.package.epoch", &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "process.interpreter.file.package.name":
 		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Process.LinuxBinprm, "file.package.name", value)
 		if err != nil || !cont {
 			return err
 		}
 		return ev.setStringFieldValue("process.interpreter.file.package.name", &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "process.interpreter.file.package.release":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("process.interpreter.file.package.release", &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "process.interpreter.file.package.source_epoch":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("process.interpreter.file.package.source_epoch", &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "process.interpreter.file.package.source_release":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("process.interpreter.file.package.source_release", &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "process.interpreter.file.package.source_version":
 		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Process.LinuxBinprm, "file.package.source_version", value)
 		if err != nil || !cont {
@@ -38676,8 +42524,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.parent.file.name", &ev.BaseEvent.ProcessContext.Parent.FileEvent.BasenameStr, value)
 	case "process.parent.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "process.parent.file.name.length"}
+	case "process.parent.file.package.epoch":
+		return ev.setIntFieldValue("process.parent.file.package.epoch", &ev.BaseEvent.ProcessContext.Parent.FileEvent.PkgEpoch, value)
 	case "process.parent.file.package.name":
 		return ev.setStringFieldValue("process.parent.file.package.name", &ev.BaseEvent.ProcessContext.Parent.FileEvent.PkgName, value)
+	case "process.parent.file.package.release":
+		return ev.setStringFieldValue("process.parent.file.package.release", &ev.BaseEvent.ProcessContext.Parent.FileEvent.PkgRelease, value)
+	case "process.parent.file.package.source_epoch":
+		return ev.setIntFieldValue("process.parent.file.package.source_epoch", &ev.BaseEvent.ProcessContext.Parent.FileEvent.PkgSrcEpoch, value)
+	case "process.parent.file.package.source_release":
+		return ev.setStringFieldValue("process.parent.file.package.source_release", &ev.BaseEvent.ProcessContext.Parent.FileEvent.PkgSrcRelease, value)
 	case "process.parent.file.package.source_version":
 		return ev.setStringFieldValue("process.parent.file.package.source_version", &ev.BaseEvent.ProcessContext.Parent.FileEvent.PkgSrcVersion, value)
 	case "process.parent.file.package.version":
@@ -38790,12 +42646,36 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.parent.interpreter.file.name", &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent.BasenameStr, value)
 	case "process.parent.interpreter.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "process.parent.interpreter.file.name.length"}
+	case "process.parent.interpreter.file.package.epoch":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Parent.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("process.parent.interpreter.file.package.epoch", &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "process.parent.interpreter.file.package.name":
 		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Parent.LinuxBinprm, "file.package.name", value)
 		if err != nil || !cont {
 			return err
 		}
 		return ev.setStringFieldValue("process.parent.interpreter.file.package.name", &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent.PkgName, value)
+	case "process.parent.interpreter.file.package.release":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Parent.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("process.parent.interpreter.file.package.release", &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "process.parent.interpreter.file.package.source_epoch":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Parent.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("process.parent.interpreter.file.package.source_epoch", &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "process.parent.interpreter.file.package.source_release":
+		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Parent.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("process.parent.interpreter.file.package.source_release", &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "process.parent.interpreter.file.package.source_version":
 		cont, err := SetInterpreterFields(&ev.BaseEvent.ProcessContext.Parent.LinuxBinprm, "file.package.source_version", value)
 		if err != nil || !cont {
@@ -39210,6 +43090,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "ptrace.tracee.ancestors.file.name.length"}
+	case "ptrace.tracee.ancestors.file.package.epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.file.package.epoch", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PkgEpoch, value)
 	case "ptrace.tracee.ancestors.file.package.name":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -39218,6 +43106,30 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.ancestors.file.package.name", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PkgName, value)
+	case "ptrace.tracee.ancestors.file.package.release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.file.package.release", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PkgRelease, value)
+	case "ptrace.tracee.ancestors.file.package.source_epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.file.package.source_epoch", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PkgSrcEpoch, value)
+	case "ptrace.tracee.ancestors.file.package.source_release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.file.package.source_release", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.FileEvent.PkgSrcRelease, value)
 	case "ptrace.tracee.ancestors.file.package.source_version":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -39498,6 +43410,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "ptrace.tracee.ancestors.interpreter.file.name.length"}
+	case "ptrace.tracee.ancestors.interpreter.file.package.epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.interpreter.file.package.epoch", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "ptrace.tracee.ancestors.interpreter.file.package.name":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -39510,6 +43434,42 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("ptrace.tracee.ancestors.interpreter.file.package.name", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "ptrace.tracee.ancestors.interpreter.file.package.release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.interpreter.file.package.release", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "ptrace.tracee.ancestors.interpreter.file.package.source_epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.interpreter.file.package.source_epoch", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "ptrace.tracee.ancestors.interpreter.file.package.source_release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.interpreter.file.package.source_release", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "ptrace.tracee.ancestors.interpreter.file.package.source_version":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -39904,11 +43864,31 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "ptrace.tracee.file.name.length"}
+	case "ptrace.tracee.file.package.epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.file.package.epoch", &ev.PTrace.Tracee.Process.FileEvent.PkgEpoch, value)
 	case "ptrace.tracee.file.package.name":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.file.package.name", &ev.PTrace.Tracee.Process.FileEvent.PkgName, value)
+	case "ptrace.tracee.file.package.release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.file.package.release", &ev.PTrace.Tracee.Process.FileEvent.PkgRelease, value)
+	case "ptrace.tracee.file.package.source_epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.file.package.source_epoch", &ev.PTrace.Tracee.Process.FileEvent.PkgSrcEpoch, value)
+	case "ptrace.tracee.file.package.source_release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.file.package.source_release", &ev.PTrace.Tracee.Process.FileEvent.PkgSrcRelease, value)
 	case "ptrace.tracee.file.package.source_version":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -40105,6 +44085,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "ptrace.tracee.interpreter.file.name.length"}
+	case "ptrace.tracee.interpreter.file.package.epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("ptrace.tracee.interpreter.file.package.epoch", &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "ptrace.tracee.interpreter.file.package.name":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -40114,6 +44103,33 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("ptrace.tracee.interpreter.file.package.name", &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "ptrace.tracee.interpreter.file.package.release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("ptrace.tracee.interpreter.file.package.release", &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "ptrace.tracee.interpreter.file.package.source_epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("ptrace.tracee.interpreter.file.package.source_epoch", &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "ptrace.tracee.interpreter.file.package.source_release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("ptrace.tracee.interpreter.file.package.source_release", &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "ptrace.tracee.interpreter.file.package.source_version":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -40518,6 +44534,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "ptrace.tracee.parent.file.name.length"}
+	case "ptrace.tracee.parent.file.package.epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.parent.file.package.epoch", &ev.PTrace.Tracee.Parent.FileEvent.PkgEpoch, value)
 	case "ptrace.tracee.parent.file.package.name":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -40526,6 +44550,30 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.parent.file.package.name", &ev.PTrace.Tracee.Parent.FileEvent.PkgName, value)
+	case "ptrace.tracee.parent.file.package.release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.parent.file.package.release", &ev.PTrace.Tracee.Parent.FileEvent.PkgRelease, value)
+	case "ptrace.tracee.parent.file.package.source_epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.parent.file.package.source_epoch", &ev.PTrace.Tracee.Parent.FileEvent.PkgSrcEpoch, value)
+	case "ptrace.tracee.parent.file.package.source_release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.parent.file.package.source_release", &ev.PTrace.Tracee.Parent.FileEvent.PkgSrcRelease, value)
 	case "ptrace.tracee.parent.file.package.source_version":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -40806,6 +44854,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "ptrace.tracee.parent.interpreter.file.name.length"}
+	case "ptrace.tracee.parent.interpreter.file.package.epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Parent.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("ptrace.tracee.parent.interpreter.file.package.epoch", &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "ptrace.tracee.parent.interpreter.file.package.name":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -40818,6 +44878,42 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("ptrace.tracee.parent.interpreter.file.package.name", &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.PkgName, value)
+	case "ptrace.tracee.parent.interpreter.file.package.release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Parent.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("ptrace.tracee.parent.interpreter.file.package.release", &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "ptrace.tracee.parent.interpreter.file.package.source_epoch":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Parent.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("ptrace.tracee.parent.interpreter.file.package.source_epoch", &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "ptrace.tracee.parent.interpreter.file.package.source_release":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.PTrace.Tracee.Parent.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("ptrace.tracee.parent.interpreter.file.package.source_release", &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "ptrace.tracee.parent.interpreter.file.package.source_version":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -41073,8 +45169,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("removexattr.file.name", &ev.RemoveXAttr.File.BasenameStr, value)
 	case "removexattr.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "removexattr.file.name.length"}
+	case "removexattr.file.package.epoch":
+		return ev.setIntFieldValue("removexattr.file.package.epoch", &ev.RemoveXAttr.File.PkgEpoch, value)
 	case "removexattr.file.package.name":
 		return ev.setStringFieldValue("removexattr.file.package.name", &ev.RemoveXAttr.File.PkgName, value)
+	case "removexattr.file.package.release":
+		return ev.setStringFieldValue("removexattr.file.package.release", &ev.RemoveXAttr.File.PkgRelease, value)
+	case "removexattr.file.package.source_epoch":
+		return ev.setIntFieldValue("removexattr.file.package.source_epoch", &ev.RemoveXAttr.File.PkgSrcEpoch, value)
+	case "removexattr.file.package.source_release":
+		return ev.setStringFieldValue("removexattr.file.package.source_release", &ev.RemoveXAttr.File.PkgSrcRelease, value)
 	case "removexattr.file.package.source_version":
 		return ev.setStringFieldValue("removexattr.file.package.source_version", &ev.RemoveXAttr.File.PkgSrcVersion, value)
 	case "removexattr.file.package.version":
@@ -41123,8 +45227,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("rename.file.destination.name", &ev.Rename.New.BasenameStr, value)
 	case "rename.file.destination.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rename.file.destination.name.length"}
+	case "rename.file.destination.package.epoch":
+		return ev.setIntFieldValue("rename.file.destination.package.epoch", &ev.Rename.New.PkgEpoch, value)
 	case "rename.file.destination.package.name":
 		return ev.setStringFieldValue("rename.file.destination.package.name", &ev.Rename.New.PkgName, value)
+	case "rename.file.destination.package.release":
+		return ev.setStringFieldValue("rename.file.destination.package.release", &ev.Rename.New.PkgRelease, value)
+	case "rename.file.destination.package.source_epoch":
+		return ev.setIntFieldValue("rename.file.destination.package.source_epoch", &ev.Rename.New.PkgSrcEpoch, value)
+	case "rename.file.destination.package.source_release":
+		return ev.setStringFieldValue("rename.file.destination.package.source_release", &ev.Rename.New.PkgSrcRelease, value)
 	case "rename.file.destination.package.source_version":
 		return ev.setStringFieldValue("rename.file.destination.package.source_version", &ev.Rename.New.PkgSrcVersion, value)
 	case "rename.file.destination.package.version":
@@ -41167,8 +45279,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("rename.file.name", &ev.Rename.Old.BasenameStr, value)
 	case "rename.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rename.file.name.length"}
+	case "rename.file.package.epoch":
+		return ev.setIntFieldValue("rename.file.package.epoch", &ev.Rename.Old.PkgEpoch, value)
 	case "rename.file.package.name":
 		return ev.setStringFieldValue("rename.file.package.name", &ev.Rename.Old.PkgName, value)
+	case "rename.file.package.release":
+		return ev.setStringFieldValue("rename.file.package.release", &ev.Rename.Old.PkgRelease, value)
+	case "rename.file.package.source_epoch":
+		return ev.setIntFieldValue("rename.file.package.source_epoch", &ev.Rename.Old.PkgSrcEpoch, value)
+	case "rename.file.package.source_release":
+		return ev.setStringFieldValue("rename.file.package.source_release", &ev.Rename.Old.PkgSrcRelease, value)
 	case "rename.file.package.source_version":
 		return ev.setStringFieldValue("rename.file.package.source_version", &ev.Rename.Old.PkgSrcVersion, value)
 	case "rename.file.package.version":
@@ -41219,8 +45339,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("rmdir.file.name", &ev.Rmdir.File.BasenameStr, value)
 	case "rmdir.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "rmdir.file.name.length"}
+	case "rmdir.file.package.epoch":
+		return ev.setIntFieldValue("rmdir.file.package.epoch", &ev.Rmdir.File.PkgEpoch, value)
 	case "rmdir.file.package.name":
 		return ev.setStringFieldValue("rmdir.file.package.name", &ev.Rmdir.File.PkgName, value)
+	case "rmdir.file.package.release":
+		return ev.setStringFieldValue("rmdir.file.package.release", &ev.Rmdir.File.PkgRelease, value)
+	case "rmdir.file.package.source_epoch":
+		return ev.setIntFieldValue("rmdir.file.package.source_epoch", &ev.Rmdir.File.PkgSrcEpoch, value)
+	case "rmdir.file.package.source_release":
+		return ev.setStringFieldValue("rmdir.file.package.source_release", &ev.Rmdir.File.PkgSrcRelease, value)
 	case "rmdir.file.package.source_version":
 		return ev.setStringFieldValue("rmdir.file.package.source_version", &ev.Rmdir.File.PkgSrcVersion, value)
 	case "rmdir.file.package.version":
@@ -41597,6 +45725,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "setrlimit.target.ancestors.file.name.length"}
+	case "setrlimit.target.ancestors.file.package.epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.ancestors.file.package.epoch", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.FileEvent.PkgEpoch, value)
 	case "setrlimit.target.ancestors.file.package.name":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -41605,6 +45741,30 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.ancestors.file.package.name", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.FileEvent.PkgName, value)
+	case "setrlimit.target.ancestors.file.package.release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.ancestors.file.package.release", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.FileEvent.PkgRelease, value)
+	case "setrlimit.target.ancestors.file.package.source_epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.ancestors.file.package.source_epoch", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.FileEvent.PkgSrcEpoch, value)
+	case "setrlimit.target.ancestors.file.package.source_release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.ancestors.file.package.source_release", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.FileEvent.PkgSrcRelease, value)
 	case "setrlimit.target.ancestors.file.package.source_version":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -41885,6 +46045,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "setrlimit.target.ancestors.interpreter.file.name.length"}
+	case "setrlimit.target.ancestors.interpreter.file.package.epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("setrlimit.target.ancestors.interpreter.file.package.epoch", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "setrlimit.target.ancestors.interpreter.file.package.name":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -41897,6 +46069,42 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("setrlimit.target.ancestors.interpreter.file.package.name", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "setrlimit.target.ancestors.interpreter.file.package.release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("setrlimit.target.ancestors.interpreter.file.package.release", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "setrlimit.target.ancestors.interpreter.file.package.source_epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("setrlimit.target.ancestors.interpreter.file.package.source_epoch", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "setrlimit.target.ancestors.interpreter.file.package.source_release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("setrlimit.target.ancestors.interpreter.file.package.source_release", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "setrlimit.target.ancestors.interpreter.file.package.source_version":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -42291,11 +46499,31 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "setrlimit.target.file.name.length"}
+	case "setrlimit.target.file.package.epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.file.package.epoch", &ev.Setrlimit.Target.Process.FileEvent.PkgEpoch, value)
 	case "setrlimit.target.file.package.name":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.file.package.name", &ev.Setrlimit.Target.Process.FileEvent.PkgName, value)
+	case "setrlimit.target.file.package.release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.file.package.release", &ev.Setrlimit.Target.Process.FileEvent.PkgRelease, value)
+	case "setrlimit.target.file.package.source_epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.file.package.source_epoch", &ev.Setrlimit.Target.Process.FileEvent.PkgSrcEpoch, value)
+	case "setrlimit.target.file.package.source_release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.file.package.source_release", &ev.Setrlimit.Target.Process.FileEvent.PkgSrcRelease, value)
 	case "setrlimit.target.file.package.source_version":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -42492,6 +46720,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "setrlimit.target.interpreter.file.name.length"}
+	case "setrlimit.target.interpreter.file.package.epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("setrlimit.target.interpreter.file.package.epoch", &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "setrlimit.target.interpreter.file.package.name":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -42501,6 +46738,33 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("setrlimit.target.interpreter.file.package.name", &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "setrlimit.target.interpreter.file.package.release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("setrlimit.target.interpreter.file.package.release", &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "setrlimit.target.interpreter.file.package.source_epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("setrlimit.target.interpreter.file.package.source_epoch", &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "setrlimit.target.interpreter.file.package.source_release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("setrlimit.target.interpreter.file.package.source_release", &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "setrlimit.target.interpreter.file.package.source_version":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -42905,6 +47169,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "setrlimit.target.parent.file.name.length"}
+	case "setrlimit.target.parent.file.package.epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.parent.file.package.epoch", &ev.Setrlimit.Target.Parent.FileEvent.PkgEpoch, value)
 	case "setrlimit.target.parent.file.package.name":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -42913,6 +47185,30 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.parent.file.package.name", &ev.Setrlimit.Target.Parent.FileEvent.PkgName, value)
+	case "setrlimit.target.parent.file.package.release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.parent.file.package.release", &ev.Setrlimit.Target.Parent.FileEvent.PkgRelease, value)
+	case "setrlimit.target.parent.file.package.source_epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.parent.file.package.source_epoch", &ev.Setrlimit.Target.Parent.FileEvent.PkgSrcEpoch, value)
+	case "setrlimit.target.parent.file.package.source_release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.parent.file.package.source_release", &ev.Setrlimit.Target.Parent.FileEvent.PkgSrcRelease, value)
 	case "setrlimit.target.parent.file.package.source_version":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -43193,6 +47489,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "setrlimit.target.parent.interpreter.file.name.length"}
+	case "setrlimit.target.parent.interpreter.file.package.epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Parent.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("setrlimit.target.parent.interpreter.file.package.epoch", &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "setrlimit.target.parent.interpreter.file.package.name":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -43205,6 +47513,42 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("setrlimit.target.parent.interpreter.file.package.name", &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent.PkgName, value)
+	case "setrlimit.target.parent.interpreter.file.package.release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Parent.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("setrlimit.target.parent.interpreter.file.package.release", &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "setrlimit.target.parent.interpreter.file.package.source_epoch":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Parent.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("setrlimit.target.parent.interpreter.file.package.source_epoch", &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "setrlimit.target.parent.interpreter.file.package.source_release":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Setrlimit.Target.Parent.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("setrlimit.target.parent.interpreter.file.package.source_release", &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "setrlimit.target.parent.interpreter.file.package.source_version":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -43504,8 +47848,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("setxattr.file.name", &ev.SetXAttr.File.BasenameStr, value)
 	case "setxattr.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "setxattr.file.name.length"}
+	case "setxattr.file.package.epoch":
+		return ev.setIntFieldValue("setxattr.file.package.epoch", &ev.SetXAttr.File.PkgEpoch, value)
 	case "setxattr.file.package.name":
 		return ev.setStringFieldValue("setxattr.file.package.name", &ev.SetXAttr.File.PkgName, value)
+	case "setxattr.file.package.release":
+		return ev.setStringFieldValue("setxattr.file.package.release", &ev.SetXAttr.File.PkgRelease, value)
+	case "setxattr.file.package.source_epoch":
+		return ev.setIntFieldValue("setxattr.file.package.source_epoch", &ev.SetXAttr.File.PkgSrcEpoch, value)
+	case "setxattr.file.package.source_release":
+		return ev.setStringFieldValue("setxattr.file.package.source_release", &ev.SetXAttr.File.PkgSrcRelease, value)
 	case "setxattr.file.package.source_version":
 		return ev.setStringFieldValue("setxattr.file.package.source_version", &ev.SetXAttr.File.PkgSrcVersion, value)
 	case "setxattr.file.package.version":
@@ -43856,6 +48208,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "signal.target.ancestors.file.name.length"}
+	case "signal.target.ancestors.file.package.epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("signal.target.ancestors.file.package.epoch", &ev.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PkgEpoch, value)
 	case "signal.target.ancestors.file.package.name":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -43864,6 +48224,30 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("signal.target.ancestors.file.package.name", &ev.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PkgName, value)
+	case "signal.target.ancestors.file.package.release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("signal.target.ancestors.file.package.release", &ev.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PkgRelease, value)
+	case "signal.target.ancestors.file.package.source_epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("signal.target.ancestors.file.package.source_epoch", &ev.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PkgSrcEpoch, value)
+	case "signal.target.ancestors.file.package.source_release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("signal.target.ancestors.file.package.source_release", &ev.Signal.Target.Ancestor.ProcessContext.Process.FileEvent.PkgSrcRelease, value)
 	case "signal.target.ancestors.file.package.source_version":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -44144,6 +48528,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "signal.target.ancestors.interpreter.file.name.length"}
+	case "signal.target.ancestors.interpreter.file.package.epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("signal.target.ancestors.interpreter.file.package.epoch", &ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "signal.target.ancestors.interpreter.file.package.name":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -44156,6 +48552,42 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("signal.target.ancestors.interpreter.file.package.name", &ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "signal.target.ancestors.interpreter.file.package.release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("signal.target.ancestors.interpreter.file.package.release", &ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "signal.target.ancestors.interpreter.file.package.source_epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("signal.target.ancestors.interpreter.file.package.source_epoch", &ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "signal.target.ancestors.interpreter.file.package.source_release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("signal.target.ancestors.interpreter.file.package.source_release", &ev.Signal.Target.Ancestor.ProcessContext.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "signal.target.ancestors.interpreter.file.package.source_version":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -44550,11 +48982,31 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "signal.target.file.name.length"}
+	case "signal.target.file.package.epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("signal.target.file.package.epoch", &ev.Signal.Target.Process.FileEvent.PkgEpoch, value)
 	case "signal.target.file.package.name":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("signal.target.file.package.name", &ev.Signal.Target.Process.FileEvent.PkgName, value)
+	case "signal.target.file.package.release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("signal.target.file.package.release", &ev.Signal.Target.Process.FileEvent.PkgRelease, value)
+	case "signal.target.file.package.source_epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("signal.target.file.package.source_epoch", &ev.Signal.Target.Process.FileEvent.PkgSrcEpoch, value)
+	case "signal.target.file.package.source_release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("signal.target.file.package.source_release", &ev.Signal.Target.Process.FileEvent.PkgSrcRelease, value)
 	case "signal.target.file.package.source_version":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -44751,6 +49203,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "signal.target.interpreter.file.name.length"}
+	case "signal.target.interpreter.file.package.epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Process.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("signal.target.interpreter.file.package.epoch", &ev.Signal.Target.Process.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "signal.target.interpreter.file.package.name":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -44760,6 +49221,33 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("signal.target.interpreter.file.package.name", &ev.Signal.Target.Process.LinuxBinprm.FileEvent.PkgName, value)
+	case "signal.target.interpreter.file.package.release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Process.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("signal.target.interpreter.file.package.release", &ev.Signal.Target.Process.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "signal.target.interpreter.file.package.source_epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Process.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("signal.target.interpreter.file.package.source_epoch", &ev.Signal.Target.Process.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "signal.target.interpreter.file.package.source_release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Process.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("signal.target.interpreter.file.package.source_release", &ev.Signal.Target.Process.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "signal.target.interpreter.file.package.source_version":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -45164,6 +49652,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "signal.target.parent.file.name.length"}
+	case "signal.target.parent.file.package.epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("signal.target.parent.file.package.epoch", &ev.Signal.Target.Parent.FileEvent.PkgEpoch, value)
 	case "signal.target.parent.file.package.name":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -45172,6 +49668,30 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("signal.target.parent.file.package.name", &ev.Signal.Target.Parent.FileEvent.PkgName, value)
+	case "signal.target.parent.file.package.release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("signal.target.parent.file.package.release", &ev.Signal.Target.Parent.FileEvent.PkgRelease, value)
+	case "signal.target.parent.file.package.source_epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("signal.target.parent.file.package.source_epoch", &ev.Signal.Target.Parent.FileEvent.PkgSrcEpoch, value)
+	case "signal.target.parent.file.package.source_release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("signal.target.parent.file.package.source_release", &ev.Signal.Target.Parent.FileEvent.PkgSrcRelease, value)
 	case "signal.target.parent.file.package.source_version":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -45452,6 +49972,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return &eval.ErrFieldReadOnly{Field: "signal.target.parent.interpreter.file.name.length"}
+	case "signal.target.parent.interpreter.file.package.epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Parent.LinuxBinprm, "file.package.epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("signal.target.parent.interpreter.file.package.epoch", &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.PkgEpoch, value)
 	case "signal.target.parent.interpreter.file.package.name":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -45464,6 +49996,42 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return err
 		}
 		return ev.setStringFieldValue("signal.target.parent.interpreter.file.package.name", &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.PkgName, value)
+	case "signal.target.parent.interpreter.file.package.release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Parent.LinuxBinprm, "file.package.release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("signal.target.parent.interpreter.file.package.release", &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.PkgRelease, value)
+	case "signal.target.parent.interpreter.file.package.source_epoch":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Parent.LinuxBinprm, "file.package.source_epoch", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setIntFieldValue("signal.target.parent.interpreter.file.package.source_epoch", &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.PkgSrcEpoch, value)
+	case "signal.target.parent.interpreter.file.package.source_release":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		cont, err := SetInterpreterFields(&ev.Signal.Target.Parent.LinuxBinprm, "file.package.source_release", value)
+		if err != nil || !cont {
+			return err
+		}
+		return ev.setStringFieldValue("signal.target.parent.interpreter.file.package.source_release", &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.PkgSrcRelease, value)
 	case "signal.target.parent.interpreter.file.package.source_version":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -45717,8 +50285,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("splice.file.name", &ev.Splice.File.BasenameStr, value)
 	case "splice.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "splice.file.name.length"}
+	case "splice.file.package.epoch":
+		return ev.setIntFieldValue("splice.file.package.epoch", &ev.Splice.File.PkgEpoch, value)
 	case "splice.file.package.name":
 		return ev.setStringFieldValue("splice.file.package.name", &ev.Splice.File.PkgName, value)
+	case "splice.file.package.release":
+		return ev.setStringFieldValue("splice.file.package.release", &ev.Splice.File.PkgRelease, value)
+	case "splice.file.package.source_epoch":
+		return ev.setIntFieldValue("splice.file.package.source_epoch", &ev.Splice.File.PkgSrcEpoch, value)
+	case "splice.file.package.source_release":
+		return ev.setStringFieldValue("splice.file.package.source_release", &ev.Splice.File.PkgSrcRelease, value)
 	case "splice.file.package.source_version":
 		return ev.setStringFieldValue("splice.file.package.source_version", &ev.Splice.File.PkgSrcVersion, value)
 	case "splice.file.package.version":
@@ -45785,8 +50361,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("unlink.file.name", &ev.Unlink.File.BasenameStr, value)
 	case "unlink.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "unlink.file.name.length"}
+	case "unlink.file.package.epoch":
+		return ev.setIntFieldValue("unlink.file.package.epoch", &ev.Unlink.File.PkgEpoch, value)
 	case "unlink.file.package.name":
 		return ev.setStringFieldValue("unlink.file.package.name", &ev.Unlink.File.PkgName, value)
+	case "unlink.file.package.release":
+		return ev.setStringFieldValue("unlink.file.package.release", &ev.Unlink.File.PkgRelease, value)
+	case "unlink.file.package.source_epoch":
+		return ev.setIntFieldValue("unlink.file.package.source_epoch", &ev.Unlink.File.PkgSrcEpoch, value)
+	case "unlink.file.package.source_release":
+		return ev.setStringFieldValue("unlink.file.package.source_release", &ev.Unlink.File.PkgSrcRelease, value)
 	case "unlink.file.package.source_version":
 		return ev.setStringFieldValue("unlink.file.package.source_version", &ev.Unlink.File.PkgSrcVersion, value)
 	case "unlink.file.package.version":
@@ -45845,8 +50429,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("utimes.file.name", &ev.Utimes.File.BasenameStr, value)
 	case "utimes.file.name.length":
 		return &eval.ErrFieldReadOnly{Field: "utimes.file.name.length"}
+	case "utimes.file.package.epoch":
+		return ev.setIntFieldValue("utimes.file.package.epoch", &ev.Utimes.File.PkgEpoch, value)
 	case "utimes.file.package.name":
 		return ev.setStringFieldValue("utimes.file.package.name", &ev.Utimes.File.PkgName, value)
+	case "utimes.file.package.release":
+		return ev.setStringFieldValue("utimes.file.package.release", &ev.Utimes.File.PkgRelease, value)
+	case "utimes.file.package.source_epoch":
+		return ev.setIntFieldValue("utimes.file.package.source_epoch", &ev.Utimes.File.PkgSrcEpoch, value)
+	case "utimes.file.package.source_release":
+		return ev.setStringFieldValue("utimes.file.package.source_release", &ev.Utimes.File.PkgSrcRelease, value)
 	case "utimes.file.package.source_version":
 		return ev.setStringFieldValue("utimes.file.package.source_version", &ev.Utimes.File.PkgSrcVersion, value)
 	case "utimes.file.package.version":

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -79,7 +79,19 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
@@ -112,7 +124,19 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
@@ -179,7 +203,19 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
@@ -212,7 +248,19 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
@@ -269,7 +317,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.CgroupWrite.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.CgroupWrite.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.CgroupWrite.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.CgroupWrite.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.CgroupWrite.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.CgroupWrite.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.CgroupWrite.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.CgroupWrite.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.CgroupWrite.File)
 		}
@@ -283,7 +335,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Chdir.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Chdir.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Chdir.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Chdir.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Chdir.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Chdir.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Chdir.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Chdir.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Chdir.File)
 		}
@@ -300,7 +356,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Chmod.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Chmod.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Chmod.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Chmod.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Chmod.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Chmod.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Chmod.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Chmod.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Chmod.File)
 		}
@@ -320,7 +380,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Chown.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Chown.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Chown.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Chown.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Chown.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Chown.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Chown.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Chown.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Chown.File)
 		}
@@ -372,7 +436,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Exec.Process.FileEvent)
 		}
 		if ev.Exec.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Exec.Process.FileEvent)
+		}
+		if ev.Exec.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Exec.Process.FileEvent)
+		}
+		if ev.Exec.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Exec.Process.FileEvent)
+		}
+		if ev.Exec.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Exec.Process.FileEvent)
+		}
+		if ev.Exec.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Exec.Process.FileEvent)
 		}
 		if !forADs && ev.Exec.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Exec.Process.FileEvent)
@@ -408,7 +484,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
 		}
 		if ev.Exec.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Exec.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Exec.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Exec.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Exec.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
 		}
 		if !forADs && ev.Exec.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Exec.Process.LinuxBinprm.FileEvent)
@@ -483,7 +571,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Exit.Process.FileEvent)
 		}
 		if ev.Exit.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Exit.Process.FileEvent)
+		}
+		if ev.Exit.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Exit.Process.FileEvent)
+		}
+		if ev.Exit.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Exit.Process.FileEvent)
+		}
+		if ev.Exit.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Exit.Process.FileEvent)
+		}
+		if ev.Exit.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Exit.Process.FileEvent)
 		}
 		if !forADs && ev.Exit.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Exit.Process.FileEvent)
@@ -519,7 +619,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
 		}
 		if ev.Exit.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Exit.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Exit.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Exit.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Exit.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
 		}
 		if !forADs && ev.Exit.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Exit.Process.LinuxBinprm.FileEvent)
@@ -549,7 +661,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Link.Source)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Link.Source)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Link.Source)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Link.Source)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Link.Source)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Link.Source)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Link.Source)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Link.Source)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Link.Source)
 		}
@@ -562,7 +678,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Link.Target)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Link.Target)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Link.Target)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Link.Target)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Link.Target)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Link.Target)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Link.Target)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Link.Target)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Link.Target)
 		}
@@ -582,7 +702,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.LoadModule.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.LoadModule.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.LoadModule.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.LoadModule.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.LoadModule.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.LoadModule.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.LoadModule.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.LoadModule.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.LoadModule.File)
 		}
@@ -598,7 +722,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Mkdir.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Mkdir.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Mkdir.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Mkdir.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Mkdir.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Mkdir.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Mkdir.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Mkdir.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Mkdir.File)
 		}
@@ -618,7 +746,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.MMap.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.MMap.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.MMap.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.MMap.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.MMap.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.MMap.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.MMap.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.MMap.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.MMap.File)
 		}
@@ -662,7 +794,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Open.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Open.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Open.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Open.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Open.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Open.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Open.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Open.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Open.File)
 		}
@@ -713,7 +849,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.PTrace.Tracee.Process.FileEvent)
 		}
 		if ev.PTrace.Tracee.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.PTrace.Tracee.Process.FileEvent)
+		}
+		if ev.PTrace.Tracee.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.PTrace.Tracee.Process.FileEvent)
+		}
+		if ev.PTrace.Tracee.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.PTrace.Tracee.Process.FileEvent)
+		}
+		if ev.PTrace.Tracee.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.PTrace.Tracee.Process.FileEvent)
+		}
+		if ev.PTrace.Tracee.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.PTrace.Tracee.Process.FileEvent)
 		}
 		if !forADs && ev.PTrace.Tracee.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.PTrace.Tracee.Process.FileEvent)
@@ -749,7 +897,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
 		}
 		if ev.PTrace.Tracee.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.PTrace.Tracee.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.PTrace.Tracee.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.PTrace.Tracee.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.PTrace.Tracee.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
 		}
 		if !forADs && ev.PTrace.Tracee.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent)
@@ -796,7 +956,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.PTrace.Tracee.Parent.FileEvent)
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.PTrace.Tracee.Parent.FileEvent)
+		}
+		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.PTrace.Tracee.Parent.FileEvent)
+		}
+		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.PTrace.Tracee.Parent.FileEvent)
+		}
+		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.PTrace.Tracee.Parent.FileEvent)
+		}
+		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.PTrace.Tracee.Parent.FileEvent)
 		}
 		if !forADs && ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.PTrace.Tracee.Parent.FileEvent)
@@ -838,7 +1010,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
 		}
 		if !forADs && ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
@@ -889,7 +1073,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.RemoveXAttr.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.RemoveXAttr.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.RemoveXAttr.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.RemoveXAttr.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.RemoveXAttr.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.RemoveXAttr.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.RemoveXAttr.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.RemoveXAttr.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.RemoveXAttr.File)
 		}
@@ -905,7 +1093,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Rename.Old)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Rename.Old)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Rename.Old)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Rename.Old)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Rename.Old)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Rename.Old)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Rename.Old)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Rename.Old)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Rename.Old)
 		}
@@ -918,7 +1110,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Rename.New)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Rename.New)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Rename.New)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Rename.New)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Rename.New)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Rename.New)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Rename.New)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Rename.New)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Rename.New)
 		}
@@ -938,7 +1134,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Rmdir.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Rmdir.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Rmdir.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Rmdir.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Rmdir.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Rmdir.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Rmdir.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Rmdir.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Rmdir.File)
 		}
@@ -980,7 +1180,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Setrlimit.Target.Process.FileEvent)
 		}
 		if ev.Setrlimit.Target.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Setrlimit.Target.Process.FileEvent)
+		}
+		if ev.Setrlimit.Target.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Setrlimit.Target.Process.FileEvent)
+		}
+		if ev.Setrlimit.Target.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Setrlimit.Target.Process.FileEvent)
+		}
+		if ev.Setrlimit.Target.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Setrlimit.Target.Process.FileEvent)
+		}
+		if ev.Setrlimit.Target.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Setrlimit.Target.Process.FileEvent)
 		}
 		if !forADs && ev.Setrlimit.Target.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Setrlimit.Target.Process.FileEvent)
@@ -1016,7 +1228,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
 		}
 		if ev.Setrlimit.Target.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Setrlimit.Target.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Setrlimit.Target.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Setrlimit.Target.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Setrlimit.Target.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
 		}
 		if !forADs && ev.Setrlimit.Target.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent)
@@ -1063,7 +1287,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Setrlimit.Target.Parent.FileEvent)
 		}
 		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Setrlimit.Target.Parent.FileEvent)
+		}
+		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Setrlimit.Target.Parent.FileEvent)
+		}
+		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Setrlimit.Target.Parent.FileEvent)
+		}
+		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Setrlimit.Target.Parent.FileEvent)
+		}
+		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Setrlimit.Target.Parent.FileEvent)
 		}
 		if !forADs && ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Setrlimit.Target.Parent.FileEvent)
@@ -1105,7 +1341,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
 		}
 		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
 		}
 		if !forADs && ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
@@ -1164,7 +1412,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.SetXAttr.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.SetXAttr.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.SetXAttr.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.SetXAttr.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.SetXAttr.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.SetXAttr.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.SetXAttr.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.SetXAttr.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.SetXAttr.File)
 		}
@@ -1199,7 +1451,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Signal.Target.Process.FileEvent)
 		}
 		if ev.Signal.Target.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Signal.Target.Process.FileEvent)
+		}
+		if ev.Signal.Target.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Signal.Target.Process.FileEvent)
+		}
+		if ev.Signal.Target.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Signal.Target.Process.FileEvent)
+		}
+		if ev.Signal.Target.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Signal.Target.Process.FileEvent)
+		}
+		if ev.Signal.Target.Process.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Signal.Target.Process.FileEvent)
 		}
 		if !forADs && ev.Signal.Target.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Signal.Target.Process.FileEvent)
@@ -1235,7 +1499,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
 		}
 		if ev.Signal.Target.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Signal.Target.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Signal.Target.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Signal.Target.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
+		}
+		if ev.Signal.Target.Process.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
 		}
 		if !forADs && ev.Signal.Target.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent)
@@ -1282,7 +1558,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Signal.Target.Parent.FileEvent)
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Signal.Target.Parent.FileEvent)
+		}
+		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Signal.Target.Parent.FileEvent)
+		}
+		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Signal.Target.Parent.FileEvent)
+		}
+		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Signal.Target.Parent.FileEvent)
+		}
+		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Signal.Target.Parent.FileEvent)
 		}
 		if !forADs && ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Signal.Target.Parent.FileEvent)
@@ -1324,7 +1612,19 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
+		}
+		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
+			_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
 		}
 		if !forADs && ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
@@ -1375,7 +1675,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Splice.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Splice.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Splice.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Splice.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Splice.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Splice.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Splice.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Splice.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Splice.File)
 		}
@@ -1390,7 +1694,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Unlink.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Unlink.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Unlink.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Unlink.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Unlink.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Unlink.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Unlink.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Unlink.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Unlink.File)
 		}
@@ -1414,7 +1722,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Utimes.File)
 		_ = ev.FieldHandlers.ResolvePackageName(ev, &ev.Utimes.File)
 		_ = ev.FieldHandlers.ResolvePackageVersion(ev, &ev.Utimes.File)
+		_ = ev.FieldHandlers.ResolvePackageEpoch(ev, &ev.Utimes.File)
+		_ = ev.FieldHandlers.ResolvePackageRelease(ev, &ev.Utimes.File)
 		_ = ev.FieldHandlers.ResolvePackageSourceVersion(ev, &ev.Utimes.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceEpoch(ev, &ev.Utimes.File)
+		_ = ev.FieldHandlers.ResolvePackageSourceRelease(ev, &ev.Utimes.File)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveHashesFromEvent(ev, &ev.Utimes.File)
 		}
@@ -1479,7 +1791,11 @@ type FieldHandlers interface {
 	ResolveOnDemandArg6Str(ev *Event, e *OnDemandEvent) string
 	ResolveOnDemandArg6Uint(ev *Event, e *OnDemandEvent) int
 	ResolveOnDemandName(ev *Event, e *OnDemandEvent) string
+	ResolvePackageEpoch(ev *Event, e *FileEvent) int
 	ResolvePackageName(ev *Event, e *FileEvent) string
+	ResolvePackageRelease(ev *Event, e *FileEvent) string
+	ResolvePackageSourceEpoch(ev *Event, e *FileEvent) int
+	ResolvePackageSourceRelease(ev *Event, e *FileEvent) string
 	ResolvePackageSourceVersion(ev *Event, e *FileEvent) string
 	ResolvePackageVersion(ev *Event, e *FileEvent) string
 	ResolveProcessArgs(ev *Event, e *Process) string
@@ -1681,8 +1997,20 @@ func (dfh *FakeFieldHandlers) ResolveOnDemandArg6Uint(ev *Event, e *OnDemandEven
 func (dfh *FakeFieldHandlers) ResolveOnDemandName(ev *Event, e *OnDemandEvent) string {
 	return string(e.Name)
 }
+func (dfh *FakeFieldHandlers) ResolvePackageEpoch(ev *Event, e *FileEvent) int {
+	return int(e.PkgEpoch)
+}
 func (dfh *FakeFieldHandlers) ResolvePackageName(ev *Event, e *FileEvent) string {
 	return string(e.PkgName)
+}
+func (dfh *FakeFieldHandlers) ResolvePackageRelease(ev *Event, e *FileEvent) string {
+	return string(e.PkgRelease)
+}
+func (dfh *FakeFieldHandlers) ResolvePackageSourceEpoch(ev *Event, e *FileEvent) int {
+	return int(e.PkgSrcEpoch)
+}
+func (dfh *FakeFieldHandlers) ResolvePackageSourceRelease(ev *Event, e *FileEvent) string {
+	return string(e.PkgSrcRelease)
 }
 func (dfh *FakeFieldHandlers) ResolvePackageSourceVersion(ev *Event, e *FileEvent) string {
 	return string(e.PkgSrcVersion)

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -453,7 +453,11 @@ type FileEvent struct {
 
 	PkgName       string `field:"package.name,handler:ResolvePackageName"`                    // SECLDoc[package.name] Definition:`[Experimental] Name of the package that provided this file`
 	PkgVersion    string `field:"package.version,handler:ResolvePackageVersion"`              // SECLDoc[package.version] Definition:`[Experimental] Full version of the package that provided this file`
+	PkgEpoch      int    `field:"package.epoch,handler:ResolvePackageEpoch"`                  // SECLDoc[package.epoch] Definition:`[Experimental] Epoch of the package that provided this file`
+	PkgRelease    string `field:"package.release,handler:ResolvePackageRelease"`              // SECLDoc[package.release] Definition:`[Experimental] Release of the package that provided this file`
 	PkgSrcVersion string `field:"package.source_version,handler:ResolvePackageSourceVersion"` // SECLDoc[package.source_version] Definition:`[Experimental] Full version of the source package of the package that provided this file`
+	PkgSrcEpoch   int    `field:"package.source_epoch,handler:ResolvePackageSourceEpoch"`     // SECLDoc[package.source_epoch] Definition:`[Experimental] Epoch of the source package of the package that provided this file`
+	PkgSrcRelease string `field:"package.source_release,handler:ResolvePackageSourceRelease"` // SECLDoc[package.source_release] Definition:`[Experimental] Release of the source package of the package that provided this file`
 
 	HashState HashState `field:"-"`
 	Hashes    []string  `field:"hashes,handler:ResolveHashesFromEvent,opts:skip_ad,weight:999"` // SECLDoc[hashes] Definition:`[Experimental] List of cryptographic hashes computed for this file`

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
@@ -212,13 +212,25 @@ func protoDecodeFileEvent(fi *adproto.FileInfo) *model.FileEvent {
 		Filesystem:    fi.Filesystem,
 		PkgName:       fi.PackageName,
 		PkgVersion:    fi.PackageVersion,
+		PkgEpoch:      int(ptrOrZero(fi.PackageEpoch)),
+		PkgRelease:    ptrOrZero(fi.PackageRelease),
 		PkgSrcVersion: fi.PackageSrcVersion,
+		PkgSrcEpoch:   int(ptrOrZero(fi.PackageSrcEpoch)),
+		PkgSrcRelease: ptrOrZero(fi.PackageSrcRelease),
 		Hashes:        make([]string, len(fi.Hashes)),
 		HashState:     model.HashState(fi.HashState),
 	}
 	copy(fe.Hashes, fi.Hashes)
 
 	return fe
+}
+
+func ptrOrZero[T any](ptr *T) T {
+	if ptr != nil {
+		return *ptr
+	}
+	var zero T
+	return zero
 }
 
 func protoDecodeFileActivityNode(fan *adproto.FileActivityNode) *FileNode {

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/text/runes"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 // ToProto encodes an activity tree to its protobuf representation
@@ -236,7 +237,11 @@ func fileEventToProto(fe *model.FileEvent) *adproto.FileInfo {
 		Filesystem:        escape(fe.Filesystem),
 		PackageName:       fe.PkgName,
 		PackageVersion:    fe.PkgVersion,
+		PackageEpoch:      pointer.Ptr(uint32(fe.PkgEpoch)),
+		PackageRelease:    pointer.Ptr(fe.PkgRelease),
 		PackageSrcVersion: fe.PkgSrcVersion,
+		PackageSrcEpoch:   pointer.Ptr(uint32(fe.PkgSrcEpoch)),
+		PackageSrcRelease: pointer.Ptr(fe.PkgSrcRelease),
 		Hashes:            make([]string, len(fe.Hashes)),
 		HashState:         adproto.HashState(fe.HashState),
 	}

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -74,6 +74,16 @@ type FileSerializer struct {
 	PackageName string `json:"package_name,omitempty"`
 	// System package version
 	PackageVersion string `json:"package_version,omitempty"`
+	// System package epoch
+	PackageEpoch int `json:"package_epoch,omitempty"`
+	// System package release
+	PackageRelease string `json:"package_release,omitempty"`
+	// System package source version
+	PackageSrcVersion string `json:"package_source_version,omitempty"`
+	// System package source epoch
+	PackageSrcEpoch int `json:"package_source_epoch,omitempty"`
+	// System package source release
+	PackageSrcRelease string `json:"package_source_release,omitempty"`
 	// List of cryptographic hashes of the file
 	Hashes []string `json:"hashes,omitempty"`
 	// State of the hashes or reason why they weren't computed
@@ -814,6 +824,11 @@ func newFileSerializer(fe *model.FileEvent, e *model.Event, forceInode uint64, m
 		InUpperLayer:        getInUpperLayer(&fe.FileFields),
 		PackageName:         e.FieldHandlers.ResolvePackageName(e, fe),
 		PackageVersion:      e.FieldHandlers.ResolvePackageVersion(e, fe),
+		PackageEpoch:        e.FieldHandlers.ResolvePackageEpoch(e, fe),
+		PackageRelease:      e.FieldHandlers.ResolvePackageRelease(e, fe),
+		PackageSrcVersion:   e.FieldHandlers.ResolvePackageSourceVersion(e, fe),
+		PackageSrcEpoch:     e.FieldHandlers.ResolvePackageSourceEpoch(e, fe),
+		PackageSrcRelease:   e.FieldHandlers.ResolvePackageSourceRelease(e, fe),
 		HashState:           fe.HashState.String(),
 		MountPath:           fe.MountPath,
 		MountSource:         model.MountSourceToString(fe.MountSource),

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -3261,6 +3261,16 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 			out.PackageName = string(in.String())
 		case "package_version":
 			out.PackageVersion = string(in.String())
+		case "package_epoch":
+			out.PackageEpoch = int(in.Int())
+		case "package_release":
+			out.PackageRelease = string(in.String())
+		case "package_source_version":
+			out.PackageSrcVersion = string(in.String())
+		case "package_source_epoch":
+			out.PackageSrcEpoch = int(in.Int())
+		case "package_source_release":
+			out.PackageSrcRelease = string(in.String())
 		case "hashes":
 			if in.IsNull() {
 				in.Skip()
@@ -3495,6 +3505,31 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 		const prefix string = ",\"package_version\":"
 		out.RawString(prefix)
 		out.String(string(in.PackageVersion))
+	}
+	if in.PackageEpoch != 0 {
+		const prefix string = ",\"package_epoch\":"
+		out.RawString(prefix)
+		out.Int(int(in.PackageEpoch))
+	}
+	if in.PackageRelease != "" {
+		const prefix string = ",\"package_release\":"
+		out.RawString(prefix)
+		out.String(string(in.PackageRelease))
+	}
+	if in.PackageSrcVersion != "" {
+		const prefix string = ",\"package_source_version\":"
+		out.RawString(prefix)
+		out.String(string(in.PackageSrcVersion))
+	}
+	if in.PackageSrcEpoch != 0 {
+		const prefix string = ",\"package_source_epoch\":"
+		out.RawString(prefix)
+		out.Int(int(in.PackageSrcEpoch))
+	}
+	if in.PackageSrcRelease != "" {
+		const prefix string = ",\"package_source_release\":"
+		out.RawString(prefix)
+		out.String(string(in.PackageSrcRelease))
 	}
 	if len(in.Hashes) != 0 {
 		const prefix string = ",\"hashes\":"
@@ -3854,6 +3889,16 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 			out.PackageName = string(in.String())
 		case "package_version":
 			out.PackageVersion = string(in.String())
+		case "package_epoch":
+			out.PackageEpoch = int(in.Int())
+		case "package_release":
+			out.PackageRelease = string(in.String())
+		case "package_source_version":
+			out.PackageSrcVersion = string(in.String())
+		case "package_source_epoch":
+			out.PackageSrcEpoch = int(in.Int())
+		case "package_source_release":
+			out.PackageSrcRelease = string(in.String())
 		case "hashes":
 			if in.IsNull() {
 				in.Skip()
@@ -4128,6 +4173,31 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		const prefix string = ",\"package_version\":"
 		out.RawString(prefix)
 		out.String(string(in.PackageVersion))
+	}
+	if in.PackageEpoch != 0 {
+		const prefix string = ",\"package_epoch\":"
+		out.RawString(prefix)
+		out.Int(int(in.PackageEpoch))
+	}
+	if in.PackageRelease != "" {
+		const prefix string = ",\"package_release\":"
+		out.RawString(prefix)
+		out.String(string(in.PackageRelease))
+	}
+	if in.PackageSrcVersion != "" {
+		const prefix string = ",\"package_source_version\":"
+		out.RawString(prefix)
+		out.String(string(in.PackageSrcVersion))
+	}
+	if in.PackageSrcEpoch != 0 {
+		const prefix string = ",\"package_source_epoch\":"
+		out.RawString(prefix)
+		out.Int(int(in.PackageSrcEpoch))
+	}
+	if in.PackageSrcRelease != "" {
+		const prefix string = ",\"package_source_release\":"
+		out.RawString(prefix)
+		out.String(string(in.PackageSrcRelease))
 	}
 	if len(in.Hashes) != 0 {
 		const prefix string = ",\"hashes\":"


### PR DESCRIPTION
### What does this PR do?

In addition to the currently available package version and package source version, this PR gives access to the package release and epoch, through SECL fields, in the serializer and in the activity dumps.

In addition to that the source version parsing is improved in the new collector v2.

### Motivation

### Describe how you validated your changes

### Additional Notes
