### PR TITLE
[ AGNTLOG-310 ] Lock down dynamic symbols exported in the agent binary

### DIFF
--- a/datadog-agent.map
+++ b/datadog-agent.map
@@ -1,0 +1,6 @@
+DD_AGENT_1.0 {
+    global:
+        nvml*;
+    local:
+        *;
+};

--- a/releasenotes/notes/c-symbol-lockdown-727d8656351db12c.yaml
+++ b/releasenotes/notes/c-symbol-lockdown-727d8656351db12c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Lock down dynamic symbol exports in the Linux Agent binary to prevent unexpected symbol conflicts.

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -253,6 +253,11 @@ def get_build_flags(
     if sys.platform.startswith('linux') and run_path:
         ldflags += f"-X {REPO_PATH}/pkg/config/setup.defaultRunPath={run_path} "
 
+    # lock down the agent to only use the symbols in the datadog-agent.map file
+    # required because some go dependencies (such as go-nvml) will automatically include the --export-dynamic flag
+    if sys.platform.startswith('linux'):
+        extldflags += f"-Wl,--version-script={get_repo_root()}/datadog-agent.map "
+
     # setting python homes in the code
     if python_home_3:
         ldflags += f"-X {REPO_PATH}/pkg/collector/python.pythonHome3={python_home_3} "


### PR DESCRIPTION
### What does this PR do?
The goal of this PR is to restrict the exported dynamic symbols exported by the agent to only include those necessary for runtime operations. A go dependency (go-nvml) included in some build versions of the agent has triggered an automatic export of all symbols within the binary, which has in turn caused some symbol conflicts/segfaults that needed significant investigation to identify and fix. While the individual error case has been patched, removing unneeded dynamic symbols offers a much more secure mitigation moving forward.

Note that we *DO* export the nvml symbols as global symbols in this change - this is a tentative choice intended to be reviewed here. All of the existing test setups for the subset of functionality that interacts with nvml report successful runs with symbols exported. 

### Motivation

### Describe how you validated your changes
Ultimately the testing of this change was reliant on the existing suite of automated tests. The binary was hand verified as fully functional for the purposes of the logs agent, but no other system was manually vetted.


### Additional Notes
