### PR TITLE
[e2e] Skip system-probe is running on Ubuntu 14.04

### DIFF
--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -333,6 +333,9 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 		if client.Host.OSFlavor == componentos.CentOS {
 			tt.Skip("System-probe is broken on CentOS 7")
 		}
+		if client.Host.OSVersion == "ubuntu-14-04" {
+			tt.Skip("System-probe is flaky on Ubuntu 14.04")
+		}
 		err := client.SetConfig(client.Helper.GetConfigFolder()+"system-probe.yaml", "system_probe_config.enabled", "true")
 		require.NoError(tt, err)
 
@@ -344,6 +347,9 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 		if client.Host.OSFlavor == componentos.CentOS {
 			tt.Skip("System-probe is broken on CentOS 7")
 		}
+		if client.Host.OSVersion == "ubuntu-14-04" {
+			tt.Skip("System-probe is flaky on Ubuntu 14.04")
+		}
 		require.Eventually(tt, func() bool {
 			return AgentProcessIsRunning(client, "system-probe")
 		}, 1*time.Minute, 500*time.Millisecond, "system-probe should be running ")
@@ -352,6 +358,9 @@ func CheckSystemProbeBehavior(t *testing.T, client *TestClient) {
 	t.Run("ebpf programs are unpacked and valid", func(tt *testing.T) {
 		if client.Host.OSFlavor == componentos.CentOS {
 			tt.Skip("System-probe is broken on CentOS 7")
+		}
+		if client.Host.OSVersion == "ubuntu-14-04" {
+			tt.Skip("System-probe is flaky on Ubuntu 14.04")
 		}
 		ebpfPath := "/opt/datadog-agent/embedded/share/system-probe/ebpf"
 		output, err := client.Host.Execute(fmt.Sprintf("find %s -name '*.o'", ebpfPath))


### PR DESCRIPTION
### What does this PR do?
* Skips system-probe tests on Ubuntu 14.04

### Motivation
* Since https://github.com/DataDog/datadog-agent/pull/40818, it's been flaky on this specific os version. Before this PR, it was silently passing while flaking/failing due to matching `system-probe.yaml` in the other processes

### Describe how you validated your changes

### Additional Notes
