### PR TITLE
fix(assign_issue): Remove usage of sudo

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -23,9 +23,9 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Install yq
       run: |
-        sudo add-apt-repository ppa:rmescandon/yq
-        sudo apt update
-        sudo apt install yq -y
+        add-apt-repository ppa:rmescandon/yq
+        apt update
+        apt install yq -y
     - name: Install dda
       uses: ./.github/actions/install-dda
       with:


### PR DESCRIPTION
### What does this PR do?
Remove usage of `sudo` when installing the missing dependency.

### Motivation
The workflow [fails](https://github.com/DataDog/datadog-agent/actions/runs/17802040919/job/50604185757) because `sudo` is not known. Let's remove it.

### Describe how you validated your changes
Not possible

### Additional Notes
