### PR TITLE
[tracer] Fix bug in TestTCPFailureConnectionTimeout

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2593,7 +2593,8 @@ func (s *TracerSuite) TestTCPFailureConnectionTimeout() {
 		}
 		sfd, err := syscall.Socket(syscall.AF_INET, flags, syscall.IPPROTO_TCP)
 		require.NoError(t, err)
-		defer syscall.Close(sfd)
+		f := os.NewFile(uintptr(sfd), "")
+		defer f.Close()
 
 		//syscall.TCP_USER_TIMEOUT is 18 but not defined in our linter. Set it to 500ms
 		err = syscall.SetsockoptInt(sfd, syscall.IPPROTO_TCP, 18, 500)
@@ -2608,7 +2609,6 @@ func (s *TracerSuite) TestTCPFailureConnectionTimeout() {
 			}
 		}
 
-		f := os.NewFile(uintptr(sfd), "")
 		c, err := net.FileConn(f)
 		require.NoError(t, err)
 		t.Cleanup(func() { c.Close() })


### PR DESCRIPTION
### What does this PR do?
This PR fixes a double closing bug in TestTCPFailureConnectionTimeout. The FD was getting closed a second time by the *os.File finalizer.

### Motivation
This test flaked recently. I'm not certain this issue is the cause of the flake, but I'll start with fixing this.