### PR TITLE
[INCIDENT-43183] fix(ci): Disable `new-e2e-installer` job

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -609,30 +609,31 @@ new-e2e-installer-script:
     MAX_RETRIES_FLAG: "--max-retries=3"
     REMOTE_STACK_CLEANING: "true"
 
-# new-e2e-installer:
-#   extends: .new_e2e_template
-#   rules:
-#     - !reference [.on_installer_or_e2e_changes]
-#     - !reference [.manual]
-#   needs:
-#     - !reference [.needs_new_e2e_template]
-#     - deploy_deb_testing-a7_arm64
-#     - deploy_deb_testing-a7_x64
-#     - deploy_rpm_testing-a7_arm64
-#     - deploy_rpm_testing-a7_x64
-#     - deploy_suse_rpm_testing_arm64-a7
-#     - deploy_suse_rpm_testing_x64-a7
-#     - deploy_installer_oci
-#     - deploy_agent_oci
-#     - qa_installer_script_linux
-#   variables:
-#     TARGETS: ./tests/installer/unix
-#     TEAM: fleet
-#     FLEET_INSTALL_METHOD: "install_script"
-#     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
-#     E2E_USE_AWS_PROFILE: "false"
-#     MAX_RETRIES_FLAG: "--max-retries=3"
-#     REMOTE_STACK_CLEANING: "true"
+new-e2e-installer:
+  allow_failure: true
+  extends: .new_e2e_template
+  rules:
+    - !reference [.on_installer_or_e2e_changes]
+    - !reference [.manual]
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - deploy_deb_testing-a7_arm64
+    - deploy_deb_testing-a7_x64
+    - deploy_rpm_testing-a7_arm64
+    - deploy_rpm_testing-a7_x64
+    - deploy_suse_rpm_testing_arm64-a7
+    - deploy_suse_rpm_testing_x64-a7
+    - deploy_installer_oci
+    - deploy_agent_oci
+    - qa_installer_script_linux
+  variables:
+    TARGETS: ./tests/installer/unix
+    TEAM: fleet
+    FLEET_INSTALL_METHOD: "install_script"
+    E2E_LOGS_PROCESSING_TEST_DEPTH: 2
+    E2E_USE_AWS_PROFILE: "false"
+    MAX_RETRIES_FLAG: "--max-retries=3"
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer-windows:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -609,30 +609,30 @@ new-e2e-installer-script:
     MAX_RETRIES_FLAG: "--max-retries=3"
     REMOTE_STACK_CLEANING: "true"
 
-new-e2e-installer:
-  extends: .new_e2e_template
-  rules:
-    - !reference [.on_installer_or_e2e_changes]
-    - !reference [.manual]
-  needs:
-    - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_arm64
-    - deploy_deb_testing-a7_x64
-    - deploy_rpm_testing-a7_arm64
-    - deploy_rpm_testing-a7_x64
-    - deploy_suse_rpm_testing_arm64-a7
-    - deploy_suse_rpm_testing_x64-a7
-    - deploy_installer_oci
-    - deploy_agent_oci
-    - qa_installer_script_linux
-  variables:
-    TARGETS: ./tests/installer/unix
-    TEAM: fleet
-    FLEET_INSTALL_METHOD: "install_script"
-    E2E_LOGS_PROCESSING_TEST_DEPTH: 2
-    E2E_USE_AWS_PROFILE: "false"
-    MAX_RETRIES_FLAG: "--max-retries=3"
-    REMOTE_STACK_CLEANING: "true"
+# new-e2e-installer:
+#   extends: .new_e2e_template
+#   rules:
+#     - !reference [.on_installer_or_e2e_changes]
+#     - !reference [.manual]
+#   needs:
+#     - !reference [.needs_new_e2e_template]
+#     - deploy_deb_testing-a7_arm64
+#     - deploy_deb_testing-a7_x64
+#     - deploy_rpm_testing-a7_arm64
+#     - deploy_rpm_testing-a7_x64
+#     - deploy_suse_rpm_testing_arm64-a7
+#     - deploy_suse_rpm_testing_x64-a7
+#     - deploy_installer_oci
+#     - deploy_agent_oci
+#     - qa_installer_script_linux
+#   variables:
+#     TARGETS: ./tests/installer/unix
+#     TEAM: fleet
+#     FLEET_INSTALL_METHOD: "install_script"
+#     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
+#     E2E_USE_AWS_PROFILE: "false"
+#     MAX_RETRIES_FLAG: "--max-retries=3"
+#     REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer-windows:
   extends: .new_e2e_template


### PR DESCRIPTION
### What does this PR do?

Disable the `new-e2e-installer` job altogether

### Motivation

incident-43183 - the job is [consistently failing](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40ci.job.name%3Anew-e2e-installer%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline&start=1757583042893&end=1758187842893&paused=false)

### Describe how you validated your changes

Running `dda inv gitlab.compute-gitlab-ci-config` - the config is still valid with the job disabled

### Additional Notes
