### PR TITLE
Backport 41024 to 7.71.x

### DIFF
--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -27,6 +27,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
 
+const requestWithHeader = "datadog-agent-diagnose"
+
 func getLogsEndpoints(useTCP bool) (*logsConfig.Endpoints, error) {
 	datadogConfig := pkgconfigsetup.Datadog()
 	logsConfigKey := logsConfig.NewLogsConfigKeys("logs_config.", datadogConfig)
@@ -204,8 +206,11 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 	url := createEndpointURL(domain, endpointInfo)
 
 	headers := map[string]string{
-		"Content-Type": endpointInfo.ContentType,
-		"DD-API-KEY":   apiKey,
+		"Content-Type":     endpointInfo.ContentType,
+		"DD-API-KEY":       apiKey,
+		"DD-Agent-Version": version.AgentVersion,
+		"User-Agent":       fmt.Sprintf("datadog-agent/%s", version.AgentVersion),
+		"X-Requested-With": requestWithHeader,
 	}
 
 	return sendRequest(ctx, client, url, endpointInfo.Method, endpointInfo.Payload, headers)

--- a/pkg/diagnose/connectivity/core_endpoint_test.go
+++ b/pkg/diagnose/connectivity/core_endpoint_test.go
@@ -7,6 +7,7 @@ package connectivity
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 var (
@@ -157,4 +159,32 @@ func mustMarshalProto(msg proto.Message, t *testing.T) []byte {
 		t.Fatalf("Failed to marshal proto: %v", err)
 	}
 	return data
+}
+
+func TestSendHTTPRequestHeaders(t *testing.T) {
+	mockConfig := configmock.New(t)
+	log := logmock.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "api_key1", r.Header.Get("DD-API-KEY"))
+		assert.Equal(t, "application/x-protobuf", r.Header.Get("Content-Type"))
+		assert.Equal(t, version.AgentVersion, r.Header.Get("DD-Agent-Version"))
+		assert.Equal(t, fmt.Sprintf("datadog-agent/%s", version.AgentVersion), r.Header.Get("User-Agent"))
+		assert.Equal(t, requestWithHeader, r.Header.Get("X-Requested-With"))
+		w.Write([]byte("Received Protobuf"))
+	}))
+	defer ts.Close()
+
+	client := defaultforwarder.NewHTTPClient(mockConfig, 1, log)
+
+	endpointInfo := endpointInfo{
+		Endpoint:    transaction.Endpoint{Route: "/", Name: "sketch"},
+		Method:      "POST",
+		Payload:     mustMarshalProto(buildSketchPayload(), t),
+		ContentType: "application/x-protobuf",
+	}
+
+	statusCode, _, _, err := sendHTTPRequestToEndpoint(context.Background(), client, ts.URL, endpointInfo, "api_key1")
+	assert.NoError(t, err)
+	assert.Equal(t, 200, statusCode)
 }


### PR DESCRIPTION
### What does this PR do?
Backport `Add an `X-Requested-With` header to differentiate diagnose payloads in backend` to 7.71.x


### Motivation

### Describe how you validated your changes

### Additional Notes
