### PR TITLE
build: link with lazy symbol resolution on Linux

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -322,6 +322,9 @@ def get_build_flags(
                 ),
                 file=sys.stderr,
             )
+    elif sys.platform.startswith('linux'):
+        # Use lazy symbol resolution to fix NVML issues on distributions with --enable-host-bind-now
+        extldflags += "-Wl,-z,lazy "
 
     if os.getenv("DD_CC"):
         env["CC"] = os.getenv("DD_CC")


### PR DESCRIPTION
### What does this PR do?

This PR adds the `-Wl,-z,lazy` linker flag to the agent build command.

### Motivation

Since we use the go-nvml package, it adds undefined symbols to our binaries that can only be resolved on systems that have nvidia drivers installed. Because we use Cgo, the final binary is created using the system's linker, which means it is affected by the flags the linker was built with.

This is not an issue on most distributions that keep the defaults of linking with lazy symbols resolution. However, on systems where GCC was built with `-enable-host-bind-now`, the default is to resolve all the symbols on the process startup, which will fail on systems without the driver installed. One can reproduce this by running the agent or system-probe with the following env variable: `LD_BIND_NOW=1`:

```
$ LD_BIND_NOW=1 ./bin/system-probe/system-probe
./bin/system-probe/system-probe: symbol lookup error: ./bin/system-probe/system-probe: undefined symbol: nvmlGpuInstanceGetComputeInstanceProfileInfoV
```

This PR fixes this by forcing the binary to be created with lazy symbols resolution.

### Describe how you validated your changes

By building a working agent with a GCC that was built with `-enable-host-bind-now`. Also, any build failures/non working binaries should be caught by the CI.

### Additional Notes

- Even with this PR, the agent currently can not be run on systems that sets `LD_BIND_NOW`, which might be the case on hardened systems.
- We actually used to have this flag before: https://github.com/DataDog/datadog-agent/pull/33824
- It is technically possible to detect if the flag is actually needed by looking at the output of `gcc -v`, but this adding this flag unconditionally should be harmless and avoids doing some command output parsing.