### PR TITLE
fix: handle empty targets meta gracefully in remote config

### DIFF
--- a/releasenotes/notes/fix-remote-config-empty-targets-37136-037e83d6ee1fdbb1.yaml
+++ b/releasenotes/notes/fix-remote-config-empty-targets-37136-037e83d6ee1fdbb1.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix APM span/trace collection stopping after enabling Remote Configuration features.
+    The agent now gracefully handles empty targets metadata during Remote Configuration
+    initialization instead of returning a 500 Internal Server Error, preventing APM
+    data collection from being interrupted.


### PR DESCRIPTION
### What does this PR do?

Fixes APM span/trace collection stopping after enabling Remote Configuration features by gracefully handling empty targets metadata during initialization.

### Motivation

Fixes #37136 - When Remote Configuration features like "Connect Logs and Traces" and "Data Streams Monitoring" are enabled, the agent encounters a "500 Internal Server Error" with the message "empty targets meta in director local store". This error causes APM data collection to stop completely, even after disabling Remote Configuration.

The issue occurs in `flushCacheResponse()` when `UnsafeTargetsMeta()` returns an error for empty targets metadata during Remote Configuration initialization. Instead of failing with a 500 error, the function should handle this gracefully to maintain APM continuity.

### Describe how you validated your changes

- Added unit tests for `flushCacheResponse()` covering both the empty targets meta error case and other error scenarios
- Verified that the function returns valid empty targets JSON when encountering the specific error
- Confirmed that other errors are still properly propagated
- Tests pass: `go test ./pkg/config/remote/service -run "TestFlushCacheResponse" -v`

### Additional Notes

This fix ensures APM continuity during Remote Configuration state transitions while maintaining existing error handling for other failure scenarios. The change only affects the specific "empty targets meta in director local store" error case.

