### PR TITLE
dyninst/procmon: add Sync support, replace ebpf/process

### DIFF
--- a/cmd/system-probe/modules/dynamic_instrumentation.go
+++ b/cmd/system-probe/modules/dynamic_instrumentation.go
@@ -13,7 +13,6 @@ import (
 
 	dimod "github.com/DataDog/datadog-agent/pkg/dyninst/module"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
-	ebpf_process "github.com/DataDog/datadog-agent/pkg/ebpf/process"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/consumers"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
@@ -34,16 +33,13 @@ var DynamicInstrumentation = &module.Factory{
 		if godiProcessEventConsumer == nil {
 			return nil, errors.New("process event consumer not initialized")
 		}
-		godiSubscriber, err := ebpf_process.NewMonitor(godiProcessEventConsumer)
-		if err != nil {
-			return nil, err
-		}
 
 		config, err := dimod.NewConfig(agentConfiguration)
 		if err != nil {
 			return nil, fmt.Errorf("invalid dynamic instrumentation module configuration: %w", err)
 		}
-		m, err := dimod.NewModule(config, godiSubscriber)
+		const processSyncEnabled = true
+		m, err := dimod.NewModule(config, godiProcessEventConsumer, processSyncEnabled)
 		if err != nil {
 			if errors.Is(err, ebpf.ErrNotImplemented) {
 				return nil, module.ErrNotEnabled

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -625,7 +625,8 @@ func (ts *testState) initializeModule(t *testing.T) {
 	cfg.DiagsUploaderURL = ts.backendServer.URL + "/diags"
 	cfg.SymDBUploaderURL = ts.symdbURL
 
-	ts.module, err = di_module.NewModule(cfg, ts.subscriber)
+	const processSyncEnabled = false
+	ts.module, err = di_module.NewModule(cfg, ts.subscriber, processSyncEnabled)
 	require.NoError(t, err)
 }
 

--- a/pkg/dyninst/module/dependencies.go
+++ b/pkg/dyninst/module/dependencies.go
@@ -23,6 +23,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 )
 
+// ProcessSubscriber is an interface that can be used to subscribe to process
+// events.
+type ProcessSubscriber interface {
+	SubscribeExec(func(pid uint32)) (cleanup func())
+	SubscribeExit(func(pid uint32)) (cleanup func())
+}
+
 // Scraper is an interface that enables the Controller to get updates from the
 // scraper and to set the probe status to emitting.
 type Scraper interface {

--- a/pkg/dyninst/procmon/list_pids.go
+++ b/pkg/dyninst/procmon/list_pids.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"os"
+	"regexp"
+	"slices"
+	"strconv"
+)
+
+// listPids lists the PIDs of the processes in the given procfs root by pages.
+//
+// It will never report an empty page, but it may report a page smaller than
+// the page size even if it is not the last page.
+func listPids(procfsRoot string, pageSize int) iter.Seq2[[]uint32, error] {
+	return func(yield func([]uint32, error) bool) {
+		f, err := os.Open(procfsRoot)
+		if err != nil {
+			yield(nil, fmt.Errorf("open procfs: %w", err))
+			return
+		}
+		defer f.Close()
+		var sawEOF bool
+		for !sawEOF {
+			entries, err := f.Readdirnames(pageSize)
+			if errors.Is(err, io.EOF) {
+				sawEOF, err = true, nil
+			}
+			if err != nil {
+				yield(nil, fmt.Errorf("read procfs dirnames: %w", err))
+				return
+			}
+			entries = slices.DeleteFunc(entries, isNotAPid)
+			pids := make([]uint32, 0, len(entries))
+			for _, entry := range entries {
+				pid, parseErr := strconv.ParseUint(entry, 10, 32)
+				if parseErr != nil {
+					continue
+				}
+				pids = append(pids, uint32(pid))
+			}
+			if len(pids) == 0 {
+				continue
+			}
+			if !yield(pids, nil) {
+				return
+			}
+		}
+	}
+}
+
+var maybePidRegex = regexp.MustCompile(`^[1-9]\d{0,9}$`)
+
+func isNotAPid(entry string) bool {
+	return !maybePidRegex.MatchString(entry)
+}

--- a/pkg/dyninst/procmon/list_pids_test.go
+++ b/pkg/dyninst/procmon/list_pids_test.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"fmt"
+	"io/fs"
+	"iter"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListPids(t *testing.T) {
+
+	t.Run("pages all entries", func(t *testing.T) {
+		const pageSize = 2
+		dir := t.TempDir()
+		for _, name := range []string{"101", "202"} {
+			require.NoError(t, os.Mkdir(filepath.Join(dir, name), 0o755))
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "not-a-pid"), []byte(""), 0o644))
+		for i := range pageSize * 8 {
+			p := fmt.Sprintf("not-a-pid-%d", i)
+			require.NoError(t, os.Mkdir(filepath.Join(dir, p), 0o755))
+		}
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "303"), 0o755))
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "0"), 0o755)) //ignored
+
+		seq := listPids(dir, pageSize)
+		pages, err := collectErr(seq)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(pages), 2)
+
+		// Make sure no page is larger than the page size.
+		for _, page := range pages {
+			require.LessOrEqual(t, len(page), pageSize)
+		}
+
+		flat := slices.Sorted(flatten(slices.Values(pages)))
+		require.Equal(t, []uint32{101, 202, 303}, flat)
+	})
+	t.Run("directory error", func(t *testing.T) {
+		seq := listPids(filepath.Join(t.TempDir(), "missing"), 4)
+		_, err := collectErr(seq)
+		require.ErrorIs(t, err, fs.ErrNotExist)
+	})
+	t.Run("no empty pages", func(t *testing.T) {
+		dir := t.TempDir()
+		const pageSize = 2
+		for i := range pageSize * 8 {
+			p := fmt.Sprintf("not-a-pid-%d", i)
+			require.NoError(t, os.Mkdir(filepath.Join(dir, p), 0o755))
+		}
+		seq := listPids(dir, pageSize)
+		pageCount := 0
+		seq(func(_ []uint32, pageErr error) bool {
+			pageCount++
+			require.NoError(t, pageErr)
+			// Stop after the first page to ensure early termination is
+			// honored.
+			return false
+		})
+		require.Equal(t, 0, pageCount)
+	})
+	t.Run("caller stops early", func(t *testing.T) {
+		dir := t.TempDir()
+		const pageSize = 3
+		for i := range pageSize * 5 {
+			p := fmt.Sprintf("%d", i+1)
+			require.NoError(t, os.Mkdir(filepath.Join(dir, p), 0o755))
+		}
+		seq := listPids(dir, pageSize)
+		pageCount := 0
+		seq(func(_ []uint32, pageErr error) bool {
+			pageCount++
+			require.NoError(t, pageErr)
+			// Stop after the first page to ensure early termination is
+			// honored.
+			return false
+		})
+		require.Equal(t, 1, pageCount)
+	})
+}
+
+func flatten[T any](seq iter.Seq[[]T]) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for page := range seq {
+			for _, v := range page {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func collectErr[T any](seq iter.Seq2[T, error]) ([]T, error) {
+	var ret []T
+	for v, err := range seq {
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, v)
+	}
+	return ret, nil
+}

--- a/pkg/dyninst/procmon/process_monitor.go
+++ b/pkg/dyninst/procmon/process_monitor.go
@@ -11,6 +11,7 @@
 package procmon
 
 import (
+	"maps"
 	"os"
 	"sync"
 	"time"
@@ -73,10 +74,29 @@ type ProcessMonitor struct {
 
 	mu struct {
 		sync.Mutex
-		state       state
-		isClosed    bool
-		analyzeChan chan<- uint32
+
+		// Used to synchronize the sync operations with analysis. We don't
+		// want concurrent syncs, and we also don't want sync to fill up the
+		// analysis queue.
+		//
+		// Broadcasts when:
+		//   - A sync completes.
+		//   - The analysis queue is drained.
+		//   - The process monitor is closed.
+		sync.Cond
+
+		// Used to track when a sync is in progress.
+		syncing bool
+
+		// The state of the process monitor.
+		state state
+
+		// Set to true when the process monitor is closed.
+		isClosed bool
 	}
+
+	// Used to shut down the analysis worker.
+	analyzeChan chan<- uint32
 
 	wg        sync.WaitGroup
 	closeOnce sync.Once
@@ -85,7 +105,12 @@ type ProcessMonitor struct {
 // NewProcessMonitor creates a new ProcessMonitor that will send updates to the
 // given Actuator.
 func NewProcessMonitor(h Handler) *ProcessMonitor {
-	return newProcessMonitor(h, kernel.ProcFSRoot(), container.New())
+	pm, analyzeChan := newProcessMonitor(
+		h, kernel.ProcFSRoot(), container.New(),
+		makeExecutableAnalyzer(cacheSize),
+	)
+	pm.startAnalyzerWorker(analyzeChan)
+	return pm
 }
 
 // NotifyExec is a callback to notify the monitor that a process has started.
@@ -121,44 +146,126 @@ func (pm *ProcessMonitor) NotifyExit(pid uint32) {
 //	At 64 entries: ~9KiB from entries + constant overheads < 16KiB per cache
 const cacheSize = 64
 
-// newProcessMonitor is injectable with a fake FS for tests.
 func newProcessMonitor(
 	h Handler, procFS string, resolver ContainerResolver,
-) *ProcessMonitor {
+	analyzer executableAnalyzer,
+) (*ProcessMonitor, chan uint32) {
 	analyzeChan := make(chan uint32, 1) // this will never block
 	pm := &ProcessMonitor{
 		handler:            h,
 		procfsRoot:         procFS,
 		resolver:           resolver,
-		executableAnalyzer: makeExecutableAnalyzer(cacheSize),
+		executableAnalyzer: analyzer,
+		analyzeChan:        analyzeChan,
 	}
 	pm.mu.state = makeState()
-	pm.mu.analyzeChan = analyzeChan
+	pm.mu.L = &pm.mu.Mutex
 
-	// Run an analysis worker goroutine.
+	return pm, analyzeChan
+}
+
+func (pm *ProcessMonitor) startAnalyzerWorker(analyzeChan <-chan uint32) {
 	pm.wg.Add(1)
 	go func() {
 		defer pm.wg.Done()
-		for {
-			pid, ok := <-analyzeChan
-			if !ok {
-				return
-			}
+		for pid := range analyzeChan {
 			pm.analyzeProcess(pid)
 		}
 	}()
-
-	return pm
 }
+
+func (pm *ProcessMonitor) beginSync() (prevAlive map[uint32]struct{}, closed bool) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	for pm.mu.syncing && !pm.mu.isClosed {
+		pm.mu.Wait()
+	}
+	if pm.mu.isClosed {
+		return nil, true
+	}
+	pm.mu.syncing = true
+	return maps.Clone(pm.mu.state.alive), false
+}
+
+func (pm *ProcessMonitor) endSync() {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.mu.syncing = false
+	pm.mu.Broadcast()
+}
+
+// Sync synchronizes the contents of procfs with the internal process state,
+// reporting all processes that are not currently known to be interesting as
+// having executed, and calling exit for any previously known processes that are
+// no longer around.
+func (pm *ProcessMonitor) Sync() error {
+	prevAlive, closed := pm.beginSync()
+	if closed {
+		return nil
+	}
+	defer pm.endSync()
+	// Arbitrary. Big enough to not spend too much time in readdir, but small
+	// enough to hopefully not waste too much memory.
+	const readDirPageSize = 512
+	for pids, err := range listPids(pm.procfsRoot, readDirPageSize) {
+		if err != nil {
+			return err
+		}
+		for _, pid := range pids {
+			if _, ok := prevAlive[pid]; ok {
+				delete(prevAlive, pid)
+				continue
+			}
+			if closed := addPidWithBackpressure(pm, pid); closed {
+				return nil
+			}
+		}
+	}
+	// Report processes that exited before we finished syncing.
+	func() {
+		pm.mu.Lock()
+		defer pm.mu.Unlock()
+		for pid := range prevAlive {
+			pm.mu.state.handleProcessEvent(processEvent{
+				kind: processEventKindExit, pid: pid,
+			})
+		}
+		pm.mu.state.analyzeOrReport((*lockedProcessMonitor)(pm))
+	}()
+	return nil
+}
+
+// addPidWithBackpressure attempts to add the given PID to the state machine's
+// queue of processes to analyze. However, if the queue has reached its
+// backpressure limit, it waits for the queue to drain before adding the PID.
+func addPidWithBackpressure(pm *ProcessMonitor, pid uint32) (closed bool) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	for len(pm.mu.state.queued) > queueBackpressureLimit && !pm.mu.isClosed {
+		pm.mu.Wait()
+	}
+	if pm.mu.isClosed {
+		return true
+	}
+	pm.mu.state.handleProcessEvent(processEvent{
+		kind: processEventKindExec, pid: pid,
+	})
+	pm.mu.state.analyzeOrReport((*lockedProcessMonitor)(pm))
+	return false
+}
+
+// queueBackpressureLimit is the maximum number of processes that can be queued
+// for analysis before we backpressure the sync operation.
+const queueBackpressureLimit = 64 // arbitrary limit
 
 func handleEvent[Ev any](pm *ProcessMonitor, f func(*state, Ev), ev Ev) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
-	if pm.mu.isClosed {
-		return
-	}
 	f(&pm.mu.state, ev)
 	pm.mu.state.analyzeOrReport((*lockedProcessMonitor)(pm))
+	if pm.mu.syncing && len(pm.mu.state.queued) == 0 {
+		pm.mu.Broadcast()
+	}
 }
 
 // Close requests an orderly shutdown and waits for completion.
@@ -169,8 +276,9 @@ func (pm *ProcessMonitor) Close() {
 		defer pm.wg.Wait()
 		pm.mu.Lock()
 		defer pm.mu.Unlock()
-		close(pm.mu.analyzeChan)
+		close(pm.analyzeChan)
 		pm.mu.isClosed = true
+		pm.mu.Broadcast()
 	})
 }
 
@@ -212,7 +320,7 @@ type lockedProcessMonitor ProcessMonitor
 
 func (pm *lockedProcessMonitor) analyzeProcess(pid uint32) {
 	select {
-	case pm.mu.analyzeChan <- pid:
+	case pm.analyzeChan <- pid:
 	default:
 		// This should never happen, but if it does, we'll log it and shutdown
 		// the monitor rather than potentially crashing the process.

--- a/pkg/dyninst/procmon/process_monitor_sync_test.go
+++ b/pkg/dyninst/procmon/process_monitor_sync_test.go
@@ -1,0 +1,173 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	containerutils "github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+func TestProcessMonitorSyncBlockingBehaviour(t *testing.T) {
+	t.Run("close unblocks waiting syncs", func(t *testing.T) {
+		root := t.TempDir()
+		// It needs to be +3 because the one that is currently being analyzed is
+		// not in the queue yet, and then the one we would block on adding is
+		// also not in the queue yet, so we'll be able to add n+2 and then block
+		// on the n+3rd.
+		populateProcfs(t, root, queueBackpressureLimit+3)
+
+		pm, analyze := newProcessMonitorForTest(t, root)
+
+		sync1 := startSync(pm)
+		assertSyncBlocked(t, sync1)
+		// The first sync is now holding the Sync lock and has issued an
+		// analysis request.
+		_ = waitForAnalysisRequest(t, analyze)
+
+		sync2 := startSync(pm)
+		// The second sync should block because Sync serializes access while the
+		// queue backpressure prevents the first sync from completing.
+		assertSyncBlocked(t, sync2)
+		assertSyncBlocked(t, sync1)
+
+		// Closing the monitor flips isClosed and wakes any waiters, so both syncs
+		// should now unwind cleanly.
+		pm.Close()
+
+		require.NoError(t, waitForSync(t, sync1))
+		require.NoError(t, waitForSync(t, sync2))
+	})
+
+	t.Run("first sync finishing unblocks next", func(t *testing.T) {
+		root := t.TempDir()
+		populateProcfs(t, root, queueBackpressureLimit+3)
+
+		pm, analyze := newProcessMonitorForTest(t, root)
+
+		sync1 := startSync(pm)
+		assertSyncBlocked(t, sync1)
+		firstPID := waitForAnalysisRequest(t, analyze)
+
+		sync2 := startSync(pm)
+		// With sync1 still mid-flight, sync2 must block until the queue drains.
+		assertSyncBlocked(t, sync2)
+
+		pending := []uint32{firstPID}
+		for sync1 != nil {
+			for len(pending) > 0 {
+				// Complete queued analyses one at a time; sync1 should eventually
+				// finish once its outstanding requests are acknowledged.
+				pid := pending[0]
+				pending = pending[:0]
+				deliverAnalysisResult(pm, pid)
+			}
+
+			select {
+			case pid := <-analyze:
+				pending = append(pending, pid)
+				require.Len(t, pending, 1)
+			case err := <-sync1:
+				require.NoError(t, err)
+				sync1 = nil
+			case <-time.After(2 * time.Second):
+				t.Fatalf("timeout while draining analysis queue")
+			}
+		}
+
+		// With the queue empty and all the processes marked as interesting,
+		// sync2 should now complete successfully and immediately.
+		require.NoError(t, waitForSync(t, sync2))
+	})
+}
+
+func newProcessMonitorForTest(
+	t *testing.T, procfsRoot string,
+) (*ProcessMonitor, <-chan uint32) {
+	t.Helper()
+	pm, analyze := newProcessMonitor(
+		testHandler{}, procfsRoot, testResolver{}, noopAnalyzer{},
+	)
+	t.Cleanup(pm.Close)
+	return pm, analyze
+}
+
+func populateProcfs(t *testing.T, root string, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		pid := 10000 + i
+		dir := filepath.Join(root, strconv.Itoa(pid))
+		require.NoError(t, os.Mkdir(dir, 0o755))
+	}
+}
+
+func startSync(pm *ProcessMonitor) <-chan error {
+	done := make(chan error, 1)
+	go func() { done <- pm.Sync() }()
+	return done
+}
+
+func waitForAnalysisRequest(t *testing.T, ch <-chan uint32) uint32 {
+	t.Helper()
+	select {
+	case pid, ok := <-ch:
+		require.True(t, ok, "analysis request channel closed unexpectedly")
+		return pid
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for analysis request")
+		return 0
+	}
+}
+
+func assertSyncBlocked(t *testing.T, ch <-chan error) {
+	t.Helper()
+	select {
+	case err := <-ch:
+		t.Fatalf("expected sync to block, got %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func waitForSync(t *testing.T, ch <-chan error) error {
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for sync")
+		return nil
+	}
+}
+
+func deliverAnalysisResult(pm *ProcessMonitor, pid uint32) {
+	handleEvent(pm, (*state).handleAnalysisResult, analysisResult{
+		pid:             pid,
+		processAnalysis: processAnalysis{interesting: true},
+	})
+}
+
+type testHandler struct{}
+
+func (testHandler) HandleUpdate(ProcessesUpdate) {}
+
+type testResolver struct{}
+
+func (testResolver) GetContainerContext(uint32) (containerutils.ContainerID, model.CGroupContext, string, error) {
+	return "", model.CGroupContext{}, "", nil
+}
+
+type noopAnalyzer struct{}
+
+func (noopAnalyzer) checkFileKeyCache(FileKey) (bool, bool)        { return false, false }
+func (noopAnalyzer) isInteresting(*os.File, FileKey) (bool, error) { return true, nil }

--- a/pkg/dyninst/procmon/state_test.go
+++ b/pkg/dyninst/procmon/state_test.go
@@ -137,6 +137,38 @@ func TestStateMachine(t *testing.T) {
 				s(exit(8), alive(5)),
 			},
 		},
+		{
+			name: "reanalysis",
+			steps: []step{
+				s(exec(9), analyze(9), alive(9)),
+				s(exec(10), alive(9, 10)),
+				s(exec(9), alive(9, 10)), // marks for reanalysis
+				s(uninteresting(9), analyze(10), alive(9, 10)),
+				s(uninteresting(10), analyze(9), alive(9)),
+				s(interesting(9), upd(9), alive(9)),
+			},
+		},
+		{
+			name: "readded while queued",
+			steps: []step{
+				s(exec(11), analyze(11), alive(11)),
+				s(exec(12), alive(11, 12)),
+				s(exec(12), alive(11, 12)),
+				s(uninteresting(11), analyze(12), alive(12)),
+				s(uninteresting(12), alive()),
+			},
+		},
+		{
+			name: "reanalyze then exit",
+			steps: []step{
+				s(exec(13), analyze(13), alive(13)),
+				s(exec(14), alive(13, 14)),
+				s(exec(13), alive(13, 14)), // marks for reanalysis
+				s(exit(13), alive(14)),     // removes from alive
+				s(interesting(13), analyze(14), alive(14)),
+				s(uninteresting(14), alive()),
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### What does this PR do?

The ebpf/process was not adding much of anything, and was hurting in that we were never getting exec calls that happen after the first one. Processes can change their shape, and we need to re-analyze them.

The intention to avoid re-processing was fine, but it is misguided. We know that we might miss exec events from eBPF, so we must re-process if it's possible that the process changed. We could use some more memory to track information about the fingerprint when we last did the analysis, but that doesn't seem worthwhile.

Instead we make sure that we don't flood the queue from our syncing. On the whole this should retain substantially less memory.

### Motivation

This also fixes the flakes we saw in the system tests, and may explain why we failed to find some processes we expected to find.

### Describe how you validated your changes

I stressed the system tests.

### Additional Notes

This will now actually re-analyze every process every time we sync. That should be fine.